### PR TITLE
Support Kotlin DSL (build.gradle.kts) for version bumping

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,13 +34,30 @@ platform :android do
   private_lane :fetch_and_increment_build_number do
     sh "git config user.email 'CI@BOT.com'"
     sh "git config user.name 'CI-BOT'"
-    increment_version_code(
-            app_project_dir: "**/app",
-      )
-    increment_version_name(app_project_dir: '**/app', bump_type: 'patch')
-    git_add(path: "/home/runner/work/Nimaz/Nimaz/app/build.gradle")
+
+    # The project uses the Kotlin DSL (build.gradle.kts), which the
+    # android_versioning plugin does not support, so bump the versions
+    # directly here.
+    gradle_file = File.expand_path("../app/build.gradle.kts", __dir__)
+    contents = File.read(gradle_file)
+
+    current_code = contents[/versionCode\s*=\s*(\d+)/, 1]
+    UI.user_error!("Could not find versionCode in #{gradle_file}") if current_code.nil?
+    new_code = current_code.to_i + 1
+    contents = contents.sub(/versionCode\s*=\s*\d+/, "versionCode = #{new_code}")
+
+    current_name = contents[/versionName\s*=\s*"([^"]+)"/, 1]
+    UI.user_error!("Could not find versionName in #{gradle_file}") if current_name.nil?
+    major, minor, patch = current_name.split(".").map(&:to_i)
+    new_name = "#{major}.#{minor}.#{patch + 1}"
+    contents = contents.sub(/versionName\s*=\s*"[^"]+"/, "versionName = \"#{new_name}\"")
+
+    File.write(gradle_file, contents)
+    UI.success("Bumped versionCode #{current_code} -> #{new_code}, versionName #{current_name} -> #{new_name}")
+
+    git_add(path: gradle_file)
     git_commit(
-          path: "/home/runner/work/Nimaz/Nimaz/app/build.gradle",
+          path: gradle_file,
           message: "Bumped Version Code and name"
         )
     # Get the current branch name


### PR DESCRIPTION
## Summary
Updated the version bumping logic in the Android build lane to support Kotlin DSL build files (build.gradle.kts) instead of relying on the `android_versioning` plugin, which doesn't support this format.

## Key Changes
- Replaced `increment_version_code()` and `increment_version_name()` plugin calls with custom Kotlin regex-based parsing and file manipulation
- Added direct file reading and writing of build.gradle.kts to update `versionCode` and `versionName` fields
- Implemented semantic versioning bump logic (patch version increment) for `versionName`
- Added error handling to validate that version fields exist in the gradle file before modification
- Updated git operations to use the resolved gradle file path instead of hardcoded absolute paths
- Added user feedback with success message showing the version bumps applied

## Implementation Details
- Uses regex patterns to locate and extract current `versionCode` (integer) and `versionName` (semantic version string)
- Parses semantic version into major.minor.patch components and increments patch version
- Replaces version values in-place within the file contents before writing back
- Provides clear error messages if version fields cannot be found in the gradle file

https://claude.ai/code/session_01FwUXHMLQFZ8UJpE1RTtbmX