### PR TITLE
Automate version bumping via PR instead of direct commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Skip the automated version-bump PR (and its merge) so it never
+    # re-triggers a build/deploy. The bump commit/PR title carries [skip ci]
+    # for squash merges; the head_ref guard covers the open PR itself.
+    if: >-
+      github.head_ref != 'automated/version-bump' &&
+      !contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,3 +89,31 @@ jobs:
           name: assets
           path: |
             ${{ github.workspace }}/app/build/outputs/bundle/release
+
+      # The build above bumped versionCode/versionName in app/build.gradle.kts
+      # (in the working tree only). Open a PR with that change so the committed
+      # baseline stays in sync for the next deploy. This runs only on a real
+      # push to dev (a merged change), never on the bump PR itself.
+      #
+      # The PR is created with the default GITHUB_TOKEN, so GitHub's
+      # anti-recursion rule keeps it from triggering further CI runs. It is NOT
+      # auto-merged: a maintainer reviews and merges it. Use "Squash and merge"
+      # so the [skip ci] marker is preserved and the merge does not re-deploy.
+      - name: Open version bump PR
+        if: github.event_name == 'push'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: app/build.gradle.kts
+          branch: automated/version-bump
+          base: dev
+          delete-branch: true
+          commit-message: "chore(release): bump version [skip ci]"
+          title: "chore(release): bump version [skip ci]"
+          labels: version-bump
+          body: |
+            Automated version bump created after deploying to the Play Store internal track.
+
+            - Only updates `versionCode` / `versionName` in `app/build.gradle.kts`.
+            - CI checks and deployment are intentionally skipped for this PR.
+            - **Merge with "Squash and merge"** so the `[skip ci]` marker is kept and the merge does not re-trigger a deploy.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,15 +17,10 @@ android {
         applicationId = "com.arshadshah.nimaz"
         minSdk = 29
         targetSdk = 36
-
-        // Base version. `versionName` is the human-readable release version and is
-        // bumped intentionally via a normal PR. `versionCode` must be unique and
-        // strictly increasing for every Play Store upload, so in CI it is derived
-        // from the workflow run number (see VERSION_CODE in fastlane). This avoids
-        // committing/pushing a bump back to the protected branch.
-        val baseVersionCode = 300
-        versionCode = (System.getenv("VERSION_CODE")?.toIntOrNull() ?: baseVersionCode)
-        versionName = "3.0.1"
+        // Source of truth for the app version. CI bumps these at build time and
+        // opens a PR with the change instead of pushing to the protected branch.
+        versionCode = 300
+        versionName = "3.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,15 @@ android {
         applicationId = "com.arshadshah.nimaz"
         minSdk = 29
         targetSdk = 36
-        versionCode = 300
-        versionName = "3.0.0"
+
+        // Base version. `versionName` is the human-readable release version and is
+        // bumped intentionally via a normal PR. `versionCode` must be unique and
+        // strictly increasing for every Play Store upload, so in CI it is derived
+        // from the workflow run number (see VERSION_CODE in fastlane). This avoids
+        // committing/pushing a bump back to the protected branch.
+        val baseVersionCode = 300
+        versionCode = (System.getenv("VERSION_CODE")?.toIntOrNull() ?: baseVersionCode)
+        versionName = "3.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,43 +32,28 @@ platform :android do
   end
 
   private_lane :fetch_and_increment_build_number do
-    sh "git config user.email 'CI@BOT.com'"
-    sh "git config user.name 'CI-BOT'"
-
+    # We deliberately do NOT commit/push a version bump back to the repo.
+    # The `dev` branch is protected (changes must go through a PR + CodeQL),
+    # so a direct CI push is correctly rejected. Instead we derive a unique,
+    # strictly-increasing versionCode at build time from the CI run number and
+    # expose it to Gradle via the VERSION_CODE env var. build.gradle.kts reads
+    # this value, falling back to its committed base when building locally.
+    #
     # The project uses the Kotlin DSL (build.gradle.kts), which the
-    # android_versioning plugin does not support, so bump the versions
-    # directly here.
+    # android_versioning plugin does not support, hence the manual approach.
     gradle_file = File.expand_path("../app/build.gradle.kts", __dir__)
     contents = File.read(gradle_file)
 
-    current_code = contents[/versionCode\s*=\s*(\d+)/, 1]
-    UI.user_error!("Could not find versionCode in #{gradle_file}") if current_code.nil?
-    new_code = current_code.to_i + 1
-    contents = contents.sub(/versionCode\s*=\s*\d+/, "versionCode = #{new_code}")
+    base_code = contents[/baseVersionCode\s*=\s*(\d+)/, 1] || contents[/versionCode\s*=\s*(\d+)/, 1]
+    UI.user_error!("Could not find a base versionCode in #{gradle_file}") if base_code.nil?
 
-    current_name = contents[/versionName\s*=\s*"([^"]+)"/, 1]
-    UI.user_error!("Could not find versionName in #{gradle_file}") if current_name.nil?
-    major, minor, patch = current_name.split(".").map(&:to_i)
-    new_name = "#{major}.#{minor}.#{patch + 1}"
-    contents = contents.sub(/versionName\s*=\s*"[^"]+"/, "versionName = \"#{new_name}\"")
+    # GITHUB_RUN_NUMBER increments on every workflow run, guaranteeing a
+    # monotonically increasing versionCode without persisting anything to git.
+    run_number = ENV["GITHUB_RUN_NUMBER"].to_i
+    new_code = base_code.to_i + run_number
 
-    File.write(gradle_file, contents)
-    UI.success("Bumped versionCode #{current_code} -> #{new_code}, versionName #{current_name} -> #{new_name}")
-
-    git_add(path: gradle_file)
-    git_commit(
-          path: gradle_file,
-          message: "Bumped Version Code and name"
-        )
-    # Get the current branch name
-    current_branch = sh('git rev-parse --abbrev-ref HEAD').strip
-
-    push_to_git_remote(
-      remote: "origin",
-      local_branch: current_branch,
-      remote_branch: current_branch,
-      tags: true
-    )
+    ENV["VERSION_CODE"] = new_code.to_s
+    UI.success("Using versionCode #{new_code} (base #{base_code} + run #{run_number})")
   end
 
   private_lane :build_and_sign_apk_or_aab do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,28 +32,30 @@ platform :android do
   end
 
   private_lane :fetch_and_increment_build_number do
-    # We deliberately do NOT commit/push a version bump back to the repo.
-    # The `dev` branch is protected (changes must go through a PR + CodeQL),
-    # so a direct CI push is correctly rejected. Instead we derive a unique,
-    # strictly-increasing versionCode at build time from the CI run number and
-    # expose it to Gradle via the VERSION_CODE env var. build.gradle.kts reads
-    # this value, falling back to its committed base when building locally.
+    # Bump the version in build.gradle.kts for this build. We deliberately do
+    # NOT commit or push here: the `dev` branch is protected (changes must go
+    # through a PR + CodeQL), so a direct CI push is correctly rejected. The
+    # build uses the bumped file in this run, and the workflow opens a PR with
+    # the change so the committed baseline stays in sync for the next deploy.
     #
     # The project uses the Kotlin DSL (build.gradle.kts), which the
     # android_versioning plugin does not support, hence the manual approach.
     gradle_file = File.expand_path("../app/build.gradle.kts", __dir__)
     contents = File.read(gradle_file)
 
-    base_code = contents[/baseVersionCode\s*=\s*(\d+)/, 1] || contents[/versionCode\s*=\s*(\d+)/, 1]
-    UI.user_error!("Could not find a base versionCode in #{gradle_file}") if base_code.nil?
+    current_code = contents[/versionCode\s*=\s*(\d+)/, 1]
+    UI.user_error!("Could not find versionCode in #{gradle_file}") if current_code.nil?
+    new_code = current_code.to_i + 1
+    contents = contents.sub(/versionCode\s*=\s*\d+/, "versionCode = #{new_code}")
 
-    # GITHUB_RUN_NUMBER increments on every workflow run, guaranteeing a
-    # monotonically increasing versionCode without persisting anything to git.
-    run_number = ENV["GITHUB_RUN_NUMBER"].to_i
-    new_code = base_code.to_i + run_number
+    current_name = contents[/versionName\s*=\s*"([^"]+)"/, 1]
+    UI.user_error!("Could not find versionName in #{gradle_file}") if current_name.nil?
+    major, minor, patch = current_name.split(".").map(&:to_i)
+    new_name = "#{major}.#{minor}.#{patch + 1}"
+    contents = contents.sub(/versionName\s*=\s*"[^"]+"/, "versionName = \"#{new_name}\"")
 
-    ENV["VERSION_CODE"] = new_code.to_s
-    UI.success("Using versionCode #{new_code} (base #{base_code} + run #{run_number})")
+    File.write(gradle_file, contents)
+    UI.success("Bumped versionCode #{current_code} -> #{new_code}, versionName #{current_name} -> #{new_name}")
   end
 
   private_lane :build_and_sign_apk_or_aab do


### PR DESCRIPTION
## Summary
Refactored the version bumping workflow to use automated pull requests instead of direct commits to the protected `dev` branch. This ensures version changes go through the standard PR review process while preventing re-triggering of CI/CD pipelines.

## Key Changes
- **GitHub Actions workflow (`deploy.yml`)**:
  - Added conditional guards to skip deployment for the automated version-bump PR and its merge commits (using `[skip ci]` marker)
  - Added required permissions for creating pull requests (`contents: write`, `pull-requests: write`)
  - Added new step using `peter-evans/create-pull-request` action to open a PR with version bumps instead of pushing directly
  - PR is created with squash-merge instructions to preserve the `[skip ci]` marker and prevent re-deployment

- **Fastlane configuration (`Fastfile`)**:
  - Removed git configuration, commit, and push operations from `fetch_and_increment_build_number` lane
  - Now only bumps version numbers in `app/build.gradle.kts` in the working tree
  - Updated comments to clarify that the workflow (not Fastlane) handles PR creation

- **Build configuration (`app/build.gradle.kts`)**:
  - Added clarifying comments designating version fields as the source of truth
  - Noted that CI bumps these at build time and opens a PR with changes

## Implementation Details
- The version bump PR is only created on actual pushes to `dev` (merged changes), never on the bump PR itself
- The PR uses the default `GITHUB_TOKEN`, which prevents GitHub's anti-recursion rules from triggering further CI runs
- The PR is intentionally not auto-merged; maintainers must review and use "Squash and merge" to preserve the `[skip ci]` marker
- This approach respects the protected branch rules while keeping the committed baseline in sync for subsequent deployments

https://claude.ai/code/session_018nk6P3Woz4MYWV1MJkm1aW