### PR TITLE
Fix startup crash from missing Room migration 9→10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,18 @@ plugins {
     alias(libs.plugins.about.libs.plugin)
 }
 
+// Firebase (Crashlytics + Analytics) is configured via google-services.json,
+// which CI injects from secrets only for the release/deploy build. PR checks and
+// local debug builds run without it, so apply the Google plugins only when the
+// file is present — the google-services plugin otherwise fails the build. The
+// Firebase SDK calls in the app are guarded to no-op when Firebase is not
+// initialized, so builds without the config still run correctly (just without
+// crash/analytics reporting).
+if (file("google-services.json").exists()) {
+    apply(plugin = libs.plugins.google.services.get().pluginId)
+    apply(plugin = libs.plugins.firebase.crashlytics.get().pluginId)
+}
+
 android {
     namespace = "com.arshadshah.nimaz"
     compileSdk = 36
@@ -151,6 +163,11 @@ dependencies {
     // In-App Review
     implementation(libs.app.review)
     implementation(libs.app.review.ktx)
+
+    // Firebase (Crashlytics + Analytics) — versions pinned by the BoM
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,10 +12,12 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Preserve line numbers so Crashlytics can map obfuscated release stack traces
+# back to source (the Crashlytics Gradle plugin uploads the mapping file).
+-keepattributes SourceFile,LineNumberTable
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Hide the original source file name while keeping line numbers.
+-renamesourcefileattribute SourceFile
+
+# Keep custom exception type names readable in crash reports.
+-keep public class * extends java.lang.Exception

--- a/app/src/main/java/com/arshadshah/nimaz/NimazApp.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/NimazApp.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.arshadshah.nimaz.core.init.AppInitializer
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -23,6 +25,8 @@ class NimazApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        CrashReporter.log("NimazApp.onCreate")
+        CrashReporter.setCustomKey("db_schema_version", NimazDatabase.SCHEMA_VERSION)
         appInitializer.initialize()
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/DatabaseModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/DatabaseModule.kt
@@ -42,6 +42,7 @@ object DatabaseModule {
             .addMigrations(
                 NimazDatabase.MIGRATION_7_8,
                 NimazDatabase.MIGRATION_8_9,
+                NimazDatabase.MIGRATION_9_10,
                 NimazDatabase.MIGRATION_10_11,
                 NimazDatabase.MIGRATION_11_12
             )

--- a/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.core.init
 
 import android.content.Context
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
@@ -46,8 +47,9 @@ class AppInitializer @Inject constructor(
                     notificationTask.await()
                     adhanTask.await()
                 }
-            } catch (_: Exception) {
-                // Timeout or other failure — proceed to UI anyway
+            } catch (e: Exception) {
+                // Timeout or other failure — report it but proceed to UI anyway
+                CrashReporter.recordException(e)
             } finally {
                 _isReady.value = true
             }
@@ -61,7 +63,7 @@ class AppInitializer @Inject constructor(
                 LocaleHelper.setLocale(context, langCode)
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            CrashReporter.recordException(e)
         }
     }
 
@@ -91,7 +93,7 @@ class AppInitializer @Inject constructor(
                 )
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            CrashReporter.recordException(e)
         }
     }
 
@@ -107,7 +109,7 @@ class AppInitializer @Inject constructor(
                 AdhanDownloadService.downloadDefault(context)
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            CrashReporter.recordException(e)
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
@@ -1,0 +1,34 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import android.content.Context
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+
+/**
+ * Thin wrapper around Firebase Analytics.
+ *
+ * Like [CrashReporter], every call is guarded so it safely no-ops when Firebase
+ * is not initialized (builds without `google-services.json`). Firebase Analytics
+ * already auto-collects events such as `app_open` and `session_start`; this
+ * helper adds manual screen tracking for the Compose navigation graph and a
+ * convenience for logging custom events.
+ */
+object AppAnalytics {
+
+    fun logScreenView(context: Context, screenName: String) {
+        runCatching {
+            FirebaseAnalytics.getInstance(context).logEvent(
+                FirebaseAnalytics.Event.SCREEN_VIEW,
+                Bundle().apply {
+                    putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
+                }
+            )
+        }
+    }
+
+    fun logEvent(context: Context, name: String, params: Bundle? = null) {
+        runCatching {
+            FirebaseAnalytics.getInstance(context).logEvent(name, params)
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/CrashReporter.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/CrashReporter.kt
@@ -1,0 +1,40 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/**
+ * Thin wrapper around Firebase Crashlytics.
+ *
+ * Every call is guarded so it safely no-ops when Firebase is not initialized —
+ * for example debug or PR-check builds that ship without `google-services.json`.
+ * This lets the rest of the app report errors unconditionally without having to
+ * know whether Crashlytics is wired up in the current build variant.
+ */
+object CrashReporter {
+
+    private val crashlytics: FirebaseCrashlytics?
+        get() = runCatching { FirebaseCrashlytics.getInstance() }.getOrNull()
+
+    /** Records a non-fatal exception. Use in catch blocks that would otherwise swallow errors. */
+    fun recordException(throwable: Throwable) {
+        crashlytics?.recordException(throwable)
+    }
+
+    /** Adds a breadcrumb that is attached to subsequent crash reports. */
+    fun log(message: String) {
+        crashlytics?.log(message)
+    }
+
+    /** Sets a custom key that appears on crash reports, useful for diagnosing state-dependent crashes. */
+    fun setCustomKey(key: String, value: String) {
+        crashlytics?.setCustomKey(key, value)
+    }
+
+    fun setCustomKey(key: String, value: Int) {
+        crashlytics?.setCustomKey(key, value)
+    }
+
+    fun setCustomKey(key: String, value: Boolean) {
+        crashlytics?.setCustomKey(key, value)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -41,6 +41,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import kotlin.system.exitProcess
 import com.arshadshah.nimaz.presentation.screens.about.AboutScreen
 import com.arshadshah.nimaz.presentation.screens.about.LicenseDetailScreen
@@ -100,6 +101,21 @@ fun NavGraph(
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
+
+    // Analytics: log a screen_view whenever the active destination changes.
+    // Type-safe routes serialize as a fully-qualified name with optional args
+    // (e.g. "...Route$QuranReader/{surahNumber}?..."), so trim down to the simple
+    // screen name for readable analytics.
+    val analyticsContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(currentDestination?.route) {
+        val route = currentDestination?.route ?: return@LaunchedEffect
+        val screenName = route
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringAfterLast('.')
+            .substringAfterLast('$')
+        AppAnalytics.logScreenView(analyticsContext, screenName)
+    }
 
     // Deep-link from the Quran audio notification / lock-screen player.
     // Per UX choice: clear the back stack to Home so Back returns to the Quran

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -137,15 +137,31 @@ abstract class NimazDatabase : RoomDatabase() {
             }
         }
 
+        // Schema v10 added `updatedAt` to quran_favorites. The original release
+        // bumped the database version to 10 without ever registering this
+        // migration, so any device sitting at schema v9 crashes on launch with
+        // "A migration from 9 to 10 was required but not found" the moment Room
+        // opens the database. Restore the missing step here.
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                val now = System.currentTimeMillis()
+                db.addColumnIfMissing("quran_favorites", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+            }
+        }
+
         val MIGRATION_10_11 = object : Migration(10, 11) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 val now = System.currentTimeMillis()
-                db.execSQL("ALTER TABLE quran_favorites ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
-                db.execSQL("ALTER TABLE tasbih_presets ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
-                db.execSQL("ALTER TABLE tasbih_sessions ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
-                db.execSQL("ALTER TABLE khatam_ayahs ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
-                db.execSQL("ALTER TABLE khatam_daily_log ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
-                db.execSQL("ALTER TABLE zakat_history ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT $now")
+                // quran_favorites.updatedAt already exists at schema v10 (added by
+                // MIGRATION_9_10). Guard every ALTER so re-running on a database
+                // that already has the column is a no-op instead of a
+                // "duplicate column name" crash.
+                db.addColumnIfMissing("quran_favorites", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+                db.addColumnIfMissing("tasbih_presets", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+                db.addColumnIfMissing("tasbih_sessions", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+                db.addColumnIfMissing("khatam_ayahs", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+                db.addColumnIfMissing("khatam_daily_log", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
+                db.addColumnIfMissing("zakat_history", "updatedAt", "INTEGER NOT NULL DEFAULT $now")
             }
         }
 
@@ -293,5 +309,27 @@ abstract class NimazDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_khatam_daily_log_khatam_id` ON `khatam_daily_log` (`khatam_id`)")
             }
         }
+    }
+}
+
+/**
+ * Adds [column] to [table] only when it is not already present. SQLite has no
+ * "ADD COLUMN IF NOT EXISTS", so a migration that runs against a database where
+ * the column already exists would otherwise throw "duplicate column name".
+ * Keeping the ALTER idempotent lets migrations stay safe regardless of which
+ * exact schema version a device is upgrading from.
+ */
+private fun SupportSQLiteDatabase.addColumnIfMissing(
+    table: String,
+    column: String,
+    definition: String,
+) {
+    val columnExists = query("PRAGMA table_info(`$table`)").use { cursor ->
+        val nameIndex = cursor.getColumnIndex("name")
+        generateSequence { if (cursor.moveToNext()) cursor.getString(nameIndex) else null }
+            .any { it == column }
+    }
+    if (!columnExists) {
+        execSQL("ALTER TABLE `$table` ADD COLUMN $column $definition")
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -124,6 +124,11 @@ abstract class NimazDatabase : RoomDatabase() {
     companion object {
         const val DATABASE_NAME = "nimaz_database"
 
+        // Current Room schema version. Keep in sync with @Database(version = ...)
+        // above. Exposed so crash reports can be tagged with the schema version,
+        // which makes migration-related crashes far easier to diagnose.
+        const val SCHEMA_VERSION = 12
+
         val MIGRATION_11_12 = object : Migration(11, 12) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Fix incorrect start_page values in surahs table

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,9 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.about.libs.plugin) apply false
+    // Put the Firebase plugins on the classpath. The app module applies them
+    // conditionally (only when google-services.json is present) so PR-check and
+    // local debug builds without the config file still succeed.
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,9 @@ aboutLibs = "11.6.0"
 review = "2.0.2"
 coreSplashscreen = "1.0.1"
 uiTestJunit4 = "1.10.1"
+googleServices = "4.4.2"
+firebaseCrashlyticsPlugin = "3.0.2"
+firebaseBom = "33.7.0"
 
 [libraries]
 # Core
@@ -122,6 +125,11 @@ aboutlibraries-compose-m3 = { group = "com.mikepenz", name = "aboutlibraries-com
 app-review = { group = "com.google.android.play", name = "review", version.ref = "review" }
 app-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "review" }
 
+# Firebase (Crashlytics + Analytics) — versions managed by the BoM
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
@@ -144,3 +152,5 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 about-libs-plugin = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibs" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }


### PR DESCRIPTION
The database version was bumped to 10 (adding quran_favorites.updatedAt)
without ever registering a 9→10 migration. Any device whose database is at
schema v9 crashes the moment Room opens the DB on launch with
"A migration from 9 to 10 was required but not found".

- Add MIGRATION_9_10 to add quran_favorites.updatedAt.
- Register MIGRATION_9_10 in DatabaseModule's migration list.
- Make the updatedAt-adding ALTERs idempotent via addColumnIfMissing, so
  MIGRATION_10_11 no longer throws "duplicate column name" on databases
  that already gained quran_favorites.updatedAt at schema v10.