### PR TITLE
Fix KSP MissingType build failure from misspelled Room callback class

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -154,7 +154,7 @@ abstract class NimazDatabase : RoomDatabase() {
          * statement is idempotent, so it is also a harmless no-op once the asset
          * is regenerated correctly.
          */
-        val PREPACKAGED_CALLBACK = object : RoomDatabase.PrePackagedDatabaseCallback() {
+        val PREPACKAGED_CALLBACK = object : RoomDatabase.PrepackagedDatabaseCallback() {
             override fun onOpenPrepackagedDatabase(db: SupportSQLiteDatabase) {
                 UPDATED_AT_TABLES.forEach { table ->
                     db.addColumnIfMissing(table, "updatedAt", "INTEGER NOT NULL DEFAULT 0")


### PR DESCRIPTION
The release/deploy build failed in :app:kspReleaseKotlin (and PR checks in
:app:kspDebugKotlin) with:

  e: [ksp] [MissingType]: Element
  'com.arshadshah.nimaz.data.local.database.NimazDatabase'
  references a type that is not present

PREPACKAGED_CALLBACK in the @Database class was declared as
`object : RoomDatabase.PrePackagedDatabaseCallback()`, but the actual Room
class is `RoomDatabase.PrepackagedDatabaseCallback` ("Prepackaged" is one
word — no capital P in the middle). The reference was therefore unresolved.

Because KSP runs before kotlinc's main compilation, KSP2 resolved the
PREPACKAGED_CALLBACK property — a member of the @Database class — to an
error type, so Room's processor surfaced it as the opaque database-level
[MissingType] error instead of a plain "unresolved reference". This is why
the build broke deterministically in both debug and release the moment the
callback was introduced (commit c3a74ad), with no relation to the Firebase
plugins.

Fix the class name to RoomDatabase.PrepackagedDatabaseCallback. The override
(onOpenPrepackagedDatabase) and the createFromAsset(..., PREPACKAGED_CALLBACK)
call site were already correct.

https://claude.ai/code/session_01ATJhyj5UVVSfAaXsKkNitk