### PR TITLE
test(atoms): add code coverage + Robolectric Compose tests for presentation atoms

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
 
+      # TEMPORARY diagnostic: echo the full lint text report into the job log so
+      # the complete list of issues is visible while fixing them. Remove once
+      # lint is green.
+      - name: Print lint report (diagnostic)
+        if: always()
+        run: |
+          echo "===== LINT TEXT REPORTS ====="
+          find app/build -name 'lint-results*.txt' -print -exec cat {} \; 2>/dev/null || true
+          echo "===== END LINT TEXT REPORTS ====="
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,16 +28,6 @@ jobs:
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
 
-      # TEMPORARY diagnostic: echo the full lint text report into the job log so
-      # the complete list of issues is visible while fixing them. Remove once
-      # lint is green.
-      - name: Print lint report (diagnostic)
-        if: always()
-        run: |
-          echo "===== LINT TEXT REPORTS ====="
-          find app/build -name 'lint-results*.txt' -print -exec cat {} \; 2>/dev/null || true
-          echo "===== END LINT TEXT REPORTS ====="
-
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,8 +90,8 @@ android {
     }
 
     lint {
-        // Also emit a text report (in addition to the default HTML/XML) so a
-        // finalizer task can echo it to the CI console — see printLintTextReport.
+        // Also emit a text report (in addition to the default HTML/XML); the CI
+        // "Print lint report" diagnostic step cats it into the job log.
         textReport = true
     }
 }
@@ -221,33 +221,6 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
-
-// ── Lint report echo ────────────────────────────────────────────────────────
-// `lintDebug` aborts the build on error and writes details only to the HTML/XML
-// (and intermediate text) report, none of which land in the CI console. Echo the
-// generated text report so the full issue list is visible in the job log. Wired
-// as a finalizer of the report task so it runs even though lintDebug then fails.
-val buildDirForLint = layout.buildDirectory.get().asFile
-val printLintTextReport = tasks.register("printLintTextReport") {
-    doLast {
-        val reports = if (buildDirForLint.exists()) {
-            buildDirForLint.walkTopDown()
-                .filter { it.isFile && it.name.startsWith("lint-results") && it.extension == "txt" }
-                .toList()
-        } else emptyList()
-        if (reports.isEmpty()) {
-            println("LINT-REPORT-ECHO: no lint-results*.txt found under ${buildDirForLint.path}")
-        }
-        reports.forEach { report ->
-            println("===== BEGIN LINT TEXT REPORT (${report.path}) =====")
-            println(report.readText())
-            println("===== END LINT TEXT REPORT (${report.name}) =====")
-        }
-    }
-}
-// Attach to the failing tasks; finalizers run even when the finalized task fails.
-tasks.matching { it.name == "lintReportDebug" || it.name == "lintDebug" || it.name == "lint" }
-    .configureEach { finalizedBy(printLintTextReport) }
 
 // ── Code coverage (JaCoCo) ──────────────────────────────────────────────────
 // Robolectric runs the unit tests off-device, so coverage of the Compose

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.about.libs.plugin)
+    jacoco
+}
+
+jacoco {
+    toolVersion = "0.8.12"
 }
 
 // Firebase (Crashlytics + Analytics) is configured via google-services.json,
@@ -73,6 +78,15 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+    }
+
+    testOptions {
+        unitTests {
+            // Required so Robolectric can read merged Android resources/manifest,
+            // which the Compose UI tests for the atoms rely on.
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
     }
 }
 
@@ -177,6 +191,15 @@ dependencies {
     testImplementation(libs.google.truth)
     testImplementation(libs.robolectric)
 
+    // Compose UI testing under Robolectric (used by the atoms coverage tests in
+    // src/testDebug). The ui-test-manifest is registered as debugImplementation
+    // above so the merged debug manifest exposes the ComponentActivity that
+    // createComposeRule() launches.
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.androidx.compose.material3)
+    testImplementation(libs.androidx.compose.material.icons.extended)
+
     // Instrumented Testing
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -192,4 +215,116 @@ dependencies {
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+// ── Code coverage (JaCoCo) ──────────────────────────────────────────────────
+// Robolectric runs the unit tests off-device, so coverage of the Compose
+// "atoms" is collected from the standard `testDebugUnitTest` execution data.
+tasks.withType<Test>().configureEach {
+    extensions.configure(JacocoTaskExtension::class) {
+        // Needed for Robolectric + inline/synthetic classes to be reported.
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*")
+    }
+}
+
+// Class-file noise that should never count toward coverage (generated code,
+// Compose compiler artifacts, DI, framework stubs, and @Preview singletons).
+val coverageExclusions = listOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "**/*\$Companion*.*",
+    // Compose compiler generates a ComposableSingletons class per file that
+    // holds the lambdas used only by the @Preview functions — exclude it.
+    "**/*ComposableSingletons*.*",
+    // Hilt / Dagger generated code
+    "**/di/**",
+    "**/*_Factory*.*",
+    "**/*_HiltModules*.*",
+    "**/*_Impl*.*",
+    "**/hilt_aggregated_deps/**",
+    "**/dagger/hilt/**",
+    "**/*Hilt_*.*",
+)
+
+val kotlinDebugClassesDir = layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile
+val buildOutputDir = layout.buildDirectory.get().asFile
+
+fun atomsClassTree(): ConfigurableFileTree =
+    fileTree(kotlinDebugClassesDir) {
+        include("**/presentation/components/atoms/**")
+        exclude(coverageExclusions)
+    }
+
+fun debugClassTree(): ConfigurableFileTree =
+    fileTree(kotlinDebugClassesDir) {
+        exclude(coverageExclusions)
+    }
+
+fun coverageExecutionData(): ConfigurableFileTree =
+    fileTree(buildOutputDir) {
+        include("**/jacoco/testDebugUnitTest.exec", "**/outputs/unit_test_code_coverage/**/*.exec")
+    }
+
+val coverageSourceDirs = files("src/main/java")
+
+// Module-wide coverage report — satisfies "add code coverage to this app".
+tasks.register<JacocoReport>("jacocoTestReport") {
+    group = "verification"
+    description = "Generates a JaCoCo coverage report for the debug unit tests."
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+
+    classDirectories.setFrom(debugClassTree())
+    sourceDirectories.setFrom(coverageSourceDirs)
+    executionData.setFrom(coverageExecutionData())
+}
+
+// Focused report for the presentation atoms package.
+tasks.register<JacocoReport>("jacocoAtomsReport") {
+    group = "verification"
+    description = "Generates a JaCoCo coverage report scoped to the presentation atoms."
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+
+    classDirectories.setFrom(atomsClassTree())
+    sourceDirectories.setFrom(coverageSourceDirs)
+    executionData.setFrom(coverageExecutionData())
+}
+
+// Optional gate the team can run locally/CI to enforce atom coverage. Kept out
+// of the default `check` graph so it never blocks the existing CI lane.
+tasks.register<JacocoCoverageVerification>("jacocoAtomsCoverageVerification") {
+    group = "verification"
+    description = "Verifies coverage thresholds for the presentation atoms."
+    dependsOn("testDebugUnitTest")
+
+    classDirectories.setFrom(atomsClassTree())
+    sourceDirectories.setFrom(coverageSourceDirs)
+    executionData.setFrom(coverageExecutionData())
+
+    violationRules {
+        rule {
+            element = "PACKAGE"
+            includes = listOf("com.arshadshah.nimaz.presentation.components.atoms")
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+        }
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,11 +90,9 @@ android {
     }
 
     lint {
-        // Print the full lint text report to the build console (and thus the CI
-        // job log) so every issue is visible without downloading the HTML/XML
-        // report artifact.
+        // Also emit a text report (in addition to the default HTML/XML) so a
+        // finalizer task can echo it to the CI console — see printLintTextReport.
         textReport = true
-        textOutput = file("stdout")
     }
 }
 
@@ -222,6 +220,29 @@ dependencies {
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+// ── Lint report echo ────────────────────────────────────────────────────────
+// `lintDebug` aborts the build on error and writes details only to the HTML/XML
+// (and intermediate text) report, none of which land in the CI console. Echo the
+// generated text report so the full issue list is visible in the job log. Wired
+// as a finalizer of the report task so it runs even though lintDebug then fails.
+val printLintTextReport = tasks.register("printLintTextReport") {
+    doLast {
+        val reportDir = layout.buildDirectory.dir("intermediates/lint_intermediate_text_report").get().asFile
+        if (reportDir.exists()) {
+            reportDir.walkTopDown().filter { it.isFile && it.extension == "txt" }.forEach { report ->
+                println("===== BEGIN LINT TEXT REPORT (${report.name}) =====")
+                println(report.readText())
+                println("===== END LINT TEXT REPORT (${report.name}) =====")
+            }
+        } else {
+            println("No lint text report found at ${reportDir.path}")
+        }
+    }
+}
+tasks.matching { it.name == "lintReportDebug" }.configureEach {
+    finalizedBy(printLintTextReport)
 }
 
 // ── Code coverage (JaCoCo) ──────────────────────────────────────────────────

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,12 +88,6 @@ android {
             isReturnDefaultValues = true
         }
     }
-
-    lint {
-        // Also emit a text report (in addition to the default HTML/XML); the CI
-        // "Print lint report" diagnostic step cats it into the job log.
-        textReport = true
-    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,7 +116,6 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    implementation(libs.androidx.ui.test.junit4)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
@@ -191,14 +190,14 @@ dependencies {
     testImplementation(libs.google.truth)
     testImplementation(libs.robolectric)
 
-    // NOTE: The Compose UI test APIs used by the atoms tests in src/testDebug
-    // (createComposeRule, onNodeWithText, performClick, …) and the Compose
-    // runtime/material3 are already on the unit-test classpath transitively via
-    // the module's main `implementation` dependencies (ui-test-junit4, material3,
-    // material-icons-extended) and `debugImplementation(ui-test-manifest)`.
-    // Re-declaring them here (especially pulling in the Compose BOM) perturbs
-    // AGP's consistent dependency resolution for the androidTest classpath, so we
-    // intentionally rely on the inherited versions instead.
+    // Compose UI test harness for the Robolectric atom tests in src/testDebug
+    // (createComposeRule, onNodeWithText, performClick, …). Declared here as a
+    // test-only dependency at an explicit version — NOT via the Compose BOM —
+    // so it does not perturb AGP's consistent resolution for the androidTest
+    // classpath. The Compose runtime / material3 / icons it builds against are
+    // inherited from the module's main `implementation` deps, and the
+    // ComponentActivity it launches comes from `debugImplementation(ui-test-manifest)`.
+    testImplementation(libs.androidx.ui.test.junit4)
 
     // Instrumented Testing
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -227,23 +227,27 @@ dependencies {
 // (and intermediate text) report, none of which land in the CI console. Echo the
 // generated text report so the full issue list is visible in the job log. Wired
 // as a finalizer of the report task so it runs even though lintDebug then fails.
+val buildDirForLint = layout.buildDirectory.get().asFile
 val printLintTextReport = tasks.register("printLintTextReport") {
     doLast {
-        val reportDir = layout.buildDirectory.dir("intermediates/lint_intermediate_text_report").get().asFile
-        if (reportDir.exists()) {
-            reportDir.walkTopDown().filter { it.isFile && it.extension == "txt" }.forEach { report ->
-                println("===== BEGIN LINT TEXT REPORT (${report.name}) =====")
-                println(report.readText())
-                println("===== END LINT TEXT REPORT (${report.name}) =====")
-            }
-        } else {
-            println("No lint text report found at ${reportDir.path}")
+        val reports = if (buildDirForLint.exists()) {
+            buildDirForLint.walkTopDown()
+                .filter { it.isFile && it.name.startsWith("lint-results") && it.extension == "txt" }
+                .toList()
+        } else emptyList()
+        if (reports.isEmpty()) {
+            println("LINT-REPORT-ECHO: no lint-results*.txt found under ${buildDirForLint.path}")
+        }
+        reports.forEach { report ->
+            println("===== BEGIN LINT TEXT REPORT (${report.path}) =====")
+            println(report.readText())
+            println("===== END LINT TEXT REPORT (${report.name}) =====")
         }
     }
 }
-tasks.matching { it.name == "lintReportDebug" }.configureEach {
-    finalizedBy(printLintTextReport)
-}
+// Attach to the failing tasks; finalizers run even when the finalized task fails.
+tasks.matching { it.name == "lintReportDebug" || it.name == "lintDebug" || it.name == "lint" }
+    .configureEach { finalizedBy(printLintTextReport) }
 
 // ── Code coverage (JaCoCo) ──────────────────────────────────────────────────
 // Robolectric runs the unit tests off-device, so coverage of the Compose

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,14 +191,14 @@ dependencies {
     testImplementation(libs.google.truth)
     testImplementation(libs.robolectric)
 
-    // Compose UI testing under Robolectric (used by the atoms coverage tests in
-    // src/testDebug). The ui-test-manifest is registered as debugImplementation
-    // above so the merged debug manifest exposes the ComponentActivity that
-    // createComposeRule() launches.
-    testImplementation(platform(libs.androidx.compose.bom))
-    testImplementation(libs.androidx.compose.ui.test.junit4)
-    testImplementation(libs.androidx.compose.material3)
-    testImplementation(libs.androidx.compose.material.icons.extended)
+    // NOTE: The Compose UI test APIs used by the atoms tests in src/testDebug
+    // (createComposeRule, onNodeWithText, performClick, …) and the Compose
+    // runtime/material3 are already on the unit-test classpath transitively via
+    // the module's main `implementation` dependencies (ui-test-junit4, material3,
+    // material-icons-extended) and `debugImplementation(ui-test-manifest)`.
+    // Re-declaring them here (especially pulling in the Compose BOM) perturbs
+    // AGP's consistent dependency resolution for the androidTest classpath, so we
+    // intentionally rely on the inherited versions instead.
 
     // Instrumented Testing
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,14 @@ android {
             isReturnDefaultValues = true
         }
     }
+
+    lint {
+        // Print the full lint text report to the build console (and thus the CI
+        // job log) so every issue is visible without downloading the HTML/XML
+        // report artifact.
+        textReport = true
+        textOutput = file("stdout")
+    }
 }
 
 dependencies {

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!--
+      Glance's resource-based ColorProvider(@ColorRes) is annotated
+      @RestrictedApi(LIBRARY_GROUP) in the current Glance version, even though
+      app code is expected to call it to keep day/night color resources. The
+      home-screen widgets use it throughout, which lint flags as RestrictedApi.
+      Suppress only that specific false positive (matched on the message) rather
+      than disabling the RestrictedApi check or dropping themed color resources.
+    -->
+    <issue id="RestrictedApi">
+        <ignore regexp="ColorProvider can only be called from within the same library group" />
+    </issue>
+</lint>

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioService.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.arshadshah.nimaz.data.audio
 
 import android.app.Notification

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.arshadshah.nimaz.presentation.screens.quran
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.arshadshah.nimaz.widget.hijricalendar
 
 import android.content.Context

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -709,4 +709,20 @@
     <string name="adhan_download_partial_subtitle">Einige %1$s-Dateien konnten nicht heruntergeladen werden. Wird später erneut versucht.</string>
     <string name="adhan_download_failed">Adhan-Download fehlgeschlagen</string>
     <string name="adhan_download_failed_subtitle">Überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut</string>
+    <!-- Fasting sheet / Quran home / free-day labels -->
+    <string name="free_count">Frei</string>
+    <string name="free_count_label">Freie Anzahl</string>
+    <string name="quran_home_page_range_format">S. %1$d–%2$d</string>
+    <string name="quran_home_surah_starts">▸ %1$s beginnt</string>
+    <string name="quran_home_juz_indicator">Juz %1$d</string>
+    <string name="fasting_sheet_status">Status</string>
+    <string name="fasting_sheet_type">Fastenart</string>
+    <string name="fasting_sheet_note">Notiz</string>
+    <string name="fasting_sheet_save">Speichern</string>
+    <string name="fasting_sheet_delete">Löschen</string>
+    <string name="fasting_sheet_exemption_reason">Befreiungsgrund</string>
+    <string name="fasting_sheet_select_reason">Grund auswählen</string>
+    <string name="fasting_sheet_edit_makeup">Nachholfasten bearbeiten</string>
+    <string name="fasting_sheet_reason">Grund</string>
+    <string name="fasting_sheet_fidya_amount">Fidya-Betrag</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -710,4 +710,20 @@
     <string name="adhan_download_partial_subtitle">Certains fichiers %1$s n\'ont pas pu être téléchargés. Nouvel essai ultérieur.</string>
     <string name="adhan_download_failed">Échec du téléchargement de l\'Adhan</string>
     <string name="adhan_download_failed_subtitle">Vérifiez votre connexion Internet et réessayez</string>
+    <!-- Fasting sheet / Quran home / free-day labels -->
+    <string name="free_count">Libre</string>
+    <string name="free_count_label">Nombre libre</string>
+    <string name="quran_home_page_range_format">p. %1$d–%2$d</string>
+    <string name="quran_home_surah_starts">▸ %1$s commence</string>
+    <string name="quran_home_juz_indicator">Juz %1$d</string>
+    <string name="fasting_sheet_status">Statut</string>
+    <string name="fasting_sheet_type">Type de jeûne</string>
+    <string name="fasting_sheet_note">Note</string>
+    <string name="fasting_sheet_save">Enregistrer</string>
+    <string name="fasting_sheet_delete">Supprimer</string>
+    <string name="fasting_sheet_exemption_reason">Motif d\'exemption</string>
+    <string name="fasting_sheet_select_reason">Sélectionner un motif</string>
+    <string name="fasting_sheet_edit_makeup">Modifier le jeûne de rattrapage</string>
+    <string name="fasting_sheet_reason">Motif</string>
+    <string name="fasting_sheet_fidya_amount">Montant de la Fidya</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -711,4 +711,20 @@
     <string name="adhan_download_partial_subtitle">Beberapa file %1$s tidak dapat diunduh. Akan dicoba lagi nanti.</string>
     <string name="adhan_download_failed">Unduhan adzan gagal</string>
     <string name="adhan_download_failed_subtitle">Periksa koneksi internet Anda dan coba lagi</string>
+    <!-- Fasting sheet / Quran home / free-day labels -->
+    <string name="free_count">Bebas</string>
+    <string name="free_count_label">Jumlah bebas</string>
+    <string name="quran_home_page_range_format">hlm. %1$d–%2$d</string>
+    <string name="quran_home_surah_starts">▸ %1$s dimulai</string>
+    <string name="quran_home_juz_indicator">Juz %1$d</string>
+    <string name="fasting_sheet_status">Status</string>
+    <string name="fasting_sheet_type">Jenis Puasa</string>
+    <string name="fasting_sheet_note">Catatan</string>
+    <string name="fasting_sheet_save">Simpan</string>
+    <string name="fasting_sheet_delete">Hapus</string>
+    <string name="fasting_sheet_exemption_reason">Alasan Pengecualian</string>
+    <string name="fasting_sheet_select_reason">Pilih alasan</string>
+    <string name="fasting_sheet_edit_makeup">Edit Puasa Qadha</string>
+    <string name="fasting_sheet_reason">Alasan</string>
+    <string name="fasting_sheet_fidya_amount">Jumlah Fidyah</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -710,4 +710,20 @@
     <string name="adhan_download_partial_subtitle">Beberapa fail %1$s tidak dapat dimuat turun. Akan dicuba semula kemudian.</string>
     <string name="adhan_download_failed">Muat turun azan gagal</string>
     <string name="adhan_download_failed_subtitle">Semak sambungan internet anda dan cuba semula</string>
+    <!-- Fasting sheet / Quran home / free-day labels -->
+    <string name="free_count">Bebas</string>
+    <string name="free_count_label">Kiraan bebas</string>
+    <string name="quran_home_page_range_format">ms. %1$d–%2$d</string>
+    <string name="quran_home_surah_starts">▸ %1$s bermula</string>
+    <string name="quran_home_juz_indicator">Juzuk %1$d</string>
+    <string name="fasting_sheet_status">Status</string>
+    <string name="fasting_sheet_type">Jenis Puasa</string>
+    <string name="fasting_sheet_note">Nota</string>
+    <string name="fasting_sheet_save">Simpan</string>
+    <string name="fasting_sheet_delete">Padam</string>
+    <string name="fasting_sheet_exemption_reason">Sebab Pengecualian</string>
+    <string name="fasting_sheet_select_reason">Pilih sebab</string>
+    <string name="fasting_sheet_edit_makeup">Edit Puasa Ganti</string>
+    <string name="fasting_sheet_reason">Sebab</string>
+    <string name="fasting_sheet_fidya_amount">Jumlah Fidyah</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -711,4 +711,20 @@
     <string name="adhan_download_partial_subtitle">Bazı %1$s dosyaları indirilemedi. Daha sonra tekrar denenecek.</string>
     <string name="adhan_download_failed">Ezan indirmesi başarısız</string>
     <string name="adhan_download_failed_subtitle">İnternet bağlantınızı kontrol edip tekrar deneyin</string>
+    <!-- Fasting sheet / Quran home / free-day labels -->
+    <string name="free_count">Serbest</string>
+    <string name="free_count_label">Serbest sayısı</string>
+    <string name="quran_home_page_range_format">s. %1$d–%2$d</string>
+    <string name="quran_home_surah_starts">▸ %1$s başlıyor</string>
+    <string name="quran_home_juz_indicator">Cüz %1$d</string>
+    <string name="fasting_sheet_status">Durum</string>
+    <string name="fasting_sheet_type">Oruç Türü</string>
+    <string name="fasting_sheet_note">Not</string>
+    <string name="fasting_sheet_save">Kaydet</string>
+    <string name="fasting_sheet_delete">Sil</string>
+    <string name="fasting_sheet_exemption_reason">Muafiyet Nedeni</string>
+    <string name="fasting_sheet_select_reason">Neden seçin</string>
+    <string name="fasting_sheet_edit_makeup">Kaza Orucunu Düzenle</string>
+    <string name="fasting_sheet_reason">Neden</string>
+    <string name="fasting_sheet_fidya_amount">Fidye Tutarı</string>
 </resources>

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/ArabicTextTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/ArabicTextTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.google.common.truth.Truth.assertThat

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/ArabicTextTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/ArabicTextTest.kt
@@ -1,0 +1,166 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ArabicTextTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // ── toArabicNumber (pure) ───────────────────────────────────────────────
+
+    @Test
+    fun `toArabicNumber converts each digit`() {
+        assertThat(toArabicNumber(0)).isEqualTo("٠")
+        assertThat(toArabicNumber(1234567890)).isEqualTo("١٢٣٤٥٦٧٨٩٠")
+    }
+
+    @Test
+    fun `toArabicNumber converts multi-digit numbers`() {
+        assertThat(toArabicNumber(255)).isEqualTo("٢٥٥")
+    }
+
+    // ── ArabicText ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `ArabicText renders with default style`() {
+        composeRule.setThemedContent {
+            ArabicText(text = "السلام")
+        }
+        composeRule.onNodeWithText("السلام").assertExists()
+    }
+
+    @Test
+    fun `ArabicText renders with a supplied style and overrides`() {
+        composeRule.setThemedContent {
+            ArabicText(
+                text = "مرحبا",
+                size = ArabicTextSize.SMALL,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = TextStyle(fontSize = ArabicTextSize.LARGE.fontSize)
+            )
+        }
+        composeRule.onNodeWithText("مرحبا").assertExists()
+    }
+
+    @Test
+    fun `ArabicTextSize presets expose font metrics`() {
+        // Touch every enum entry so the values are exercised.
+        ArabicTextSize.entries.forEach { size ->
+            assertThat(size.fontSize.value).isGreaterThan(0f)
+            assertThat(size.lineHeight.value).isGreaterThan(0f)
+        }
+        assertThat(ArabicTextSize.entries).hasSize(5)
+    }
+
+    // ── QuranVerseText ──────────────────────────────────────────────────────
+
+    @Test
+    fun `QuranVerseText shows verse number end marker`() {
+        composeRule.setThemedContent {
+            QuranVerseText(arabicText = "الحمد لله", verseNumber = 2)
+        }
+        composeRule.onNodeWithText("الحمد لله", substring = true).assertExists()
+    }
+
+    @Test
+    fun `QuranVerseText hides verse number when disabled`() {
+        composeRule.setThemedContent {
+            QuranVerseText(
+                arabicText = "قل هو الله",
+                verseNumber = null,
+                showVerseNumber = false,
+                customFontSize = 30f
+            )
+        }
+        composeRule.onNodeWithText("قل هو الله", substring = true).assertExists()
+    }
+
+    // ── HadithArabicText / DuaArabicText ────────────────────────────────────
+
+    @Test
+    fun `HadithArabicText renders with and without custom font size`() {
+        composeRule.setThemedContent {
+            HadithArabicText(text = "إنما الأعمال")
+        }
+        composeRule.onNodeWithText("إنما الأعمال").assertExists()
+    }
+
+    @Test
+    fun `HadithArabicText renders with custom font size`() {
+        composeRule.setThemedContent {
+            HadithArabicText(text = "بالنيات", customFontSize = 22f)
+        }
+        composeRule.onNodeWithText("بالنيات").assertExists()
+    }
+
+    @Test
+    fun `DuaArabicText renders with default and custom font size`() {
+        composeRule.setThemedContent {
+            DuaArabicText(text = "اللهم")
+        }
+        composeRule.onNodeWithText("اللهم").assertExists()
+    }
+
+    @Test
+    fun `DuaArabicText renders with custom font size`() {
+        composeRule.setThemedContent {
+            DuaArabicText(text = "ربنا", customFontSize = 26f)
+        }
+        composeRule.onNodeWithText("ربنا").assertExists()
+    }
+
+    // ── BismillahText ───────────────────────────────────────────────────────
+
+    @Test
+    fun `BismillahText renders bismillah`() {
+        composeRule.setThemedContent {
+            BismillahText()
+        }
+        composeRule.onNodeWithText("بِسْمِ", substring = true).assertExists()
+    }
+
+    // ── AyahDisplay ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `AyahDisplay shows translation without transliteration`() {
+        composeRule.setThemedContent {
+            AyahDisplay(
+                arabicText = "الحمد لله",
+                translation = "All praise is due to Allah",
+                verseNumber = 2
+            )
+        }
+        composeRule.onNodeWithText("All praise is due to Allah").assertExists()
+    }
+
+    @Test
+    fun `AyahDisplay shows transliteration when enabled`() {
+        composeRule.setThemedContent {
+            AyahDisplay(
+                arabicText = "الحمد لله",
+                translation = "All praise is due to Allah",
+                verseNumber = 2,
+                transliteration = "Alhamdu lillah",
+                showTransliteration = true
+            )
+        }
+        composeRule.onNodeWithText("Alhamdu lillah").assertExists()
+        composeRule.onNodeWithText("All praise is due to Allah").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/AtomTestSupport.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/AtomTestSupport.kt
@@ -1,0 +1,20 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+
+/**
+ * Wraps atom content in a [MaterialTheme] so the components resolve their
+ * default colour-scheme / typography values. Using the bare MaterialTheme
+ * (instead of the app's NimazTheme) keeps the Robolectric harness free of the
+ * Activity/window side effects that NimazTheme performs, which are irrelevant
+ * to exercising the atoms.
+ */
+internal fun ComposeContentTestRule.setThemedContent(content: @Composable () -> Unit) {
+    setContent {
+        MaterialTheme {
+            content()
+        }
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBadgeTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBadgeTest.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBadgeTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBadgeTest.kt
@@ -1,0 +1,128 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazBadgeTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // ── Enums / sealed types ────────────────────────────────────────────────
+
+    @Test
+    fun `NimazBadgeSize presets are defined`() {
+        assertThat(NimazBadgeSize.entries).hasSize(3)
+        NimazBadgeSize.entries.forEach {
+            assertThat(it.height.value).isGreaterThan(0f)
+            assertThat(it.horizontalPadding.value).isGreaterThan(0f)
+        }
+    }
+
+    @Test
+    fun `BadgeType variants carry labels and colors`() {
+        val types = listOf(
+            BadgeType.Sahih, BadgeType.Hasan, BadgeType.Daif, BadgeType.Mawdu,
+            BadgeType.Meccan, BadgeType.Medinan, BadgeType.Prayed, BadgeType.Missed,
+            BadgeType.Pending, BadgeType.Qada, BadgeType.Jamaah, BadgeType.Fasted,
+            BadgeType.NotFasted, BadgeType.Makeup, BadgeType.Exempted
+        )
+        types.forEach { assertThat(it.label).isNotEmpty() }
+
+        val custom = BadgeType.Custom("Custom", Color.Gray)
+        assertThat(custom.label).isEqualTo("Custom")
+        assertThat(custom.color).isEqualTo(Color.Gray)
+    }
+
+    // ── NimazBadge ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `NimazBadge renders filled`() {
+        composeRule.setThemedContent {
+            NimazBadge(text = "Filled")
+        }
+        composeRule.onNodeWithText("Filled").assertExists()
+    }
+
+    @Test
+    fun `NimazBadge renders outlined`() {
+        composeRule.setThemedContent {
+            NimazBadge(text = "Outlined", outlined = true, size = NimazBadgeSize.LARGE)
+        }
+        composeRule.onNodeWithText("Outlined").assertExists()
+    }
+
+    // ── StatusBadge ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `StatusBadge renders from a badge type`() {
+        composeRule.setThemedContent {
+            StatusBadge(type = BadgeType.Sahih, outlined = true, size = NimazBadgeSize.SMALL)
+        }
+        composeRule.onNodeWithText("Sahih").assertExists()
+    }
+
+    // ── HadithGradeBadge ────────────────────────────────────────────────────
+
+    @Test
+    fun `HadithGradeBadge maps known grades`() {
+        composeRule.setThemedContent {
+            androidx.compose.foundation.layout.Column {
+                HadithGradeBadge(grade = "sahih")
+                HadithGradeBadge(grade = "hasan")
+                HadithGradeBadge(grade = "daif")
+                HadithGradeBadge(grade = "da'if")
+                HadithGradeBadge(grade = "mawdu")
+                HadithGradeBadge(grade = "mawdu'")
+            }
+        }
+        composeRule.onNodeWithText("Sahih").assertExists()
+        composeRule.onNodeWithText("Hasan").assertExists()
+        // "daif"/"da'if" and "mawdu"/"mawdu'" each map to the same label.
+        composeRule.onAllNodesWithText("Da'if").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Mawdu'").assertCountEquals(2)
+    }
+
+    @Test
+    fun `HadithGradeBadge falls back to custom for unknown grade`() {
+        composeRule.setThemedContent {
+            HadithGradeBadge(grade = "Unknown")
+        }
+        composeRule.onNodeWithText("Unknown").assertExists()
+    }
+
+    // ── getHadithGradeBadgeColors (pure) ────────────────────────────────────
+
+    @Test
+    fun `getHadithGradeBadgeColors covers all grades`() {
+        assertThat(getHadithGradeBadgeColors("sahih").first).isEqualTo(BadgeType.Sahih.color)
+        assertThat(getHadithGradeBadgeColors("hasan").first).isEqualTo(BadgeType.Hasan.color)
+        assertThat(getHadithGradeBadgeColors("daif").first).isEqualTo(BadgeType.Daif.color)
+        assertThat(getHadithGradeBadgeColors("da'if").first).isEqualTo(BadgeType.Daif.color)
+        assertThat(getHadithGradeBadgeColors("mawdu").first).isEqualTo(BadgeType.Mawdu.color)
+        assertThat(getHadithGradeBadgeColors("mawdu'").first).isEqualTo(BadgeType.Mawdu.color)
+        val fallback = getHadithGradeBadgeColors("???")
+        assertThat(fallback.first).isEqualTo(Color.Gray)
+        assertThat(fallback.second).isEqualTo(Color.White)
+    }
+
+    // ── SurahNumberBadge ────────────────────────────────────────────────────
+
+    @Test
+    fun `SurahNumberBadge renders number`() {
+        composeRule.setThemedContent {
+            SurahNumberBadge(number = 114)
+        }
+        composeRule.onNodeWithText("114").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBannerTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBannerTest.kt
@@ -3,7 +3,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBannerTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazBannerTest.kt
@@ -1,0 +1,181 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazBannerTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `banner variants enum is complete`() {
+        assertThat(NimazBannerVariant.entries).hasSize(4)
+    }
+
+    // ── INFO ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `info banner renders without border or icon`() {
+        composeRule.setThemedContent {
+            NimazBanner(message = "Info message", variant = NimazBannerVariant.INFO)
+        }
+        composeRule.onNodeWithText("Info message").assertExists()
+    }
+
+    @Test
+    fun `info banner renders with icon`() {
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Info with icon",
+                variant = NimazBannerVariant.INFO,
+                icon = Icons.Default.Info
+            )
+        }
+        composeRule.onNodeWithText("Info with icon").assertExists()
+    }
+
+    @Test
+    fun `info banner renders with border and icon`() {
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Bordered info",
+                variant = NimazBannerVariant.INFO,
+                icon = Icons.Default.Info,
+                showBorder = true
+            )
+        }
+        composeRule.onNodeWithText("Bordered info").assertExists()
+    }
+
+    @Test
+    fun `info banner renders with border and no icon`() {
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Bordered no icon",
+                variant = NimazBannerVariant.INFO,
+                showBorder = true
+            )
+        }
+        composeRule.onNodeWithText("Bordered no icon").assertExists()
+    }
+
+    // ── WARNING ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `warning banner renders full content and fires action`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Warning message",
+                variant = NimazBannerVariant.WARNING,
+                icon = Icons.Default.Warning,
+                title = "Warning title",
+                actionLabel = "Fix",
+                onAction = { clicked = true }
+            )
+        }
+        composeRule.onNodeWithText("Warning title").assertExists()
+        composeRule.onNodeWithText("Warning message").assertExists()
+        composeRule.onNodeWithText("Fix").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `warning banner renders minimal content`() {
+        composeRule.setThemedContent {
+            NimazBanner(message = "Plain warning", variant = NimazBannerVariant.WARNING)
+        }
+        composeRule.onNodeWithText("Plain warning").assertExists()
+    }
+
+    // ── UPDATE ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `update banner renders action and fires it`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Update available",
+                variant = NimazBannerVariant.UPDATE,
+                actionLabel = "Update",
+                onAction = { clicked = true }
+            )
+        }
+        composeRule.onNodeWithText("Update").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `update banner renders loading spinner`() {
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Downloading",
+                variant = NimazBannerVariant.UPDATE,
+                isLoading = true
+            )
+        }
+        composeRule.onNodeWithText("Downloading").assertExists()
+    }
+
+    @Test
+    fun `update banner renders message only`() {
+        composeRule.setThemedContent {
+            NimazBanner(message = "Up to date", variant = NimazBannerVariant.UPDATE)
+        }
+        composeRule.onNodeWithText("Up to date").assertExists()
+    }
+
+    // ── ERROR ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `error banner renders clickable surface and fires click`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Tap for help",
+                variant = NimazBannerVariant.ERROR,
+                icon = Icons.Default.Warning,
+                title = "Calibration",
+                onClick = { clicked = true }
+            )
+        }
+        composeRule.onNodeWithText("Tap for help").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `error banner renders action button and fires it`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazBanner(
+                message = "Calibrate compass",
+                variant = NimazBannerVariant.ERROR,
+                title = "Calibration",
+                actionLabel = "Calibrate",
+                onAction = { clicked = true }
+            )
+        }
+        composeRule.onNodeWithText("Calibrate").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `error banner renders minimal content`() {
+        composeRule.setThemedContent {
+            NimazBanner(message = "Plain error", variant = NimazBannerVariant.ERROR)
+        }
+        composeRule.onNodeWithText("Plain error").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCardTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCardTest.kt
@@ -1,0 +1,123 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazCardTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `card styles enum is complete`() {
+        assertThat(NimazCardStyle.entries).hasSize(4)
+    }
+
+    private fun assertClickableCard(style: NimazCardStyle) {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazCard(style = style, onClick = { clicked = true }) {
+                Text("Clickable")
+            }
+        }
+        composeRule.onNodeWithText("Clickable").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    private fun assertStaticCard(style: NimazCardStyle) {
+        composeRule.setThemedContent {
+            NimazCard(style = style) {
+                Text("Static")
+            }
+        }
+        composeRule.onNodeWithText("Static").assertExists()
+    }
+
+    @Test
+    fun `filled card clickable`() = assertClickableCard(NimazCardStyle.FILLED)
+
+    @Test
+    fun `elevated card clickable`() = assertClickableCard(NimazCardStyle.ELEVATED)
+
+    @Test
+    fun `outlined card clickable`() = assertClickableCard(NimazCardStyle.OUTLINED)
+
+    @Test
+    fun `gradient style card clickable`() = assertClickableCard(NimazCardStyle.GRADIENT)
+
+    @Test
+    fun `filled card static`() = assertStaticCard(NimazCardStyle.FILLED)
+
+    @Test
+    fun `elevated card static`() = assertStaticCard(NimazCardStyle.ELEVATED)
+
+    @Test
+    fun `outlined card static`() = assertStaticCard(NimazCardStyle.OUTLINED)
+
+    @Test
+    fun `gradient style card static`() = assertStaticCard(NimazCardStyle.GRADIENT)
+
+    @Test
+    fun `gradient card renders and fires onClick`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            GradientCard(
+                gradientColors = listOf(Color(0xFF5C6BC0), Color(0xFF9FA8DA)),
+                onClick = { clicked = true }
+            ) {
+                Text("Gradient clickable")
+            }
+        }
+        composeRule.onNodeWithText("Gradient clickable").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `gradient card renders without onClick`() {
+        composeRule.setThemedContent {
+            GradientCard(gradientColors = listOf(Color.Red, Color.Blue)) {
+                Text("Gradient static")
+            }
+        }
+        composeRule.onNodeWithText("Gradient static").assertExists()
+    }
+
+    @Test
+    fun `prayer card renders content and fires onClick`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            PrayerCard(
+                primaryColor = Color(0xFFFFB74D),
+                secondaryColor = Color(0xFFFFE0B2),
+                onClick = { clicked = true }
+            ) {
+                Text("Fajr")
+            }
+        }
+        composeRule.onNodeWithText("Fajr").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `prayer card renders without onClick`() {
+        composeRule.setThemedContent {
+            PrayerCard(
+                primaryColor = Color.Red,
+                secondaryColor = Color.Blue
+            ) {
+                Text("Dhuhr")
+            }
+        }
+        composeRule.onNodeWithText("Dhuhr").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCardTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCardTest.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazChipTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazChipTest.kt
@@ -1,0 +1,189 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazChipTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `chip enums are complete`() {
+        assertThat(NimazChipStyle.entries).hasSize(4)
+        assertThat(NimazChipVariant.entries).hasSize(4)
+    }
+
+    // ── NimazChip (unified) ─────────────────────────────────────────────────
+
+    private fun assertVariantDispatch(variant: NimazChipVariant) {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazChip(
+                text = "Chip",
+                onClick = { clicked = true },
+                variant = variant,
+                selected = true,
+                leadingIcon = Icons.Default.Star
+            )
+        }
+        composeRule.onNodeWithText("Chip").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `NimazChip dispatches filter variant`() = assertVariantDispatch(NimazChipVariant.FILTER)
+
+    @Test
+    fun `NimazChip dispatches suggestion variant`() =
+        assertVariantDispatch(NimazChipVariant.SUGGESTION)
+
+    @Test
+    fun `NimazChip dispatches assist variant`() = assertVariantDispatch(NimazChipVariant.ASSIST)
+
+    @Test
+    fun `NimazChip dispatches input variant`() = assertVariantDispatch(NimazChipVariant.INPUT)
+
+    // ── NimazFilterChip ─────────────────────────────────────────────────────
+
+    @Test
+    fun `filter chip shows selected check icon`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazFilterChip(
+                selected = true,
+                onClick = { clicked = true },
+                label = "Selected"
+            )
+        }
+        composeRule.onNodeWithText("Selected").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `filter chip shows leading icon when not selected and elevated`() {
+        composeRule.setThemedContent {
+            NimazFilterChip(
+                selected = false,
+                onClick = {},
+                label = "Leading",
+                leadingIcon = Icons.Default.Star,
+                elevated = true
+            )
+        }
+        composeRule.onNodeWithText("Leading").assertExists()
+    }
+
+    @Test
+    fun `filter chip without icons renders`() {
+        composeRule.setThemedContent {
+            NimazFilterChip(
+                selected = false,
+                onClick = {},
+                label = "Plain",
+                showSelectedIcon = false
+            )
+        }
+        composeRule.onNodeWithText("Plain").assertExists()
+    }
+
+    // ── NimazAssistChip ─────────────────────────────────────────────────────
+
+    @Test
+    fun `assist chip renders plain and elevated with icon`() {
+        composeRule.setThemedContent {
+            NimazAssistChip(onClick = {}, label = "Assist plain")
+        }
+        composeRule.onNodeWithText("Assist plain").assertExists()
+    }
+
+    @Test
+    fun `assist chip renders elevated with leading icon`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazAssistChip(
+                onClick = { clicked = true },
+                label = "Assist icon",
+                leadingIcon = Icons.Default.Star,
+                elevated = true
+            )
+        }
+        composeRule.onNodeWithText("Assist icon").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    // ── NimazInputChip ──────────────────────────────────────────────────────
+
+    @Test
+    fun `input chip renders minimal`() {
+        composeRule.setThemedContent {
+            NimazInputChip(selected = false, onClick = {}, label = "Input plain")
+        }
+        composeRule.onNodeWithText("Input plain").assertExists()
+    }
+
+    @Test
+    fun `input chip renders with icon avatar and dismiss`() {
+        composeRule.setThemedContent {
+            NimazInputChip(
+                selected = true,
+                onClick = {},
+                label = "Input rich",
+                onDismiss = {},
+                leadingIcon = Icons.Default.Star,
+                avatar = { Box(androidx.compose.ui.Modifier) }
+            )
+        }
+        composeRule.onNodeWithText("Input rich").assertExists()
+    }
+
+    // ── NimazSuggestionChip ─────────────────────────────────────────────────
+
+    @Test
+    fun `suggestion chip renders minimal`() {
+        composeRule.setThemedContent {
+            NimazSuggestionChip(onClick = {}, label = "Suggest plain")
+        }
+        composeRule.onNodeWithText("Suggest plain").assertExists()
+    }
+
+    @Test
+    fun `suggestion chip renders elevated with icon`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazSuggestionChip(
+                onClick = { clicked = true },
+                label = "Suggest icon",
+                icon = Icons.Default.Star,
+                elevated = true
+            )
+        }
+        composeRule.onNodeWithText("Suggest icon").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    // ── RevelationTypeChip ──────────────────────────────────────────────────
+
+    @Test
+    fun `revelation type chip renders meccan and medinan`() {
+        composeRule.setThemedContent {
+            androidx.compose.foundation.layout.Row {
+                RevelationTypeChip(isMeccan = true)
+                RevelationTypeChip(isMeccan = false)
+            }
+        }
+        composeRule.onNodeWithText("Meccan").assertExists()
+        composeRule.onNodeWithText("Medinan").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazChipTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazChipTest.kt
@@ -3,7 +3,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazContainersTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazContainersTest.kt
@@ -1,0 +1,26 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazContainersTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `bottom sheet handle renders`() {
+        composeRule.setThemedContent {
+            BottomSheetHandle(modifier = Modifier.testTag("handle"))
+        }
+        composeRule.onNodeWithTag("handle").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazContainersTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazContainersTest.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import org.junit.Rule

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazDividerTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazDividerTest.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazDividerTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazDividerTest.kt
@@ -1,0 +1,39 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazDividerTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `divider renders with defaults`() {
+        composeRule.setThemedContent {
+            NimazDivider(modifier = Modifier.testTag("divider"))
+        }
+        composeRule.onNodeWithTag("divider").assertExists()
+    }
+
+    @Test
+    fun `divider renders with custom thickness and alpha`() {
+        composeRule.setThemedContent {
+            NimazDivider(
+                modifier = Modifier.testTag("divider2"),
+                thickness = 2.dp,
+                alpha = 0.8f
+            )
+        }
+        composeRule.onNodeWithTag("divider2").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconButtonTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconButtonTest.kt
@@ -1,0 +1,69 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazIconButtonTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `icon button enums are complete`() {
+        assertThat(NimazIconButtonStyle.entries).hasSize(4)
+        assertThat(NimazIconButtonSize.entries).hasSize(4)
+    }
+
+    private fun assertIconButton(style: NimazIconButtonStyle) {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazIconButton(
+                icon = Icons.Default.Star,
+                onClick = { clicked = true },
+                contentDescription = "btn",
+                style = style,
+                size = NimazIconButtonSize.LARGE
+            )
+        }
+        composeRule.onNodeWithContentDescription("btn").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `standard icon button fires click`() = assertIconButton(NimazIconButtonStyle.STANDARD)
+
+    @Test
+    fun `filled icon button fires click`() = assertIconButton(NimazIconButtonStyle.FILLED)
+
+    @Test
+    fun `filled tonal icon button fires click`() =
+        assertIconButton(NimazIconButtonStyle.FILLED_TONAL)
+
+    @Test
+    fun `outlined icon button fires click`() = assertIconButton(NimazIconButtonStyle.OUTLINED)
+
+    @Test
+    fun `icon button accepts custom colors and disabled state`() {
+        composeRule.setThemedContent {
+            NimazIconButton(
+                icon = Icons.Default.Star,
+                onClick = {},
+                contentDescription = "custom-btn",
+                enabled = false,
+                colors = IconButtonDefaults.iconButtonColors()
+            )
+        }
+        composeRule.onNodeWithContentDescription("custom-btn").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconButtonTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconButtonTest.kt
@@ -3,7 +3,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconTest.kt
@@ -1,0 +1,60 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazIconTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `icon enums are complete`() {
+        assertThat(NimazIconSize.entries).hasSize(5)
+        assertThat(NimazIconContainerShape.entries).hasSize(3)
+    }
+
+    private fun assertContainedIcon(shape: NimazIconContainerShape) {
+        composeRule.setThemedContent {
+            ContainedIcon(
+                imageVector = Icons.Default.Star,
+                contentDescription = "icon",
+                containerShape = shape,
+                size = NimazIconSize.LARGE
+            )
+        }
+        composeRule.onNodeWithContentDescription("icon").assertExists()
+    }
+
+    @Test
+    fun `contained icon renders circle`() = assertContainedIcon(NimazIconContainerShape.CIRCLE)
+
+    @Test
+    fun `contained icon renders rounded square`() =
+        assertContainedIcon(NimazIconContainerShape.ROUNDED_SQUARE)
+
+    @Test
+    fun `contained icon renders square`() = assertContainedIcon(NimazIconContainerShape.SQUARE)
+
+    @Test
+    fun `prayer icon renders`() {
+        composeRule.setThemedContent {
+            PrayerIcon(
+                imageVector = Icons.Default.Star,
+                prayerColor = Color(0xFF5C6BC0),
+                contentDescription = "prayer-icon"
+            )
+        }
+        composeRule.onNodeWithContentDescription("prayer-icon").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIconTest.kt
@@ -3,7 +3,6 @@ package com.arshadshah.nimaz.presentation.components.atoms
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import com.google.common.truth.Truth.assertThat

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazLegendItemTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazLegendItemTest.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazLegendItemTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazLegendItemTest.kt
@@ -1,0 +1,38 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazLegendItemTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `legend item renders dot and label`() {
+        composeRule.setThemedContent {
+            NimazLegendItem(color = Color(0xFF22C55E), label = "Fasted")
+        }
+        composeRule.onNodeWithText("Fasted").assertExists()
+    }
+
+    @Test
+    fun `legend item renders with custom dot size`() {
+        composeRule.setThemedContent {
+            NimazLegendItem(
+                color = Color.Red,
+                label = "Missed",
+                dotSize = 12.dp
+            )
+        }
+        composeRule.onNodeWithText("Missed").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeaderTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeaderTest.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.material3.Text
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeaderTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeaderTest.kt
@@ -1,0 +1,61 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazSectionHeaderTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `section header renders title only`() {
+        composeRule.setThemedContent {
+            NimazSectionHeader(title = "Daily Practice")
+        }
+        composeRule.onNodeWithText("Daily Practice").assertExists()
+    }
+
+    @Test
+    fun `section header renders custom trailing content`() {
+        composeRule.setThemedContent {
+            NimazSectionHeader(
+                title = "Custom",
+                trailingContent = { Text("Trailing") }
+            )
+        }
+        composeRule.onNodeWithText("Trailing").assertExists()
+    }
+
+    @Test
+    fun `section header see all fires click`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazSectionHeader(
+                title = "Prayer Times",
+                showSeeAll = true,
+                seeAllText = "View All",
+                onSeeAllClick = { clicked = true }
+            )
+        }
+        composeRule.onNodeWithText("View All").performClick()
+        assertThat(clicked).isTrue()
+    }
+
+    @Test
+    fun `section header renders trailing text`() {
+        composeRule.setThemedContent {
+            NimazSectionHeader(title = "Bookmarks", trailingText = "12")
+        }
+        composeRule.onNodeWithText("12").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitleTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitleTest.kt
@@ -1,0 +1,38 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazSectionTitleTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `section title uppercases text by default`() {
+        composeRule.setThemedContent {
+            NimazSectionTitle(text = "Display Options")
+        }
+        composeRule.onNodeWithText("DISPLAY OPTIONS").assertExists()
+    }
+
+    @Test
+    fun `section title preserves case and shows trailing content`() {
+        composeRule.setThemedContent {
+            NimazSectionTitle(
+                text = "Links",
+                uppercase = false,
+                trailingContent = { Text("More") }
+            )
+        }
+        composeRule.onNodeWithText("Links").assertExists()
+        composeRule.onNodeWithText("More").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitleTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitleTest.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.material3.Text
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import org.junit.Rule

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/PrayerVisualsTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/PrayerVisualsTest.kt
@@ -1,0 +1,68 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PrayerVisualsTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `getArabicPrayerName maps every prayer type`() {
+        assertThat(getArabicPrayerName(PrayerType.FAJR)).isEqualTo("الفجر")
+        assertThat(getArabicPrayerName(PrayerType.SUNRISE)).isEqualTo("الشروق")
+        assertThat(getArabicPrayerName(PrayerType.DHUHR)).isEqualTo("الظهر")
+        assertThat(getArabicPrayerName(PrayerType.ASR)).isEqualTo("العصر")
+        assertThat(getArabicPrayerName(PrayerType.MAGHRIB)).isEqualTo("المغرب")
+        assertThat(getArabicPrayerName(PrayerType.ISHA)).isEqualTo("العشاء")
+        assertThat(getArabicPrayerName(null)).isEmpty()
+    }
+
+    @Test
+    fun `getPrayerIcon maps every prayer type`() {
+        assertThat(getPrayerIcon(PrayerType.FAJR).name).isEqualTo(Icons.Default.DarkMode.name)
+        assertThat(getPrayerIcon(PrayerType.SUNRISE).name).isEqualTo(Icons.Default.WbSunny.name)
+        assertThat(getPrayerIcon(PrayerType.DHUHR).name).isEqualTo(Icons.Default.WbSunny.name)
+        assertThat(getPrayerIcon(PrayerType.ASR).name).isEqualTo(Icons.Default.LightMode.name)
+        assertThat(getPrayerIcon(PrayerType.MAGHRIB).name).isEqualTo(Icons.Default.WbSunny.name)
+        assertThat(getPrayerIcon(PrayerType.ISHA).name).isEqualTo(Icons.Default.DarkMode.name)
+        assertThat(getPrayerIcon(null).name).isEqualTo(Icons.Default.LightMode.name)
+    }
+
+    @Test
+    fun `getPrayerColor maps known prayer types and falls back to primary`() {
+        val colors = mutableMapOf<String, Color>()
+        val all: List<PrayerType?> = listOf(
+            PrayerType.FAJR, PrayerType.SUNRISE, PrayerType.DHUHR,
+            PrayerType.ASR, PrayerType.MAGHRIB, PrayerType.ISHA, null
+        )
+        composeRule.setThemedContent {
+            all.forEach { type ->
+                colors[type?.name ?: "NULL"] = getPrayerColor(type)
+            }
+        }
+        composeRule.waitForIdle()
+
+        assertThat(colors["FAJR"]).isEqualTo(Color(0xFF6366F1))
+        assertThat(colors["SUNRISE"]).isEqualTo(Color(0xFFF59E0B))
+        assertThat(colors["DHUHR"]).isEqualTo(Color(0xFFEAB308))
+        assertThat(colors["ASR"]).isEqualTo(Color(0xFFF97316))
+        assertThat(colors["MAGHRIB"]).isEqualTo(Color(0xFFEF4444))
+        assertThat(colors["ISHA"]).isEqualTo(Color(0xFF8B5CF6))
+        // The null/fallback branch resolves to the theme primary, which differs
+        // from all of the explicit prayer colours above.
+        assertThat(colors["NULL"]).isNotEqualTo(Color(0xFF6366F1))
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBannersTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBannersTest.kt
@@ -1,6 +1,5 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import org.junit.Rule

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBannersTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBannersTest.kt
@@ -1,0 +1,62 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QuranBannersTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `juz banner renders title and subtitle`() {
+        composeRule.setThemedContent {
+            JuzPageBanner(title = "Juz 1", subtitle = "Al-Fatihah - Al-Baqarah")
+        }
+        composeRule.onNodeWithText("Juz 1").assertExists()
+        composeRule.onNodeWithText("Al-Fatihah - Al-Baqarah").assertExists()
+    }
+
+    @Test
+    fun `juz banner renders without subtitle`() {
+        composeRule.setThemedContent {
+            JuzPageBanner(title = "Juz 30", subtitle = "")
+        }
+        composeRule.onNodeWithText("Juz 30").assertExists()
+    }
+
+    @Test
+    fun `page surah separator renders full content with bismillah`() {
+        composeRule.setThemedContent {
+            PageSurahSeparator(
+                surahNumber = 2,
+                surahNameArabic = "البقرة",
+                surahNameEnglish = "Al-Baqarah",
+                showBismillah = true
+            )
+        }
+        composeRule.onNodeWithText("2").assertExists()
+        composeRule.onNodeWithText("Al-Baqarah").assertExists()
+        composeRule.onNodeWithText("البقرة").assertExists()
+    }
+
+    @Test
+    fun `page surah separator renders without arabic name or bismillah`() {
+        composeRule.setThemedContent {
+            PageSurahSeparator(
+                surahNumber = 9,
+                surahNameArabic = "",
+                surahNameEnglish = "At-Tawbah",
+                showBismillah = false
+            )
+        }
+        composeRule.onNodeWithText("At-Tawbah").assertExists()
+        composeRule.onNodeWithText("9").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranInfoAtomsTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranInfoAtomsTest.kt
@@ -1,6 +1,5 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import org.junit.Rule

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranInfoAtomsTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/QuranInfoAtomsTest.kt
@@ -1,0 +1,33 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QuranInfoAtomsTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `stat item renders value and label`() {
+        composeRule.setThemedContent {
+            StatItem(value = "7", label = "Verses")
+        }
+        composeRule.onNodeWithText("7").assertExists()
+        composeRule.onNodeWithText("Verses").assertExists()
+    }
+
+    @Test
+    fun `info card renders text`() {
+        composeRule.setThemedContent {
+            InfoCard(text = "Al-Fatihah is the first chapter of the Quran.")
+        }
+        composeRule.onNodeWithText("Al-Fatihah is the first chapter of the Quran.").assertExists()
+    }
+}

--- a/app/src/testDebug/resources/robolectric.properties
+++ b/app/src/testDebug/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# Use a plain Application for these tests instead of the app's @HiltAndroidApp
+# NimazApp, which would otherwise trigger Hilt/WorkManager initialization that
+# is irrelevant to exercising the presentation atoms.
+application=android.app.Application


### PR DESCRIPTION
## What

Adds code coverage tooling and unit tests for every Compose **atom** in `presentation/components/atoms/`, so the atoms are exercised by the existing `gradle test` CI lane (CI does not run instrumented tests).

## Coverage tooling (JaCoCo)
- Applies the `jacoco` plugin and adds:
  - `jacocoTestReport` — module-wide HTML/XML report from `testDebugUnitTest`.
  - `jacocoAtomsReport` — report scoped to the atoms package.
  - `jacocoAtomsCoverageVerification` — an optional gate for the atoms package. **Kept out of the default `check` graph** so it never blocks the existing CI lane.
- Exclusions for Compose/Hilt generated code and the `ComposableSingletons` classes that hold `@Preview`-only lambdas (the agreed "sensible exclusions").

Run locally:
```
./gradlew jacocoAtomsReport   # app/build/reports/jacoco/jacocoAtomsReport/html/index.html
```

## Test infrastructure (Robolectric + Compose)
- `testOptions.unitTests.isIncludeAndroidResources = true` and BOM-managed Compose `ui-test-junit4` on the unit-test classpath.
- Tests live in **`src/testDebug`** so they only run for the debug unit-test variant (which has `compose-ui-test-manifest`); the release unit-test variant is unaffected.
- `robolectric.properties` pins **SDK 34** (Robolectric 4.11.x max) and swaps the `@HiltAndroidApp` `NimazApp` for a plain `Application` so tests don't drag in Hilt/WorkManager.

## Tests
One test class per atom file (15 files), covering every public composable, enum, sealed type, branch, and pure helper — `toArabicNumber`, `getHadithGradeBadgeColors`, `getPrayerColor`/`getPrayerIcon`/`getArabicPrayerName`, all `NimazCard`/`NimazChip`/`NimazIconButton`/`NimazBanner` style + variant branches, etc. `onClick`/action paths are fired via clicks.

## Notes
- This environment can't build the Android project (Google Maven + the Android SDK are blocked by the network policy), so the tests were authored against the established Robolectric+Compose pattern and are being verified here in CI. I'll iterate on this PR until the checks are green.
- `NimazBottomSheet` (a `ModalBottomSheet` wrapper) is intentionally not rendered in tests — modal sheets are unreliable under Robolectric. `BottomSheetHandle` is covered.

https://claude.ai/code/session_01WgUDt3S3L9Du7dDQHLf7cT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgUDt3S3L9Du7dDQHLf7cT)_