### PR TITLE
Add Islamic month-start indicators to calendar

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/util/HijriDateCalculator.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/HijriDateCalculator.kt
@@ -62,6 +62,24 @@ object HijriDateCalculator {
         "ذو الحجة"
     )
 
+    // Hijri month names abbreviated for compact UI (e.g. calendar day cells).
+    // Numbered Rabi'/Jumada pairs are disambiguated so a single glance tells
+    // which of the two months a day belongs to.
+    private val hijriMonthNamesShort = listOf(
+        "Muh",
+        "Saf",
+        "Rabi 1",
+        "Rabi 2",
+        "Jum 1",
+        "Jum 2",
+        "Rajab",
+        "Shab",
+        "Ram",
+        "Shaw",
+        "Qidah",
+        "Hijja"
+    )
+
     private val hijrahChronology = HijrahChronology.INSTANCE
 
     fun getHijriMonthName(month: Int): String {
@@ -70,6 +88,13 @@ object HijriDateCalculator {
 
     fun getHijriMonthNameArabic(month: Int): String {
         return hijriMonthNamesArabic.getOrElse(month - 1) { "غير معروف" }
+    }
+
+    /**
+     * Short Hijri month name suitable for tight spaces such as calendar cells.
+     */
+    fun getHijriMonthNameShort(month: Int): String {
+        return hijriMonthNamesShort.getOrElse(month - 1) { "?" }
     }
 
     /**

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazCalendar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazCalendar.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -20,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -76,13 +76,20 @@ enum class IndicatorPosition {
  *   Null uses the default (today/selected/transparent).
  * @param textColor Custom text color override. Null uses the default.
  * @param fontWeight Custom font weight override. Null uses the default.
+ * @param isHijriMonthStart Marks this cell as the first day of a Hijri month.
+ *   Renders a colored top stripe so the start (and, by the cell before it, the
+ *   end) of each Islamic month is easy to spot when scanning the grid.
+ * @param hijriMonthStartLabel Short Hijri month name shown on the start cell
+ *   (e.g. "Rajab"). Only drawn when [isHijriMonthStart] is true.
  */
 data class CalendarDayState(
     val indicatorColor: Color? = null,
     val indicatorPosition: IndicatorPosition = IndicatorPosition.BOTTOM_CENTER,
     val backgroundColor: Color? = null,
     val textColor: Color? = null,
-    val fontWeight: FontWeight? = null
+    val fontWeight: FontWeight? = null,
+    val isHijriMonthStart: Boolean = false,
+    val hijriMonthStartLabel: String? = null
 )
 
 /**
@@ -202,17 +209,17 @@ fun NimazCalendar(
                         modifier = Modifier.padding(top = 14.dp),
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
                     )
-                    Row(
+                    FlowRow(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 14.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
+                        horizontalArrangement = Arrangement.spacedBy(
+                            16.dp,
+                            Alignment.CenterHorizontally
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        legendItems.forEachIndexed { index, item ->
-                            if (index > 0) {
-                                Spacer(modifier = Modifier.width(16.dp))
-                            }
+                        legendItems.forEach { item ->
                             NimazLegendItem(color = item.color, label = item.label)
                         }
                     }
@@ -445,6 +452,35 @@ private fun CalendarDayCell(
             fontSize = 13.sp
         )
 
+        // Hijri month-start marker — a colored top stripe plus the short month
+        // name. Because each Islamic month begins exactly one cell after the
+        // previous one ends, marking the start also visually delimits the end
+        // of the preceding month. On a primary-filled selected cell the accent
+        // flips to onPrimary so it stays legible.
+        if (dayState.isHijriMonthStart) {
+            val accent = if (isSelectedBackgroundFill) scheme.onPrimary else scheme.primary
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(3.dp)
+                    .background(accent)
+            )
+            dayState.hijriMonthStartLabel?.let { label ->
+                Text(
+                    text = label,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 5.dp),
+                    color = accent,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 8.sp,
+                    maxLines = 1,
+                    softWrap = false
+                )
+            }
+        }
+
         // Indicator dot — picks a contrasting tone on selected cells so the
         // dot stays visible against primary fill.
         dayState.indicatorColor?.let { color ->
@@ -542,8 +578,12 @@ private fun NimazCalendarIslamicPreview() {
                 onNextMonth = {},
                 headerTitle = "Rajab 1447",
                 dayStateProvider = { date ->
+                    // Jan 20, 2026 is 1 Sha'ban 1447 — demo the month-start marker.
+                    val isMonthStart = date == LocalDate.of(2026, 1, 20)
                     CalendarDayState(
-                        indicatorColor = eventDays[date]
+                        indicatorColor = eventDays[date],
+                        isHijriMonthStart = isMonthStart,
+                        hijriMonthStartLabel = if (isMonthStart) "Shab" else null
                     )
                 },
                 legendItems = listOf(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.HijriDateCalculator.getHijriMonthName
 import com.arshadshah.nimaz.core.util.HijriDateCalculator.getHijriMonthNameArabic
 import com.arshadshah.nimaz.domain.model.HijriMonth
@@ -265,11 +266,21 @@ private fun CalendarSection(
             },
             dayStateProvider = { date ->
                 val events = eventMap[date] ?: emptyList()
+                // A Gregorian day whose Hijri day-of-month is 1 is the first day
+                // of an Islamic month — mark it so the start (and the end, one
+                // cell earlier) of each month is obvious on the grid.
+                val hijri = HijriDateCalculator.toHijri(date)
+                val isMonthStart = hijri.day == 1
                 CalendarDayState(
-                    indicatorColor = getEventDotColor(events)
+                    indicatorColor = getEventDotColor(events),
+                    isHijriMonthStart = isMonthStart,
+                    hijriMonthStartLabel = if (isMonthStart) {
+                        HijriDateCalculator.getHijriMonthNameShort(hijri.month)
+                    } else null
                 )
             },
             legendItems = listOf(
+                CalendarLegendItem(MaterialTheme.colorScheme.primary, stringResource(R.string.month_start)),
                 CalendarLegendItem(Color(0xFFEAB308), stringResource(R.string.eid)),
                 CalendarLegendItem(Color(0xFF22C55E), stringResource(R.string.holy_night)),
                 CalendarLegendItem(Color(0xFFA855F7), stringResource(R.string.fasting))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -398,6 +398,7 @@
     <string name="islamic_calendar">Islamischer Kalender</string>
     <string name="eid">Eid</string>
     <string name="holy_night">Heilige Nacht</string>
+    <string name="month_start">Monatsbeginn</string>
     <string name="events">Ereignisse</string>
     <string name="upcoming_events">Bevorstehende Ereignisse</string>
     <string name="hadith_title">Hadith</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -398,6 +398,7 @@
     <string name="islamic_calendar">Calendrier islamique</string>
     <string name="eid">Aïd</string>
     <string name="holy_night">Nuit sacrée</string>
+    <string name="month_start">Début du mois</string>
     <string name="events">Événements</string>
     <string name="upcoming_events">Événements à venir</string>
     <string name="hadith_title">Hadith</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -398,6 +398,7 @@
     <string name="islamic_calendar">Kalender Islam</string>
     <string name="eid">Hari Raya</string>
     <string name="holy_night">Malam Suci</string>
+    <string name="month_start">Awal bulan</string>
     <string name="events">Peristiwa</string>
     <string name="upcoming_events">Peristiwa Mendatang</string>
     <string name="hadith_title">Hadis</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -398,6 +398,7 @@
     <string name="islamic_calendar">Kalendar Islam</string>
     <string name="eid">Hari Raya</string>
     <string name="holy_night">Malam Mulia</string>
+    <string name="month_start">Awal bulan</string>
     <string name="events">Peristiwa</string>
     <string name="upcoming_events">Peristiwa Akan Datang</string>
     <string name="hadith_title">Hadis</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -398,6 +398,7 @@
     <string name="islamic_calendar">İslami Takvim</string>
     <string name="eid">Bayram</string>
     <string name="holy_night">Kandil</string>
+    <string name="month_start">Ay başı</string>
     <string name="events">Etkinlikler</string>
     <string name="upcoming_events">Yaklaşan Etkinlikler</string>
     <string name="hadith_title">Hadis</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,7 @@
     <string name="islamic_calendar">Islamic Calendar</string>
     <string name="eid">Eid</string>
     <string name="holy_night">Holy Night</string>
+    <string name="month_start">Month start</string>
     <string name="events">Events</string>
     <string name="upcoming_events">Upcoming Events</string>
 


### PR DESCRIPTION
Mark the first Gregorian day of each Hijri month on the Islamic calendar
grid with a colored top stripe and the short month name. This makes the
start (and, one cell earlier, the end) of each Islamic month easy to spot.

- Add isHijriMonthStart/hijriMonthStartLabel to CalendarDayState and render
  the marker in NimazCalendar's day cell
- Wire it up in IslamicCalendarScreen via HijriDateCalculator (Hijri day == 1)
- Add getHijriMonthNameShort() for compact cell labels
- Add a "Month start" legend entry and switch the legend to a FlowRow so it
  wraps gracefully with the extra item

https://claude.ai/code/session_015Edw9Deg6V6Wkesm5YbA9s