### PR TITLE
Fix in-app update giving no feedback on slow networks

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +45,16 @@ class MainActivity : ComponentActivity() {
 
     private lateinit var inAppUpdateManager: InAppUpdateManager
 
+    // Receives the result of the Play in-app update confirmation dialog so the
+    // manager can fall back to an interactive state if the user cancels. Must be
+    // registered before the activity is STARTED, hence a field initializer.
+    private val updateFlowLauncher =
+        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            if (::inAppUpdateManager.isInitialized) {
+                inAppUpdateManager.onUpdateFlowResult(result.resultCode)
+            }
+        }
+
     // Pending surah to navigate to from a Quran audio notification tap. NavGraph
     // observes this and consumes it after navigation.
     private var pendingQuranSurah by mutableStateOf<Int?>(null)
@@ -67,6 +78,7 @@ class MainActivity : ComponentActivity() {
 
         // Initialize in-app update manager
         inAppUpdateManager = InAppUpdateManager(this)
+        inAppUpdateManager.setUpdateFlowLauncher(updateFlowLauncher)
         inAppUpdateManager.checkForUpdate()
 
         setContent {

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/InAppUpdateManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/InAppUpdateManager.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.core.util
 
 import android.app.Activity
 import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
@@ -17,6 +19,14 @@ sealed interface UpdateState {
     data object Idle : UpdateState
     data object Checking : UpdateState
     data object UpdateAvailable : UpdateState
+
+    /**
+     * The user requested an update and we're fetching the AppUpdateInfo / bringing
+     * up the Play confirmation dialog. This can take several seconds on slow
+     * connections, so it's surfaced as a distinct loading state to give immediate
+     * feedback that the tap was registered.
+     */
+    data object Starting : UpdateState
     data object Downloading : UpdateState
     data class Downloaded(val completeUpdate: () -> Unit) : UpdateState
     data object NoUpdateAvailable : UpdateState
@@ -30,8 +40,14 @@ class InAppUpdateManager(private val activity: Activity) {
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.Idle)
     val updateState: StateFlow<UpdateState> = _updateState.asStateFlow()
 
+    // Launcher for the Play update confirmation dialog. Must be registered by the
+    // host Activity before it is STARTED (see MainActivity), so it's injected
+    // rather than created here.
+    private var updateFlowLauncher: ActivityResultLauncher<IntentSenderRequest>? = null
+
     private val installStateListener = InstallStateUpdatedListener { state ->
         when (state.installStatus()) {
+            InstallStatus.PENDING,
             InstallStatus.DOWNLOADING -> {
                 _updateState.value = UpdateState.Downloading
             }
@@ -46,8 +62,17 @@ class InAppUpdateManager(private val activity: Activity) {
                 _updateState.value = UpdateState.Error("Update download failed")
             }
 
+            InstallStatus.CANCELED -> {
+                // User cancelled the download — return to an actionable state.
+                _updateState.value = UpdateState.UpdateAvailable
+            }
+
             else -> {}
         }
+    }
+
+    fun setUpdateFlowLauncher(launcher: ActivityResultLauncher<IntentSenderRequest>) {
+        updateFlowLauncher = launcher
     }
 
     fun checkForUpdate() {
@@ -73,17 +98,57 @@ class InAppUpdateManager(private val activity: Activity) {
     }
 
     fun startUpdate() {
+        // Reflect the tap immediately. Fetching AppUpdateInfo and showing the Play
+        // dialog is asynchronous and can take a few seconds on slow connections;
+        // without this the banner/button would appear unresponsive ("nothing
+        // happened") even though the flow is in progress.
+        _updateState.value = UpdateState.Starting
+
         appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
-            if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
-            ) {
-                appUpdateManager.startUpdateFlowForResult(
-                    info,
-                    activity,
-                    AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
-                    UPDATE_REQUEST_CODE
-                )
+            val launcher = updateFlowLauncher
+            when {
+                info.installStatus() == InstallStatus.DOWNLOADED -> {
+                    _updateState.value = UpdateState.Downloaded {
+                        appUpdateManager.completeUpdate()
+                    }
+                }
+
+                info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) &&
+                    launcher != null -> {
+                    val launched = appUpdateManager.startUpdateFlowForResult(
+                        info,
+                        launcher,
+                        AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE)
+                    )
+                    if (!launched) {
+                        // Couldn't launch the dialog — restore the actionable state.
+                        _updateState.value = UpdateState.UpdateAvailable
+                    }
+                    // Otherwise the install listener / onUpdateFlowResult drive the
+                    // next state once the user responds to the dialog.
+                }
+
+                else -> {
+                    _updateState.value = UpdateState.NoUpdateAvailable
+                }
             }
+        }.addOnFailureListener { e ->
+            Log.e(TAG, "Start update failed", e)
+            _updateState.value = UpdateState.Error(e.message ?: "Update failed to start")
+        }
+    }
+
+    /**
+     * Result of the Play update confirmation dialog, forwarded by the host
+     * Activity. When the user dismisses or cancels the dialog we fall back to
+     * [UpdateState.UpdateAvailable] so the banner/button becomes interactive again
+     * instead of being stuck on the [UpdateState.Starting] spinner. On a confirmed
+     * update the install listener takes over and drives the download states.
+     */
+    fun onUpdateFlowResult(resultCode: Int) {
+        if (resultCode != Activity.RESULT_OK && _updateState.value == UpdateState.Starting) {
+            _updateState.value = UpdateState.UpdateAvailable
         }
     }
 
@@ -103,6 +168,5 @@ class InAppUpdateManager(private val activity: Activity) {
 
     companion object {
         private const val TAG = "InAppUpdateManager"
-        const val UPDATE_REQUEST_CODE = 1001
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/AboutScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/AboutScreen.kt
@@ -255,7 +255,9 @@ private fun LinksCard(
         val updateManager = LocalInAppUpdateManager.current
         val updateState = updateManager?.updateState?.collectAsState()?.value ?: UpdateState.Idle
         val updateSubtitle = when (updateState) {
+            is UpdateState.Checking -> stringResource(R.string.update_checking)
             is UpdateState.UpdateAvailable -> stringResource(R.string.update_new_version)
+            is UpdateState.Starting -> stringResource(R.string.update_starting)
             is UpdateState.Downloading -> stringResource(R.string.update_downloading)
             is UpdateState.Downloaded -> stringResource(R.string.update_downloaded)
             is UpdateState.NoUpdateAvailable -> stringResource(R.string.update_up_to_date)
@@ -270,6 +272,10 @@ private fun LinksCard(
                 when (updateState) {
                     is UpdateState.UpdateAvailable -> updateManager?.startUpdate()
                     is UpdateState.Downloaded -> updateState.completeUpdate()
+                    // Already in progress — ignore taps so we don't restart the flow.
+                    is UpdateState.Checking,
+                    is UpdateState.Starting,
+                    is UpdateState.Downloading -> Unit
                     else -> updateManager?.checkForUpdate()
                 }
             },

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -446,6 +446,7 @@ private fun buildHomeBannerItems(
     val fix = stringResource(R.string.fix)
 
     val updateAvailable = stringResource(R.string.update_available)
+    val startingUpdate = stringResource(R.string.starting_update)
     val downloadingUpdate = stringResource(R.string.downloading_update)
     val updateReady = stringResource(R.string.update_ready)
     val updateAction = stringResource(R.string.update_action)
@@ -508,6 +509,15 @@ private fun buildHomeBannerItems(
                     variant = HomeBannerVariant.UPDATE,
                     actionLabel = updateAction,
                     onAction = { updateManager?.startUpdate() },
+                )
+            )
+            is UpdateState.Starting -> add(
+                HomeBannerItem(
+                    id = "starting_update",
+                    icon = Icons.Default.Download,
+                    title = startingUpdate,
+                    variant = HomeBannerVariant.UPDATE,
+                    isLoading = true,
                 )
             )
             is UpdateState.Downloading -> add(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -35,6 +35,7 @@
     <string name="update_available">Eine neue Version von Nimaz ist verfügbar</string>
     <string name="update_action">Aktualisieren</string>
     <string name="downloading_update">Update wird heruntergeladen…</string>
+    <string name="starting_update">Update wird gestartet…</string>
     <string name="update_ready">Update zur Installation bereit</string>
     <string name="restart">Neustart</string>
     <string name="notifications_disabled_title">Benachrichtigungen deaktiviert</string>
@@ -133,6 +134,8 @@
     <string name="open_source_licenses_subtitle">Drittanbieter-Bibliotheken</string>
     <string name="check_for_updates">Nach Updates suchen</string>
     <string name="update_new_version">Neue Version verfügbar</string>
+    <string name="update_checking">Wird geprüft…</string>
+    <string name="update_starting">Wird gestartet…</string>
     <string name="update_downloading">Wird heruntergeladen…</string>
     <string name="update_downloaded">Bereit zur Installation</string>
     <string name="update_up_to_date">Sie sind auf dem neuesten Stand</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,6 +35,7 @@
     <string name="update_available">Une nouvelle version de Nimaz est disponible</string>
     <string name="update_action">Mettre à jour</string>
     <string name="downloading_update">Téléchargement de la mise à jour…</string>
+    <string name="starting_update">Démarrage de la mise à jour…</string>
     <string name="update_ready">Mise à jour prête à installer</string>
     <string name="restart">Redémarrer</string>
     <string name="notifications_disabled_title">Notifications désactivées</string>
@@ -133,6 +134,8 @@
     <string name="open_source_licenses_subtitle">Bibliothèques tierces</string>
     <string name="check_for_updates">Vérifier les mises à jour</string>
     <string name="update_new_version">Nouvelle version disponible</string>
+    <string name="update_checking">Vérification…</string>
+    <string name="update_starting">Démarrage…</string>
     <string name="update_downloading">Téléchargement…</string>
     <string name="update_downloaded">Prêt à installer</string>
     <string name="update_up_to_date">Vous êtes à jour</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -35,6 +35,7 @@
     <string name="update_available">Versi baru Nimaz tersedia</string>
     <string name="update_action">Perbarui</string>
     <string name="downloading_update">Mengunduh pembaruan…</string>
+    <string name="starting_update">Memulai pembaruan…</string>
     <string name="update_ready">Pembaruan siap dipasang</string>
     <string name="restart">Mulai Ulang</string>
     <string name="notifications_disabled_title">Notifikasi Dinonaktifkan</string>
@@ -133,6 +134,8 @@
     <string name="open_source_licenses_subtitle">Pustaka pihak ketiga</string>
     <string name="check_for_updates">Periksa Pembaruan</string>
     <string name="update_new_version">Versi baru tersedia</string>
+    <string name="update_checking">Memeriksa…</string>
+    <string name="update_starting">Memulai…</string>
     <string name="update_downloading">Mengunduh…</string>
     <string name="update_downloaded">Siap dipasang</string>
     <string name="update_up_to_date">Anda sudah menggunakan versi terbaru</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -35,6 +35,7 @@
     <string name="update_available">Versi baharu Nimaz tersedia</string>
     <string name="update_action">Kemas Kini</string>
     <string name="downloading_update">Memuat turun kemas kini\u2026</string>
+    <string name="starting_update">Memulakan kemas kini\u2026</string>
     <string name="update_ready">Kemas kini sedia untuk dipasang</string>
     <string name="restart">Mulakan Semula</string>
     <string name="notifications_disabled_title">Pemberitahuan Dilumpuhkan</string>
@@ -133,6 +134,8 @@
     <string name="open_source_licenses_subtitle">Pustaka pihak ketiga</string>
     <string name="check_for_updates">Semak Kemas Kini</string>
     <string name="update_new_version">Versi baharu tersedia</string>
+    <string name="update_checking">Menyemak…</string>
+    <string name="update_starting">Memulakan…</string>
     <string name="update_downloading">Memuat turun\u2026</string>
     <string name="update_downloaded">Sedia untuk dipasang</string>
     <string name="update_up_to_date">Anda sudah dikemas kini</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -35,6 +35,7 @@
     <string name="update_available">Nimaz\'ın yeni bir sürümü mevcut</string>
     <string name="update_action">Güncelle</string>
     <string name="downloading_update">Güncelleme indiriliyor…</string>
+    <string name="starting_update">Güncelleme başlatılıyor…</string>
     <string name="update_ready">Güncelleme yüklenmeye hazır</string>
     <string name="restart">Yeniden Başlat</string>
     <string name="notifications_disabled_title">Bildirimler Devre Dışı</string>
@@ -133,6 +134,8 @@
     <string name="open_source_licenses_subtitle">Üçüncü taraf kütüphaneler</string>
     <string name="check_for_updates">Güncellemeleri Kontrol Et</string>
     <string name="update_new_version">Yeni sürüm mevcut</string>
+    <string name="update_checking">Kontrol ediliyor…</string>
+    <string name="update_starting">Başlatılıyor…</string>
     <string name="update_downloading">İndiriliyor…</string>
     <string name="update_downloaded">Yüklenmeye hazır</string>
     <string name="update_up_to_date">Güncelsiniz</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <!-- Home Screen - Banners -->
     <string name="update_available">A new version of Nimaz is available</string>
     <string name="update_action">Update</string>
+    <string name="starting_update">Starting update…</string>
     <string name="downloading_update">Downloading update…</string>
     <string name="update_ready">Update ready to install</string>
     <string name="restart">Restart</string>
@@ -198,6 +199,8 @@
     <string name="open_source_licenses_subtitle">Third-party libraries</string>
     <string name="check_for_updates">Check for Updates</string>
     <string name="update_new_version">New version available</string>
+    <string name="update_checking">Checking…</string>
+    <string name="update_starting">Starting…</string>
     <string name="update_downloading">Downloading…</string>
     <string name="update_downloaded">Ready to install</string>
     <string name="update_up_to_date">You\'re up to date</string>


### PR DESCRIPTION
Tapping the update banner button or the About-screen update row called
startUpdate(), which kicked off an asynchronous appUpdateInfo fetch and
the Play confirmation dialog without ever changing updateState. On slow
connections this fetch takes several seconds, so the UI stayed on
"Update available" and looked like nothing happened — prompting repeated
taps.

Add an immediate UpdateState.Starting loading state set the moment
startUpdate() is invoked, and surface it as a spinner in the home banner
and as "Starting…" in the About screen. The update flow now uses the
ActivityResultLauncher overload so a cancelled/dismissed Play dialog
reverts to UpdateAvailable instead of being stuck on the spinner;
in-progress states also ignore further taps. Also handle PENDING and
CANCELED install statuses for smoother feedback.