### PR TITLE
Fix Play Store upload to explicitly handle AAB artifacts

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,8 @@ platform :android do
     build_and_sign_apk_or_aab
     upload_to_play_store(
       track: "internal",
+      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+      skip_upload_apk: true, # Only the AAB is uploaded to the Play Store; the APK is kept for the GitHub release
       json_key: ENV["ANDROID_JSON_KEY_FILE"] # Use your Google Play JSON key
     )
   end
@@ -27,6 +29,8 @@ platform :android do
     build_and_sign_apk_or_aab
     upload_to_play_store(
       track: "beta",
+      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+      skip_upload_apk: true, # Only the AAB is uploaded to the Play Store; the APK is kept for the GitHub release
       json_key: ENV["ANDROID_JSON_KEY_FILE"] # Use your Google Play JSON key
     )
   end
@@ -69,9 +73,10 @@ platform :android do
 
     # Build a signed APK first. This is not uploaded to the Play Store (which
     # takes the AAB) but is attached to the GitHub release so the exact
-    # published version can be sideloaded/audited. Building it before the bundle
-    # keeps the AAB as the last gradle output, so upload_to_play_store still
-    # picks the .aab up from the lane context automatically.
+    # published version can be sideloaded/audited. Because both an APK and an
+    # AAB end up in the lane context, the upload lanes pass the AAB path
+    # explicitly and set skip_upload_apk so upload_to_play_store doesn't error
+    # on finding both artifacts.
     gradle(
       task: "assemble",
       build_type: "release",


### PR DESCRIPTION
## Summary
Updated the Android Fastfile to explicitly specify the AAB path when uploading to the Play Store and skip APK uploads, since both APK and AAB artifacts are now generated during the build process.

## Changes
- Modified `upload_to_play_store` calls in both `internal` and `beta` lanes to:
  - Explicitly pass the AAB path via `aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]`
  - Set `skip_upload_apk: true` to prevent upload errors when both artifacts are present
- Updated the `build_and_sign_apk_or_aab` lane comment to explain the new approach:
  - Previously relied on AAB being the last Gradle output to be picked up automatically
  - Now explicitly passes the AAB path since both APK and AAB exist in the lane context
  - APK is retained for GitHub releases while only AAB goes to Play Store

## Implementation Details
The changes ensure that when both APK and AAB artifacts are generated, the upload process correctly identifies and uploads only the AAB to the Play Store while preserving the APK for sideloading and auditing purposes on GitHub releases.

https://claude.ai/code/session_01CswJ8hjuB2Gs5L4JFzujie