### PR TITLE
test: add Tier 1 unit tests for core business-logic calculators

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
 
+      # Build (but do NOT run) the instrumented test sources. There is no
+      # emulator in this lane, so this is a compile/sanity check only — it
+      # ensures the androidTest code stays valid and ready for a device /
+      # Firebase Test Lab lane. No tests are executed on a device here.
+      - name: Compile instrumented tests (build only, no emulator)
+        run: bash ./gradlew assembleDebugAndroidTest --stacktrace
+
       - name: Generate coverage reports
         if: always()
         run: bash ./gradlew jacocoTestReport jacocoDomainDataReport --stacktrace

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,6 +28,52 @@ jobs:
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
 
+      - name: Generate coverage reports
+        if: always()
+        run: bash ./gradlew jacocoTestReport jacocoDomainDataReport --stacktrace
+
+      - name: Report coverage
+        if: always()
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import os, re, xml.etree.ElementTree as ET
+
+          def report(path, label):
+              if not os.path.exists(path):
+                  print(f"### {label}\n- report not found at `{path}`\n")
+                  return
+              data = re.sub(r"<!DOCTYPE[^>]*>", "", open(path, encoding="utf-8").read())
+              root = ET.fromstring(data)
+              res = {c.get("type"): (int(c.get("covered")), int(c.get("missed")))
+                     for c in root.findall("counter")}
+              def fmt(t):
+                  cov, miss = res.get(t, (0, 0))
+                  tot = cov + miss
+                  pct = (100.0 * cov / tot) if tot else 0.0
+                  return f"{pct:.1f}% ({cov}/{tot})"
+              print(f"### {label}")
+              print(f"- Instruction: {fmt('INSTRUCTION')}")
+              print(f"- Line: {fmt('LINE')}")
+              print(f"- Branch: {fmt('BRANCH')}")
+              print("")
+
+          print("## Code coverage (debug unit tests)")
+          report("app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml",
+                 "Whole module")
+          report("app/build/reports/jacoco/jacocoDomainDataReport/jacocoDomainDataReport.xml",
+                 "Business logic (domain + data + core util)")
+          PY
+
+      - name: Enforce business-logic coverage floor
+        run: bash ./gradlew jacocoDomainDataCoverageVerification --stacktrace
+
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: app/build/reports/jacoco/
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -441,7 +441,11 @@ fun businessLogicClassTree(): ConfigurableFileTree =
 tasks.register<JacocoReport>("jacocoDomainDataReport") {
     group = "verification"
     description = "Generates a JaCoCo coverage report scoped to domain + data + core util."
-    dependsOn("testDebugUnitTest")
+    // Depend on jacocoTestReport too: both reports read execution data from a
+    // file tree rooted at the build dir, which overlaps jacocoTestReport's
+    // output. Declaring the dependency satisfies Gradle's input/output
+    // validation when both reports run in the same invocation (as CI does).
+    dependsOn("testDebugUnitTest", "jacocoTestReport")
 
     reports {
         html.required.set(true)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -423,3 +423,57 @@ tasks.register<JacocoCoverageVerification>("jacocoOrganismsCoverageVerification"
         }
     }
 }
+
+// ── Business-logic coverage (domain + data + core utilities) ────────────────
+// The non-UI layers where a wrong value is a correctness bug rather than a
+// visual one. Generated/DI/entity noise is stripped via coverageExclusions.
+fun businessLogicClassTree(): ConfigurableFileTree =
+    fileTree(kotlinDebugClassesDir) {
+        include(
+            "**/com/arshadshah/nimaz/domain/**",
+            "**/com/arshadshah/nimaz/data/**",
+            "**/com/arshadshah/nimaz/core/util/**",
+        )
+        exclude(coverageExclusions)
+    }
+
+// Focused report for the business-logic layers (consumed by the CI summary).
+tasks.register<JacocoReport>("jacocoDomainDataReport") {
+    group = "verification"
+    description = "Generates a JaCoCo coverage report scoped to domain + data + core util."
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+
+    classDirectories.setFrom(businessLogicClassTree())
+    sourceDirectories.setFrom(coverageSourceDirs)
+    executionData.setFrom(coverageExecutionData())
+}
+
+// Regression floor for the business-logic layers. Deliberately conservative so
+// it never blocks day-to-day work; ratchet `minimum` up toward the figure the
+// "Report coverage" CI step prints once a baseline is established.
+tasks.register<JacocoCoverageVerification>("jacocoDomainDataCoverageVerification") {
+    group = "verification"
+    description = "Verifies a minimum coverage floor for the business-logic layers."
+    dependsOn("testDebugUnitTest")
+
+    classDirectories.setFrom(businessLogicClassTree())
+    sourceDirectories.setFrom(coverageSourceDirs)
+    executionData.setFrom(coverageExecutionData())
+
+    violationRules {
+        rule {
+            element = "BUNDLE"
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.10".toBigDecimal()
+            }
+        }
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,7 +41,11 @@ android {
         versionCode = 314
         versionName = "3.0.14"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // HiltTestRunner swaps in HiltTestApplication so @HiltAndroidTest
+        // instrumented tests can inject. Instrumented tests are compiled in CI
+        // but not executed (no emulator); they run on a device / Firebase Test
+        // Lab when that lane is added.
+        testInstrumentationRunner = "com.arshadshah.nimaz.HiltTestRunner"
 
         // Room schema export
         ksp {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,27 @@ android {
             isReturnDefaultValues = true
         }
     }
+
+    // The instrumented-test dependencies (mockk, truth, hilt-testing, …) each
+    // bundle META-INF license/notice files, which collide when packaging the
+    // androidTest APK (DuplicateRelativeFileException). Drop the duplicates.
+    packaging {
+        resources {
+            excludes += setOf(
+                "/META-INF/LICENSE.md",
+                "/META-INF/LICENSE-notice.md",
+                "/META-INF/LICENSE",
+                "/META-INF/LICENSE.txt",
+                "/META-INF/NOTICE.md",
+                "/META-INF/NOTICE",
+                "/META-INF/NOTICE.txt",
+                "/META-INF/{AL2.0,LGPL2.1}",
+                "/META-INF/*.kotlin_module",
+                "/META-INF/DEPENDENCIES",
+                "/META-INF/INDEX.LIST",
+            )
+        }
+    }
 }
 
 dependencies {

--- a/app/src/androidTest/java/com/arshadshah/nimaz/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/HiltTestRunner.kt
@@ -1,0 +1,24 @@
+package com.arshadshah.nimaz
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+/**
+ * Custom instrumentation runner that swaps in [HiltTestApplication] so Hilt can
+ * inject test components. Wired via `testInstrumentationRunner` in build.gradle.
+ *
+ * NOTE: instrumented tests are not executed in the current CI lane (no
+ * emulator). They are compiled for sanity via `assembleDebugAndroidTest`, and
+ * are ready to run on a device / Firebase Test Lab when that lane is added.
+ */
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?
+    ): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppNavigationCrawlTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppNavigationCrawlTest.kt
@@ -1,0 +1,183 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.HiltTestActivity
+import com.arshadshah.nimaz.core.navigation.NavGraph
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Comprehensive "visit every screen like a user" crawl.
+ *
+ * Hosts the real [NavGraph] (driven by a captured [NavHostController]) inside a
+ * Hilt activity, then navigates to every destination in the app and asserts the
+ * screen composes without crashing — a composition failure throws at
+ * `waitForIdle()` and fails the owning test, pinpointing the broken screen.
+ *
+ * NOT run in CI (no emulator). Run locally in Android Studio across devices
+ * before a release: `./gradlew connectedDebugAndroidTest` or right-click → Run.
+ *
+ * Caveats to expect on first local run:
+ *  - Detail screens are visited with sample ids (e.g. ProphetDetail(1)); adjust
+ *    to ids present in your seeded data if a screen legitimately needs them.
+ *  - A screen with an indefinite animation/sensor loop (e.g. Qibla compass) can
+ *    keep Compose "busy"; if `waitForIdle()` stalls there, drive that screen
+ *    with `mainClock.autoAdvance = false` or move it to its own test.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class AppNavigationCrawlTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<HiltTestActivity>()
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        composeRule.setContent {
+            navController = rememberNavController()
+            NimazTheme {
+                NavGraph(navController = navController)
+            }
+        }
+        // Wait until onboarding state resolves and the NavHost (with its start
+        // destination) is actually composed before driving navigation.
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            navController.currentDestination != null
+        }
+    }
+
+    /** Navigate to [route] and assert the destination composed without crashing. */
+    private fun visit(route: Route) {
+        composeRule.runOnUiThread { navController.navigate(route) }
+        composeRule.waitForIdle()
+        assertThat(navController.currentDestination).isNotNull()
+    }
+
+    private fun visitAll(vararg routes: Route) = routes.forEach { visit(it) }
+
+    // ── Bottom-nav sections ─────────────────────────────────────────
+    @Test
+    fun crawl_mainSections() = visitAll(
+        Route.Home, Route.Quran, Route.Tasbih, Route.QiblaNav, Route.More
+    )
+
+    // ── Quran ───────────────────────────────────────────────────────
+    @Test
+    fun crawl_quran() = visitAll(
+        Route.QuranReader(surahNumber = 1),
+        Route.QuranPage(pageNumber = 1),
+        Route.QuranJuz(juzNumber = 1),
+        Route.SurahInfo(surahNumber = 1),
+        Route.Tafseer(surahNumber = 1, ayahNumber = 1),
+        Route.QuranSearch,
+        Route.QuranBookmarks,
+        Route.SelectReciter
+    )
+
+    // ── Hadith ──────────────────────────────────────────────────────
+    @Test
+    fun crawl_hadith() = visitAll(
+        Route.HadithHome,
+        Route.HadithBook(bookId = "1"),
+        Route.HadithChapter(bookId = "1", chapterId = "1"),
+        Route.HadithReader(hadithId = "1"),
+        Route.HadithSearch,
+        Route.HadithBookmarks
+    )
+
+    // ── Dua ─────────────────────────────────────────────────────────
+    @Test
+    fun crawl_dua() = visitAll(
+        Route.DuaHome,
+        Route.DuaCategory(categoryId = "1"),
+        Route.DuaReader(duaId = "1"),
+        Route.DuaFavorites,
+        Route.DuaSearch
+    )
+
+    // ── Prayer ──────────────────────────────────────────────────────
+    @Test
+    fun crawl_prayer() = visitAll(
+        Route.PrayerTimes,
+        Route.PrayerTracker(),
+        Route.PrayerStats,
+        Route.QadaPrayers,
+        Route.MonthlyPrayerTimes
+    )
+
+    // ── Fasting ─────────────────────────────────────────────────────
+    @Test
+    fun crawl_fasting() = visitAll(
+        Route.FastingHome, Route.FastingTracker, Route.FastingStats
+    )
+
+    // ── Tasbih ──────────────────────────────────────────────────────
+    @Test
+    fun crawl_tasbih() = visitAll(
+        Route.TasbihHome,
+        Route.TasbihCounter(),
+        Route.TasbihPresets,
+        Route.TasbihStats,
+        Route.TasbihHistory,
+        Route.TasbihAddPreset
+    )
+
+    // ── Zakat ───────────────────────────────────────────────────────
+    @Test
+    fun crawl_zakat() = visitAll(Route.ZakatCalculator, Route.ZakatHistory)
+
+    // ── Calendar / search / bookmarks ───────────────────────────────
+    @Test
+    fun crawl_calendarAndSearch() = visitAll(
+        Route.IslamicCalendar,
+        Route.IslamicMonth(month = 9, year = 1446),
+        Route.AllBookmarks,
+        Route.GlobalSearch
+    )
+
+    // ── Content libraries (names, prophets, khatam) ─────────────────
+    @Test
+    fun crawl_contentLibraries() = visitAll(
+        Route.AsmaUlHusnaList,
+        Route.AsmaUlHusnaDetail(nameId = 1),
+        Route.AsmaUnNabiList,
+        Route.AsmaUnNabiDetail(nameId = 1),
+        Route.ProphetsList,
+        Route.ProphetDetail(prophetId = 1),
+        Route.KhatamList,
+        Route.KhatamCreate
+    )
+
+    // ── Settings & about ────────────────────────────────────────────
+    @Test
+    fun crawl_settings() = visitAll(
+        Route.Settings,
+        Route.SettingsPrayerCalculation,
+        Route.SettingsNotifications,
+        Route.SettingsAppearance,
+        Route.SettingsLanguage,
+        Route.SettingsLocation,
+        Route.SettingsQuran,
+        Route.SettingsWidgets,
+        Route.SettingsHelp,
+        Route.SettingsSync,
+        Route.SettingsAbout,
+        Route.Licenses
+    )
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/NavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/NavigationInstrumentedTest.kt
@@ -1,0 +1,65 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.MainActivity
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end navigation tests that drive the real app through Hilt + Compose.
+ *
+ * IMPORTANT: these are NOT run in the current CI lane — there is no emulator.
+ * They are compiled (`assembleDebugAndroidTest`) so the code is verified and
+ * cannot bit-rot, and are ready to execute on a device or Firebase Test Lab
+ * once an instrumented-test lane is added. See HiltTestRunner.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class NavigationInstrumentedTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun appLaunches_bottomNavigationIsVisible() {
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Home").assertIsDisplayed()
+        composeRule.onNodeWithText("Quran").assertIsDisplayed()
+        composeRule.onNodeWithText("Qibla").assertIsDisplayed()
+    }
+
+    @Test
+    fun bottomNav_navigateToQuran_thenBackToHome() {
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Quran").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Home").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Home").assertIsDisplayed()
+    }
+
+    @Test
+    fun bottomNav_navigateToTasbih() {
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Tasbih").performClick()
+        composeRule.waitForIdle()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/NavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/NavigationInstrumentedTest.kt
@@ -2,10 +2,16 @@ package com.arshadshah.nimaz.navigation
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.arshadshah.nimaz.MainActivity
+import com.arshadshah.nimaz.HiltTestActivity
+import com.arshadshah.nimaz.core.navigation.NavGraph
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.core.testing.TestTags
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -14,12 +20,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * End-to-end navigation tests that drive the real app through Hilt + Compose.
+ * Bottom-navigation user-flow test driven through the real [NavGraph] (selected
+ * via [TestTags]). Hosted in a Hilt activity and started on Home so the
+ * navigation bar is present (a cold launch lands on Onboarding, which has no
+ * bottom bar).
  *
- * IMPORTANT: these are NOT run in the current CI lane — there is no emulator.
- * They are compiled (`assembleDebugAndroidTest`) so the code is verified and
- * cannot bit-rot, and are ready to execute on a device or Firebase Test Lab
- * once an instrumented-test lane is added. See HiltTestRunner.
+ * NOT run in CI (no emulator) — run locally / on Firebase Test Lab.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
@@ -29,37 +35,48 @@ class NavigationInstrumentedTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeRule = createAndroidComposeRule<MainActivity>()
+    val composeRule = createAndroidComposeRule<HiltTestActivity>()
+
+    private lateinit var navController: NavHostController
 
     @Before
     fun setUp() {
         hiltRule.inject()
+        composeRule.setContent {
+            navController = rememberNavController()
+            NimazTheme {
+                NavGraph(navController = navController)
+            }
+        }
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            navController.currentDestination != null
+        }
+        // Land on a main screen so the bottom navigation is shown.
+        composeRule.runOnUiThread { navController.navigate(Route.Home) }
+        composeRule.waitForIdle()
     }
 
     @Test
-    fun appLaunches_bottomNavigationIsVisible() {
-        composeRule.waitForIdle()
-        composeRule.onNodeWithText("Home").assertIsDisplayed()
-        composeRule.onNodeWithText("Quran").assertIsDisplayed()
-        composeRule.onNodeWithText("Qibla").assertIsDisplayed()
+    fun bottomNav_allSectionsAreDisplayed() {
+        composeRule.onNodeWithTag(TestTags.NAV_HOME).assertIsDisplayed()
+        composeRule.onNodeWithTag(TestTags.NAV_QURAN).assertIsDisplayed()
+        composeRule.onNodeWithTag(TestTags.NAV_TASBIH).assertIsDisplayed()
+        composeRule.onNodeWithTag(TestTags.NAV_QIBLA).assertIsDisplayed()
+        composeRule.onNodeWithTag(TestTags.NAV_MORE).assertIsDisplayed()
     }
 
     @Test
-    fun bottomNav_navigateToQuran_thenBackToHome() {
+    fun bottomNav_clickThroughEverySection() {
+        composeRule.onNodeWithTag(TestTags.NAV_QURAN).performClick()
         composeRule.waitForIdle()
-
-        composeRule.onNodeWithText("Quran").performClick()
+        composeRule.onNodeWithTag(TestTags.NAV_TASBIH).performClick()
         composeRule.waitForIdle()
-
-        composeRule.onNodeWithText("Home").performClick()
+        composeRule.onNodeWithTag(TestTags.NAV_QIBLA).performClick()
         composeRule.waitForIdle()
-        composeRule.onNodeWithText("Home").assertIsDisplayed()
-    }
-
-    @Test
-    fun bottomNav_navigateToTasbih() {
+        composeRule.onNodeWithTag(TestTags.NAV_MORE).performClick()
         composeRule.waitForIdle()
-        composeRule.onNodeWithText("Tasbih").performClick()
+        composeRule.onNodeWithTag(TestTags.NAV_HOME).performClick()
         composeRule.waitForIdle()
+        composeRule.onNodeWithTag(TestTags.NAV_HOME).assertIsDisplayed()
     }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+        Debug-only host activity for instrumented Compose navigation tests.
+        Not present in the release build.
+    -->
+    <application>
+        <activity
+            android:name=".HiltTestActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Nimaz.PostSplash" />
+    </application>
+</manifest>

--- a/app/src/debug/java/com/arshadshah/nimaz/HiltTestActivity.kt
+++ b/app/src/debug/java/com/arshadshah/nimaz/HiltTestActivity.kt
@@ -1,0 +1,13 @@
+package com.arshadshah.nimaz
+
+import androidx.activity.ComponentActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * Empty Hilt-enabled host activity for instrumented Compose tests that need to
+ * drive [com.arshadshah.nimaz.core.navigation.NavGraph] directly (e.g. the
+ * navigation crawl). Lives in the debug source set so it ships only in the
+ * debug/androidTest APK, never in release.
+ */
+@AndroidEntryPoint
+class HiltTestActivity : ComponentActivity()

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -35,8 +35,11 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -93,12 +96,14 @@ import com.arshadshah.nimaz.presentation.viewmodel.OnboardingViewModel
 
 @Composable
 fun NavGraph(
+    // Injectable so instrumented navigation tests can drive the graph directly;
+    // production callers use the default in-composition controller.
+    navController: NavHostController = rememberNavController(),
     pendingQuranSurah: Int? = null,
     onPendingQuranSurahConsumed: () -> Unit = {},
     pendingIslamicCalendar: Boolean = false,
     onPendingIslamicCalendarConsumed: () -> Unit = {},
 ) {
-    val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
@@ -220,7 +225,7 @@ fun NavGraph(
 
                 item(
                     icon = { Icon(navItem.icon, contentDescription = navItem.label) },
-                    label = { Text(navItem.label) },
+                    label = { Text(navItem.label, modifier = Modifier.testTag(navItem.tag)) },
                     selected = selected,
                     onClick = {
                         navController.navigate(navItem.route) {
@@ -926,15 +931,16 @@ fun NavGraph(
 private data class BottomNavItem(
     val route: Route,
     val label: String,
-    val icon: ImageVector
+    val icon: ImageVector,
+    val tag: String
 )
 
 private val bottomNavItems = listOf(
-    BottomNavItem(Route.Home, "Home", Icons.Default.Home),
-    BottomNavItem(Route.Quran, "Quran", Icons.Default.MenuBook),
-    BottomNavItem(Route.Tasbih, "Tasbih", Icons.Default.TouchApp),
-    BottomNavItem(Route.QiblaNav, "Qibla", Icons.Default.Explore),
-    BottomNavItem(Route.More, "More", Icons.Default.MoreHoriz)
+    BottomNavItem(Route.Home, "Home", Icons.Default.Home, TestTags.NAV_HOME),
+    BottomNavItem(Route.Quran, "Quran", Icons.Default.MenuBook, TestTags.NAV_QURAN),
+    BottomNavItem(Route.Tasbih, "Tasbih", Icons.Default.TouchApp, TestTags.NAV_TASBIH),
+    BottomNavItem(Route.QiblaNav, "Qibla", Icons.Default.Explore, TestTags.NAV_QIBLA),
+    BottomNavItem(Route.More, "More", Icons.Default.MoreHoriz, TestTags.NAV_MORE)
 )
 
 private fun restartApp(context: Context) {

--- a/app/src/main/java/com/arshadshah/nimaz/core/testing/TestTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/testing/TestTags.kt
@@ -1,0 +1,110 @@
+package com.arshadshah.nimaz.core.testing
+
+/**
+ * Central registry of Compose UI test tags ("selectors").
+ *
+ * Single source of truth so instrumented / UI tests select elements by a stable
+ * id instead of localized, visible text — and so a tag can be renamed in exactly
+ * one place rather than chasing raw strings across the codebase.
+ *
+ * Usage in a composable:
+ * ```
+ * Scaffold(modifier = Modifier.testTag(TestTags.SCREEN_HOME)) { ... }
+ * ```
+ * Usage in a test:
+ * ```
+ * composeRule.onNodeWithTag(TestTags.SCREEN_HOME).assertIsDisplayed()
+ * ```
+ *
+ * Conventions:
+ * - `NAV_*`     bottom-navigation / rail destinations
+ * - `SCREEN_*`  the root container of a screen (for "did it render / not crash")
+ * - everything else: a specific interactive element (button, field, list, …)
+ */
+object TestTags {
+
+    // ── Bottom navigation ────────────────────────────────────────────
+    const val NAV_HOME = "nav.home"
+    const val NAV_QURAN = "nav.quran"
+    const val NAV_TASBIH = "nav.tasbih"
+    const val NAV_QIBLA = "nav.qibla"
+    const val NAV_MORE = "nav.more"
+
+    // ── Common, reused across screens ────────────────────────────────
+    const val BACK_BUTTON = "common.back"
+    const val TOP_APP_BAR = "common.topAppBar"
+    const val LOADING_INDICATOR = "common.loading"
+    const val ERROR_STATE = "common.error"
+    const val EMPTY_STATE = "common.empty"
+
+    // ── Screen roots (one per destination) ───────────────────────────
+    const val SCREEN_ONBOARDING = "screen.onboarding"
+    const val SCREEN_HOME = "screen.home"
+    const val SCREEN_QURAN = "screen.quran"
+    const val SCREEN_QURAN_READER = "screen.quranReader"
+    const val SCREEN_TAFSEER = "screen.tafseer"
+    const val SCREEN_SURAH_INFO = "screen.surahInfo"
+    const val SCREEN_QURAN_SEARCH = "screen.quranSearch"
+    const val SCREEN_BOOKMARKS = "screen.bookmarks"
+    const val SCREEN_SELECT_RECITER = "screen.selectReciter"
+    const val SCREEN_HADITH = "screen.hadith"
+    const val SCREEN_HADITH_CHAPTERS = "screen.hadithChapters"
+    const val SCREEN_HADITH_READER = "screen.hadithReader"
+    const val SCREEN_DUA = "screen.dua"
+    const val SCREEN_DUA_CATEGORY = "screen.duaCategory"
+    const val SCREEN_DUA_READER = "screen.duaReader"
+    const val SCREEN_DUA_COLLECTION = "screen.duaCollection"
+    const val SCREEN_SEARCH = "screen.search"
+    const val SCREEN_PRAYER_TRACKER = "screen.prayerTracker"
+    const val SCREEN_PRAYER_STATS = "screen.prayerStats"
+    const val SCREEN_MONTHLY_PRAYER_TIMES = "screen.monthlyPrayerTimes"
+    const val SCREEN_FASTING = "screen.fasting"
+    const val SCREEN_TASBIH = "screen.tasbih"
+    const val SCREEN_TASBIH_HISTORY = "screen.tasbihHistory"
+    const val SCREEN_TASBIH_ADD_PRESET = "screen.tasbihAddPreset"
+    const val SCREEN_ZAKAT_CALCULATOR = "screen.zakatCalculator"
+    const val SCREEN_ZAKAT_HISTORY = "screen.zakatHistory"
+    const val SCREEN_QIBLA = "screen.qibla"
+    const val SCREEN_ISLAMIC_CALENDAR = "screen.islamicCalendar"
+    const val SCREEN_MORE = "screen.more"
+    const val SCREEN_SETTINGS = "screen.settings"
+    const val SCREEN_SETTINGS_PRAYER = "screen.settingsPrayer"
+    const val SCREEN_SETTINGS_NOTIFICATIONS = "screen.settingsNotifications"
+    const val SCREEN_SETTINGS_APPEARANCE = "screen.settingsAppearance"
+    const val SCREEN_SETTINGS_LANGUAGE = "screen.settingsLanguage"
+    const val SCREEN_SETTINGS_LOCATION = "screen.settingsLocation"
+    const val SCREEN_SETTINGS_QURAN = "screen.settingsQuran"
+    const val SCREEN_SETTINGS_WIDGETS = "screen.settingsWidgets"
+    const val SCREEN_SETTINGS_HELP = "screen.settingsHelp"
+    const val SCREEN_SETTINGS_SYNC = "screen.settingsSync"
+    const val SCREEN_ABOUT = "screen.about"
+    const val SCREEN_LICENSES = "screen.licenses"
+    const val SCREEN_LICENSE_DETAIL = "screen.licenseDetail"
+    const val SCREEN_ASMA_UL_HUSNA = "screen.asmaUlHusna"
+    const val SCREEN_ASMA_UL_HUSNA_DETAIL = "screen.asmaUlHusnaDetail"
+    const val SCREEN_ASMA_UN_NABI = "screen.asmaUnNabi"
+    const val SCREEN_ASMA_UN_NABI_DETAIL = "screen.asmaUnNabiDetail"
+    const val SCREEN_PROPHETS = "screen.prophets"
+    const val SCREEN_PROPHET_DETAIL = "screen.prophetDetail"
+    const val SCREEN_KHATAM = "screen.khatam"
+    const val SCREEN_KHATAM_DETAIL = "screen.khatamDetail"
+    const val SCREEN_KHATAM_CREATE = "screen.khatamCreate"
+
+    // ── Feature-specific primary actions ─────────────────────────────
+    // Tasbih
+    const val TASBIH_COUNTER = "tasbih.counter"
+    const val TASBIH_INCREMENT = "tasbih.increment"
+    const val TASBIH_RESET = "tasbih.reset"
+
+    // Zakat
+    const val ZAKAT_CASH_FIELD = "zakat.cashField"
+    const val ZAKAT_CALCULATE = "zakat.calculate"
+    const val ZAKAT_RESULT = "zakat.result"
+
+    // Prayer tracker
+    const val PRAYER_TRACKER_TABS = "prayerTracker.tabs"
+    const val PRAYER_MARK_PRAYED = "prayerTracker.markPrayed"
+
+    /** Stable per-prayer toggle tag, e.g. tag for "FAJR". */
+    fun prayerToggle(prayerName: String): String = "prayerTracker.toggle.$prayerName"
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -77,7 +79,7 @@ fun BookmarksScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_BOOKMARKS),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.bookmarks_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.stringResource
@@ -72,7 +74,7 @@ fun IslamicCalendarScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_ISLAMIC_CALENDAR),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.islamic_calendar),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -63,7 +65,7 @@ fun DuaCategoryScreen(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_DUA_CATEGORY),
         topBar = {
             NimazBackTopAppBar(
                 title = state.category?.nameEnglish ?: "Duas",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.stringResource
@@ -91,7 +93,7 @@ fun DuasCollectionScreen(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_DUA_COLLECTION),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.duas_adhkar),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -60,7 +62,7 @@ fun HadithChaptersScreen(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_HADITH_CHAPTERS),
         topBar = {
             NimazBackTopAppBar(
                 title = state.book?.nameEnglish ?: "Chapters",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
@@ -77,7 +79,7 @@ fun HadithCollectionScreen(
     val context = LocalContext.current
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_HADITH),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.hadith_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -97,7 +99,7 @@ fun HadithReaderScreen(
     val hasNext = state.currentHadithIndex < state.hadiths.size - 1
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_HADITH_READER),
         topBar = {
             NimazBackTopAppBar(
                 title = state.chapter?.nameEnglish ?: "Loading...",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpSupportScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpSupportScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -164,7 +166,7 @@ fun HelpSupportScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS_HELP),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.help_support),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -88,7 +90,7 @@ fun MoreMenuScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_MORE),
         topBar = {
             NimazTopAppBar(
                 title = stringResource(R.string.more),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -73,7 +75,7 @@ fun MonthlyPrayerTimesScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_MONTHLY_PRAYER_TIMES),
         topBar = {
             NimazBackTopAppBar(
                 title = "Monthly Prayer Times",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -64,7 +66,7 @@ fun PrayerStatsScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_PRAYER_STATS),
         topBar = {
             NimazBackTopAppBar(
                 title = "Statistics",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
@@ -53,12 +53,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.testing.TestTags
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerRecord
 import com.arshadshah.nimaz.domain.model.PrayerStatus
@@ -97,7 +99,9 @@ fun PrayerTrackerScreen(
     )
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .testTag(TestTags.SCREEN_PRAYER_TRACKER),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.prayer_tracker_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreen.kt
@@ -66,6 +66,8 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
@@ -161,7 +163,9 @@ fun QiblaScreen(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .testTag(TestTags.SCREEN_QIBLA),
     ) { paddingValues ->
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -113,7 +115,7 @@ fun QuranHomeScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_QURAN),
         topBar = {
             NimazTopAppBar(
                 title = stringResource(R.string.quran_home_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -105,7 +107,7 @@ fun SelectReciterScreen(
     val currentReciter = popularReciters.find { it.id == selectedReciterId } ?: popularReciters[0]
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SELECT_RECITER),
         topBar = {
             NimazBackTopAppBar(
                 title = "Select Reciter",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -80,7 +82,7 @@ fun SearchScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SEARCH),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.search_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -57,7 +59,7 @@ fun AppearanceSettingsScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS_APPEARANCE),
         topBar = {
             NimazBackTopAppBar(
                 title = "Appearance",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -143,7 +145,7 @@ fun NotificationSettingsScreen(
     val selectedAdhanName = notificationState.selectedAdhanSound
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS_NOTIFICATIONS),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.notifications),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -58,7 +60,7 @@ fun PrayerSettingsScreen(
     var showHighLatitudeDialog by remember { mutableStateOf(false) }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS_PRAYER),
         topBar = {
             NimazBackTopAppBar(
                 title = "Prayer Settings",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -91,7 +93,7 @@ fun QuranSettingsScreen(
     // Font files: res/font/amiri_regular.ttf, res/font/amiri_bold.ttf
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS_QURAN),
         topBar = {
             NimazBackTopAppBar(
                 title = "Quran Settings",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -71,7 +73,7 @@ fun SettingsScreen(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_SETTINGS),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.settings),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -57,7 +59,7 @@ fun AddPresetScreen(
     var nameError by remember { mutableStateOf(false) }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_TASBIH_ADD_PRESET),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.add_preset_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihHistoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihHistoryScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -61,7 +63,7 @@ fun TasbihHistoryScreen(
     val liveTotalToday = statsState.baseTotalToday + currentSessionCount
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_TASBIH_HISTORY),
         topBar = {
             NimazBackTopAppBar(
                 title = stringResource(R.string.tasbih_history),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -81,6 +82,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.testing.TestTags
 import com.arshadshah.nimaz.domain.model.TasbihPreset
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
@@ -108,7 +110,9 @@ fun TasbihScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .testTag(TestTags.SCREEN_TASBIH),
         topBar = {
             NimazTopAppBar(
                 title = stringResource(R.string.tasbih_title),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -59,6 +60,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.arshadshah.nimaz.core.testing.TestTags
 import com.arshadshah.nimaz.domain.model.NisabType
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -81,7 +83,9 @@ fun ZakatCalculatorScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .testTag(TestTags.SCREEN_ZAKAT_CALCULATOR),
         topBar = {
             NimazBackTopAppBar(
                 title = "Zakat Calculator",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.testing.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -65,7 +67,7 @@ fun ZakatHistoryScreen(
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection).testTag(TestTags.SCREEN_ZAKAT_HISTORY),
         topBar = {
             NimazBackTopAppBar(
                 title = "Zakat History",

--- a/app/src/test/java/com/arshadshah/nimaz/core/navigation/RouteSerializationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/navigation/RouteSerializationTest.kt
@@ -10,61 +10,63 @@ import org.junit.Test
  * argument is dropped, navigation to that destination breaks at runtime. These
  * tests pin the route contract (round-trip + argument preservation + defaults)
  * and the bottom-navigation wiring.
+ *
+ * Each concrete route is round-tripped via its own (reified) serializer — the
+ * `Route` parent interface is intentionally not `@Serializable`, only its
+ * subtypes are, matching how Navigation encodes typed destinations.
  */
 class RouteSerializationTest {
 
     private val json = Json
 
-    private inline fun <reified T : Route> roundTrip(route: T): Route {
-        val encoded = json.encodeToString(Route.serializer(), route)
-        return json.decodeFromString(Route.serializer(), encoded)
+    private inline fun <reified T : Route> assertRoundTrips(route: T) {
+        val decoded: T = json.decodeFromString(json.encodeToString(route))
+        assertThat(decoded).isEqualTo(route)
     }
 
     @Test
     fun `object routes round-trip to the same singleton`() {
-        val objects = listOf(
-            Route.Home, Route.Quran, Route.Tasbih, Route.QiblaNav, Route.More,
-            Route.PrayerTimes, Route.ZakatCalculator, Route.Qibla, Route.Settings,
-            Route.Onboarding, Route.GlobalSearch, Route.KhatamList
-        )
-        for (route in objects) {
-            assertThat(roundTrip(route)).isEqualTo(route)
-        }
+        assertRoundTrips(Route.Home)
+        assertRoundTrips(Route.Quran)
+        assertRoundTrips(Route.Tasbih)
+        assertRoundTrips(Route.QiblaNav)
+        assertRoundTrips(Route.More)
+        assertRoundTrips(Route.PrayerTimes)
+        assertRoundTrips(Route.ZakatCalculator)
+        assertRoundTrips(Route.Qibla)
+        assertRoundTrips(Route.Settings)
+        assertRoundTrips(Route.Onboarding)
+        assertRoundTrips(Route.GlobalSearch)
+        assertRoundTrips(Route.KhatamList)
     }
 
     @Test
     fun `parameterized routes preserve their arguments`() {
-        assertThat(roundTrip(Route.QuranReader(surahNumber = 2, ayahNumber = 255)))
-            .isEqualTo(Route.QuranReader(2, 255))
-        assertThat(roundTrip(Route.HadithBook(bookId = "bukhari")))
-            .isEqualTo(Route.HadithBook("bukhari"))
-        assertThat(roundTrip(Route.TasbihCounter(presetId = 7L)))
-            .isEqualTo(Route.TasbihCounter(7L))
-        assertThat(roundTrip(Route.IslamicMonth(month = 9, year = 1446)))
-            .isEqualTo(Route.IslamicMonth(9, 1446))
-        assertThat(roundTrip(Route.KhatamDetail(khatamId = 3L)))
-            .isEqualTo(Route.KhatamDetail(3L))
-        assertThat(roundTrip(Route.AsmaUlHusnaDetail(nameId = 42)))
-            .isEqualTo(Route.AsmaUlHusnaDetail(42))
+        assertRoundTrips(Route.QuranReader(surahNumber = 2, ayahNumber = 255))
+        assertRoundTrips(Route.HadithBook(bookId = "bukhari"))
+        assertRoundTrips(Route.HadithChapter(bookId = "bukhari", chapterId = "1"))
+        assertRoundTrips(Route.TasbihCounter(presetId = 7L))
+        assertRoundTrips(Route.IslamicMonth(month = 9, year = 1446))
+        assertRoundTrips(Route.KhatamDetail(khatamId = 3L))
+        assertRoundTrips(Route.AsmaUlHusnaDetail(nameId = 42))
+        assertRoundTrips(Route.LicenseDetail(libraryHashCode = 123))
     }
 
     @Test
     fun `default route arguments are applied and survive a round-trip`() {
-        // QuranReader.ayahNumber and PrayerTracker.initialTab have defaults.
         assertThat(Route.QuranReader(surahNumber = 1).ayahNumber).isEqualTo(1)
         assertThat(Route.PrayerTracker().initialTab).isEqualTo(0)
         assertThat(Route.TasbihCounter().presetId).isNull()
 
-        val decoded = roundTrip(Route.QuranReader(surahNumber = 5))
-        assertThat(decoded).isEqualTo(Route.QuranReader(5, 1))
+        // A QuranReader created with only the surah keeps its default ayah of 1.
+        assertRoundTrips(Route.QuranReader(surahNumber = 5))
+        assertThat(Route.QuranReader(surahNumber = 5)).isEqualTo(Route.QuranReader(5, 1))
     }
 
     @Test
     fun `nullable route arguments round-trip when present and absent`() {
-        assertThat(roundTrip(Route.TasbihCounter(presetId = null)))
-            .isEqualTo(Route.TasbihCounter(null))
-        assertThat(roundTrip(Route.TasbihCounter(presetId = 99L)))
-            .isEqualTo(Route.TasbihCounter(99L))
+        assertRoundTrips(Route.TasbihCounter(presetId = null))
+        assertRoundTrips(Route.TasbihCounter(presetId = 99L))
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/core/navigation/RouteSerializationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/navigation/RouteSerializationTest.kt
@@ -1,0 +1,78 @@
+package com.arshadshah.nimaz.core.navigation
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Navigation routes are `@Serializable` because type-safe Compose Navigation
+ * encodes them into the back-stack. If a route stops serializing or a typed
+ * argument is dropped, navigation to that destination breaks at runtime. These
+ * tests pin the route contract (round-trip + argument preservation + defaults)
+ * and the bottom-navigation wiring.
+ */
+class RouteSerializationTest {
+
+    private val json = Json
+
+    private inline fun <reified T : Route> roundTrip(route: T): Route {
+        val encoded = json.encodeToString(Route.serializer(), route)
+        return json.decodeFromString(Route.serializer(), encoded)
+    }
+
+    @Test
+    fun `object routes round-trip to the same singleton`() {
+        val objects = listOf(
+            Route.Home, Route.Quran, Route.Tasbih, Route.QiblaNav, Route.More,
+            Route.PrayerTimes, Route.ZakatCalculator, Route.Qibla, Route.Settings,
+            Route.Onboarding, Route.GlobalSearch, Route.KhatamList
+        )
+        for (route in objects) {
+            assertThat(roundTrip(route)).isEqualTo(route)
+        }
+    }
+
+    @Test
+    fun `parameterized routes preserve their arguments`() {
+        assertThat(roundTrip(Route.QuranReader(surahNumber = 2, ayahNumber = 255)))
+            .isEqualTo(Route.QuranReader(2, 255))
+        assertThat(roundTrip(Route.HadithBook(bookId = "bukhari")))
+            .isEqualTo(Route.HadithBook("bukhari"))
+        assertThat(roundTrip(Route.TasbihCounter(presetId = 7L)))
+            .isEqualTo(Route.TasbihCounter(7L))
+        assertThat(roundTrip(Route.IslamicMonth(month = 9, year = 1446)))
+            .isEqualTo(Route.IslamicMonth(9, 1446))
+        assertThat(roundTrip(Route.KhatamDetail(khatamId = 3L)))
+            .isEqualTo(Route.KhatamDetail(3L))
+        assertThat(roundTrip(Route.AsmaUlHusnaDetail(nameId = 42)))
+            .isEqualTo(Route.AsmaUlHusnaDetail(42))
+    }
+
+    @Test
+    fun `default route arguments are applied and survive a round-trip`() {
+        // QuranReader.ayahNumber and PrayerTracker.initialTab have defaults.
+        assertThat(Route.QuranReader(surahNumber = 1).ayahNumber).isEqualTo(1)
+        assertThat(Route.PrayerTracker().initialTab).isEqualTo(0)
+        assertThat(Route.TasbihCounter().presetId).isNull()
+
+        val decoded = roundTrip(Route.QuranReader(surahNumber = 5))
+        assertThat(decoded).isEqualTo(Route.QuranReader(5, 1))
+    }
+
+    @Test
+    fun `nullable route arguments round-trip when present and absent`() {
+        assertThat(roundTrip(Route.TasbihCounter(presetId = null)))
+            .isEqualTo(Route.TasbihCounter(null))
+        assertThat(roundTrip(Route.TasbihCounter(presetId = 99L)))
+            .isEqualTo(Route.TasbihCounter(99L))
+    }
+
+    @Test
+    fun `bottom navigation exposes the five main destinations in order`() {
+        assertThat(BottomNavDestination.values().map { it.title })
+            .containsExactly("Home", "Quran", "Tasbih", "Qibla", "More").inOrder()
+        assertThat(BottomNavDestination.HOME.route).isEqualTo(Route.Home)
+        assertThat(BottomNavDestination.QURAN.route).isEqualTo(Route.Quran)
+        assertThat(BottomNavDestination.QIBLA.route).isEqualTo(Route.QiblaNav)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/TajweedParserTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/TajweedParserTest.kt
@@ -1,0 +1,114 @@
+package com.arshadshah.nimaz.core.util
+
+import android.app.Application
+import androidx.compose.ui.graphics.Color
+import com.arshadshah.nimaz.presentation.theme.NimazColors.TajweedColors
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [TajweedParser] — turns pre-baked tajweed JSON into a colored
+ * [androidx.compose.ui.text.AnnotatedString]. Covers plain-text extraction,
+ * markup detection, rule-to-color mapping (light vs dark), the legacy v1 rule
+ * codes, and the graceful fallback for malformed input.
+ *
+ * Runs under Robolectric so the Compose `Color` / `AnnotatedString` types
+ * resolve, matching the convention used by the other Compose-touching tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class TajweedParserTest {
+
+    private val sampleJson =
+        """[{"t":"بِ","r":"g"},{"t":"سْمِ","r":null}]"""
+
+    // ── hasTajweedMarkup ────────────────────────────────────────────
+
+    @Test
+    fun `hasTajweedMarkup recognizes pre-parsed json`() {
+        assertThat(TajweedParser.hasTajweedMarkup(sampleJson)).isTrue()
+    }
+
+    @Test
+    fun `hasTajweedMarkup rejects plain text`() {
+        assertThat(TajweedParser.hasTajweedMarkup("بِسْمِ اللَّهِ")).isFalse()
+        assertThat(TajweedParser.hasTajweedMarkup("")).isFalse()
+    }
+
+    // ── stripTags ───────────────────────────────────────────────────
+
+    @Test
+    fun `stripTags concatenates the text of all segments`() {
+        assertThat(TajweedParser.stripTags(sampleJson)).isEqualTo("بِسْمِ")
+    }
+
+    @Test
+    fun `stripTags falls back to regex extraction for malformed json`() {
+        val malformed = """[{"t":"بِ","r":"g"},{"t":"سْمِ"""" // truncated / invalid
+        assertThat(TajweedParser.stripTags(malformed)).isEqualTo("بِسْمِ")
+    }
+
+    @Test
+    fun `stripTags returns non-json text unchanged`() {
+        assertThat(TajweedParser.stripTags("بِسْمِ اللَّهِ")).isEqualTo("بِسْمِ اللَّهِ")
+    }
+
+    // ── parse: text content ─────────────────────────────────────────
+
+    @Test
+    fun `parse preserves the full concatenated text`() {
+        val annotated = TajweedParser.parse(sampleJson, isDarkTheme = false)
+        assertThat(annotated.text).isEqualTo("بِسْمِ")
+    }
+
+    @Test
+    fun `parse falls back to plain text for malformed json`() {
+        val malformed = """not really json"""
+        val annotated = TajweedParser.parse(malformed, isDarkTheme = false)
+        assertThat(annotated.text).isEqualTo("not really json")
+        assertThat(annotated.spanStyles).isEmpty()
+    }
+
+    // ── parse: coloring ─────────────────────────────────────────────
+
+    @Test
+    fun `parse applies a colored span only to segments with a rule`() {
+        val annotated = TajweedParser.parse(sampleJson, isDarkTheme = false)
+        // Only the first segment ("بِ", rule "g") should be styled.
+        assertThat(annotated.spanStyles).hasSize(1)
+        val span = annotated.spanStyles.first()
+        assertThat(span.start).isEqualTo(0)
+        assertThat(span.end).isEqualTo("بِ".length)
+        assertThat(span.item.color).isEqualTo(TajweedColors.GhunnahLight)
+    }
+
+    @Test
+    fun `parse uses dark-theme colors when dark theme is enabled`() {
+        val annotated = TajweedParser.parse(sampleJson, isDarkTheme = true)
+        assertThat(annotated.spanStyles.first().item.color)
+            .isEqualTo(TajweedColors.GhunnahDark)
+    }
+
+    @Test
+    fun `parse maps legacy v1 rule codes to colors`() {
+        // "m" is the legacy code for Madd Normal.
+        val legacy = """[{"t":"اللَّه","r":"m"}]"""
+        val annotated = TajweedParser.parse(legacy, isDarkTheme = false)
+        assertThat(annotated.spanStyles).hasSize(1)
+        assertThat(annotated.spanStyles.first().item.color)
+            .isEqualTo(TajweedColors.MaddNormalLight)
+    }
+
+    @Test
+    fun `parse leaves unknown rule codes unstyled when default color is unspecified`() {
+        val unknown = """[{"t":"x","r":"zzz"}]"""
+        val annotated = TajweedParser.parse(
+            unknown, isDarkTheme = false, defaultColor = Color.Unspecified
+        )
+        assertThat(annotated.text).isEqualTo("x")
+        assertThat(annotated.spanStyles).isEmpty()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/database/dao/ZakatDaoTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/database/dao/ZakatDaoTest.kt
@@ -1,0 +1,134 @@
+package com.arshadshah.nimaz.data.local.database.dao
+
+import androidx.room.Room
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Instrumented-style DAO tests backed by a real in-memory Room database running
+ * under Robolectric (so they execute in the standard unit-test lane). These
+ * exercise the actual SQL — ordering, the conditional SUM, the partial UPDATE,
+ * REPLACE-on-conflict and deletes — which the mock-DAO repository tests cannot.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ZakatDaoTest {
+
+    private lateinit var db: NimazDatabase
+    private lateinit var dao: ZakatDao
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, NimazDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.zakatDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun entity(
+        id: Long = 0,
+        calculatedAt: Long = 1000,
+        zakatDue: Double = 250.0,
+        isPaid: Boolean = false,
+        paidAt: Long? = null
+    ) = ZakatHistoryEntity(
+        id = id, calculatedAt = calculatedAt, totalAssets = 10_000.0,
+        totalLiabilities = 0.0, netWorth = 10_000.0, zakatDue = zakatDue,
+        nisabType = "GOLD", nisabValue = 5_686.2, isPaid = isPaid, paidAt = paidAt
+    )
+
+    @Test
+    fun `insert returns a row id and the row is retrievable`() = runTest {
+        val id = dao.insertCalculation(entity())
+        assertThat(id).isGreaterThan(0L)
+
+        val all = dao.getAllHistorySync()
+        assertThat(all).hasSize(1)
+        assertThat(all.first().id).isEqualTo(id)
+        assertThat(all.first().zakatDue).isWithin(1e-9).of(250.0)
+    }
+
+    @Test
+    fun `getAllHistory is ordered by calculatedAt descending`() = runTest {
+        dao.insertCalculation(entity(calculatedAt = 1000))
+        dao.insertCalculation(entity(calculatedAt = 3000))
+        dao.insertCalculation(entity(calculatedAt = 2000))
+
+        val ordered = dao.getAllHistory().first()
+        assertThat(ordered.map { it.calculatedAt }).containsExactly(3000L, 2000L, 1000L).inOrder()
+    }
+
+    @Test
+    fun `getTotalPaid is null when nothing is paid and sums only paid rows`() = runTest {
+        dao.insertCalculation(entity(zakatDue = 100.0, isPaid = false))
+        dao.insertCalculation(entity(zakatDue = 200.0, isPaid = false))
+
+        // SUM() over zero matching rows returns NULL.
+        assertThat(dao.getTotalPaid()).isNull()
+
+        val paidId = dao.insertCalculation(entity(zakatDue = 50.0, isPaid = false))
+        dao.markAsPaid(paidId, paidAt = 9999)
+
+        assertThat(dao.getTotalPaid()).isWithin(1e-9).of(50.0)
+    }
+
+    @Test
+    fun `markAsPaid flips the paid flag and stamps paidAt`() = runTest {
+        val id = dao.insertCalculation(entity(isPaid = false))
+
+        dao.markAsPaid(id, paidAt = 12345)
+
+        val row = dao.getAllHistorySync().first { it.id == id }
+        assertThat(row.isPaid).isTrue()
+        assertThat(row.paidAt).isEqualTo(12345)
+    }
+
+    @Test
+    fun `deleteCalculation removes only the targeted row`() = runTest {
+        val keep = dao.insertCalculation(entity(calculatedAt = 1000))
+        val remove = dao.insertCalculation(entity(calculatedAt = 2000))
+
+        dao.deleteCalculation(remove)
+
+        val ids = dao.getAllHistorySync().map { it.id }
+        assertThat(ids).containsExactly(keep)
+    }
+
+    @Test
+    fun `insertCalculations replaces rows on primary key conflict`() = runTest {
+        val id = dao.insertCalculation(entity(zakatDue = 100.0))
+
+        // Same id, different value -> REPLACE strategy overwrites.
+        dao.insertCalculations(listOf(entity(id = id, zakatDue = 999.0)))
+
+        val all = dao.getAllHistorySync()
+        assertThat(all).hasSize(1)
+        assertThat(all.first().zakatDue).isWithin(1e-9).of(999.0)
+    }
+
+    @Test
+    fun `deleteAllUserData clears the table`() = runTest {
+        dao.insertCalculation(entity(calculatedAt = 1000))
+        dao.insertCalculation(entity(calculatedAt = 2000))
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllHistorySync()).isEmpty()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImplTest.kt
@@ -169,7 +169,7 @@ class PrayerRepositoryImplTest {
             )
         }
         coVerify(exactly = 0) {
-            prayerDao.updatePrayerStatus(any(), any(), any(), any(), any())
+            prayerDao.updatePrayerStatus(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -181,8 +181,10 @@ class PrayerRepositoryImplTest {
             todayEpoch, PrayerName.FAJR, PrayerStatus.LATE, prayedAt = 1600, isJamaah = false
         )
 
+        // The DAO method has a trailing `timestamp: Long = now()` default param,
+        // so match it with any() rather than a fixed value.
         coVerify {
-            prayerDao.updatePrayerStatus(todayEpoch, "fajr", "late", 1600, false)
+            prayerDao.updatePrayerStatus(todayEpoch, "fajr", "late", 1600L, false, any())
         }
         coVerify(exactly = 0) { prayerDao.insertPrayerRecord(any()) }
     }

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImplTest.kt
@@ -1,0 +1,228 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.data.local.database.dao.LocationDao
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.data.local.database.entity.PrayerRecordEntity
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Unit tests for [PrayerRepositoryImpl]. The DAOs are mocked (matching the
+ * style of [FastingRepositoryImplTest]) so the focus is on the repository's
+ * own logic: the perfect-day streak algorithm, entity<->domain mapping, the
+ * lowercase status/name conventions, and the create-vs-update branch in
+ * updatePrayerStatus.
+ */
+class PrayerRepositoryImplTest {
+
+    private lateinit var prayerDao: PrayerDao
+    private lateinit var locationDao: LocationDao
+    private lateinit var calculator: PrayerTimeCalculator
+    private lateinit var repository: PrayerRepositoryImpl
+
+    private val oneDay = 86_400_000L
+    private val todayEpoch =
+        LocalDate.now().atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+
+    @Before
+    fun setUp() {
+        prayerDao = mockk(relaxed = true)
+        locationDao = mockk(relaxed = true)
+        calculator = mockk(relaxed = true)
+        repository = PrayerRepositoryImpl(prayerDao, locationDao, calculator)
+    }
+
+    private fun entity(
+        id: Long = 1,
+        date: Long = todayEpoch,
+        prayerName: String = "fajr",
+        status: String = "prayed",
+        prayedAt: Long? = 1500,
+        isJamaah: Boolean = false
+    ) = PrayerRecordEntity(
+        id = id, date = date, prayerName = prayerName, status = status,
+        prayedAt = prayedAt, scheduledTime = date, isJamaah = isJamaah,
+        isQadaFor = null, note = null, createdAt = 100, updatedAt = 200
+    )
+
+    // ── Streak algorithm ────────────────────────────────────────────
+
+    @Test
+    fun `current streak counts consecutive perfect days ending today`() = runTest {
+        coEvery { prayerDao.getPerfectDays() } returns
+            listOf(todayEpoch, todayEpoch - oneDay, todayEpoch - 2 * oneDay)
+
+        assertThat(repository.getCurrentStreak(todayEpoch)).isEqualTo(3)
+    }
+
+    @Test
+    fun `current streak anchors to yesterday when today is not yet perfect`() = runTest {
+        coEvery { prayerDao.getPerfectDays() } returns
+            listOf(todayEpoch - oneDay, todayEpoch - 2 * oneDay)
+
+        assertThat(repository.getCurrentStreak(todayEpoch)).isEqualTo(2)
+    }
+
+    @Test
+    fun `current streak is zero when neither today nor yesterday is perfect`() = runTest {
+        coEvery { prayerDao.getPerfectDays() } returns
+            listOf(todayEpoch - 3 * oneDay, todayEpoch - 4 * oneDay)
+
+        assertThat(repository.getCurrentStreak(todayEpoch)).isEqualTo(0)
+    }
+
+    @Test
+    fun `longest streak finds the longest consecutive run regardless of recency`() = runTest {
+        val base = todayEpoch - 100 * oneDay
+        coEvery { prayerDao.getPerfectDays() } returns listOf(
+            base, base + oneDay, base + 2 * oneDay,          // run of 3
+            base + 10 * oneDay, base + 11 * oneDay           // run of 2
+        )
+
+        assertThat(repository.getLongestStreak()).isEqualTo(3)
+    }
+
+    @Test
+    fun `empty perfect-day history yields zero streaks`() = runTest {
+        coEvery { prayerDao.getPerfectDays() } returns emptyList()
+
+        assertThat(repository.getCurrentStreak(todayEpoch)).isEqualTo(0)
+        assertThat(repository.getLongestStreak()).isEqualTo(0)
+    }
+
+    // ── Entity <-> domain mapping ───────────────────────────────────
+
+    @Test
+    fun `records for a date are mapped from entities to domain models`() = runTest {
+        every { prayerDao.getPrayerRecordsForDate(todayEpoch) } returns
+            flowOf(listOf(entity(prayerName = "isha", status = "missed", prayedAt = null)))
+
+        val records = repository.getPrayerRecordsForDate(todayEpoch).first()
+
+        assertThat(records).hasSize(1)
+        assertThat(records.first().prayerName).isEqualTo(PrayerName.ISHA)
+        assertThat(records.first().status).isEqualTo(PrayerStatus.MISSED)
+        assertThat(records.first().prayedAt).isNull()
+    }
+
+    @Test
+    fun `getPrayerRecord lowercases the prayer name for the query`() = runTest {
+        coEvery { prayerDao.getPrayerRecord(todayEpoch, "dhuhr") } returns
+            entity(prayerName = "dhuhr", status = "prayed")
+
+        val record = repository.getPrayerRecord(todayEpoch, PrayerName.DHUHR)
+
+        assertThat(record).isNotNull()
+        assertThat(record!!.prayerName).isEqualTo(PrayerName.DHUHR)
+        coVerify { prayerDao.getPrayerRecord(todayEpoch, "dhuhr") }
+    }
+
+    @Test
+    fun `today's records are exposed as a name-to-status map`() = runTest {
+        every { prayerDao.getPrayerRecordsForDate(any()) } returns flowOf(
+            listOf(
+                entity(prayerName = "fajr", status = "prayed"),
+                entity(prayerName = "asr", status = "missed")
+            )
+        )
+
+        val map = repository.getTodayPrayerRecords().first()
+
+        assertThat(map[PrayerName.FAJR]).isEqualTo(PrayerStatus.PRAYED)
+        assertThat(map[PrayerName.ASR]).isEqualTo(PrayerStatus.MISSED)
+    }
+
+    // ── updatePrayerStatus create-vs-update branch ──────────────────
+
+    @Test
+    fun `updatePrayerStatus inserts a new lowercase record when none exists`() = runTest {
+        coEvery { prayerDao.getPrayerRecord(todayEpoch, "maghrib") } returns null
+
+        repository.updatePrayerStatus(
+            todayEpoch, PrayerName.MAGHRIB, PrayerStatus.PRAYED, prayedAt = 1700, isJamaah = true
+        )
+
+        coVerify {
+            prayerDao.insertPrayerRecord(
+                match {
+                    it.id == 0L &&
+                        it.prayerName == "maghrib" &&
+                        it.status == "prayed" &&
+                        it.prayedAt == 1700L &&
+                        it.isJamaah &&
+                        it.scheduledTime == todayEpoch
+                }
+            )
+        }
+        coVerify(exactly = 0) {
+            prayerDao.updatePrayerStatus(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `updatePrayerStatus updates in place when a record already exists`() = runTest {
+        coEvery { prayerDao.getPrayerRecord(todayEpoch, "fajr") } returns entity()
+
+        repository.updatePrayerStatus(
+            todayEpoch, PrayerName.FAJR, PrayerStatus.LATE, prayedAt = 1600, isJamaah = false
+        )
+
+        coVerify {
+            prayerDao.updatePrayerStatus(todayEpoch, "fajr", "late", 1600, false)
+        }
+        coVerify(exactly = 0) { prayerDao.insertPrayerRecord(any()) }
+    }
+
+    @Test
+    fun `inserting a record lowercases name and status for storage`() = runTest {
+        val record = PrayerRecord(
+            id = 0, date = todayEpoch, prayerName = PrayerName.ISHA,
+            status = PrayerStatus.PRAYED, prayedAt = 1500, scheduledTime = todayEpoch,
+            isJamaah = true, isQadaFor = null, note = null, createdAt = 100, updatedAt = 200
+        )
+
+        repository.insertPrayerRecord(record)
+
+        coVerify {
+            prayerDao.insertPrayerRecord(
+                match { it.prayerName == "isha" && it.status == "prayed" && it.isJamaah }
+            )
+        }
+    }
+
+    // ── Stats aggregation ───────────────────────────────────────────
+
+    @Test
+    fun `prayer stats echo scalar counts and the queried date range`() = runTest {
+        coEvery { prayerDao.getPrayedCountInRange(any(), any()) } returns 10
+        coEvery { prayerDao.getMissedCountInRange(any(), any()) } returns 2
+        coEvery { prayerDao.getJamaahCountInRange(any(), any()) } returns 4
+        coEvery { prayerDao.getPerfectDaysCount(any(), any()) } returns 3
+        coEvery { prayerDao.getPerfectDays() } returns emptyList()
+
+        val stats = repository.getPrayerStats(startDate = 1000, endDate = 5000)
+
+        assertThat(stats.totalPrayed).isEqualTo(10)
+        assertThat(stats.totalMissed).isEqualTo(2)
+        assertThat(stats.totalJamaah).isEqualTo(4)
+        assertThat(stats.perfectDays).isEqualTo(3)
+        assertThat(stats.startDate).isEqualTo(1000)
+        assertThat(stats.endDate).isEqualTo(5000)
+        assertThat(stats.currentStreak).isEqualTo(0)
+        assertThat(stats.longestStreak).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImplTest.kt
@@ -1,0 +1,75 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [ZakatRepositoryImpl]. Mostly thin DAO delegation; the one
+ * piece of real logic is [ZakatRepositoryImpl.getTotalPaid] coalescing the
+ * DAO's nullable SUM() result to 0.0 (the SUM is null when no rows are paid).
+ */
+class ZakatRepositoryImplTest {
+
+    private lateinit var dao: ZakatDao
+    private lateinit var repository: ZakatRepositoryImpl
+
+    private fun historyEntity(id: Long = 1) = ZakatHistoryEntity(
+        id = id, calculatedAt = 1000, totalAssets = 10_000.0, totalLiabilities = 0.0,
+        netWorth = 10_000.0, zakatDue = 250.0, nisabType = "GOLD", nisabValue = 5_686.2
+    )
+
+    @Before
+    fun setUp() {
+        dao = mockk(relaxed = true)
+        repository = ZakatRepositoryImpl(dao)
+    }
+
+    @Test
+    fun `getAllHistory delegates to the dao flow`() = runTest {
+        val entities = listOf(historyEntity(1), historyEntity(2))
+        every { dao.getAllHistory() } returns flowOf(entities)
+
+        assertThat(repository.getAllHistory().first()).isEqualTo(entities)
+    }
+
+    @Test
+    fun `insertCalculation returns the new row id from the dao`() = runTest {
+        val entity = historyEntity()
+        coEvery { dao.insertCalculation(entity) } returns 42L
+
+        assertThat(repository.insertCalculation(entity)).isEqualTo(42L)
+        coVerify { dao.insertCalculation(entity) }
+    }
+
+    @Test
+    fun `getTotalPaid returns the dao sum when present`() = runTest {
+        coEvery { dao.getTotalPaid() } returns 250.0
+        assertThat(repository.getTotalPaid()).isWithin(1e-9).of(250.0)
+    }
+
+    @Test
+    fun `getTotalPaid coalesces a null dao sum to zero`() = runTest {
+        // SUM() returns null when there are no paid rows.
+        coEvery { dao.getTotalPaid() } returns null
+        assertThat(repository.getTotalPaid()).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `markAsPaid and deleteCalculation delegate to the dao`() = runTest {
+        repository.markAsPaid(5L, 9999L)
+        repository.deleteCalculation(7L)
+
+        coVerify { dao.markAsPaid(5L, 9999L) }
+        coVerify { dao.deleteCalculation(7L) }
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/sync/SyncPayloadSerializationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/sync/SyncPayloadSerializationTest.kt
@@ -1,0 +1,191 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Serialization round-trip tests for [SyncPayload] — the contract for
+ * device-to-device data transfer. If a field stops serializing or the schema
+ * drifts, user data (prayers, fasting, Quran progress, tasbih, khatam,
+ * tafseer, zakat, preferences) is silently lost or corrupted on transfer.
+ *
+ * Uses the same `Json { ignoreUnknownKeys = true }` configuration as the
+ * production encode/decode path in SyncViewModel.
+ */
+class SyncPayloadSerializationTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun roundTrip(payload: SyncPayload): SyncPayload {
+        val encoded = json.encodeToString(SyncPayload.serializer(), payload)
+        return json.decodeFromString(SyncPayload.serializer(), encoded)
+    }
+
+    /** A payload with every collection populated and all nullable fields set. */
+    private fun fullyPopulatedPayload() = SyncPayload(
+        exportedAt = 111L,
+        appVersion = 11,
+        bookmarks = listOf(
+            SyncBookmark(
+                id = 1, ayahId = 10, surahNumber = 2, ayahNumber = 5,
+                note = "a note", color = "#FFAABB", createdAt = 100, updatedAt = 200
+            )
+        ),
+        favorites = listOf(
+            SyncFavorite(ayahId = 10, surahNumber = 2, ayahNumber = 5, createdAt = 100, updatedAt = 200)
+        ),
+        readingProgress = SyncReadingProgress(
+            lastReadSurah = 2, lastReadAyah = 5, lastReadPage = 3, lastReadJuz = 1,
+            totalAyahsRead = 500, currentKhatmaCount = 2, updatedAt = 200
+        ),
+        prayerRecords = listOf(
+            SyncPrayerRecord(
+                id = 1, date = 1000, prayerName = "FAJR", status = "PRAYED",
+                prayedAt = 1500, scheduledTime = 900, isJamaah = true,
+                isQadaFor = 42, note = "n", createdAt = 100, updatedAt = 200
+            )
+        ),
+        fastRecords = listOf(
+            SyncFastRecord(
+                id = 1, date = 1000, hijriDate = "1/9/1446", hijriMonth = 9, hijriYear = 1446,
+                fastType = "RAMADAN", status = "FASTED", exemptionReason = "TRAVEL",
+                suhoorTime = 800, iftarTime = 1900, note = "n", createdAt = 100, updatedAt = 200
+            )
+        ),
+        makeupFasts = listOf(
+            SyncMakeupFast(
+                id = 1, originalDate = 1000, originalHijriDate = "1/9/1446", reason = "Travel",
+                status = "PENDING", completedDate = 5000, fidyaAmount = 12.5,
+                note = "n", createdAt = 100, updatedAt = 200
+            )
+        ),
+        tasbihPresets = listOf(
+            SyncTasbihPreset(
+                id = 1, name = "SubhanAllah", arabic = "ar", transliteration = "tr",
+                translation = "tn", targetCount = 33, isCustom = 1, displayOrder = 0, updatedAt = 200
+            )
+        ),
+        tasbihSessions = listOf(
+            SyncTasbihSession(
+                id = 1, presetId = 2, presetName = "SubhanAllah", date = 1000,
+                currentCount = 33, targetCount = 33, totalLaps = 1, isCompleted = true,
+                duration = 5000, startedAt = 100, completedAt = 300, note = "n", updatedAt = 400
+            )
+        ),
+        khatams = listOf(
+            SyncKhatam(
+                id = 1, name = "Ramadan Khatam", notes = "notes", status = "ACTIVE",
+                isActive = true, dailyTarget = 20, deadline = 9999, reminderEnabled = true,
+                reminderTime = "06:00", totalAyahsRead = 100, createdAt = 100,
+                startedAt = 150, completedAt = null, updatedAt = 200
+            )
+        ),
+        khatamAyahs = listOf(SyncKhatamAyah(khatamId = 1, ayahId = 5, readAt = 150, updatedAt = 200)),
+        khatamDailyLogs = listOf(SyncKhatamDailyLog(khatamId = 1, date = 1000, ayahsRead = 20, updatedAt = 200)),
+        tafseerHighlights = listOf(
+            SyncTafseerHighlight(
+                id = 1, ayahId = 5, tafseerId = "ibnkathir", startOffset = 0, endOffset = 10,
+                color = "#FF0000", note = "n", createdAt = 100, updatedAt = 200
+            )
+        ),
+        tafseerNotes = listOf(
+            SyncTafseerNote(
+                id = 1, ayahId = 5, tafseerId = "ibnkathir", text = "my note",
+                createdAt = 100, updatedAt = 200
+            )
+        ),
+        zakatHistory = listOf(
+            SyncZakatHistory(
+                id = 1, calculatedAt = 1000, totalAssets = 10_000.0, totalLiabilities = 2_000.0,
+                netWorth = 8_000.0, zakatDue = 200.0, nisabType = "GOLD", nisabValue = 5_686.2,
+                isPaid = false, paidAt = null, notes = "n", updatedAt = 200
+            )
+        ),
+        preferences = mapOf("calc_method" to "MWL", "theme" to "dark")
+    )
+
+    // ── Round-trips ─────────────────────────────────────────────────
+
+    @Test
+    fun `a fully populated payload survives an encode-decode round-trip`() {
+        val original = fullyPopulatedPayload()
+        assertThat(roundTrip(original)).isEqualTo(original)
+    }
+
+    @Test
+    fun `nullable fields preserve their null values through a round-trip`() {
+        val original = fullyPopulatedPayload().copy(
+            readingProgress = null,
+            bookmarks = listOf(
+                SyncBookmark(
+                    id = 1, ayahId = 10, surahNumber = 2, ayahNumber = 5,
+                    note = null, color = null, createdAt = 100, updatedAt = 200
+                )
+            ),
+            prayerRecords = listOf(
+                SyncPrayerRecord(
+                    id = 1, date = 1000, prayerName = "FAJR", status = "MISSED",
+                    prayedAt = null, scheduledTime = 900, isJamaah = false,
+                    isQadaFor = null, note = null, createdAt = 100, updatedAt = 200
+                )
+            )
+        )
+        val decoded = roundTrip(original)
+        assertThat(decoded).isEqualTo(original)
+        assertThat(decoded.readingProgress).isNull()
+        assertThat(decoded.bookmarks.first().note).isNull()
+        assertThat(decoded.prayerRecords.first().prayedAt).isNull()
+    }
+
+    @Test
+    fun `an empty default payload round-trips to an equal payload`() {
+        val original = SyncPayload(exportedAt = 0L)
+        val decoded = roundTrip(original)
+        assertThat(decoded).isEqualTo(original)
+        assertThat(decoded.bookmarks).isEmpty()
+        assertThat(decoded.preferences).isEmpty()
+    }
+
+    @Test
+    fun `preferences map content is preserved exactly`() {
+        val prefs = mapOf("a" to "1", "b" to "two", "empty" to "")
+        val decoded = roundTrip(SyncPayload(exportedAt = 0L, preferences = prefs))
+        assertThat(decoded.preferences).containsExactlyEntriesIn(prefs)
+    }
+
+    // ── Forward / backward compatibility ────────────────────────────
+
+    @Test
+    fun `decoding tolerates unknown future fields`() {
+        // A payload written by a newer app version may carry fields this
+        // version doesn't know about; ignoreUnknownKeys must skip them.
+        val futureJson = """{"appVersion":42,"unknownFutureField":"x","bookmarks":[]}"""
+        val decoded = json.decodeFromString(SyncPayload.serializer(), futureJson)
+        assertThat(decoded.appVersion).isEqualTo(42)
+        assertThat(decoded.bookmarks).isEmpty()
+    }
+
+    @Test
+    fun `decoding a minimal payload fills every collection with defaults`() {
+        // An older payload that omits newer sections must still decode, with
+        // the missing sections defaulting to empty rather than failing.
+        val decoded = json.decodeFromString(SyncPayload.serializer(), "{}")
+        assertThat(decoded.appVersion).isEqualTo(0)
+        assertThat(decoded.bookmarks).isEmpty()
+        assertThat(decoded.favorites).isEmpty()
+        assertThat(decoded.readingProgress).isNull()
+        assertThat(decoded.prayerRecords).isEmpty()
+        assertThat(decoded.fastRecords).isEmpty()
+        assertThat(decoded.makeupFasts).isEmpty()
+        assertThat(decoded.tasbihPresets).isEmpty()
+        assertThat(decoded.tasbihSessions).isEmpty()
+        assertThat(decoded.khatams).isEmpty()
+        assertThat(decoded.khatamAyahs).isEmpty()
+        assertThat(decoded.khatamDailyLogs).isEmpty()
+        assertThat(decoded.tafseerHighlights).isEmpty()
+        assertThat(decoded.tafseerNotes).isEmpty()
+        assertThat(decoded.zakatHistory).isEmpty()
+        assertThat(decoded.preferences).isEmpty()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/KhatamModelsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/KhatamModelsTest.kt
@@ -1,0 +1,103 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for the Khatam (Quran completion) progress models: progress
+ * percentages with division-by-zero guards, status parsing, and the juz
+ * boundary table that underpins all per-juz progress reporting.
+ */
+class KhatamModelsTest {
+
+    // ── Khatam.progressPercent ──────────────────────────────────────
+
+    @Test
+    fun `khatam progress is zero when nothing has been read`() {
+        val khatam = Khatam(name = "Test", totalAyahsRead = 0)
+        assertThat(khatam.progressPercent).isWithin(1e-6f).of(0f)
+    }
+
+    @Test
+    fun `khatam progress is one when the whole quran has been read`() {
+        val khatam = Khatam(name = "Test", totalAyahsRead = Khatam.TOTAL_QURAN_AYAHS)
+        assertThat(khatam.progressPercent).isWithin(1e-6f).of(1f)
+    }
+
+    @Test
+    fun `khatam progress is the read fraction of total ayahs`() {
+        val khatam = Khatam(name = "Test", totalAyahsRead = 3118) // half of 6236
+        assertThat(khatam.progressPercent).isWithin(1e-4f).of(0.5f)
+    }
+
+    // ── KhatamStatus parsing ────────────────────────────────────────
+
+    @Test
+    fun `khatam status parses known values case-insensitively`() {
+        assertThat(KhatamStatus.fromString("completed")).isEqualTo(KhatamStatus.COMPLETED)
+        assertThat(KhatamStatus.fromString("ABANDONED")).isEqualTo(KhatamStatus.ABANDONED)
+        assertThat(KhatamStatus.fromString("Active")).isEqualTo(KhatamStatus.ACTIVE)
+    }
+
+    @Test
+    fun `khatam status defaults to active for unknown values`() {
+        assertThat(KhatamStatus.fromString("")).isEqualTo(KhatamStatus.ACTIVE)
+        assertThat(KhatamStatus.fromString("garbage")).isEqualTo(KhatamStatus.ACTIVE)
+    }
+
+    @Test
+    fun `khatam status round-trips through its db string`() {
+        for (status in KhatamStatus.values()) {
+            assertThat(KhatamStatus.fromString(status.toDbString())).isEqualTo(status)
+        }
+    }
+
+    // ── Per-juz / per-surah progress guards ─────────────────────────
+
+    @Test
+    fun `juz progress percent is the read fraction`() {
+        val info = JuzProgressInfo(juzNumber = 1, totalAyahs = 148, readAyahs = 74)
+        assertThat(info.progressPercent).isWithin(1e-4f).of(0.5f)
+    }
+
+    @Test
+    fun `juz progress percent is zero when total ayahs is zero`() {
+        val info = JuzProgressInfo(juzNumber = 1, totalAyahs = 0, readAyahs = 0)
+        assertThat(info.progressPercent).isEqualTo(0f)
+    }
+
+    @Test
+    fun `surah progress percent is zero when total ayahs is zero`() {
+        val info = SurahProgressInfo(
+            surahNumber = 1, surahName = "Al-Fatiha", totalAyahs = 0, readAyahs = 0
+        )
+        assertThat(info.progressPercent).isEqualTo(0f)
+    }
+
+    // ── Juz boundary table integrity ────────────────────────────────
+
+    @Test
+    fun `there are exactly thirty juz ranges`() {
+        assertThat(KhatamConstants.JUZ_AYAH_RANGES).hasSize(30)
+    }
+
+    @Test
+    fun `juz ranges are contiguous and cover all 6236 ayahs without gaps`() {
+        val ranges = KhatamConstants.JUZ_AYAH_RANGES
+        assertThat(ranges.first().first).isEqualTo(1)
+        assertThat(ranges.last().second).isEqualTo(Khatam.TOTAL_QURAN_AYAHS)
+
+        var coveredAyahs = 0
+        for (i in ranges.indices) {
+            val (start, end) = ranges[i]
+            // Each range must be non-empty and well-ordered.
+            assertThat(end).isAtLeast(start)
+            coveredAyahs += (end - start + 1)
+            // Each range must begin exactly one ayah after the previous one ends.
+            if (i > 0) {
+                assertThat(start).isEqualTo(ranges[i - 1].second + 1)
+            }
+        }
+        assertThat(coveredAyahs).isEqualTo(Khatam.TOTAL_QURAN_AYAHS)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/QiblaCalculatorTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/QiblaCalculatorTest.kt
@@ -1,0 +1,106 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [QiblaCalculator] — great-circle bearing and distance to the
+ * Kaaba plus the compass-rotation helpers. The expected bearings below are the
+ * well-known Qibla directions for major cities; the distance assertions use a
+ * deterministic one-degree offset so the haversine result can be checked
+ * against the analytic value (≈111.19 km per degree of latitude).
+ */
+class QiblaCalculatorTest {
+
+    private val kaabaLat = 21.4225
+    private val kaabaLon = 39.8262
+
+    // ── Bearing ─────────────────────────────────────────────────────
+
+    @Test
+    fun `bearing from London points roughly south-east toward Mecca`() {
+        val direction = QiblaCalculator.calculateQiblaDirection(51.5074, -0.1278)
+        assertThat(direction.bearing).isWithin(1.0).of(119.0)
+    }
+
+    @Test
+    fun `bearing from New York points roughly north-east toward Mecca`() {
+        val direction = QiblaCalculator.calculateQiblaDirection(40.7128, -74.0060)
+        assertThat(direction.bearing).isWithin(1.5).of(58.5)
+    }
+
+    @Test
+    fun `bearing is always normalized to the 0 to 360 range`() {
+        // A southern-hemisphere, eastern location (Jakarta) exercises the
+        // (bearing + 360) % 360 normalization.
+        val direction = QiblaCalculator.calculateQiblaDirection(-6.2088, 106.8456)
+        assertThat(direction.bearing).isAtLeast(0.0)
+        assertThat(direction.bearing).isLessThan(360.0)
+    }
+
+    @Test
+    fun `bearing and distance are near zero at the Kaaba itself`() {
+        val direction = QiblaCalculator.calculateQiblaDirection(kaabaLat, kaabaLon)
+        assertThat(direction.distance).isWithin(1e-6).of(0.0)
+        assertThat(direction.bearing).isWithin(1e-6).of(0.0)
+    }
+
+    // ── Distance ────────────────────────────────────────────────────
+
+    @Test
+    fun `distance for a one-degree latitude offset matches the analytic value`() {
+        // One degree of latitude along the same meridian ≈ π/180 * 6371 km.
+        val expectedKm = Math.toRadians(1.0) * 6371.0
+        val direction = QiblaCalculator.calculateQiblaDirection(kaabaLat + 1.0, kaabaLon)
+        assertThat(direction.distance).isWithin(0.5).of(expectedKm)
+    }
+
+    @Test
+    fun `calculateDistanceToMecca returns the same value in meters`() {
+        val lat = kaabaLat + 1.0
+        val lon = kaabaLon
+        val km = QiblaCalculator.calculateQiblaDirection(lat, lon).distance
+        val meters = QiblaCalculator.calculateDistanceToMecca(lat, lon)
+        assertThat(meters).isWithin(1e-3).of(km * 1000.0)
+    }
+
+    // ── Qibla rotation angle ────────────────────────────────────────
+
+    @Test
+    fun `qibla angle is zero when heading already faces the bearing`() {
+        assertThat(QiblaCalculator.calculateQiblaAngle(119f, 119.0)).isWithin(1e-4f).of(0f)
+    }
+
+    @Test
+    fun `qibla angle equals the bearing when heading is north`() {
+        assertThat(QiblaCalculator.calculateQiblaAngle(0f, 119.0)).isWithin(1e-4f).of(119f)
+    }
+
+    @Test
+    fun `qibla angle wraps into 0 to 360 for negative differences`() {
+        // 10 - 350 = -340 -> +360 = 20
+        assertThat(QiblaCalculator.calculateQiblaAngle(350f, 10.0)).isWithin(1e-4f).of(20f)
+    }
+
+    // ── Cardinal direction buckets ──────────────────────────────────
+
+    @Test
+    fun `cardinal direction maps the eight compass octants`() {
+        assertThat(QiblaCalculator.getCardinalDirection(0.0)).isEqualTo("N")
+        assertThat(QiblaCalculator.getCardinalDirection(45.0)).isEqualTo("NE")
+        assertThat(QiblaCalculator.getCardinalDirection(90.0)).isEqualTo("E")
+        assertThat(QiblaCalculator.getCardinalDirection(135.0)).isEqualTo("SE")
+        assertThat(QiblaCalculator.getCardinalDirection(180.0)).isEqualTo("S")
+        assertThat(QiblaCalculator.getCardinalDirection(225.0)).isEqualTo("SW")
+        assertThat(QiblaCalculator.getCardinalDirection(270.0)).isEqualTo("W")
+        assertThat(QiblaCalculator.getCardinalDirection(315.0)).isEqualTo("NW")
+    }
+
+    @Test
+    fun `cardinal direction wraps around north at the 337_5 boundary`() {
+        assertThat(QiblaCalculator.getCardinalDirection(337.5)).isEqualTo("N")
+        assertThat(QiblaCalculator.getCardinalDirection(359.9)).isEqualTo("N")
+        assertThat(QiblaCalculator.getCardinalDirection(22.4)).isEqualTo("N")
+        assertThat(QiblaCalculator.getCardinalDirection(22.5)).isEqualTo("NE")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/ZakatCalculatorTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/ZakatCalculatorTest.kt
@@ -1,0 +1,144 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [ZakatCalculator] — the pure wealth-calculation logic that
+ * determines how much Zakat a user owes. Bugs here produce religiously
+ * significant wrong answers, so the nisab thresholds, the 2.5% rate and the
+ * asset/liability netting are all pinned down explicitly.
+ */
+class ZakatCalculatorTest {
+
+    private val noLiabilities = ZakatLiabilities()
+
+    // ── Nisab value derivation ──────────────────────────────────────
+
+    @Test
+    fun `gold nisab value is 87_48 grams times metal price`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 10_000.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 70.0,
+            currency = "USD"
+        )
+        assertThat(result.nisabValue).isWithin(1e-9).of(87.48 * 70.0)
+    }
+
+    @Test
+    fun `silver nisab value is 612_36 grams times metal price`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 10_000.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.SILVER,
+            metalPricePerGram = 0.8,
+            currency = "USD"
+        )
+        assertThat(result.nisabValue).isWithin(1e-9).of(612.36 * 0.8)
+    }
+
+    // ── Zakat due (2.5% of net worth above nisab) ───────────────────
+
+    @Test
+    fun `zakat due is 2_5 percent of net worth when above nisab`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 10_000.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 70.0, // nisab = 6123.6, below 10000
+            currency = "USD"
+        )
+        assertThat(result.isAboveNisab).isTrue()
+        assertThat(result.zakatDue).isWithin(1e-9).of(10_000.0 * 0.025)
+        assertThat(result.zakatableAmount).isWithin(1e-9).of(10_000.0)
+    }
+
+    @Test
+    fun `no zakat is due when net worth is below nisab`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 5_000.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 70.0, // nisab = 6123.6, above 5000
+            currency = "USD"
+        )
+        assertThat(result.isAboveNisab).isFalse()
+        assertThat(result.zakatDue).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `net worth exactly equal to nisab is above threshold and owes zakat`() {
+        // nisab = 87.48 * 100 = 8748, net worth = 8748 exactly
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 8_748.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 100.0,
+            currency = "USD"
+        )
+        assertThat(result.isAboveNisab).isTrue()
+        assertThat(result.zakatDue).isWithin(1e-9).of(8_748.0 * 0.025)
+    }
+
+    // ── Asset / liability netting ───────────────────────────────────
+
+    @Test
+    fun `liabilities are subtracted from assets to get net worth`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 10_000.0, bankBalance = 5_000.0),
+            liabilities = ZakatLiabilities(debts = 3_000.0, loans = 2_000.0),
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 70.0,
+            currency = "USD"
+        )
+        assertThat(result.totalAssets).isWithin(1e-9).of(15_000.0)
+        assertThat(result.totalLiabilities).isWithin(1e-9).of(5_000.0)
+        assertThat(result.netWorth).isWithin(1e-9).of(10_000.0)
+    }
+
+    @Test
+    fun `net worth is clamped to zero when liabilities exceed assets`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 1_000.0),
+            liabilities = ZakatLiabilities(debts = 3_000.0),
+            nisabType = NisabType.GOLD,
+            metalPricePerGram = 70.0,
+            currency = "USD"
+        )
+        assertThat(result.netWorth).isEqualTo(0.0)
+        assertThat(result.isAboveNisab).isFalse()
+        assertThat(result.zakatDue).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `metal grams are excluded from the cash-style asset total`() {
+        // ZakatAssets.total intentionally omits goldGrams / silverGrams because
+        // they must be converted to value separately.
+        val assets = ZakatAssets(goldGrams = 100.0, silverGrams = 500.0)
+        assertThat(assets.total).isEqualTo(0.0)
+    }
+
+    // ── Pass-through metadata ───────────────────────────────────────
+
+    @Test
+    fun `currency and nisab type are carried through to the result`() {
+        val result = ZakatCalculator.calculate(
+            assets = ZakatAssets(cashOnHand = 10_000.0),
+            liabilities = noLiabilities,
+            nisabType = NisabType.SILVER,
+            metalPricePerGram = 0.8,
+            currency = "GBP"
+        )
+        assertThat(result.currency).isEqualTo("GBP")
+        assertThat(result.nisabType).isEqualTo(NisabType.SILVER)
+    }
+
+    @Test
+    fun `zakat rate constant is 2_5 percent`() {
+        assertThat(ZakatCalculator.ZAKAT_RATE).isEqualTo(0.025)
+        assertThat(ZakatCalculator.GOLD_NISAB_GRAMS).isEqualTo(87.48)
+        assertThat(ZakatCalculator.SILVER_NISAB_GRAMS).isEqualTo(612.36)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/AsmaUlHusnaUseCasesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/AsmaUlHusnaUseCasesTest.kt
@@ -1,0 +1,79 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.repository.AsmaUlHusnaRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the Asma-ul-Husna use cases. Each is a thin delegation onto
+ * [AsmaUlHusnaRepository]; these guard the wiring, in particular that
+ * "favorites" reads from getFavoriteNames() rather than getAllNames() and that
+ * the search query is forwarded unchanged.
+ */
+class AsmaUlHusnaUseCasesTest {
+
+    private lateinit var repository: AsmaUlHusnaRepository
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+    }
+
+    private fun name(id: Int, english: String = "Ar-Rahman", favorite: Boolean = false) =
+        AsmaUlHusna(
+            id = id, number = id, nameArabic = "الرحمن",
+            nameTransliteration = "Ar-Rahman", nameEnglish = english,
+            meaning = "The Most Gracious", explanation = "", benefits = "",
+            quranReferences = emptyList(), usageInDua = "", displayOrder = id,
+            isFavorite = favorite
+        )
+
+    @Test
+    fun `getAllNames exposes the repository flow`() = runTest {
+        val names = listOf(name(1), name(2))
+        every { repository.getAllNames() } returns flowOf(names)
+
+        assertThat(GetAllAsmaUlHusnaUseCase(repository)().first()).isEqualTo(names)
+    }
+
+    @Test
+    fun `getNameById returns the repository value`() = runTest {
+        coEvery { repository.getNameById(1) } returns name(1)
+        assertThat(GetAsmaUlHusnaByIdUseCase(repository)(1)).isEqualTo(name(1))
+    }
+
+    @Test
+    fun `searchNames forwards the query to the repository`() = runTest {
+        val result = listOf(name(1))
+        every { repository.searchNames("rahman") } returns flowOf(result)
+
+        assertThat(SearchAsmaUlHusnaUseCase(repository)("rahman").first()).isEqualTo(result)
+        verify { repository.searchNames("rahman") }
+    }
+
+    @Test
+    fun `toggleFavorite delegates with the name id`() = runTest {
+        ToggleAsmaUlHusnaFavoriteUseCase(repository)(7)
+        coVerify { repository.toggleFavorite(7) }
+    }
+
+    @Test
+    fun `getFavorites reads from getFavoriteNames not getAllNames`() = runTest {
+        val favorites = listOf(name(1, favorite = true))
+        every { repository.getFavoriteNames() } returns flowOf(favorites)
+
+        assertThat(GetFavoriteAsmaUlHusnaUseCase(repository)().first()).isEqualTo(favorites)
+        verify { repository.getFavoriteNames() }
+        verify(exactly = 0) { repository.getAllNames() }
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/KhatamUseCasesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/KhatamUseCasesTest.kt
@@ -1,0 +1,132 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Khatam
+import com.arshadshah.nimaz.domain.model.KhatamStats
+import com.arshadshah.nimaz.domain.repository.KhatamRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the Khatam use cases. Each use case is a thin delegation onto
+ * [KhatamRepository]; these tests guard the wiring (correct repository method,
+ * correct arguments, return value passed straight through) since a mis-wired
+ * use case would silently call the wrong operation.
+ */
+class KhatamUseCasesTest {
+
+    private lateinit var repository: KhatamRepository
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `CreateKhatam passes the khatam through and returns the new id`() = runTest {
+        val khatam = Khatam(name = "Ramadan")
+        coEvery { repository.createKhatam(khatam) } returns 7L
+
+        val id = CreateKhatamUseCase(repository)(khatam)
+
+        assertThat(id).isEqualTo(7L)
+        coVerify { repository.createKhatam(khatam) }
+    }
+
+    @Test
+    fun `GetActiveKhatam returns the repository value`() = runTest {
+        val active = Khatam(id = 3, name = "Active")
+        coEvery { repository.getActiveKhatam() } returns active
+
+        assertThat(GetActiveKhatamUseCase(repository)()).isEqualTo(active)
+    }
+
+    @Test
+    fun `ObserveActiveKhatam exposes the repository flow`() = runTest {
+        val active = Khatam(id = 3, name = "Active")
+        every { repository.observeActiveKhatam() } returns flowOf(active)
+
+        assertThat(ObserveActiveKhatamUseCase(repository)().first()).isEqualTo(active)
+    }
+
+    @Test
+    fun `SetActiveKhatam delegates with the khatam id`() = runTest {
+        SetActiveKhatamUseCase(repository)(11L)
+        coVerify { repository.setActiveKhatam(11L) }
+    }
+
+    @Test
+    fun `MarkAyahsRead forwards the khatam id and ayah ids`() = runTest {
+        val ayahs = listOf(1, 2, 3)
+        MarkAyahsReadUseCase(repository)(5L, ayahs)
+        coVerify { repository.markAyahsRead(5L, ayahs) }
+    }
+
+    @Test
+    fun `GetReadAyahIds returns the repository set`() = runTest {
+        coEvery { repository.getReadAyahIds(5L) } returns setOf(1, 2, 3)
+        assertThat(GetReadAyahIdsUseCase(repository)(5L)).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `UnmarkAyahRead and MarkSurahAsRead delegate with their arguments`() = runTest {
+        UnmarkAyahReadUseCase(repository)(5L, 42)
+        MarkSurahAsReadUseCase(repository)(5L, 2)
+
+        coVerify { repository.unmarkAyahRead(5L, 42) }
+        coVerify { repository.markSurahAsRead(5L, 2) }
+    }
+
+    @Test
+    fun `GetNextUnreadPosition returns the repository pair`() = runTest {
+        coEvery { repository.getNextUnreadPosition(5L) } returns (2 to 5)
+        assertThat(GetNextUnreadPositionUseCase(repository)(5L)).isEqualTo(2 to 5)
+    }
+
+    @Test
+    fun `LogDailyProgress forwards id, date and ayahs read`() = runTest {
+        LogDailyProgressUseCase(repository)(5L, 1000L, 20)
+        coVerify { repository.logDailyProgress(5L, 1000L, 20) }
+    }
+
+    @Test
+    fun `GetKhatamStats returns the repository stats`() = runTest {
+        val stats = KhatamStats(
+            totalKhatamsCompleted = 2, totalKhatamsActive = 1,
+            totalAyahsReadAllTime = 12_472, longestStreak = 30, currentStreak = 5
+        )
+        coEvery { repository.getKhatamStats() } returns stats
+
+        assertThat(GetKhatamStatsUseCase(repository)()).isEqualTo(stats)
+    }
+
+    @Test
+    fun `lifecycle use cases delegate to the matching repository operation`() = runTest {
+        CompleteKhatamUseCase(repository)(1L)
+        AbandonKhatamUseCase(repository)(2L)
+        ReactivateKhatamUseCase(repository)(3L)
+        DeleteKhatamUseCase(repository)(4L)
+
+        coVerify { repository.completeKhatam(1L) }
+        coVerify { repository.abandonKhatam(2L) }
+        coVerify { repository.reactivateKhatam(3L) }
+        coVerify { repository.deleteKhatam(4L) }
+    }
+
+    @Test
+    fun `list observers expose the repository flows`() = runTest {
+        val all = listOf(Khatam(id = 1, name = "A"), Khatam(id = 2, name = "B"))
+        every { repository.observeAllKhatams() } returns flowOf(all)
+        every { repository.observeInProgressKhatams() } returns flowOf(all)
+
+        assertThat(ObserveAllKhatamsUseCase(repository)().first()).isEqualTo(all)
+        assertThat(ObserveInProgressKhatamsUseCase(repository)().first()).isEqualTo(all)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModelTest.kt
@@ -1,0 +1,256 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStats
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Unit tests for [PrayerTrackerViewModel] — the prayer status/stats state
+ * machine. Focuses on the status-transition logic (prayedAt is stamped only
+ * for PRAYED/LATE), the future-day navigation guard, the epoch conversion used
+ * for record lookups, and the qada grouping-by-month aggregation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrayerTrackerViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var repository: PrayerRepository
+    private lateinit var viewModel: PrayerTrackerViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk(relaxed = true)
+
+        // Defaults so init {} (loadCurrentLocation/loadToday/loadStats/loadQada)
+        // completes without touching real infrastructure.
+        every { repository.getCurrentLocation() } returns flowOf(null)
+        every { repository.getPrayerRecordsForDate(any()) } returns flowOf(emptyList())
+        every { repository.getPrayerRecordsInRange(any(), any()) } returns flowOf(emptyList())
+        every { repository.getMissedPrayersRequiringQada() } returns flowOf(emptyList())
+        coEvery { repository.getPrayerStats(any(), any()) } returns emptyStats()
+        coEvery { repository.getCurrentStreak(any()) } returns 0
+        coEvery { repository.getLongestStreak() } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = PrayerTrackerViewModel(repository)
+
+    private fun dateToEpoch(date: LocalDate): Long =
+        date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+
+    private fun emptyStats() = PrayerStats(
+        totalPrayed = 0, totalMissed = 0, totalJamaah = 0,
+        prayedByPrayer = emptyMap(), missedByPrayer = emptyMap(),
+        currentStreak = 0, longestStreak = 0, perfectDays = 0,
+        startDate = 0, endDate = 0
+    )
+
+    private fun prayerRecord(
+        id: Long = 1,
+        date: Long,
+        prayerName: PrayerName = PrayerName.FAJR,
+        status: PrayerStatus = PrayerStatus.MISSED
+    ) = PrayerRecord(
+        id = id, date = date, prayerName = prayerName, status = status,
+        prayedAt = null, scheduledTime = date, isJamaah = false,
+        isQadaFor = null, note = null, createdAt = date, updatedAt = date
+    )
+
+    // ── Initial state ───────────────────────────────────────────────
+
+    @Test
+    fun `initial tracker state selects today and finishes loading`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.trackerState.value
+        assertThat(state.selectedDate).isEqualTo(LocalDate.now())
+        assertThat(state.isLoading).isFalse()
+    }
+
+    // ── Date navigation ─────────────────────────────────────────────
+
+    @Test
+    fun `NavigateToNextDay does not advance past today`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(PrayerTrackerEvent.NavigateToNextDay)
+        advanceUntilIdle()
+
+        assertThat(viewModel.trackerState.value.selectedDate).isEqualTo(LocalDate.now())
+    }
+
+    @Test
+    fun `NavigateToPreviousDay then NavigateToNextDay returns to today`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(PrayerTrackerEvent.NavigateToPreviousDay)
+        advanceUntilIdle()
+        assertThat(viewModel.trackerState.value.selectedDate)
+            .isEqualTo(LocalDate.now().minusDays(1))
+
+        viewModel.onEvent(PrayerTrackerEvent.NavigateToNextDay)
+        advanceUntilIdle()
+        assertThat(viewModel.trackerState.value.selectedDate).isEqualTo(LocalDate.now())
+    }
+
+    @Test
+    fun `SelectDate updates state and loads that date's records`() = runTest {
+        val target = LocalDate.of(2025, 6, 15)
+        val epoch = dateToEpoch(target)
+        every { repository.getPrayerRecordsForDate(epoch) } returns
+            flowOf(listOf(prayerRecord(date = epoch)))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(PrayerTrackerEvent.SelectDate(target))
+        advanceUntilIdle()
+
+        val state = viewModel.trackerState.value
+        assertThat(state.selectedDate).isEqualTo(target)
+        assertThat(state.prayerRecords).hasSize(1)
+        assertThat(state.isLoading).isFalse()
+    }
+
+    // ── Status transitions (prayedAt stamping) ──────────────────────
+
+    @Test
+    fun `MarkPrayerPrayed records PRAYED with a prayedAt timestamp and jamaah flag`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        val todayEpoch = dateToEpoch(LocalDate.now())
+
+        viewModel.onEvent(PrayerTrackerEvent.MarkPrayerPrayed(PrayerName.FAJR, isJamaah = true))
+        advanceUntilIdle()
+
+        coVerify {
+            repository.updatePrayerStatus(
+                todayEpoch, PrayerName.FAJR, PrayerStatus.PRAYED,
+                match { it != null }, true
+            )
+        }
+    }
+
+    @Test
+    fun `MarkPrayerMissed records MISSED with no prayedAt timestamp`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        val todayEpoch = dateToEpoch(LocalDate.now())
+
+        viewModel.onEvent(PrayerTrackerEvent.MarkPrayerMissed(PrayerName.ISHA))
+        advanceUntilIdle()
+
+        coVerify {
+            repository.updatePrayerStatus(
+                todayEpoch, PrayerName.ISHA, PrayerStatus.MISSED, null, false
+            )
+        }
+    }
+
+    @Test
+    fun `UpdatePrayerStatus stamps prayedAt for LATE but not for PENDING`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        val todayEpoch = dateToEpoch(LocalDate.now())
+
+        viewModel.onEvent(
+            PrayerTrackerEvent.UpdatePrayerStatus(PrayerName.DHUHR, PrayerStatus.LATE)
+        )
+        viewModel.onEvent(
+            PrayerTrackerEvent.UpdatePrayerStatus(PrayerName.ASR, PrayerStatus.PENDING)
+        )
+        advanceUntilIdle()
+
+        coVerify {
+            repository.updatePrayerStatus(
+                todayEpoch, PrayerName.DHUHR, PrayerStatus.LATE, match { it != null }, false
+            )
+        }
+        coVerify {
+            repository.updatePrayerStatus(
+                todayEpoch, PrayerName.ASR, PrayerStatus.PENDING, null, false
+            )
+        }
+    }
+
+    @Test
+    fun `MarkQadaCompleted marks the record's prayer as QADA using its own date`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val recordDate = dateToEpoch(LocalDate.of(2025, 3, 5))
+        val record = prayerRecord(date = recordDate, prayerName = PrayerName.MAGHRIB)
+
+        viewModel.onEvent(PrayerTrackerEvent.MarkQadaCompleted(record))
+        advanceUntilIdle()
+
+        coVerify {
+            repository.updatePrayerStatus(
+                recordDate, PrayerName.MAGHRIB, PrayerStatus.QADA, match { it != null }, false
+            )
+        }
+    }
+
+    // ── Stats period ────────────────────────────────────────────────
+
+    @Test
+    fun `SetStatsPeriod updates the active period`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(PrayerTrackerEvent.SetStatsPeriod(StatsPeriod.YEAR))
+        advanceUntilIdle()
+
+        assertThat(viewModel.statsState.value.period).isEqualTo(StatsPeriod.YEAR)
+        assertThat(viewModel.statsState.value.isLoading).isFalse()
+    }
+
+    // ── Qada grouping ───────────────────────────────────────────────
+
+    @Test
+    fun `qada prayers are grouped by month and counted`() = runTest {
+        val marchRecord = prayerRecord(id = 1, date = dateToEpoch(LocalDate.of(2025, 3, 5)))
+        val marchRecord2 = prayerRecord(id = 2, date = dateToEpoch(LocalDate.of(2025, 3, 20)))
+        val aprilRecord = prayerRecord(id = 3, date = dateToEpoch(LocalDate.of(2025, 4, 2)))
+        every { repository.getMissedPrayersRequiringQada() } returns
+            flowOf(listOf(marchRecord, marchRecord2, aprilRecord))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.qadaState.value
+        assertThat(state.totalMissed).isEqualTo(3)
+        assertThat(state.groupedByMonth.keys).containsExactly("MARCH 2025", "APRIL 2025")
+        assertThat(state.groupedByMonth["MARCH 2025"]).hasSize(2)
+        assertThat(state.isLoading).isFalse()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModelTest.kt
@@ -1,0 +1,275 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.repository.ZakatRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [ZakatViewModel] — the interactive calculator state machine.
+ *
+ * Unlike [com.arshadshah.nimaz.domain.model.ZakatCalculator], this ViewModel
+ * folds gold/silver *grams* into the asset total (via the configured per-gram
+ * prices) and auto-recalculates whenever an input changes. These tests pin
+ * down that conversion, the nisab comparison, the auto-recalc gating, and the
+ * history/persistence delegation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ZakatViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var repository: ZakatRepository
+    private lateinit var viewModel: ZakatViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk(relaxed = true)
+        every { repository.getAllHistory() } returns flowOf(emptyList())
+        coEvery { repository.getTotalPaid() } returns 0.0
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = ZakatViewModel(repository)
+
+    // ── Auto-recalculation gating ───────────────────────────────────
+
+    @Test
+    fun `no calculation is produced while all inputs are zero`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(0.0))
+        advanceUntilIdle()
+
+        assertThat(viewModel.calculatorState.value.calculation).isNull()
+    }
+
+    @Test
+    fun `updating cash triggers a recalculation`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        advanceUntilIdle()
+
+        val calc = viewModel.calculatorState.value.calculation
+        assertThat(calc).isNotNull()
+        assertThat(calc!!.totalAssets).isWithin(1e-9).of(10_000.0)
+        assertThat(calc.isAboveNisab).isTrue() // default gold nisab = 87.48 * 65 = 5686.2
+        assertThat(calc.zakatDue).isWithin(1e-9).of(10_000.0 * 0.025)
+    }
+
+    // ── Metal grams are converted to value and included in assets ───
+
+    @Test
+    fun `gold grams are converted to value using the configured price`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // 100g gold at the default 65/g = 6500, above gold nisab (5686.2).
+        viewModel.onEvent(ZakatEvent.UpdateGold(100.0))
+        advanceUntilIdle()
+
+        val calc = viewModel.calculatorState.value.calculation!!
+        assertThat(calc.goldValue).isWithin(1e-9).of(6_500.0)
+        assertThat(calc.totalAssets).isWithin(1e-9).of(6_500.0)
+        assertThat(calc.isAboveNisab).isTrue()
+        assertThat(calc.zakatDue).isWithin(1e-9).of(6_500.0 * 0.025)
+    }
+
+    @Test
+    fun `changing the gold price recalculates the nisab and zakat`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(6_000.0))
+        advanceUntilIdle()
+        // At 65/g the gold nisab is 5686.2 -> above; bump the price so the
+        // nisab (87.48 * 100 = 8748) now exceeds the 6000 net worth.
+        viewModel.onEvent(ZakatEvent.UpdateGoldPrice(100.0))
+        advanceUntilIdle()
+
+        val calc = viewModel.calculatorState.value.calculation!!
+        assertThat(calc.nisabValue).isWithin(1e-9).of(87.48 * 100.0)
+        assertThat(calc.isAboveNisab).isFalse()
+        assertThat(calc.zakatDue).isEqualTo(0.0)
+    }
+
+    // ── Liabilities & net worth (ViewModel does NOT clamp to zero) ──
+
+    @Test
+    fun `net worth can go negative when liabilities exceed assets`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(1_000.0))
+        viewModel.onEvent(ZakatEvent.UpdateDebts(3_000.0))
+        advanceUntilIdle()
+
+        val calc = viewModel.calculatorState.value.calculation!!
+        assertThat(calc.netWorth).isWithin(1e-9).of(-2_000.0)
+        assertThat(calc.isAboveNisab).isFalse()
+        assertThat(calc.zakatDue).isEqualTo(0.0)
+    }
+
+    // ── Nisab type switch ───────────────────────────────────────────
+
+    @Test
+    fun `switching to silver nisab uses the silver threshold`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(1_000.0))
+        viewModel.onEvent(ZakatEvent.SetNisabType(NisabType.SILVER))
+        advanceUntilIdle()
+
+        val calc = viewModel.calculatorState.value.calculation!!
+        assertThat(calc.nisabType).isEqualTo(NisabType.SILVER)
+        // silver nisab = 612.36 * 0.80 = 489.888, net worth 1000 is above it.
+        assertThat(calc.nisabValue).isWithin(1e-6).of(612.36 * 0.80)
+        assertThat(calc.isAboveNisab).isTrue()
+    }
+
+    // ── ClearAll / ToggleBreakdown ──────────────────────────────────
+
+    @Test
+    fun `ClearAll resets inputs but preserves prices and currency`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateGoldPrice(70.0))
+        viewModel.onEvent(ZakatEvent.SetCurrency("GBP"))
+        viewModel.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.ClearAll)
+        advanceUntilIdle()
+
+        val state = viewModel.calculatorState.value
+        assertThat(state.assets.cashOnHand).isEqualTo(0.0)
+        assertThat(state.calculation).isNull()
+        assertThat(state.goldPricePerGram).isEqualTo(70.0)
+        assertThat(state.currency).isEqualTo("GBP")
+    }
+
+    @Test
+    fun `ToggleBreakdown flips the breakdown flag`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.calculatorState.value.showBreakdown).isFalse()
+        viewModel.onEvent(ZakatEvent.ToggleBreakdown)
+        assertThat(viewModel.calculatorState.value.showBreakdown).isTrue()
+        viewModel.onEvent(ZakatEvent.ToggleBreakdown)
+        assertThat(viewModel.calculatorState.value.showBreakdown).isFalse()
+    }
+
+    // ── Persistence delegation ──────────────────────────────────────
+
+    @Test
+    fun `SaveCalculation persists when a calculation exists`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        advanceUntilIdle()
+        viewModel.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.insertCalculation(any()) }
+    }
+
+    @Test
+    fun `SaveCalculation is a no-op when there is no calculation`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.insertCalculation(any()) }
+    }
+
+    @Test
+    fun `MarkAsPaid and DeleteCalculation delegate to the repository`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(ZakatEvent.MarkAsPaid(42L))
+        viewModel.onEvent(ZakatEvent.DeleteCalculation(7L))
+        advanceUntilIdle()
+
+        coVerify { repository.markAsPaid(42L, any()) }
+        coVerify { repository.deleteCalculation(7L) }
+    }
+
+    // ── History mapping ─────────────────────────────────────────────
+
+    @Test
+    fun `history entities are mapped into the history state`() = runTest {
+        val entity = ZakatHistoryEntity(
+            id = 5,
+            calculatedAt = 1000L,
+            totalAssets = 10_000.0,
+            totalLiabilities = 2_000.0,
+            netWorth = 8_000.0,
+            zakatDue = 200.0,
+            nisabType = "GOLD",
+            nisabValue = 5_686.2
+        )
+        every { repository.getAllHistory() } returns flowOf(listOf(entity))
+        coEvery { repository.getTotalPaid() } returns 200.0
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.historyState.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.history).hasSize(1)
+        assertThat(state.history.first().id).isEqualTo(5)
+        assertThat(state.history.first().nisabType).isEqualTo(NisabType.GOLD)
+        assertThat(state.totalZakatPaid).isWithin(1e-9).of(200.0)
+    }
+
+    @Test
+    fun `unparseable nisab type in history falls back to gold`() = runTest {
+        val entity = ZakatHistoryEntity(
+            id = 1,
+            calculatedAt = 1000L,
+            totalAssets = 1.0,
+            totalLiabilities = 0.0,
+            netWorth = 1.0,
+            zakatDue = 0.0,
+            nisabType = "PLATINUM", // not a valid NisabType
+            nisabValue = 0.0
+        )
+        every { repository.getAllHistory() } returns flowOf(listOf(entity))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.historyState.value.history.first().nisabType)
+            .isEqualTo(NisabType.GOLD)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/WidgetStateSerializationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/WidgetStateSerializationTest.kt
@@ -1,0 +1,140 @@
+package com.arshadshah.nimaz.widget
+
+import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarData
+import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarEventData
+import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarWidgetState
+import com.arshadshah.nimaz.widget.hijridate.HijriDateData
+import com.arshadshah.nimaz.widget.hijridate.HijriDateWidgetState
+import com.arshadshah.nimaz.widget.nextprayer.NextPrayerData
+import com.arshadshah.nimaz.widget.nextprayer.NextPrayerWidgetState
+import com.arshadshah.nimaz.widget.prayertimes.PrayerTimesData
+import com.arshadshah.nimaz.widget.prayertimes.PrayerTimesWidgetState
+import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerData
+import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWidgetState
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Serialization round-trip tests for the Glance widget state sealed
+ * interfaces. Each widget persists its state as JSON via its StateDefinition,
+ * so the polymorphic discrimination (Loading vs Success vs Error) must survive
+ * an encode/decode cycle — otherwise a widget loses or mis-restores its state.
+ */
+class WidgetStateSerializationTest {
+
+    private val json = Json
+
+    @Test
+    fun `next prayer state round-trips all variants`() {
+        val states = listOf(
+            NextPrayerWidgetState.Loading,
+            NextPrayerWidgetState.Success(
+                NextPrayerData(
+                    prayerName = "Asr", prayerTime = "3:45 PM", countdown = "1h 20m",
+                    isValid = true, nextPrayerEpochMillis = 1_700_000_000_000
+                )
+            ),
+            NextPrayerWidgetState.Error("boom"),
+            NextPrayerWidgetState.Error(null)
+        )
+        for (state in states) {
+            val encoded = json.encodeToString(NextPrayerWidgetState.serializer(), state)
+            val decoded = json.decodeFromString(NextPrayerWidgetState.serializer(), encoded)
+            assertThat(decoded).isEqualTo(state)
+        }
+    }
+
+    @Test
+    fun `prayer times state round-trips all variants`() {
+        val states = listOf(
+            PrayerTimesWidgetState.Loading,
+            PrayerTimesWidgetState.Success(
+                PrayerTimesData(
+                    locationName = "Dublin", fajrTime = "5:00", ishaTime = "22:00",
+                    fajrPassed = true, ishaPassed = false, nextPrayerEpochMillis = 123
+                )
+            ),
+            PrayerTimesWidgetState.Error("err")
+        )
+        for (state in states) {
+            val encoded = json.encodeToString(PrayerTimesWidgetState.serializer(), state)
+            assertThat(json.decodeFromString(PrayerTimesWidgetState.serializer(), encoded))
+                .isEqualTo(state)
+        }
+    }
+
+    @Test
+    fun `prayer tracker state round-trips all variants`() {
+        val states = listOf(
+            PrayerTrackerWidgetState.Loading,
+            PrayerTrackerWidgetState.Success(
+                PrayerTrackerData(
+                    dateLabel = "Mon 16", fajr = true, dhuhr = true, asr = false,
+                    maghrib = false, isha = false, prayedCount = 2, totalCount = 5
+                )
+            ),
+            PrayerTrackerWidgetState.Error(null)
+        )
+        for (state in states) {
+            val encoded = json.encodeToString(PrayerTrackerWidgetState.serializer(), state)
+            assertThat(json.decodeFromString(PrayerTrackerWidgetState.serializer(), encoded))
+                .isEqualTo(state)
+        }
+    }
+
+    @Test
+    fun `hijri date state round-trips all variants`() {
+        val states = listOf(
+            HijriDateWidgetState.Loading,
+            HijriDateWidgetState.Success(
+                HijriDateData(
+                    hijriDay = 15, hijriMonth = "Ramadan", hijriYear = 1446,
+                    gregorianDayOfWeek = "Monday", gregorianDate = "16 Jun 2026"
+                )
+            ),
+            HijriDateWidgetState.Error("x")
+        )
+        for (state in states) {
+            val encoded = json.encodeToString(HijriDateWidgetState.serializer(), state)
+            assertThat(json.decodeFromString(HijriDateWidgetState.serializer(), encoded))
+                .isEqualTo(state)
+        }
+    }
+
+    @Test
+    fun `hijri calendar state round-trips including nested events`() {
+        val states = listOf(
+            HijriCalendarWidgetState.Loading,
+            HijriCalendarWidgetState.Success(
+                HijriCalendarData(
+                    hijriMonth = 9, hijriMonthName = "Ramadan", hijriYear = 1446,
+                    gregorianDate = "Jun 2026", daysInMonth = 30, firstDayOfWeekOffset = 2,
+                    todayHijriDay = 15,
+                    events = listOf(
+                        HijriCalendarEventData(name = "Laylat al-Qadr", nameArabic = "ليلة القدر", type = "night"),
+                        HijriCalendarEventData(name = "Eid", nameArabic = "عيد", type = "holiday")
+                    )
+                )
+            ),
+            HijriCalendarWidgetState.Error(null)
+        )
+        for (state in states) {
+            val encoded = json.encodeToString(HijriCalendarWidgetState.serializer(), state)
+            val decoded = json.decodeFromString(HijriCalendarWidgetState.serializer(), encoded)
+            assertThat(decoded).isEqualTo(state)
+        }
+    }
+
+    @Test
+    fun `loading and success are discriminated as distinct subtypes`() {
+        // A Loading payload must not decode into Success (and vice versa); this
+        // guards the sealed-interface type discriminator.
+        val loadingJson = json.encodeToString(
+            NextPrayerWidgetState.serializer(), NextPrayerWidgetState.Loading
+        )
+        val decoded = json.decodeFromString(NextPrayerWidgetState.serializer(), loadingJson)
+        assertThat(decoded).isInstanceOf(NextPrayerWidgetState.Loading::class.java)
+        assertThat(decoded).isNotInstanceOf(NextPrayerWidgetState.Success::class.java)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerStateDefinitionTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerStateDefinitionTest.kt
@@ -1,0 +1,64 @@
+package com.arshadshah.nimaz.widget.nextprayer
+
+import androidx.datastore.core.CorruptionException
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+/**
+ * Tests for the DataStore [androidx.datastore.core.Serializer] backing the
+ * Next Prayer widget. Covers the persistence contract used by Glance:
+ * writeTo/readFrom must round-trip state, and unreadable bytes must surface as
+ * a CorruptionException (so DataStore can fall back to the default) rather
+ * than crashing the widget.
+ */
+class NextPrayerStateDefinitionTest {
+
+    private val serializer = NextPrayerStateDefinition.NextPrayerWidgetStateSerializer
+
+    private suspend fun roundTrip(state: NextPrayerWidgetState): NextPrayerWidgetState {
+        val out = ByteArrayOutputStream()
+        serializer.writeTo(state, out)
+        return serializer.readFrom(ByteArrayInputStream(out.toByteArray()))
+    }
+
+    @Test
+    fun `default value is a success with empty data`() {
+        assertThat(serializer.defaultValue)
+            .isEqualTo(NextPrayerWidgetState.Success(NextPrayerData()))
+    }
+
+    @Test
+    fun `writeTo then readFrom round-trips a success state`() = runTest {
+        val state = NextPrayerWidgetState.Success(
+            NextPrayerData(
+                prayerName = "Maghrib", prayerTime = "8:30 PM", countdown = "12m 4s",
+                isValid = true, nextPrayerEpochMillis = 1_700_000_000_000
+            )
+        )
+        assertThat(roundTrip(state)).isEqualTo(state)
+    }
+
+    @Test
+    fun `writeTo then readFrom round-trips loading and error states`() = runTest {
+        assertThat(roundTrip(NextPrayerWidgetState.Loading))
+            .isEqualTo(NextPrayerWidgetState.Loading)
+        assertThat(roundTrip(NextPrayerWidgetState.Error("network")))
+            .isEqualTo(NextPrayerWidgetState.Error("network"))
+    }
+
+    @Test
+    fun `readFrom surfaces unreadable bytes as a CorruptionException`() = runTest {
+        val garbage = ByteArrayInputStream("this is not valid json {".toByteArray())
+        try {
+            serializer.readFrom(garbage)
+            fail("expected CorruptionException for unreadable data")
+        } catch (e: CorruptionException) {
+            // expected — DataStore will replace the file with defaultValue
+            assertThat(e.message).contains("Could not read NextPrayer data")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This is the first slice of a broader test-coverage improvement effort. A coverage analysis showed that the **Compose UI layer is well tested** (~60 Robolectric component tests under `src/testDebug`), but the **business-logic layer** — the code that produces correctness-critical, user-facing answers — had almost no coverage. For a worship app, a wrong Qibla bearing or an incorrect Zakat amount is a high-severity failure.

This PR adds **Tier 1**: focused, fast unit tests for the pure calculation logic that previously had **zero tests**.

### What's covered

| Test | Target | Highlights |
|---|---|---|
| `ZakatCalculatorTest` | `domain/model/ZakatModels.kt` | Gold/silver nisab derivation, 2.5% rate, asset/liability netting, net-worth clamped at 0, exactly-at-nisab boundary, metal-grams excluded from cash total, metadata pass-through |
| `QiblaCalculatorTest` | `domain/model/QiblaModels.kt` | Great-circle bearing vs known Qibla for London (≈119°) & NYC (≈58.5°), 0–360 normalization, haversine distance vs analytic one-degree value, compass-rotation angle wrapping, cardinal-direction buckets + boundaries |
| `KhatamModelsTest` | `domain/model/KhatamModels.kt` | Progress percentages with division-by-zero guards, status parse/round-trip, and a juz-boundary-table integrity check (30 ranges, contiguous, covering all 6236 ayahs with no gaps) |
| `TajweedParserTest` | `core/util/TajweedParser.kt` | Markup detection, plain-text extraction, light/dark rule→color mapping, legacy v1 rule codes, malformed-input fallback (Robolectric, matching the existing Compose-test convention) |

### Verification

The local toolchain could not run Gradle in this session (the build kept being blocked by a degraded command-safety classifier), so these tests are being verified by CI on this PR. The tests are pure-logic and assert against values either analytically derived or read directly from the source under test.

### Follow-ups (next tiers)

- **Tier 2** — business-logic ViewModels (`PrayerTrackerViewModel`, `ZakatViewModel`, `QiblaViewModel`), copying the existing `HomeViewModelTest`/`FastingViewModelTest` patterns.
- **Tier 3** — data integrity: `SyncDataExporter`/`SyncDataImporter` round-trips, more `RepositoryImpl` tests, and use-case coverage.
- **Tier 4** — widget workers (scheduling/timing) via WorkManager's test harness.
- Consider a JaCoCo `jacocoCoverageVerification` floor scoped to `domain`/`data` wired into CI to stop the business-logic gap from growing.

https://claude.ai/code/session_019s5b8xCkdH2VCn4mF9NNtL

---
_Generated by [Claude Code](https://claude.ai/code/session_019s5b8xCkdH2VCn4mF9NNtL)_