### PR TITLE
feat(qaida): progress, lesson unlocking & gamification logic (#176)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -80,6 +80,10 @@ import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonContentUseCase
 import com.arshadshah.nimaz.domain.usecase.GetQaidaLettersUseCase
 import com.arshadshah.nimaz.domain.usecase.GetQaidaCellUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkCellHeardUseCase
+import com.arshadshah.nimaz.domain.usecase.UnlockNextLessonUseCase
+import com.arshadshah.nimaz.domain.usecase.GetLessonProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCourseProgressUseCase
 import com.arshadshah.nimaz.domain.usecase.HelpUseCases
 import com.arshadshah.nimaz.domain.usecase.GetHelpTopicsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetHelpTopicDetailUseCase
@@ -354,11 +358,16 @@ object UseCaseModule {
     fun provideQaidaUseCases(
         repository: QaidaRepository
     ): QaidaUseCases {
+        val unlockNextLesson = UnlockNextLessonUseCase(repository)
         return QaidaUseCases(
             getLessons = GetQaidaLessonsUseCase(repository),
             getLessonContent = GetQaidaLessonContentUseCase(repository),
             getLetters = GetQaidaLettersUseCase(repository),
-            getCell = GetQaidaCellUseCase(repository)
+            getCell = GetQaidaCellUseCase(repository),
+            markCellHeard = MarkCellHeardUseCase(repository, unlockNextLesson),
+            unlockNextLesson = unlockNextLesson,
+            getLessonProgress = GetLessonProgressUseCase(repository),
+            getCourseProgress = GetCourseProgressUseCase(repository)
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QaidaDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QaidaDao.kt
@@ -63,6 +63,9 @@ interface QaidaDao {
     @Query("SELECT * FROM qaida_cells WHERE line_id = :lineId ORDER BY position ASC")
     suspend fun getCellsForLine(lineId: Int): List<QaidaCellEntity>
 
+    @Query("SELECT COUNT(*) FROM qaida_cells WHERE lesson_id = :lessonId")
+    suspend fun countCellsForLesson(lessonId: Int): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCells(cells: List<QaidaCellEntity>)
 
@@ -91,6 +94,9 @@ interface QaidaDao {
 
     @Query("SELECT * FROM qaida_cell_progress WHERE lesson_id = :lessonId")
     fun getCellProgressForLesson(lessonId: Int): Flow<List<QaidaCellProgressEntity>>
+
+    @Query("SELECT COUNT(*) FROM qaida_cell_progress WHERE lesson_id = :lessonId AND is_completed = 1")
+    suspend fun countCompletedCells(lessonId: Int): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertCellProgress(progress: QaidaCellProgressEntity)

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.data.repository
 
 import com.arshadshah.nimaz.data.local.database.dao.QaidaDao
 import com.arshadshah.nimaz.data.local.database.entity.QaidaCellEntity
+import com.arshadshah.nimaz.data.local.database.entity.QaidaCellProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonWithContent
@@ -11,6 +12,7 @@ import com.arshadshah.nimaz.domain.model.LessonStatus
 import com.arshadshah.nimaz.domain.model.LineType
 import com.arshadshah.nimaz.domain.model.MakhrajArea
 import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCellProgress
 import com.arshadshah.nimaz.domain.model.QaidaLesson
 import com.arshadshah.nimaz.domain.model.QaidaLessonContent
 import com.arshadshah.nimaz.domain.model.QaidaLessonProgress
@@ -61,7 +63,11 @@ class QaidaRepositoryImpl @Inject constructor(
         return qaidaDao.getCellsForLesson(lessonId).map { entities -> entities.map { it.toDomain() } }
     }
 
-    // ── Progress ──────────────────────────────────────────────────────────
+    override suspend fun getCellCountForLesson(lessonId: Int): Int {
+        return qaidaDao.countCellsForLesson(lessonId)
+    }
+
+    // ── Lesson progress ─────────────────────────────────────────────────────
     override fun getAllProgress(): Flow<List<QaidaLessonProgress>> {
         return qaidaDao.getAllProgress().map { entities -> entities.map { it.toDomain() } }
     }
@@ -76,6 +82,23 @@ class QaidaRepositoryImpl @Inject constructor(
 
     override suspend fun upsertLessonProgress(progress: QaidaLessonProgress) {
         qaidaDao.upsertLessonProgress(progress.toEntity())
+    }
+
+    // ── Cell progress ───────────────────────────────────────────────────────
+    override suspend fun getCellProgress(lessonId: Int, cellId: Int): QaidaCellProgress? {
+        return qaidaDao.getCellProgress(lessonId, cellId)?.toDomain()
+    }
+
+    override fun observeCellProgressForLesson(lessonId: Int): Flow<List<QaidaCellProgress>> {
+        return qaidaDao.getCellProgressForLesson(lessonId).map { entities -> entities.map { it.toDomain() } }
+    }
+
+    override suspend fun getCompletedCellCount(lessonId: Int): Int {
+        return qaidaDao.countCompletedCells(lessonId)
+    }
+
+    override suspend fun upsertCellProgress(progress: QaidaCellProgress) {
+        qaidaDao.upsertCellProgress(progress.toEntity())
     }
 
     // ── Mapping ───────────────────────────────────────────────────────────
@@ -197,6 +220,26 @@ class QaidaRepositoryImpl @Inject constructor(
             completedCells = completedCells,
             totalCells = totalCells,
             updatedAt = updatedAt
+        )
+    }
+
+    private fun QaidaCellProgressEntity.toDomain(): QaidaCellProgress {
+        return QaidaCellProgress(
+            lessonId = lessonId,
+            cellId = cellId,
+            heardCount = heardCount,
+            isCompleted = isCompleted,
+            lastPracticedAt = lastPracticedAt
+        )
+    }
+
+    private fun QaidaCellProgress.toEntity(): QaidaCellProgressEntity {
+        return QaidaCellProgressEntity(
+            lessonId = lessonId,
+            cellId = cellId,
+            heardCount = heardCount,
+            isCompleted = isCompleted,
+            lastPracticedAt = lastPracticedAt
         )
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QaidaModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QaidaModels.kt
@@ -112,6 +112,52 @@ data class QaidaLessonProgress(
 )
 
 /**
+ * Fine-grained per-cell practice tracking. A cell becomes [isCompleted] (i.e.
+ * "heard") the first time its audio is played; [heardCount] counts replays.
+ */
+data class QaidaCellProgress(
+    val lessonId: Int,
+    val cellId: Int,
+    val heardCount: Int,
+    val isCompleted: Boolean,
+    val lastPracticedAt: Long
+)
+
+/**
+ * Derived display state for a single lesson: the seeded [QaidaLesson] combined
+ * with the learner's stored progress and the data-driven unlock rules. Unlike
+ * [QaidaLessonProgress] (raw persisted data), [status] here is always the
+ * authoritative value derived from gating + completion.
+ */
+data class QaidaLessonState(
+    val lesson: QaidaLesson,
+    val status: LessonStatus,
+    val stars: Int,
+    val completedCells: Int,
+    val totalCells: Int,
+    val completionFraction: Float,
+    val lastCellId: Int?
+)
+
+/**
+ * Whole-course rollup for a progress dashboard: every lesson's derived state
+ * plus aggregate stats and the "continue where you left off" pointer.
+ *
+ * [nextLessonId] is the first unlocked-but-incomplete lesson (the global
+ * resume pointer); null once every lesson is completed.
+ */
+data class QaidaCourseProgress(
+    val lessons: List<QaidaLessonState>,
+    val completedLessons: Int,
+    val totalLessons: Int,
+    val totalStars: Int,
+    val maxStars: Int,
+    val totalCellsHeard: Int,
+    val overallFraction: Float,
+    val nextLessonId: Int?
+)
+
+/**
  * The kind of token a [QaidaCell] represents.
  */
 enum class TokenType {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QaidaProgressRules.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QaidaProgressRules.kt
@@ -1,0 +1,159 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * Single source of truth for every Qaida "learning loop" threshold (epic #171,
+ * sub-issue E of #176): completion gating, star awards, unlock rules and the
+ * derived status / course-progress mappers.
+ *
+ * All magic numbers live here so they are trivially tunable and the pure logic
+ * is unit-testable in isolation from Room, DataStore and the UI.
+ */
+object QaidaProgressRules {
+
+    /** Stars awarded per lesson range from [MIN_STARS]..[MAX_STARS]. */
+    const val MIN_STARS: Int = 1
+    const val MAX_STARS: Int = 3
+
+    /**
+     * Fraction of a lesson's cells that must be heard for it to count as
+     * COMPLETED — and therefore unlock the next lesson. Default = 100%.
+     */
+    const val COMPLETION_THRESHOLD: Float = 1.0f
+
+    /** Fraction of cells heard required to earn the first star ("finished once"). */
+    const val ONE_STAR_THRESHOLD: Float = 0.5f
+
+    /** Fraction of cells heard required to earn the second star ("all cells heard"). */
+    const val TWO_STAR_THRESHOLD: Float = 1.0f
+
+    /**
+     * Alternative, star-based unlock gate: a previous lesson with at least this
+     * many stars also unlocks the next one (see [unlocksNext]). Defaults to the
+     * "all cells heard" tier so the cell-fraction and star gates agree.
+     */
+    const val UNLOCK_MIN_STARS: Int = 2
+
+    /**
+     * Completion fraction in 0f..1f. Guards against a zero/empty total so an
+     * un-seeded lesson reports 0% rather than NaN.
+     */
+    fun completionFraction(completedCells: Int, totalCells: Int): Float {
+        if (totalCells <= 0) return 0f
+        return (completedCells.toFloat() / totalCells).coerceIn(0f, 1f)
+    }
+
+    /** Whether a lesson has reached the [COMPLETION_THRESHOLD]. */
+    fun isComplete(completedCells: Int, totalCells: Int): Boolean =
+        completionFraction(completedCells, totalCells) >= COMPLETION_THRESHOLD
+
+    /**
+     * Stars earned for a lesson. The third star requires the optional
+     * practice/quiz pass on top of having heard every cell.
+     */
+    fun starsFor(
+        completedCells: Int,
+        totalCells: Int,
+        practicePassed: Boolean = false
+    ): Int {
+        val fraction = completionFraction(completedCells, totalCells)
+        return when {
+            fraction >= TWO_STAR_THRESHOLD && practicePassed -> MAX_STARS
+            fraction >= TWO_STAR_THRESHOLD -> 2
+            fraction >= ONE_STAR_THRESHOLD -> MIN_STARS
+            else -> 0
+        }
+    }
+
+    /**
+     * Derived status for a lesson given its raw progress and whether its unlock
+     * gate (the previous lesson) is satisfied. A locked lesson is always LOCKED
+     * regardless of any stale stored progress.
+     */
+    fun statusFor(
+        completedCells: Int,
+        totalCells: Int,
+        isUnlocked: Boolean
+    ): LessonStatus {
+        if (!isUnlocked) return LessonStatus.LOCKED
+        return when {
+            isComplete(completedCells, totalCells) -> LessonStatus.COMPLETED
+            completedCells > 0 -> LessonStatus.IN_PROGRESS
+            else -> LessonStatus.UNLOCKED
+        }
+    }
+
+    /**
+     * Whether finishing [previous] unlocks the lesson that follows it. The very
+     * first lesson has no predecessor and is unlocked by [deriveCourseProgress].
+     */
+    fun unlocksNext(previous: QaidaLessonProgress?): Boolean {
+        if (previous == null) return false
+        return previous.status == LessonStatus.COMPLETED ||
+            isComplete(previous.completedCells, previous.totalCells) ||
+            previous.stars >= UNLOCK_MIN_STARS
+    }
+
+    /**
+     * Pure derived-state mapper: combines the seeded [lessons] (ordered by
+     * [QaidaLesson.displayOrder]) with stored [progressByLessonId] into a fully
+     * gated [QaidaCourseProgress].
+     *
+     * Lesson 1 is always unlocked; each subsequent lesson unlocks only once the
+     * previous one is COMPLETED. [QaidaCourseProgress.nextLessonId] points at
+     * the first unlocked-but-incomplete lesson (the global resume pointer).
+     */
+    fun deriveCourseProgress(
+        lessons: List<QaidaLesson>,
+        progressByLessonId: Map<Int, QaidaLessonProgress>
+    ): QaidaCourseProgress {
+        val ordered = lessons.sortedBy { it.displayOrder }
+
+        var previousCompleted = true // lesson 1 is always unlocked
+        var completedLessons = 0
+        var totalStars = 0
+        var totalCellsHeard = 0
+        var nextLessonId: Int? = null
+
+        val states = ordered.map { lesson ->
+            val progress = progressByLessonId[lesson.id]
+            val completedCells = progress?.completedCells ?: 0
+            val totalCells = progress?.totalCells ?: 0
+            val isUnlocked = previousCompleted
+            val status = statusFor(completedCells, totalCells, isUnlocked)
+            val stars = if (isUnlocked) progress?.stars ?: 0 else 0
+
+            if (status == LessonStatus.COMPLETED) completedLessons++
+            totalStars += stars
+            totalCellsHeard += completedCells
+            if (nextLessonId == null &&
+                (status == LessonStatus.UNLOCKED || status == LessonStatus.IN_PROGRESS)
+            ) {
+                nextLessonId = lesson.id
+            }
+
+            previousCompleted = status == LessonStatus.COMPLETED
+
+            QaidaLessonState(
+                lesson = lesson,
+                status = status,
+                stars = stars,
+                completedCells = completedCells,
+                totalCells = totalCells,
+                completionFraction = completionFraction(completedCells, totalCells),
+                lastCellId = progress?.lastCellId
+            )
+        }
+
+        val totalLessons = ordered.size
+        return QaidaCourseProgress(
+            lessons = states,
+            completedLessons = completedLessons,
+            totalLessons = totalLessons,
+            totalStars = totalStars,
+            maxStars = totalLessons * MAX_STARS,
+            totalCellsHeard = totalCellsHeard,
+            overallFraction = if (totalLessons == 0) 0f else completedLessons.toFloat() / totalLessons,
+            nextLessonId = nextLessonId
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/QaidaRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/QaidaRepository.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.domain.repository
 
 import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCellProgress
 import com.arshadshah.nimaz.domain.model.QaidaLesson
 import com.arshadshah.nimaz.domain.model.QaidaLessonContent
 import com.arshadshah.nimaz.domain.model.QaidaLessonProgress
@@ -28,9 +29,18 @@ interface QaidaRepository {
     suspend fun getCell(cellId: Int): QaidaCell?
     fun getCellsForLesson(lessonId: Int): Flow<List<QaidaCell>>
 
-    // ── Progress (write logic delegated to sub-issue E, surfaced here) ─────
+    /** Total number of seeded cells in a lesson (the denominator for progress). */
+    suspend fun getCellCountForLesson(lessonId: Int): Int
+
+    // ── Lesson progress ───────────────────────────────────────────────────
     fun getAllProgress(): Flow<List<QaidaLessonProgress>>
     fun observeLessonProgress(lessonId: Int): Flow<QaidaLessonProgress?>
     suspend fun getLessonProgress(lessonId: Int): QaidaLessonProgress?
     suspend fun upsertLessonProgress(progress: QaidaLessonProgress)
+
+    // ── Cell progress ─────────────────────────────────────────────────────
+    suspend fun getCellProgress(lessonId: Int, cellId: Int): QaidaCellProgress?
+    fun observeCellProgressForLesson(lessonId: Int): Flow<List<QaidaCellProgress>>
+    suspend fun getCompletedCellCount(lessonId: Int): Int
+    suspend fun upsertCellProgress(progress: QaidaCellProgress)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QaidaProgressUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QaidaProgressUseCases.kt
@@ -1,0 +1,144 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.QaidaCellProgress
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLessonProgress
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.domain.model.QaidaProgressRules
+import com.arshadshah.nimaz.domain.repository.QaidaRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+/**
+ * The Qaida "learning loop" use cases (epic #171, sub-issue E of #176): the
+ * testable domain logic for persisted progress, lesson gating, stars and
+ * resume. All thresholds live in [QaidaProgressRules]; these classes only
+ * orchestrate reads/writes through the repository.
+ */
+
+/**
+ * Records that a cell's audio was tapped/played, then recomputes and persists
+ * the lesson's progress (completed cells, status, stars, resume pointer). When
+ * the lesson reaches completion it unlocks the following lesson.
+ *
+ * [now] is injectable so unit tests can assert deterministic timestamps.
+ */
+class MarkCellHeardUseCase @Inject constructor(
+    private val repository: QaidaRepository,
+    private val unlockNextLesson: UnlockNextLessonUseCase
+) {
+    suspend operator fun invoke(
+        lessonId: Int,
+        cellId: Int,
+        now: Long = System.currentTimeMillis()
+    ) {
+        // 1. Mark the individual cell as heard (incrementing replay count).
+        val existingCell = repository.getCellProgress(lessonId, cellId)
+        repository.upsertCellProgress(
+            QaidaCellProgress(
+                lessonId = lessonId,
+                cellId = cellId,
+                heardCount = (existingCell?.heardCount ?: 0) + 1,
+                isCompleted = true,
+                lastPracticedAt = now
+            )
+        )
+
+        // 2. Recompute the lesson rollup from the data-driven rules.
+        val totalCells = repository.getCellCountForLesson(lessonId)
+        val completedCells = repository.getCompletedCellCount(lessonId)
+        val stars = QaidaProgressRules.starsFor(completedCells, totalCells)
+        val status = QaidaProgressRules.statusFor(completedCells, totalCells, isUnlocked = true)
+        val existingProgress = repository.getLessonProgress(lessonId)
+
+        repository.upsertLessonProgress(
+            QaidaLessonProgress(
+                lessonId = lessonId,
+                status = status,
+                // Stars never regress once earned.
+                stars = maxOf(stars, existingProgress?.stars ?: 0),
+                lastCellId = cellId,
+                completedCells = completedCells,
+                totalCells = totalCells,
+                updatedAt = now
+            )
+        )
+
+        // 3. Completing this lesson unlocks the next one.
+        if (QaidaProgressRules.isComplete(completedCells, totalCells)) {
+            unlockNextLesson(lessonId, now)
+        }
+    }
+}
+
+/**
+ * Persists an `UNLOCKED` progress row for the lesson that follows [lessonId]
+ * (by display order), if there is one and it has not already been started.
+ * Returns the newly-unlocked lesson id, or null if nothing changed.
+ */
+class UnlockNextLessonUseCase @Inject constructor(
+    private val repository: QaidaRepository
+) {
+    suspend operator fun invoke(
+        lessonId: Int,
+        now: Long = System.currentTimeMillis()
+    ): Int? {
+        val lessons = repository.getLessons().first().sortedBy { it.displayOrder }
+        val index = lessons.indexOfFirst { it.id == lessonId }
+        if (index == -1 || index == lessons.lastIndex) return null
+
+        val next = lessons[index + 1]
+        // Don't clobber progress the learner has already made on the next lesson.
+        if (repository.getLessonProgress(next.id) != null) return null
+
+        repository.upsertLessonProgress(
+            QaidaLessonProgress(
+                lessonId = next.id,
+                status = LessonStatus.UNLOCKED,
+                stars = 0,
+                lastCellId = null,
+                completedCells = 0,
+                totalCells = repository.getCellCountForLesson(next.id),
+                updatedAt = now
+            )
+        )
+        return next.id
+    }
+}
+
+/**
+ * Observes the derived display state ([QaidaLessonState]) for a single lesson,
+ * with status correctly gated against the preceding lessons. Emits null if the
+ * lesson id is unknown.
+ */
+class GetLessonProgressUseCase @Inject constructor(
+    private val repository: QaidaRepository
+) {
+    operator fun invoke(lessonId: Int): Flow<QaidaLessonState?> =
+        combine(repository.getLessons(), repository.getAllProgress()) { lessons, progress ->
+            QaidaProgressRules.deriveCourseProgress(
+                lessons = lessons,
+                progressByLessonId = progress.associateBy { it.lessonId }
+            ).lessons.firstOrNull { it.lesson.id == lessonId }
+        }
+}
+
+/**
+ * Observes the whole-course rollup ([QaidaCourseProgress]): every lesson's
+ * gated status, overall completion %, total stars and the "continue where you
+ * left off" pointer. Recomputes reactively as progress is written.
+ */
+class GetCourseProgressUseCase @Inject constructor(
+    private val repository: QaidaRepository
+) {
+    operator fun invoke(): Flow<QaidaCourseProgress> =
+        combine(repository.getLessons(), repository.getAllProgress()) { lessons, progress ->
+            QaidaProgressRules.deriveCourseProgress(
+                lessons = lessons,
+                progressByLessonId = progress.associateBy { it.lessonId }
+            )
+        }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QaidaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QaidaUseCases.kt
@@ -38,5 +38,10 @@ data class QaidaUseCases(
     val getLessons: GetQaidaLessonsUseCase,
     val getLessonContent: GetQaidaLessonContentUseCase,
     val getLetters: GetQaidaLettersUseCase,
-    val getCell: GetQaidaCellUseCase
+    val getCell: GetQaidaCellUseCase,
+    // Progress / gamification (sub-issue E, #176)
+    val markCellHeard: MarkCellHeardUseCase,
+    val unlockNextLesson: UnlockNextLessonUseCase,
+    val getLessonProgress: GetLessonProgressUseCase,
+    val getCourseProgress: GetCourseProgressUseCase
 )

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.data.repository
 import app.cash.turbine.test
 import com.arshadshah.nimaz.data.local.database.dao.QaidaDao
 import com.arshadshah.nimaz.data.local.database.entity.QaidaCellEntity
+import com.arshadshah.nimaz.data.local.database.entity.QaidaCellProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonWithContent
@@ -12,6 +13,7 @@ import com.arshadshah.nimaz.data.local.database.entity.QaidaLineWithCells
 import com.arshadshah.nimaz.domain.model.LessonStatus
 import com.arshadshah.nimaz.domain.model.LineType
 import com.arshadshah.nimaz.domain.model.MakhrajArea
+import com.arshadshah.nimaz.domain.model.QaidaCellProgress
 import com.arshadshah.nimaz.domain.model.QaidaLessonProgress
 import com.arshadshah.nimaz.domain.model.TokenType
 import com.google.common.truth.Truth.assertThat
@@ -301,6 +303,57 @@ class QaidaRepositoryImplTest {
 
         assertThat(repository.getLessonProgress(1)).isNotNull()
         assertThat(repository.getLessonProgress(999)).isNull()
+    }
+
+    // ── Cell progress ───────────────────────────────────────────────
+
+    @Test
+    fun `getCellProgress maps entity to domain`() = runTest {
+        coEvery { dao.getCellProgress(1, 5) } returns QaidaCellProgressEntity(
+            lessonId = 1,
+            cellId = 5,
+            heardCount = 3,
+            isCompleted = true,
+            lastPracticedAt = now
+        )
+        coEvery { dao.getCellProgress(1, 999) } returns null
+
+        val progress = repository.getCellProgress(1, 5)
+        assertThat(progress).isNotNull()
+        assertThat(progress!!.heardCount).isEqualTo(3)
+        assertThat(progress.isCompleted).isTrue()
+        assertThat(repository.getCellProgress(1, 999)).isNull()
+    }
+
+    @Test
+    fun `getCellCountForLesson and getCompletedCellCount delegate to DAO`() = runTest {
+        coEvery { dao.countCellsForLesson(1) } returns 12
+        coEvery { dao.countCompletedCells(1) } returns 5
+
+        assertThat(repository.getCellCountForLesson(1)).isEqualTo(12)
+        assertThat(repository.getCompletedCellCount(1)).isEqualTo(5)
+    }
+
+    @Test
+    fun `upsertCellProgress converts domain to entity and calls DAO`() = runTest {
+        repository.upsertCellProgress(
+            QaidaCellProgress(
+                lessonId = 2,
+                cellId = 7,
+                heardCount = 1,
+                isCompleted = true,
+                lastPracticedAt = now
+            )
+        )
+
+        coVerify {
+            dao.upsertCellProgress(match<QaidaCellProgressEntity> { entity ->
+                entity.lessonId == 2 &&
+                    entity.cellId == 7 &&
+                    entity.heardCount == 1 &&
+                    entity.isCompleted
+            })
+        }
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/QaidaProgressRulesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/QaidaProgressRulesTest.kt
@@ -1,0 +1,217 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the centralized Qaida rules (#176): completion gating,
+ * star thresholds, unlock transitions and the derived course-progress mapper.
+ * No Android dependencies — runs on plain JUnit.
+ */
+class QaidaProgressRulesTest {
+
+    private fun lesson(id: Int, order: Int = id) = QaidaLesson(
+        id = id,
+        lessonNumber = id,
+        titleEnglish = "Lesson $id",
+        titleArabic = "درس",
+        titleTransliteration = "dars",
+        description = "",
+        conceptTags = emptyList(),
+        icon = "book",
+        displayOrder = order
+    )
+
+    private fun progress(
+        lessonId: Int,
+        completed: Int,
+        total: Int,
+        stars: Int = QaidaProgressRules.starsFor(completed, total),
+        status: LessonStatus = LessonStatus.IN_PROGRESS,
+        lastCellId: Int? = null
+    ) = QaidaLessonProgress(
+        lessonId = lessonId,
+        status = status,
+        stars = stars,
+        lastCellId = lastCellId,
+        completedCells = completed,
+        totalCells = total,
+        updatedAt = 0L
+    )
+
+    // ── completionFraction ──────────────────────────────────────────
+
+    @Test
+    fun `completionFraction guards against zero total`() {
+        assertThat(QaidaProgressRules.completionFraction(0, 0)).isEqualTo(0f)
+        assertThat(QaidaProgressRules.completionFraction(3, 0)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `completionFraction is clamped to one`() {
+        assertThat(QaidaProgressRules.completionFraction(5, 10)).isEqualTo(0.5f)
+        assertThat(QaidaProgressRules.completionFraction(12, 10)).isEqualTo(1f)
+    }
+
+    // ── stars ───────────────────────────────────────────────────────
+
+    @Test
+    fun `starsFor follows documented thresholds`() {
+        assertThat(QaidaProgressRules.starsFor(0, 10)).isEqualTo(0)
+        // below the first-star threshold
+        assertThat(QaidaProgressRules.starsFor(4, 10)).isEqualTo(0)
+        // first star at >= 50%
+        assertThat(QaidaProgressRules.starsFor(5, 10)).isEqualTo(1)
+        assertThat(QaidaProgressRules.starsFor(9, 10)).isEqualTo(1)
+        // second star at 100% of cells heard
+        assertThat(QaidaProgressRules.starsFor(10, 10)).isEqualTo(2)
+        // third star needs all cells heard AND the practice/quiz pass
+        assertThat(QaidaProgressRules.starsFor(10, 10, practicePassed = true)).isEqualTo(3)
+        // practice pass without full cells does not grant the third star
+        assertThat(QaidaProgressRules.starsFor(5, 10, practicePassed = true)).isEqualTo(1)
+    }
+
+    // ── isComplete ──────────────────────────────────────────────────
+
+    @Test
+    fun `isComplete only at the completion threshold`() {
+        assertThat(QaidaProgressRules.isComplete(9, 10)).isFalse()
+        assertThat(QaidaProgressRules.isComplete(10, 10)).isTrue()
+    }
+
+    // ── statusFor ───────────────────────────────────────────────────
+
+    @Test
+    fun `statusFor reports LOCKED regardless of stored progress when gated`() {
+        assertThat(QaidaProgressRules.statusFor(10, 10, isUnlocked = false))
+            .isEqualTo(LessonStatus.LOCKED)
+    }
+
+    @Test
+    fun `statusFor maps unlocked progress to UNLOCKED, IN_PROGRESS, COMPLETED`() {
+        assertThat(QaidaProgressRules.statusFor(0, 10, isUnlocked = true))
+            .isEqualTo(LessonStatus.UNLOCKED)
+        assertThat(QaidaProgressRules.statusFor(3, 10, isUnlocked = true))
+            .isEqualTo(LessonStatus.IN_PROGRESS)
+        assertThat(QaidaProgressRules.statusFor(10, 10, isUnlocked = true))
+            .isEqualTo(LessonStatus.COMPLETED)
+    }
+
+    // ── unlocksNext ─────────────────────────────────────────────────
+
+    @Test
+    fun `unlocksNext requires completion or enough stars`() {
+        assertThat(QaidaProgressRules.unlocksNext(null)).isFalse()
+        assertThat(QaidaProgressRules.unlocksNext(progress(1, 9, 10, stars = 1))).isFalse()
+        // 100% cells heard
+        assertThat(QaidaProgressRules.unlocksNext(progress(1, 10, 10))).isTrue()
+        // status already COMPLETED
+        assertThat(
+            QaidaProgressRules.unlocksNext(
+                progress(1, 0, 0, stars = 0, status = LessonStatus.COMPLETED)
+            )
+        ).isTrue()
+        // star-based gate
+        assertThat(QaidaProgressRules.unlocksNext(progress(1, 0, 0, stars = 2))).isTrue()
+    }
+
+    // ── deriveCourseProgress ────────────────────────────────────────
+
+    @Test
+    fun `deriveCourseProgress unlocks only lesson one when no progress exists`() {
+        val lessons = listOf(lesson(1), lesson(2), lesson(3))
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, emptyMap())
+
+        assertThat(course.lessons.map { it.status }).containsExactly(
+            LessonStatus.UNLOCKED,
+            LessonStatus.LOCKED,
+            LessonStatus.LOCKED
+        ).inOrder()
+        assertThat(course.completedLessons).isEqualTo(0)
+        assertThat(course.totalLessons).isEqualTo(3)
+        assertThat(course.maxStars).isEqualTo(9)
+        // Resume pointer = first unlocked-incomplete lesson
+        assertThat(course.nextLessonId).isEqualTo(1)
+        assertThat(course.overallFraction).isEqualTo(0f)
+    }
+
+    @Test
+    fun `deriveCourseProgress unlocks the next lesson when the previous is completed`() {
+        val lessons = listOf(lesson(1), lesson(2), lesson(3))
+        val progressMap = mapOf(
+            1 to progress(1, 10, 10, status = LessonStatus.COMPLETED, lastCellId = 99)
+        )
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, progressMap)
+
+        assertThat(course.lessons.map { it.status }).containsExactly(
+            LessonStatus.COMPLETED,
+            LessonStatus.UNLOCKED,
+            LessonStatus.LOCKED
+        ).inOrder()
+        assertThat(course.completedLessons).isEqualTo(1)
+        assertThat(course.totalStars).isEqualTo(2)
+        assertThat(course.totalCellsHeard).isEqualTo(10)
+        // Lesson 1 done → continue at lesson 2
+        assertThat(course.nextLessonId).isEqualTo(2)
+        assertThat(course.lessons[0].lastCellId).isEqualTo(99)
+    }
+
+    @Test
+    fun `deriveCourseProgress resume pointer prefers an in-progress lesson`() {
+        val lessons = listOf(lesson(1), lesson(2))
+        val progressMap = mapOf(1 to progress(1, 4, 10))
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, progressMap)
+
+        assertThat(course.lessons[0].status).isEqualTo(LessonStatus.IN_PROGRESS)
+        assertThat(course.nextLessonId).isEqualTo(1)
+    }
+
+    @Test
+    fun `deriveCourseProgress reports null resume pointer when every lesson is complete`() {
+        val lessons = listOf(lesson(1), lesson(2))
+        val progressMap = mapOf(
+            1 to progress(1, 10, 10, status = LessonStatus.COMPLETED),
+            2 to progress(2, 8, 8, status = LessonStatus.COMPLETED)
+        )
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, progressMap)
+
+        assertThat(course.completedLessons).isEqualTo(2)
+        assertThat(course.overallFraction).isEqualTo(1f)
+        assertThat(course.nextLessonId).isNull()
+    }
+
+    @Test
+    fun `deriveCourseProgress respects display order over id`() {
+        // id order and display order disagree; gating must follow display order.
+        val lessons = listOf(lesson(id = 2, order = 1), lesson(id = 1, order = 2))
+        val progressMap = mapOf(
+            2 to progress(2, 10, 10, status = LessonStatus.COMPLETED)
+        )
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, progressMap)
+
+        assertThat(course.lessons.map { it.lesson.id }).containsExactly(2, 1).inOrder()
+        assertThat(course.lessons[1].status).isEqualTo(LessonStatus.UNLOCKED)
+    }
+
+    @Test
+    fun `deriveCourseProgress ignores stale stars on a locked lesson`() {
+        // Lesson 2 has stored stars but lesson 1 is incomplete, so 2 stays LOCKED.
+        val lessons = listOf(lesson(1), lesson(2))
+        val progressMap = mapOf(
+            1 to progress(1, 3, 10),
+            2 to progress(2, 0, 0, stars = 3, status = LessonStatus.COMPLETED)
+        )
+
+        val course = QaidaProgressRules.deriveCourseProgress(lessons, progressMap)
+
+        assertThat(course.lessons[1].status).isEqualTo(LessonStatus.LOCKED)
+        assertThat(course.lessons[1].stars).isEqualTo(0)
+        // Only lesson 1's (zero) stars count toward the total.
+        assertThat(course.totalStars).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/QaidaProgressUseCasesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/QaidaProgressUseCasesTest.kt
@@ -1,0 +1,251 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import app.cash.turbine.test
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.QaidaCellProgress
+import com.arshadshah.nimaz.domain.model.QaidaLesson
+import com.arshadshah.nimaz.domain.model.QaidaLessonProgress
+import com.arshadshah.nimaz.domain.repository.QaidaRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Use-case tests for the Qaida learning loop (#176): cell-heard writes, lesson
+ * gating/unlock, resume pointer and derived course progress, all over a mocked
+ * repository.
+ */
+class QaidaProgressUseCasesTest {
+
+    private lateinit var repository: QaidaRepository
+    private lateinit var unlockNextLesson: UnlockNextLessonUseCase
+    private lateinit var markCellHeard: MarkCellHeardUseCase
+
+    private val now = 1_700_000_000_000L
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        unlockNextLesson = UnlockNextLessonUseCase(repository)
+        markCellHeard = MarkCellHeardUseCase(repository, unlockNextLesson)
+    }
+
+    private fun lesson(id: Int, order: Int = id) = QaidaLesson(
+        id = id,
+        lessonNumber = id,
+        titleEnglish = "Lesson $id",
+        titleArabic = "درس",
+        titleTransliteration = "dars",
+        description = "",
+        conceptTags = emptyList(),
+        icon = "book",
+        displayOrder = order
+    )
+
+    // ── MarkCellHeardUseCase ────────────────────────────────────────
+
+    @Test
+    fun `markCellHeard records cell and persists in-progress lesson without unlocking`() = runTest {
+        coEvery { repository.getCellProgress(1, 5) } returns null
+        coEvery { repository.getCellCountForLesson(1) } returns 10
+        coEvery { repository.getCompletedCellCount(1) } returns 3
+        coEvery { repository.getLessonProgress(1) } returns null
+
+        val cellSlot = slot<QaidaCellProgress>()
+        val lessonSlot = slot<QaidaLessonProgress>()
+        coEvery { repository.upsertCellProgress(capture(cellSlot)) } just Runs
+        coEvery { repository.upsertLessonProgress(capture(lessonSlot)) } just Runs
+
+        markCellHeard(lessonId = 1, cellId = 5, now = now)
+
+        assertThat(cellSlot.captured.cellId).isEqualTo(5)
+        assertThat(cellSlot.captured.heardCount).isEqualTo(1)
+        assertThat(cellSlot.captured.isCompleted).isTrue()
+        assertThat(cellSlot.captured.lastPracticedAt).isEqualTo(now)
+
+        assertThat(lessonSlot.captured.status).isEqualTo(LessonStatus.IN_PROGRESS)
+        assertThat(lessonSlot.captured.completedCells).isEqualTo(3)
+        assertThat(lessonSlot.captured.totalCells).isEqualTo(10)
+        assertThat(lessonSlot.captured.lastCellId).isEqualTo(5)
+        assertThat(lessonSlot.captured.updatedAt).isEqualTo(now)
+
+        // Nothing unlocked: getLessons (used only by unlock) is never read.
+        coVerify(exactly = 0) { repository.getLessons() }
+    }
+
+    @Test
+    fun `markCellHeard increments replay count for an already-heard cell`() = runTest {
+        coEvery { repository.getCellProgress(1, 5) } returns
+            QaidaCellProgress(1, 5, heardCount = 2, isCompleted = true, lastPracticedAt = 1L)
+        coEvery { repository.getCellCountForLesson(1) } returns 10
+        coEvery { repository.getCompletedCellCount(1) } returns 4
+
+        val cellSlot = slot<QaidaCellProgress>()
+        coEvery { repository.upsertCellProgress(capture(cellSlot)) } just Runs
+
+        markCellHeard(lessonId = 1, cellId = 5, now = now)
+
+        assertThat(cellSlot.captured.heardCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `markCellHeard completes lesson, awards stars and unlocks the next`() = runTest {
+        coEvery { repository.getCellProgress(1, 9) } returns null
+        coEvery { repository.getCellCountForLesson(1) } returns 10
+        coEvery { repository.getCompletedCellCount(1) } returns 10
+        coEvery { repository.getLessonProgress(1) } returns null
+        // Unlock path
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1), lesson(2)))
+        coEvery { repository.getLessonProgress(2) } returns null
+        coEvery { repository.getCellCountForLesson(2) } returns 8
+
+        val lessonSlots = mutableListOf<QaidaLessonProgress>()
+        coEvery { repository.upsertLessonProgress(capture(lessonSlots)) } just Runs
+
+        markCellHeard(lessonId = 1, cellId = 9, now = now)
+
+        val lesson1 = lessonSlots.first { it.lessonId == 1 }
+        assertThat(lesson1.status).isEqualTo(LessonStatus.COMPLETED)
+        assertThat(lesson1.stars).isEqualTo(2)
+
+        val lesson2 = lessonSlots.first { it.lessonId == 2 }
+        assertThat(lesson2.status).isEqualTo(LessonStatus.UNLOCKED)
+        assertThat(lesson2.totalCells).isEqualTo(8)
+        assertThat(lesson2.completedCells).isEqualTo(0)
+    }
+
+    @Test
+    fun `markCellHeard never regresses earned stars`() = runTest {
+        coEvery { repository.getCellProgress(1, 2) } returns null
+        coEvery { repository.getCellCountForLesson(1) } returns 10
+        coEvery { repository.getCompletedCellCount(1) } returns 2 // would be 0 stars
+        coEvery { repository.getLessonProgress(1) } returns QaidaLessonProgress(
+            lessonId = 1,
+            status = LessonStatus.IN_PROGRESS,
+            stars = 2,
+            lastCellId = 1,
+            completedCells = 9,
+            totalCells = 10,
+            updatedAt = 1L
+        )
+
+        val lessonSlot = slot<QaidaLessonProgress>()
+        coEvery { repository.upsertLessonProgress(capture(lessonSlot)) } just Runs
+
+        markCellHeard(lessonId = 1, cellId = 2, now = now)
+
+        assertThat(lessonSlot.captured.stars).isEqualTo(2)
+    }
+
+    // ── UnlockNextLessonUseCase ─────────────────────────────────────
+
+    @Test
+    fun `unlockNextLesson unlocks the following lesson by display order`() = runTest {
+        every { repository.getLessons() } returns flowOf(
+            listOf(lesson(id = 1, order = 1), lesson(id = 2, order = 2))
+        )
+        coEvery { repository.getLessonProgress(2) } returns null
+        coEvery { repository.getCellCountForLesson(2) } returns 6
+
+        val slot = slot<QaidaLessonProgress>()
+        coEvery { repository.upsertLessonProgress(capture(slot)) } just Runs
+
+        val unlocked = unlockNextLesson(lessonId = 1, now = now)
+
+        assertThat(unlocked).isEqualTo(2)
+        assertThat(slot.captured.lessonId).isEqualTo(2)
+        assertThat(slot.captured.status).isEqualTo(LessonStatus.UNLOCKED)
+    }
+
+    @Test
+    fun `unlockNextLesson returns null at the last lesson`() = runTest {
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1), lesson(2)))
+
+        val unlocked = unlockNextLesson(lessonId = 2, now = now)
+
+        assertThat(unlocked).isNull()
+        coVerify(exactly = 0) { repository.upsertLessonProgress(any<QaidaLessonProgress>()) }
+    }
+
+    @Test
+    fun `unlockNextLesson does not clobber existing progress on the next lesson`() = runTest {
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1), lesson(2)))
+        coEvery { repository.getLessonProgress(2) } returns QaidaLessonProgress(
+            lessonId = 2,
+            status = LessonStatus.IN_PROGRESS,
+            stars = 1,
+            lastCellId = 3,
+            completedCells = 4,
+            totalCells = 8,
+            updatedAt = 1L
+        )
+
+        val unlocked = unlockNextLesson(lessonId = 1, now = now)
+
+        assertThat(unlocked).isNull()
+        coVerify(exactly = 0) { repository.upsertLessonProgress(any<QaidaLessonProgress>()) }
+    }
+
+    // ── GetCourseProgressUseCase / GetLessonProgressUseCase ─────────
+
+    @Test
+    fun `getCourseProgress derives gated statuses and resume pointer`() = runTest {
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1), lesson(2), lesson(3)))
+        every { repository.getAllProgress() } returns flowOf(
+            listOf(
+                QaidaLessonProgress(1, LessonStatus.COMPLETED, 2, 9, 10, 10, now)
+            )
+        )
+
+        GetCourseProgressUseCase(repository)().test {
+            val course = awaitItem()
+            assertThat(course.lessons.map { it.status }).containsExactly(
+                LessonStatus.COMPLETED,
+                LessonStatus.UNLOCKED,
+                LessonStatus.LOCKED
+            ).inOrder()
+            assertThat(course.nextLessonId).isEqualTo(2)
+            assertThat(course.totalStars).isEqualTo(2)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getLessonProgress restores exact position and status for a lesson`() = runTest {
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1), lesson(2)))
+        every { repository.getAllProgress() } returns flowOf(
+            listOf(
+                QaidaLessonProgress(1, LessonStatus.IN_PROGRESS, 1, 7, 6, 10, now)
+            )
+        )
+
+        GetLessonProgressUseCase(repository)(lessonId = 1).test {
+            val state = awaitItem()
+            assertThat(state).isNotNull()
+            assertThat(state!!.status).isEqualTo(LessonStatus.IN_PROGRESS)
+            assertThat(state.lastCellId).isEqualTo(7)
+            assertThat(state.completedCells).isEqualTo(6)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getLessonProgress emits null for an unknown lesson`() = runTest {
+        every { repository.getLessons() } returns flowOf(listOf(lesson(1)))
+        every { repository.getAllProgress() } returns flowOf(emptyList())
+
+        GetLessonProgressUseCase(repository)(lessonId = 99).test {
+            assertThat(awaitItem()).isNull()
+            awaitComplete()
+        }
+    }
+}


### PR DESCRIPTION
Implements the Qaida "learning loop" domain logic over the content
repository (sub-issue D) and progress DAO (sub-issue C): persisted
progress, data-driven lesson gating, stars, and resume — all as
testable, UI-free domain code.

- QaidaProgressRules: single source of truth for completion threshold,
  star tiers, unlock gate, derived status, and the course-progress mapper
- Domain models: QaidaCellProgress, QaidaLessonState, QaidaCourseProgress
- Use cases: MarkCellHeardUseCase (records a heard cell, recomputes lesson
  rollup, unlocks the next lesson on completion), UnlockNextLessonUseCase,
  GetLessonProgressUseCase, GetCourseProgressUseCase (overall %, next
  lesson resume pointer, total stars)
- Repository + DAO: cell-progress reads/writes and cell counts
- Wires the new use cases into QaidaUseCases / RepositoryModule
- Unit tests for unlock transitions, star thresholds, resume pointer,
  cell-heard writes, and derived course progress

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YSFhCrgm5wCy2ZVTPSmaQm