### PR TITLE
Add Qaida tap-to-hear audio playback engine and reader UI

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QaidaAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QaidaAudioManager.kt
@@ -1,0 +1,201 @@
+package com.arshadshah.nimaz.data.audio
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reactive playback state for the Qaida tap-to-hear engine.
+ *
+ * Deliberately tiny compared to [AudioState]: these are sub-second single-clip
+ * taps, so there is no playlist position, duration, seek or notification state —
+ * just which token is sounding and whether it is loading/playing.
+ */
+data class QaidaAudioState(
+    /** The `audio_key` of the clip currently loaded/playing, or null when idle. */
+    val currentKey: String? = null,
+    val isPlaying: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+/**
+ * Tap-to-hear playback for single Qaida tokens (epic #171, sub-issue F of #177).
+ *
+ * A stripped-down sibling of [QuranAudioManager]: it reuses the same Media3 /
+ * ExoPlayer foundation but drops everything the Qaida does not need — no
+ * playlist position tracking, no foreground service, no notification/MediaSession,
+ * no CDN streaming. The clips are sub-second taps, not background listening.
+ *
+ * Source resolution honours sub-issue B's delivery decision: the 2 MB clip pack
+ * ships **bundled** in `assets/qaida/audio/`, so a key resolves directly to an
+ * `android_asset` URI (which Media3's `DefaultDataSource` routes to its
+ * `AssetDataSource`). A downloaded/drop-in override under
+ * `filesDir/qaida_audio/` is honoured first, so the same engine also serves the
+ * on-demand delivery mode without code changes — and works fully offline once a
+ * clip is on disk either way.
+ *
+ * A single reused [ExoPlayer] means rapid taps cancel/replace cleanly: each
+ * [play] simply swaps the current [MediaItem], and resolved items are cached so
+ * repeat taps are instant.
+ */
+@UnstableApi
+@Singleton
+class QaidaAudioManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private var player: ExoPlayer? = null
+
+    private val _state = MutableStateFlow(QaidaAudioState())
+    val state: StateFlow<QaidaAudioState> = _state.asStateFlow()
+
+    // Resolved MediaItems keyed by audio_key, so repeated taps never rebuild
+    // them — the whole point is instant replay.
+    private val mediaItemCache = ConcurrentHashMap<String, MediaItem>()
+
+    // The ordered keys currently queued, so media-item transitions can report
+    // the right currentKey when playing a whole line via playSequence().
+    private var sequenceKeys: List<String> = emptyList()
+
+    @OptIn(UnstableApi::class)
+    private fun getOrCreatePlayer(): ExoPlayer {
+        return player ?: ExoPlayer.Builder(context).build().also { newPlayer ->
+            player = newPlayer
+            newPlayer.addListener(object : Player.Listener {
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    when (playbackState) {
+                        Player.STATE_READY -> _state.update { it.copy(isLoading = false) }
+                        Player.STATE_ENDED -> {
+                            // Whole clip / sequence finished playing.
+                            if (!newPlayer.hasNextMediaItem()) {
+                                _state.update {
+                                    it.copy(currentKey = null, isPlaying = false, isLoading = false)
+                                }
+                            }
+                        }
+                        Player.STATE_IDLE -> {
+                            newPlayer.playerError?.let { err ->
+                                _state.update {
+                                    it.copy(
+                                        isPlaying = false,
+                                        isLoading = false,
+                                        error = err.message ?: "Playback error"
+                                    )
+                                }
+                            }
+                        }
+                        else -> {}
+                    }
+                }
+
+                override fun onIsPlayingChanged(isPlaying: Boolean) {
+                    _state.update { it.copy(isPlaying = isPlaying) }
+                }
+
+                override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    val key = mediaItem?.mediaId?.takeIf { it.isNotEmpty() }
+                        ?: sequenceKeys.getOrNull(newPlayer.currentMediaItemIndex)
+                    if (key != null) {
+                        _state.update { it.copy(currentKey = key) }
+                    }
+                }
+            })
+        }
+    }
+
+    /**
+     * Play the clip for a single token. Replaces anything currently playing, so
+     * rapid taps always cancel cleanly and the latest tap wins.
+     */
+    fun play(audioKey: String) {
+        if (audioKey.isBlank()) return
+        sequenceKeys = listOf(audioKey)
+        val item = mediaItemFor(audioKey)
+        val p = getOrCreatePlayer()
+        _state.update { it.copy(currentKey = audioKey, isLoading = true, error = null) }
+        p.setMediaItem(item)
+        p.prepare()
+        p.play()
+    }
+
+    /**
+     * Play several tokens back-to-back — the "play whole line" affordance.
+     * [currentKey] advances as each clip starts.
+     */
+    fun playSequence(keys: List<String>) {
+        val clean = keys.filter { it.isNotBlank() }
+        when (clean.size) {
+            0 -> return
+            1 -> {
+                play(clean.first())
+                return
+            }
+        }
+        sequenceKeys = clean
+        val items = clean.map { mediaItemFor(it) }
+        val p = getOrCreatePlayer()
+        _state.update { it.copy(currentKey = clean.first(), isLoading = true, error = null) }
+        p.setMediaItems(items)
+        p.prepare()
+        p.play()
+    }
+
+    /** Stop playback and reset to idle, keeping the resolved-item cache warm. */
+    fun stop() {
+        sequenceKeys = emptyList()
+        player?.let {
+            it.stop()
+            it.clearMediaItems()
+        }
+        _state.update { QaidaAudioState() }
+    }
+
+    /** Fully tear down the player and caches (e.g. on process teardown). */
+    fun release() {
+        sequenceKeys = emptyList()
+        player?.release()
+        player = null
+        mediaItemCache.clear()
+        _state.update { QaidaAudioState() }
+    }
+
+    private fun mediaItemFor(audioKey: String): MediaItem =
+        mediaItemCache.getOrPut(audioKey) {
+            MediaItem.Builder()
+                .setMediaId(audioKey)
+                .setUri(resolveUri(audioKey))
+                .build()
+        }
+
+    /**
+     * Resolve a token's `audio_key` to a playable URI. A downloaded/drop-in clip
+     * under `filesDir/qaida_audio/` wins (the on-demand delivery mode), otherwise
+     * the bundled asset is used (the shipped default). Both are local, so either
+     * way playback is offline and instant.
+     */
+    private fun resolveUri(audioKey: String): String {
+        val downloaded = File(File(context.filesDir, DOWNLOAD_DIR), "$audioKey.mp3")
+        return if (downloaded.exists() && downloaded.length() > 0) {
+            downloaded.toURI().toString()
+        } else {
+            "$ASSET_AUDIO_URI_PREFIX$audioKey.mp3"
+        }
+    }
+
+    companion object {
+        private const val ASSET_AUDIO_URI_PREFIX = "file:///android_asset/qaida/audio/"
+        private const val DOWNLOAD_DIR = "qaida_audio"
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
@@ -1,0 +1,155 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.data.audio.QaidaAudioManager
+import com.arshadshah.nimaz.data.audio.QaidaAudioState
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.domain.model.QaidaLetter
+import com.arshadshah.nimaz.domain.usecase.QaidaUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * The state holder behind the Qaida Reader UI (epic #171, sub-issue F of #177).
+ *
+ * It wires together the domain "learning loop" ([QaidaUseCases]) and the
+ * tap-to-hear playback engine ([QaidaAudioManager]) and exposes everything a
+ * (later) Compose screen needs as reactive [StateFlow]s. There is no UI here —
+ * just playback orchestration and reactive state.
+ *
+ * Tapping a cell both plays its clip and advances progress (`MarkCellHeard`,
+ * sub-issue E). Playback is stopped on lesson change and on [onCleared].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class QaidaReaderViewModel @Inject constructor(
+    private val qaidaUseCases: QaidaUseCases,
+    private val audioManager: QaidaAudioManager
+) : ViewModel() {
+
+    private val sharing = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS)
+
+    private val _selectedLessonId = MutableStateFlow<Int?>(null)
+    /** The lesson currently open in the reader, or null before one is chosen. */
+    val selectedLessonId: StateFlow<Int?> = _selectedLessonId.asStateFlow()
+
+    /**
+     * Whole-course rollup: every lesson with its gated status and stars, overall
+     * completion and the "continue where you left off" pointer.
+     */
+    val courseProgress: StateFlow<QaidaCourseProgress?> =
+        qaidaUseCases.getCourseProgress()
+            .stateIn(viewModelScope, sharing, null)
+
+    /** The 29-letter reference table shown alongside the lessons. */
+    val letters: StateFlow<List<QaidaLetter>> =
+        qaidaUseCases.getLetters()
+            .stateIn(viewModelScope, sharing, emptyList())
+
+    /** The selected lesson's full content: ordered lines, each with its cells. */
+    val lessonContent: StateFlow<QaidaLessonContent?> =
+        _selectedLessonId.flatMapLatest { id ->
+            if (id == null) flowOf(null) else qaidaUseCases.getLessonContent(id)
+        }.stateIn(viewModelScope, sharing, null)
+
+    /** Derived progress/stars for the selected lesson. */
+    val lessonProgress: StateFlow<QaidaLessonState?> =
+        _selectedLessonId.flatMapLatest { id ->
+            if (id == null) flowOf(null) else qaidaUseCases.getLessonProgress(id)
+        }.stateIn(viewModelScope, sharing, null)
+
+    /** Raw audio engine state (loading/playing flags + current key). */
+    val audioState: StateFlow<QaidaAudioState> = audioManager.state
+
+    /**
+     * The [QaidaCell] currently sounding, resolved from the audio engine's
+     * current key against the loaded lesson content, so the UI can highlight it.
+     */
+    val playingCell: StateFlow<QaidaCell?> =
+        combine(audioManager.state, lessonContent) { audio, content ->
+            val key = audio.currentKey ?: return@combine null
+            content?.lines
+                ?.firstNotNullOfOrNull { line -> line.cells.firstOrNull { it.audioKey == key } }
+        }.stateIn(viewModelScope, sharing, null)
+
+    /** Open a lesson, stopping any audio still playing from the previous one. */
+    fun selectLesson(lessonId: Int) {
+        if (_selectedLessonId.value == lessonId) return
+        audioManager.stop()
+        _selectedLessonId.value = lessonId
+    }
+
+    /**
+     * Handle a token tap: play its clip and mark it heard (which advances the
+     * lesson's progress and may unlock the next lesson, per sub-issue E).
+     */
+    fun onCellTapped(cell: QaidaCell) {
+        audioManager.play(cell.audioKey)
+        viewModelScope.launch {
+            qaidaUseCases.markCellHeard(cell.lessonId, cell.id)
+        }
+    }
+
+    /** Play a whole line back-to-back, marking each of its cells heard. */
+    fun playLine(lineId: Int) {
+        val line = lessonContent.value?.lines?.firstOrNull { it.line.id == lineId } ?: return
+        if (line.cells.isEmpty()) return
+        audioManager.playSequence(line.cells.map { it.audioKey })
+        viewModelScope.launch {
+            line.cells.forEach { qaidaUseCases.markCellHeard(it.lessonId, it.id) }
+        }
+    }
+
+    /** Move to the next lesson in display order, if it exists and is not locked. */
+    fun nextLesson() {
+        val lessons = courseProgress.value?.lessons ?: return
+        val index = lessons.indexOfFirst { it.lesson.id == _selectedLessonId.value }
+        if (index < 0 || index >= lessons.lastIndex) return
+        val next = lessons[index + 1]
+        if (next.status != LessonStatus.LOCKED) selectLesson(next.lesson.id)
+    }
+
+    /** Move to the previous lesson in display order, if there is one. */
+    fun previousLesson() {
+        val lessons = courseProgress.value?.lessons ?: return
+        val index = lessons.indexOfFirst { it.lesson.id == _selectedLessonId.value }
+        if (index <= 0) return
+        selectLesson(lessons[index - 1].lesson.id)
+    }
+
+    /**
+     * Open the "continue where you left off" lesson: the first unlocked-but-
+     * incomplete lesson, falling back to the first lesson if everything is done.
+     */
+    fun resume() {
+        val course = courseProgress.value ?: return
+        val target = course.nextLessonId ?: course.lessons.firstOrNull()?.lesson?.id
+        if (target != null) selectLesson(target)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        audioManager.stop()
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModelTest.kt
@@ -1,0 +1,283 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.arshadshah.nimaz.data.audio.QaidaAudioManager
+import com.arshadshah.nimaz.data.audio.QaidaAudioState
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.LineType
+import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLesson
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.domain.model.QaidaLine
+import com.arshadshah.nimaz.domain.model.QaidaLineContent
+import com.arshadshah.nimaz.domain.model.TokenType
+import com.arshadshah.nimaz.domain.usecase.GetCourseProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.GetLessonProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaCellUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonContentUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLettersUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkCellHeardUseCase
+import com.arshadshah.nimaz.domain.usecase.QaidaUseCases
+import com.arshadshah.nimaz.domain.usecase.UnlockNextLessonUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QaidaReaderViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var getLessonContent: GetQaidaLessonContentUseCase
+    private lateinit var getLetters: GetQaidaLettersUseCase
+    private lateinit var getLessonProgress: GetLessonProgressUseCase
+    private lateinit var getCourseProgress: GetCourseProgressUseCase
+    private lateinit var markCellHeard: MarkCellHeardUseCase
+    private lateinit var useCases: QaidaUseCases
+    private lateinit var audioManager: QaidaAudioManager
+    private lateinit var audioStateFlow: MutableStateFlow<QaidaAudioState>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        getLessonContent = mockk()
+        getLetters = mockk()
+        getLessonProgress = mockk()
+        getCourseProgress = mockk()
+        markCellHeard = mockk(relaxed = true)
+
+        useCases = QaidaUseCases(
+            getLessons = mockk<GetQaidaLessonsUseCase>(relaxed = true),
+            getLessonContent = getLessonContent,
+            getLetters = getLetters,
+            getCell = mockk<GetQaidaCellUseCase>(relaxed = true),
+            markCellHeard = markCellHeard,
+            unlockNextLesson = mockk<UnlockNextLessonUseCase>(relaxed = true),
+            getLessonProgress = getLessonProgress,
+            getCourseProgress = getCourseProgress
+        )
+
+        audioManager = mockk(relaxed = true)
+        audioStateFlow = MutableStateFlow(QaidaAudioState())
+        every { audioManager.state } returns audioStateFlow
+
+        // Default stubs — individual tests override the per-lesson ones.
+        every { getLetters.invoke() } returns flowOf(emptyList())
+        every { getCourseProgress.invoke() } returns flowOf(courseProgress())
+        every { getLessonProgress.invoke(any()) } returns flowOf(lessonState(1))
+        every { getLessonContent.invoke(1) } returns flowOf(lessonContent(1))
+        every { getLessonContent.invoke(2) } returns flowOf(lessonContent(2))
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun createViewModel() = QaidaReaderViewModel(useCases, audioManager)
+
+    @Test
+    fun `tapping a cell plays its clip and marks it heard`() = runTest {
+        val vm = createViewModel()
+        val cell = cell(id = 11, lessonId = 1, audioKey = "l1_alif")
+
+        vm.onCellTapped(cell)
+        advanceUntilIdle()
+
+        verify { audioManager.play("l1_alif") }
+        coVerify { markCellHeard.invoke(1, 11, any()) }
+    }
+
+    @Test
+    fun `selecting a lesson loads its content`() = runTest {
+        val vm = createViewModel()
+
+        vm.lessonContent.test {
+            assertThat(awaitItem()).isNull() // nothing selected yet
+            vm.selectLesson(1)
+            assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `switching lessons stops audio and swaps content`() = runTest {
+        val vm = createViewModel()
+
+        vm.lessonContent.test {
+            assertThat(awaitItem()).isNull()
+            vm.selectLesson(1)
+            assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
+            vm.selectLesson(2)
+            assertThat(awaitItem()?.lesson?.id).isEqualTo(2)
+        }
+
+        // stop() is called on every lesson change.
+        verify(atLeast = 2) { audioManager.stop() }
+    }
+
+    @Test
+    fun `resume opens the course resume pointer`() = runTest {
+        every { getCourseProgress.invoke() } returns flowOf(courseProgress(nextLessonId = 2))
+        val vm = createViewModel()
+
+        vm.courseProgress.test {
+            awaitItem() // initial null
+            awaitItem() // emitted rollup
+            vm.resume()
+        }
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    @Test
+    fun `playLine plays the whole line and marks every cell heard`() = runTest {
+        val vm = createViewModel()
+
+        vm.lessonContent.test {
+            assertThat(awaitItem()).isNull()
+            vm.selectLesson(1)
+            assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
+
+            vm.playLine(lineId = 100)
+            advanceUntilIdle()
+
+            verify { audioManager.playSequence(listOf("l1_alif", "l1_baa")) }
+            coVerify { markCellHeard.invoke(1, 11, any()) }
+            coVerify { markCellHeard.invoke(1, 12, any()) }
+        }
+    }
+
+    @Test
+    fun `playingCell resolves the cell for the currently sounding key`() = runTest {
+        val vm = createViewModel()
+
+        vm.playingCell.test {
+            assertThat(awaitItem()).isNull()
+            vm.selectLesson(1)
+            audioStateFlow.value = QaidaAudioState(currentKey = "l1_baa", isPlaying = true)
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem()?.id).isEqualTo(12)
+        }
+    }
+
+    @Test
+    fun `nextLesson does not advance into a locked lesson`() = runTest {
+        every { getCourseProgress.invoke() } returns flowOf(
+            courseProgress(secondStatus = LessonStatus.LOCKED)
+        )
+        val vm = createViewModel()
+
+        vm.courseProgress.test {
+            awaitItem()
+            awaitItem()
+            vm.selectLesson(1)
+            vm.nextLesson()
+        }
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(1)
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    private fun cell(
+        id: Int,
+        lessonId: Int,
+        audioKey: String,
+        lineId: Int = 100,
+        position: Int = 0
+    ) = QaidaCell(
+        id = id,
+        lineId = lineId,
+        lessonId = lessonId,
+        position = position,
+        textArabic = "ا",
+        transliteration = "alif",
+        tokenType = TokenType.LETTER,
+        audioKey = audioKey,
+        audioPath = "file:///android_asset/qaida/audio/$audioKey.mp3",
+        highlightGroup = null,
+        letterId = null,
+        notes = null
+    )
+
+    private fun lessonContent(lessonId: Int) = QaidaLessonContent(
+        lesson = lesson(lessonId),
+        lines = listOf(
+            QaidaLineContent(
+                line = QaidaLine(
+                    id = 100,
+                    lessonId = lessonId,
+                    lineNumber = 1,
+                    lineType = LineType.EXAMPLE,
+                    instructionEnglish = null,
+                    instructionArabic = null,
+                    displayOrder = 0
+                ),
+                cells = listOf(
+                    cell(id = 11, lessonId = lessonId, audioKey = "l${lessonId}_alif", position = 0),
+                    cell(id = 12, lessonId = lessonId, audioKey = "l${lessonId}_baa", position = 1)
+                )
+            )
+        )
+    )
+
+    private fun lesson(id: Int) = QaidaLesson(
+        id = id,
+        lessonNumber = id,
+        titleEnglish = "Lesson $id",
+        titleArabic = "درس",
+        titleTransliteration = "dars",
+        description = "",
+        conceptTags = emptyList(),
+        icon = "book",
+        displayOrder = id
+    )
+
+    private fun lessonState(id: Int, status: LessonStatus = LessonStatus.IN_PROGRESS) =
+        QaidaLessonState(
+            lesson = lesson(id),
+            status = status,
+            stars = 1,
+            completedCells = 1,
+            totalCells = 2,
+            completionFraction = 0.5f,
+            lastCellId = 11
+        )
+
+    private fun courseProgress(
+        nextLessonId: Int? = 1,
+        secondStatus: LessonStatus = LessonStatus.UNLOCKED
+    ) = QaidaCourseProgress(
+        lessons = listOf(
+            lessonState(1, LessonStatus.IN_PROGRESS),
+            lessonState(2, secondStatus)
+        ),
+        completedLessons = 0,
+        totalLessons = 2,
+        totalStars = 1,
+        maxStars = 6,
+        totalCellsHeard = 1,
+        overallFraction = 0f,
+        nextLessonId = nextLessonId
+    )
+}


### PR DESCRIPTION
## Summary
Implements the Qaida Reader feature with a complete tap-to-hear audio playback system. This includes a stripped-down audio manager for single-clip playback, a reactive ViewModel orchestrating the learning loop, and comprehensive test coverage.

## Key Changes

- **QaidaAudioManager**: A specialized audio engine for Qaida token playback
  - Reuses Media3/ExoPlayer foundation but drops unnecessary features (playlist tracking, notifications, streaming)
  - Supports single-clip playback via `play()` and sequential playback via `playSequence()` for "play whole line"
  - Implements smart URI resolution: prefers downloaded clips from `filesDir/qaida_audio/` but falls back to bundled assets in `assets/qaida/audio/`
  - Maintains a MediaItem cache for instant replay on repeated taps
  - Exposes reactive `QaidaAudioState` (current key, loading/playing flags, errors)

- **QaidaReaderViewModel**: State holder for the Qaida Reader UI
  - Wires together domain use cases and audio playback engine
  - Exposes reactive StateFlows for lesson content, progress, letters reference, and audio state
  - Implements learning loop: tapping a cell plays its clip and marks it heard (advancing progress)
  - Handles lesson navigation (next/previous/resume) with gating logic (respects locked lessons)
  - Derives `playingCell` by matching audio engine's current key against loaded lesson content for UI highlighting
  - Stops audio on lesson change and ViewModel teardown

- **QaidaReaderViewModelTest**: Comprehensive test suite covering
  - Cell tapping (playback + progress marking)
  - Lesson selection and content loading
  - Lesson switching (audio stops, content swaps)
  - Resume functionality (opens course progress pointer)
  - Line playback (sequential audio + all cells marked heard)
  - Playing cell resolution (matches audio key to cell)
  - Lesson gating (respects locked lessons on navigation)

## Implementation Details

- Uses Kotlin coroutines and Flow for reactive state management
- Leverages Media3's `DefaultDataSource` which automatically routes `android_asset://` URIs to `AssetDataSource`
- ConcurrentHashMap for thread-safe MediaItem caching
- Single reused ExoPlayer instance ensures rapid taps cancel/replace cleanly
- Comprehensive mocking and Turbine testing for async flows

https://claude.ai/code/session_011VfFiemRs8fsxMQVHRkhxT