### PR TITLE
refactor(widget): centralise duplicated widget plumbing into widget/core

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/util/DateTimeExtensions.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/DateTimeExtensions.kt
@@ -1,0 +1,16 @@
+package com.arshadshah.nimaz.core.util
+
+import java.time.LocalDate
+
+/** Number of milliseconds in a calendar day. */
+const val MILLIS_PER_DAY: Long = 86_400_000L
+
+/**
+ * Epoch milliseconds at UTC midnight of this date.
+ *
+ * This is the canonical key used for date-bucketed database rows (prayer
+ * records, fasts, tasbih sessions, …). The codebase previously computed it two
+ * equivalent-but-different-looking ways — `toEpochDay() * 86400000L` and
+ * `atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000` — which are unified here.
+ */
+fun LocalDate.toUtcMidnightMillis(): Long = toEpochDay() * MILLIS_PER_DAY

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/FlowExtensions.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/FlowExtensions.kt
@@ -1,0 +1,14 @@
+package com.arshadshah.nimaz.core.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Map every item of each emitted list.
+ *
+ * Shorthand for the very common `flow.map { list -> list.map(transform) }` used
+ * throughout the repositories to turn a [Flow] of database entities into a
+ * [Flow] of domain models, e.g. `dao.getAll().mapItems { it.toDomain() }`.
+ */
+inline fun <T, R> Flow<List<T>>.mapItems(crossinline transform: (T) -> R): Flow<List<R>> =
+    map { list -> list.map(transform) }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,6 +26,19 @@ class PreferencesDataStore @Inject constructor(
     private val context: Context
 ) {
     private val dataStore = context.dataStore
+
+    /** Observe a preference, falling back to [default] when it has not been set. */
+    private fun <T> preference(key: Preferences.Key<T>, default: T): Flow<T> =
+        dataStore.data.map { it[key] ?: default }
+
+    /** Observe a nullable preference (no default — emits null until set). */
+    private fun <T> preference(key: Preferences.Key<T>): Flow<T?> =
+        dataStore.data.map { it[key] }
+
+    /** Persist a single preference value. */
+    private suspend fun <T> put(key: Preferences.Key<T>, value: T) {
+        dataStore.edit { it[key] = value }
+    }
 
     // Keys
     private object PreferencesKeys {
@@ -154,278 +168,154 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Onboarding
-    val onboardingCompleted: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ONBOARDING_COMPLETED] ?: false
-    }
+    val onboardingCompleted: Flow<Boolean> = preference(PreferencesKeys.ONBOARDING_COMPLETED, false)
 
-    suspend fun setOnboardingCompleted(completed: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ONBOARDING_COMPLETED] = completed
-        }
-    }
+    suspend fun setOnboardingCompleted(completed: Boolean) =
+        put(PreferencesKeys.ONBOARDING_COMPLETED, completed)
 
     // Theme
-    val themeMode: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.THEME_MODE] ?: "system"
-    }
+    val themeMode: Flow<String> = preference(PreferencesKeys.THEME_MODE, "system")
 
-    suspend fun setThemeMode(mode: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.THEME_MODE] = mode
-        }
-    }
+    suspend fun setThemeMode(mode: String) = put(PreferencesKeys.THEME_MODE, mode)
 
-    val dynamicColor: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DYNAMIC_COLOR] ?: false
-    }
+    val dynamicColor: Flow<Boolean> = preference(PreferencesKeys.DYNAMIC_COLOR, false)
 
-    suspend fun setDynamicColor(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.DYNAMIC_COLOR] = enabled
-        }
-    }
+    suspend fun setDynamicColor(enabled: Boolean) = put(PreferencesKeys.DYNAMIC_COLOR, enabled)
 
     // Appearance
-    val showIslamicPatterns: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_ISLAMIC_PATTERNS] ?: true
-    }
+    val showIslamicPatterns: Flow<Boolean> = preference(PreferencesKeys.SHOW_ISLAMIC_PATTERNS, true)
 
-    suspend fun setShowIslamicPatterns(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.SHOW_ISLAMIC_PATTERNS] = enabled }
-    }
+    suspend fun setShowIslamicPatterns(enabled: Boolean) =
+        put(PreferencesKeys.SHOW_ISLAMIC_PATTERNS, enabled)
 
-    val animationsEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ANIMATIONS_ENABLED] ?: true
-    }
+    val animationsEnabled: Flow<Boolean> = preference(PreferencesKeys.ANIMATIONS_ENABLED, true)
 
-    suspend fun setAnimationsEnabled(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.ANIMATIONS_ENABLED] = enabled }
-    }
+    suspend fun setAnimationsEnabled(enabled: Boolean) =
+        put(PreferencesKeys.ANIMATIONS_ENABLED, enabled)
 
     // Display
-    val showCountdown: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_COUNTDOWN] ?: true
-    }
+    val showCountdown: Flow<Boolean> = preference(PreferencesKeys.SHOW_COUNTDOWN, true)
 
-    suspend fun setShowCountdown(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.SHOW_COUNTDOWN] = enabled }
-    }
+    suspend fun setShowCountdown(enabled: Boolean) = put(PreferencesKeys.SHOW_COUNTDOWN, enabled)
 
-    val showQuickActions: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_QUICK_ACTIONS] ?: true
-    }
+    val showQuickActions: Flow<Boolean> = preference(PreferencesKeys.SHOW_QUICK_ACTIONS, true)
 
-    suspend fun setShowQuickActions(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.SHOW_QUICK_ACTIONS] = enabled }
-    }
+    suspend fun setShowQuickActions(enabled: Boolean) =
+        put(PreferencesKeys.SHOW_QUICK_ACTIONS, enabled)
 
-    val hapticFeedback: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HAPTIC_FEEDBACK] ?: true
-    }
+    val hapticFeedback: Flow<Boolean> = preference(PreferencesKeys.HAPTIC_FEEDBACK, true)
 
-    suspend fun setHapticFeedback(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.HAPTIC_FEEDBACK] = enabled }
-    }
+    suspend fun setHapticFeedback(enabled: Boolean) = put(PreferencesKeys.HAPTIC_FEEDBACK, enabled)
 
-    val use24HourFormat: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.USE_24_HOUR_FORMAT] ?: false
-    }
+    val use24HourFormat: Flow<Boolean> = preference(PreferencesKeys.USE_24_HOUR_FORMAT, false)
 
-    suspend fun setUse24HourFormat(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.USE_24_HOUR_FORMAT] = enabled }
-    }
+    suspend fun setUse24HourFormat(enabled: Boolean) =
+        put(PreferencesKeys.USE_24_HOUR_FORMAT, enabled)
 
-    val useHijriPrimary: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.USE_HIJRI_PRIMARY] ?: false
-    }
+    val useHijriPrimary: Flow<Boolean> = preference(PreferencesKeys.USE_HIJRI_PRIMARY, false)
 
-    suspend fun setUseHijriPrimary(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.USE_HIJRI_PRIMARY] = enabled }
-    }
+    suspend fun setUseHijriPrimary(enabled: Boolean) =
+        put(PreferencesKeys.USE_HIJRI_PRIMARY, enabled)
 
     // Language
-    val appLanguage: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.APP_LANGUAGE] ?: "en"
-    }
+    val appLanguage: Flow<String> = preference(PreferencesKeys.APP_LANGUAGE, "en")
 
-    suspend fun setAppLanguage(language: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.APP_LANGUAGE] = language
-        }
-    }
+    suspend fun setAppLanguage(language: String) = put(PreferencesKeys.APP_LANGUAGE, language)
 
     // Help content version (0 = never seeded)
-    val helpContentVersion: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HELP_CONTENT_VERSION] ?: 0
-    }
+    val helpContentVersion: Flow<Int> = preference(PreferencesKeys.HELP_CONTENT_VERSION, 0)
 
-    suspend fun setHelpContentVersion(version: Int) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.HELP_CONTENT_VERSION] = version
-        }
-    }
+    suspend fun setHelpContentVersion(version: Int) =
+        put(PreferencesKeys.HELP_CONTENT_VERSION, version)
 
     // Hadith backfill version (0 = never applied)
-    val hadithBackfillVersion: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_BACKFILL_VERSION] ?: 0
-    }
+    val hadithBackfillVersion: Flow<Int> = preference(PreferencesKeys.HADITH_BACKFILL_VERSION, 0)
 
-    suspend fun setHadithBackfillVersion(version: Int) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.HADITH_BACKFILL_VERSION] = version
-        }
-    }
+    suspend fun setHadithBackfillVersion(version: Int) =
+        put(PreferencesKeys.HADITH_BACKFILL_VERSION, version)
 
     // Tasbih counter style — true = bead strand, false = classic circle.
-    val tasbihBeadMode: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_BEAD_MODE] ?: false
-    }
+    val tasbihBeadMode: Flow<Boolean> = preference(PreferencesKeys.TASBIH_BEAD_MODE, false)
 
-    suspend fun setTasbihBeadMode(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_BEAD_MODE] = enabled
-        }
-    }
+    suspend fun setTasbihBeadMode(enabled: Boolean) = put(PreferencesKeys.TASBIH_BEAD_MODE, enabled)
 
     // Tasbih bead design — stable key of the chosen BeadDesign (default "wood").
-    val tasbihBeadDesign: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_BEAD_DESIGN] ?: "wood"
-    }
+    val tasbihBeadDesign: Flow<String> = preference(PreferencesKeys.TASBIH_BEAD_DESIGN, "wood")
 
-    suspend fun setTasbihBeadDesign(key: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_BEAD_DESIGN] = key
-        }
-    }
+    suspend fun setTasbihBeadDesign(key: String) = put(PreferencesKeys.TASBIH_BEAD_DESIGN, key)
 
     // Currently selected tasbih preset id (-1 = free count). Shared across screens
     // so the Choose-Dhikr picker can drive the counter on a separate back-stack entry.
-    val tasbihSelectedPresetId: Flow<Long> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_SELECTED_PRESET] ?: -1L
-    }
+    val tasbihSelectedPresetId: Flow<Long> = preference(PreferencesKeys.TASBIH_SELECTED_PRESET, -1L)
 
-    suspend fun setTasbihSelectedPresetId(id: Long) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_SELECTED_PRESET] = id
-        }
-    }
+    suspend fun setTasbihSelectedPresetId(id: Long) =
+        put(PreferencesKeys.TASBIH_SELECTED_PRESET, id)
 
     // Versioned runtime seed of new default presets (prepackaged DB only has the
     // original five). Bump the latest version in the VM when new defaults are added.
-    val tasbihPresetSeedVersion: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_PRESET_SEED_VERSION] ?: 0
-    }
+    val tasbihPresetSeedVersion: Flow<Int> =
+        preference(PreferencesKeys.TASBIH_PRESET_SEED_VERSION, 0)
 
-    suspend fun setTasbihPresetSeedVersion(version: Int) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_PRESET_SEED_VERSION] = version
-        }
-    }
+    suspend fun setTasbihPresetSeedVersion(version: Int) =
+        put(PreferencesKeys.TASBIH_PRESET_SEED_VERSION, version)
 
     // Favourite preset ids (stored as strings).
-    val tasbihFavorites: Flow<Set<String>> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_FAVORITES] ?: emptySet()
-    }
+    val tasbihFavorites: Flow<Set<String>> =
+        preference(PreferencesKeys.TASBIH_FAVORITES, emptySet())
 
-    suspend fun setTasbihFavorites(ids: Set<String>) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_FAVORITES] = ids
-        }
-    }
+    suspend fun setTasbihFavorites(ids: Set<String>) = put(PreferencesKeys.TASBIH_FAVORITES, ids)
 
     // Bead strand handedness — false = right-handed (beads advance right→left),
     // true = left-handed (beads advance left→right).
-    val tasbihLeftHanded: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_LEFT_HANDED] ?: false
-    }
+    val tasbihLeftHanded: Flow<Boolean> = preference(PreferencesKeys.TASBIH_LEFT_HANDED, false)
 
-    suspend fun setTasbihLeftHanded(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_LEFT_HANDED] = enabled
-        }
-    }
+    suspend fun setTasbihLeftHanded(enabled: Boolean) =
+        put(PreferencesKeys.TASBIH_LEFT_HANDED, enabled)
 
     // Dua content version (0 = never seeded)
-    val duaContentVersion: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_CONTENT_VERSION] ?: 0
-    }
+    val duaContentVersion: Flow<Int> = preference(PreferencesKeys.DUA_CONTENT_VERSION, 0)
 
-    suspend fun setDuaContentVersion(version: Int) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.DUA_CONTENT_VERSION] = version
-        }
-    }
+    suspend fun setDuaContentVersion(version: Int) =
+        put(PreferencesKeys.DUA_CONTENT_VERSION, version)
 
     // Qaida content version (0 = never seeded)
-    val qaidaContentVersion: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.QAIDA_CONTENT_VERSION] ?: 0
-    }
+    val qaidaContentVersion: Flow<Int> = preference(PreferencesKeys.QAIDA_CONTENT_VERSION, 0)
 
-    suspend fun setQaidaContentVersion(version: Int) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.QAIDA_CONTENT_VERSION] = version
-        }
-    }
+    suspend fun setQaidaContentVersion(version: Int) =
+        put(PreferencesKeys.QAIDA_CONTENT_VERSION, version)
 
-    val arabicFontSize: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ARABIC_FONT_SIZE] ?: "medium"
-    }
+    val arabicFontSize: Flow<String> = preference(PreferencesKeys.ARABIC_FONT_SIZE, "medium")
 
-    suspend fun setArabicFontSize(size: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ARABIC_FONT_SIZE] = size
-        }
-    }
+    suspend fun setArabicFontSize(size: String) = put(PreferencesKeys.ARABIC_FONT_SIZE, size)
 
     // Prayer Settings
-    val calculationMethod: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.CALCULATION_METHOD] ?: "MUSLIM_WORLD_LEAGUE"
-    }
+    val calculationMethod: Flow<String> =
+        preference(PreferencesKeys.CALCULATION_METHOD, "MUSLIM_WORLD_LEAGUE")
 
-    suspend fun setCalculationMethod(method: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.CALCULATION_METHOD] = method
-        }
-    }
+    suspend fun setCalculationMethod(method: String) =
+        put(PreferencesKeys.CALCULATION_METHOD, method)
 
-    val asrCalculation: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ASR_CALCULATION] ?: "standard"
-    }
+    val asrCalculation: Flow<String> = preference(PreferencesKeys.ASR_CALCULATION, "standard")
 
-    suspend fun setAsrCalculation(calculation: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ASR_CALCULATION] = calculation
-        }
-    }
+    suspend fun setAsrCalculation(calculation: String) =
+        put(PreferencesKeys.ASR_CALCULATION, calculation)
 
-    val highLatitudeRule: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HIGH_LATITUDE_RULE] ?: "MIDDLE_OF_NIGHT"
-    }
+    val highLatitudeRule: Flow<String> =
+        preference(PreferencesKeys.HIGH_LATITUDE_RULE, "MIDDLE_OF_NIGHT")
 
-    suspend fun setHighLatitudeRule(rule: String) {
-        dataStore.edit { it[PreferencesKeys.HIGH_LATITUDE_RULE] = rule }
-    }
+    suspend fun setHighLatitudeRule(rule: String) = put(PreferencesKeys.HIGH_LATITUDE_RULE, rule)
 
-    val currentLocationId: Flow<Long?> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.CURRENT_LOCATION_ID]
-    }
+    val currentLocationId: Flow<Long?> = preference(PreferencesKeys.CURRENT_LOCATION_ID)
 
-    suspend fun setCurrentLocationId(id: Long) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.CURRENT_LOCATION_ID] = id
-        }
-    }
+    suspend fun setCurrentLocationId(id: Long) = put(PreferencesKeys.CURRENT_LOCATION_ID, id)
 
     // Prayer Adjustments
-    val fajrAdjustment: Flow<Int> = dataStore.data.map { it[PreferencesKeys.FAJR_ADJUSTMENT] ?: 0 }
-    val sunriseAdjustment: Flow<Int> =
-        dataStore.data.map { it[PreferencesKeys.SUNRISE_ADJUSTMENT] ?: 0 }
-    val dhuhrAdjustment: Flow<Int> =
-        dataStore.data.map { it[PreferencesKeys.DHUHR_ADJUSTMENT] ?: 0 }
-    val asrAdjustment: Flow<Int> = dataStore.data.map { it[PreferencesKeys.ASR_ADJUSTMENT] ?: 0 }
-    val maghribAdjustment: Flow<Int> =
-        dataStore.data.map { it[PreferencesKeys.MAGHRIB_ADJUSTMENT] ?: 0 }
-    val ishaAdjustment: Flow<Int> = dataStore.data.map { it[PreferencesKeys.ISHA_ADJUSTMENT] ?: 0 }
+    val fajrAdjustment: Flow<Int> = preference(PreferencesKeys.FAJR_ADJUSTMENT, 0)
+    val sunriseAdjustment: Flow<Int> = preference(PreferencesKeys.SUNRISE_ADJUSTMENT, 0)
+    val dhuhrAdjustment: Flow<Int> = preference(PreferencesKeys.DHUHR_ADJUSTMENT, 0)
+    val asrAdjustment: Flow<Int> = preference(PreferencesKeys.ASR_ADJUSTMENT, 0)
+    val maghribAdjustment: Flow<Int> = preference(PreferencesKeys.MAGHRIB_ADJUSTMENT, 0)
+    val ishaAdjustment: Flow<Int> = preference(PreferencesKeys.ISHA_ADJUSTMENT, 0)
 
     suspend fun setPrayerAdjustment(prayer: String, minutes: Int) {
         dataStore.edit { prefs ->
@@ -443,46 +333,34 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Notifications
-    val prayerNotificationsEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED] ?: true
-    }
+    val prayerNotificationsEnabled: Flow<Boolean> =
+        preference(PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED, true)
 
-    suspend fun setPrayerNotificationsEnabled(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED] = enabled
-        }
-    }
+    suspend fun setPrayerNotificationsEnabled(enabled: Boolean) =
+        put(PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED, enabled)
 
-    val adhanEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ADHAN_ENABLED] ?: false
-    }
+    val adhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ADHAN_ENABLED, false)
 
-    suspend fun setAdhanEnabled(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ADHAN_ENABLED] = enabled
-        }
-    }
+    suspend fun setAdhanEnabled(enabled: Boolean) = put(PreferencesKeys.ADHAN_ENABLED, enabled)
 
-    val selectedAdhanSound: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SELECTED_ADHAN_SOUND] ?: "MISHARY"
-    }
+    val selectedAdhanSound: Flow<String> =
+        preference(PreferencesKeys.SELECTED_ADHAN_SOUND, "MISHARY")
 
-    suspend fun setSelectedAdhanSound(sound: String) {
-        dataStore.edit { it[PreferencesKeys.SELECTED_ADHAN_SOUND] = sound }
-    }
+    suspend fun setSelectedAdhanSound(sound: String) =
+        put(PreferencesKeys.SELECTED_ADHAN_SOUND, sound)
 
     val fajrNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.FAJR_NOTIFICATION_ENABLED] ?: true }
+        preference(PreferencesKeys.FAJR_NOTIFICATION_ENABLED, true)
     val sunriseNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.SUNRISE_NOTIFICATION_ENABLED] ?: false }
+        preference(PreferencesKeys.SUNRISE_NOTIFICATION_ENABLED, false)
     val dhuhrNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.DHUHR_NOTIFICATION_ENABLED] ?: true }
+        preference(PreferencesKeys.DHUHR_NOTIFICATION_ENABLED, true)
     val asrNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.ASR_NOTIFICATION_ENABLED] ?: true }
+        preference(PreferencesKeys.ASR_NOTIFICATION_ENABLED, true)
     val maghribNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.MAGHRIB_NOTIFICATION_ENABLED] ?: true }
+        preference(PreferencesKeys.MAGHRIB_NOTIFICATION_ENABLED, true)
     val ishaNotificationEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.ISHA_NOTIFICATION_ENABLED] ?: true }
+        preference(PreferencesKeys.ISHA_NOTIFICATION_ENABLED, true)
 
     suspend fun setPrayerNotificationEnabled(prayer: String, enabled: Boolean) {
         dataStore.edit { prefs ->
@@ -500,16 +378,11 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Per-prayer adhan enabled
-    val fajrAdhanEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.FAJR_ADHAN_ENABLED] ?: true }
-    val dhuhrAdhanEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.DHUHR_ADHAN_ENABLED] ?: true }
-    val asrAdhanEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.ASR_ADHAN_ENABLED] ?: true }
-    val maghribAdhanEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.MAGHRIB_ADHAN_ENABLED] ?: true }
-    val ishaAdhanEnabled: Flow<Boolean> =
-        dataStore.data.map { it[PreferencesKeys.ISHA_ADHAN_ENABLED] ?: true }
+    val fajrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.FAJR_ADHAN_ENABLED, true)
+    val dhuhrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.DHUHR_ADHAN_ENABLED, true)
+    val asrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ASR_ADHAN_ENABLED, true)
+    val maghribAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.MAGHRIB_ADHAN_ENABLED, true)
+    val ishaAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ISHA_ADHAN_ENABLED, true)
 
     suspend fun setPrayerAdhanEnabled(prayer: String, enabled: Boolean) {
         dataStore.edit { prefs ->
@@ -536,85 +409,57 @@ class PreferencesDataStore @Inject constructor(
             "asr" -> asrAdhanEnabled
             "maghrib" -> maghribAdhanEnabled
             "isha" -> ishaAdhanEnabled
-            "sunrise" -> kotlinx.coroutines.flow.flowOf(false) // Sunrise never gets adhan
-            else -> kotlinx.coroutines.flow.flowOf(false)
+            "sunrise" -> flowOf(false) // Sunrise never gets adhan
+            else -> flowOf(false)
         }
     }
 
-    val adhanRespectDnd: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.ADHAN_RESPECT_DND] ?: true
-    }
+    val adhanRespectDnd: Flow<Boolean> = preference(PreferencesKeys.ADHAN_RESPECT_DND, true)
 
-    suspend fun setAdhanRespectDnd(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.ADHAN_RESPECT_DND] = enabled }
-    }
+    suspend fun setAdhanRespectDnd(enabled: Boolean) =
+        put(PreferencesKeys.ADHAN_RESPECT_DND, enabled)
 
-    val notificationVibration: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.NOTIFICATION_VIBRATION] ?: true
-    }
+    val notificationVibration: Flow<Boolean> =
+        preference(PreferencesKeys.NOTIFICATION_VIBRATION, true)
 
-    suspend fun setNotificationVibration(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.NOTIFICATION_VIBRATION] = enabled }
-    }
+    suspend fun setNotificationVibration(enabled: Boolean) =
+        put(PreferencesKeys.NOTIFICATION_VIBRATION, enabled)
 
-    val notificationReminderMinutes: Flow<Int> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.NOTIFICATION_REMINDER_MINUTES] ?: 15
-    }
+    val notificationReminderMinutes: Flow<Int> =
+        preference(PreferencesKeys.NOTIFICATION_REMINDER_MINUTES, 15)
 
-    suspend fun setNotificationReminderMinutes(minutes: Int) {
-        dataStore.edit { it[PreferencesKeys.NOTIFICATION_REMINDER_MINUTES] = minutes }
-    }
+    suspend fun setNotificationReminderMinutes(minutes: Int) =
+        put(PreferencesKeys.NOTIFICATION_REMINDER_MINUTES, minutes)
 
-    val showReminderBefore: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_REMINDER_BEFORE] ?: true
-    }
+    val showReminderBefore: Flow<Boolean> = preference(PreferencesKeys.SHOW_REMINDER_BEFORE, true)
 
-    suspend fun setShowReminderBefore(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.SHOW_REMINDER_BEFORE] = enabled }
-    }
+    suspend fun setShowReminderBefore(enabled: Boolean) =
+        put(PreferencesKeys.SHOW_REMINDER_BEFORE, enabled)
 
-    val persistentNotification: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.PERSISTENT_NOTIFICATION] ?: false
-    }
+    val persistentNotification: Flow<Boolean> =
+        preference(PreferencesKeys.PERSISTENT_NOTIFICATION, false)
 
-    suspend fun setPersistentNotification(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.PERSISTENT_NOTIFICATION] = enabled }
-    }
+    suspend fun setPersistentNotification(enabled: Boolean) =
+        put(PreferencesKeys.PERSISTENT_NOTIFICATION, enabled)
 
     // Quran Settings
-    val quranTranslatorId: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.QURAN_TRANSLATOR_ID] ?: "sahih_international"
-    }
+    val quranTranslatorId: Flow<String> =
+        preference(PreferencesKeys.QURAN_TRANSLATOR_ID, "sahih_international")
 
-    suspend fun setQuranTranslatorId(translatorId: String) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.QURAN_TRANSLATOR_ID] = translatorId
-        }
-    }
+    suspend fun setQuranTranslatorId(translatorId: String) =
+        put(PreferencesKeys.QURAN_TRANSLATOR_ID, translatorId)
 
-    val showTranslation: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_TRANSLATION] ?: true
-    }
+    val showTranslation: Flow<Boolean> = preference(PreferencesKeys.SHOW_TRANSLATION, true)
 
-    suspend fun setShowTranslation(show: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.SHOW_TRANSLATION] = show
-        }
-    }
+    suspend fun setShowTranslation(show: Boolean) = put(PreferencesKeys.SHOW_TRANSLATION, show)
 
-    val showTransliteration: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_TRANSLITERATION] ?: false
-    }
+    val showTransliteration: Flow<Boolean> =
+        preference(PreferencesKeys.SHOW_TRANSLITERATION, false)
 
-    suspend fun setShowTransliteration(show: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.SHOW_TRANSLITERATION] = show
-        }
-    }
+    suspend fun setShowTransliteration(show: Boolean) =
+        put(PreferencesKeys.SHOW_TRANSLITERATION, show)
 
-    val selectedReciterId: Flow<String?> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SELECTED_RECITER_ID]
-    }
+    val selectedReciterId: Flow<String?> = preference(PreferencesKeys.SELECTED_RECITER_ID)
 
     suspend fun setSelectedReciterId(reciterId: String?) {
         dataStore.edit {
@@ -623,193 +468,121 @@ class PreferencesDataStore @Inject constructor(
         }
     }
 
-    val quranArabicFont: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.QURAN_ARABIC_FONT] ?: "amiri"
-    }
+    val quranArabicFont: Flow<String> = preference(PreferencesKeys.QURAN_ARABIC_FONT, "amiri")
 
-    suspend fun setQuranArabicFont(fontId: String) {
-        dataStore.edit { it[PreferencesKeys.QURAN_ARABIC_FONT] = fontId }
-    }
+    suspend fun setQuranArabicFont(fontId: String) =
+        put(PreferencesKeys.QURAN_ARABIC_FONT, fontId)
 
-    val quranArabicFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.QURAN_ARABIC_FONT_SIZE] ?: 28f
-    }
+    val quranArabicFontSize: Flow<Float> =
+        preference(PreferencesKeys.QURAN_ARABIC_FONT_SIZE, 28f)
 
-    suspend fun setQuranArabicFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.QURAN_ARABIC_FONT_SIZE] = size }
-    }
+    suspend fun setQuranArabicFontSize(size: Float) =
+        put(PreferencesKeys.QURAN_ARABIC_FONT_SIZE, size)
 
-    val quranTranslationFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE] ?: 16f
-    }
+    val quranTranslationFontSize: Flow<Float> =
+        preference(PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setQuranTranslationFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE] = size }
-    }
+    suspend fun setQuranTranslationFontSize(size: Float) =
+        put(PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE, size)
 
-    val continuousReading: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.CONTINUOUS_READING] ?: true
-    }
+    val continuousReading: Flow<Boolean> = preference(PreferencesKeys.CONTINUOUS_READING, true)
 
-    suspend fun setContinuousReading(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.CONTINUOUS_READING] = enabled }
-    }
+    suspend fun setContinuousReading(enabled: Boolean) =
+        put(PreferencesKeys.CONTINUOUS_READING, enabled)
 
-    val keepScreenOn: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.KEEP_SCREEN_ON] ?: true
-    }
+    val keepScreenOn: Flow<Boolean> = preference(PreferencesKeys.KEEP_SCREEN_ON, true)
 
-    suspend fun setKeepScreenOn(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.KEEP_SCREEN_ON] = enabled }
-    }
+    suspend fun setKeepScreenOn(enabled: Boolean) = put(PreferencesKeys.KEEP_SCREEN_ON, enabled)
 
-    val showTajweed: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.SHOW_TAJWEED] ?: false
-    }
+    val showTajweed: Flow<Boolean> = preference(PreferencesKeys.SHOW_TAJWEED, false)
 
-    suspend fun setShowTajweed(enabled: Boolean) {
-        dataStore.edit { it[PreferencesKeys.SHOW_TAJWEED] = enabled }
-    }
+    suspend fun setShowTajweed(enabled: Boolean) = put(PreferencesKeys.SHOW_TAJWEED, enabled)
 
     // Dua Settings
-    val duaArabicFont: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_ARABIC_FONT] ?: "amiri"
-    }
+    val duaArabicFont: Flow<String> = preference(PreferencesKeys.DUA_ARABIC_FONT, "amiri")
 
-    suspend fun setDuaArabicFont(fontId: String) {
-        dataStore.edit { it[PreferencesKeys.DUA_ARABIC_FONT] = fontId }
-    }
+    suspend fun setDuaArabicFont(fontId: String) = put(PreferencesKeys.DUA_ARABIC_FONT, fontId)
 
-    val duaArabicFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_ARABIC_FONT_SIZE] ?: 28f
-    }
+    val duaArabicFontSize: Flow<Float> = preference(PreferencesKeys.DUA_ARABIC_FONT_SIZE, 28f)
 
-    suspend fun setDuaArabicFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.DUA_ARABIC_FONT_SIZE] = size }
-    }
+    suspend fun setDuaArabicFontSize(size: Float) =
+        put(PreferencesKeys.DUA_ARABIC_FONT_SIZE, size)
 
-    val duaTranslationFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_TRANSLATION_FONT_SIZE] ?: 16f
-    }
+    val duaTranslationFontSize: Flow<Float> =
+        preference(PreferencesKeys.DUA_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setDuaTranslationFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.DUA_TRANSLATION_FONT_SIZE] = size }
-    }
+    suspend fun setDuaTranslationFontSize(size: Float) =
+        put(PreferencesKeys.DUA_TRANSLATION_FONT_SIZE, size)
 
-    val duaShowArabic: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_SHOW_ARABIC] ?: true
-    }
+    val duaShowArabic: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_ARABIC, true)
 
-    suspend fun setDuaShowArabic(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.DUA_SHOW_ARABIC] = show }
-    }
+    suspend fun setDuaShowArabic(show: Boolean) = put(PreferencesKeys.DUA_SHOW_ARABIC, show)
 
-    val duaShowTransliteration: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_SHOW_TRANSLITERATION] ?: true
-    }
+    val duaShowTransliteration: Flow<Boolean> =
+        preference(PreferencesKeys.DUA_SHOW_TRANSLITERATION, true)
 
-    suspend fun setDuaShowTransliteration(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.DUA_SHOW_TRANSLITERATION] = show }
-    }
+    suspend fun setDuaShowTransliteration(show: Boolean) =
+        put(PreferencesKeys.DUA_SHOW_TRANSLITERATION, show)
 
-    val duaShowTranslation: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.DUA_SHOW_TRANSLATION] ?: true
-    }
+    val duaShowTranslation: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_TRANSLATION, true)
 
-    suspend fun setDuaShowTranslation(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.DUA_SHOW_TRANSLATION] = show }
-    }
+    suspend fun setDuaShowTranslation(show: Boolean) =
+        put(PreferencesKeys.DUA_SHOW_TRANSLATION, show)
 
     // Hadith Settings
-    val hadithArabicFont: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_ARABIC_FONT] ?: "amiri"
-    }
+    val hadithArabicFont: Flow<String> = preference(PreferencesKeys.HADITH_ARABIC_FONT, "amiri")
 
-    suspend fun setHadithArabicFont(fontId: String) {
-        dataStore.edit { it[PreferencesKeys.HADITH_ARABIC_FONT] = fontId }
-    }
+    suspend fun setHadithArabicFont(fontId: String) =
+        put(PreferencesKeys.HADITH_ARABIC_FONT, fontId)
 
-    val hadithArabicFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_ARABIC_FONT_SIZE] ?: 24f
-    }
+    val hadithArabicFontSize: Flow<Float> =
+        preference(PreferencesKeys.HADITH_ARABIC_FONT_SIZE, 24f)
 
-    suspend fun setHadithArabicFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.HADITH_ARABIC_FONT_SIZE] = size }
-    }
+    suspend fun setHadithArabicFontSize(size: Float) =
+        put(PreferencesKeys.HADITH_ARABIC_FONT_SIZE, size)
 
-    val hadithTranslationFontSize: Flow<Float> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE] ?: 16f
-    }
+    val hadithTranslationFontSize: Flow<Float> =
+        preference(PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setHadithTranslationFontSize(size: Float) {
-        dataStore.edit { it[PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE] = size }
-    }
+    suspend fun setHadithTranslationFontSize(size: Float) =
+        put(PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE, size)
 
-    val hadithShowArabic: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_SHOW_ARABIC] ?: true
-    }
+    val hadithShowArabic: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_ARABIC, true)
 
-    suspend fun setHadithShowArabic(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.HADITH_SHOW_ARABIC] = show }
-    }
+    suspend fun setHadithShowArabic(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_ARABIC, show)
 
-    val hadithShowTranslation: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_SHOW_TRANSLATION] ?: true
-    }
+    val hadithShowTranslation: Flow<Boolean> =
+        preference(PreferencesKeys.HADITH_SHOW_TRANSLATION, true)
 
-    suspend fun setHadithShowTranslation(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.HADITH_SHOW_TRANSLATION] = show }
-    }
+    suspend fun setHadithShowTranslation(show: Boolean) =
+        put(PreferencesKeys.HADITH_SHOW_TRANSLATION, show)
 
-    val hadithShowGrade: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_SHOW_GRADE] ?: true
-    }
+    val hadithShowGrade: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_GRADE, true)
 
-    suspend fun setHadithShowGrade(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.HADITH_SHOW_GRADE] = show }
-    }
+    suspend fun setHadithShowGrade(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_GRADE, show)
 
-    val hadithShowChain: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.HADITH_SHOW_CHAIN] ?: true
-    }
+    val hadithShowChain: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_CHAIN, true)
 
-    suspend fun setHadithShowChain(show: Boolean) {
-        dataStore.edit { it[PreferencesKeys.HADITH_SHOW_CHAIN] = show }
-    }
+    suspend fun setHadithShowChain(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_CHAIN, show)
 
     // Tasbih Settings
-    val tasbihVibrationEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_VIBRATION_ENABLED] ?: true
-    }
+    val tasbihVibrationEnabled: Flow<Boolean> =
+        preference(PreferencesKeys.TASBIH_VIBRATION_ENABLED, true)
 
-    suspend fun setTasbihVibrationEnabled(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_VIBRATION_ENABLED] = enabled
-        }
-    }
+    suspend fun setTasbihVibrationEnabled(enabled: Boolean) =
+        put(PreferencesKeys.TASBIH_VIBRATION_ENABLED, enabled)
 
-    val tasbihSoundEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.TASBIH_SOUND_ENABLED] ?: true
-    }
+    val tasbihSoundEnabled: Flow<Boolean> = preference(PreferencesKeys.TASBIH_SOUND_ENABLED, true)
 
-    suspend fun setTasbihSoundEnabled(enabled: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.TASBIH_SOUND_ENABLED] = enabled
-        }
-    }
+    suspend fun setTasbihSoundEnabled(enabled: Boolean) =
+        put(PreferencesKeys.TASBIH_SOUND_ENABLED, enabled)
 
     // Location
-    val latitude: Flow<Double> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.LATITUDE] ?: 0.0
-    }
+    val latitude: Flow<Double> = preference(PreferencesKeys.LATITUDE, 0.0)
 
-    val longitude: Flow<Double> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.LONGITUDE] ?: 0.0
-    }
+    val longitude: Flow<Double> = preference(PreferencesKeys.LONGITUDE, 0.0)
 
-    val locationName: Flow<String> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.LOCATION_NAME] ?: ""
-    }
+    val locationName: Flow<String> = preference(PreferencesKeys.LOCATION_NAME, "")
 
     suspend fun updateLocation(latitude: Double, longitude: Double, name: String) {
         dataStore.edit { preferences ->

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaEntity
 import com.arshadshah.nimaz.domain.model.AsmaUlHusna
 import com.arshadshah.nimaz.domain.repository.AsmaUlHusnaRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
@@ -37,7 +38,7 @@ class AsmaUlHusnaRepositoryImpl @Inject constructor(
     }
 
     override fun getFavoriteNames(): Flow<List<AsmaUlHusna>> {
-        return dao.getFavoriteNames().map { list -> list.map { it.toDomain(isFavorite = true) } }
+        return dao.getFavoriteNames().mapItems { it.toDomain(isFavorite = true) }
     }
 
     override suspend fun toggleFavorite(nameId: Int) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUnNabiRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUnNabiRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.arshadshah.nimaz.data.local.database.entity.AsmaUnNabiEntity
 import com.arshadshah.nimaz.domain.model.AsmaUnNabi
 import com.arshadshah.nimaz.domain.repository.AsmaUnNabiRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -36,7 +37,7 @@ class AsmaUnNabiRepositoryImpl @Inject constructor(
     }
 
     override fun getFavoriteNames(): Flow<List<AsmaUnNabi>> {
-        return dao.getFavoriteNames().map { list -> list.map { it.toDomain(isFavorite = true) } }
+        return dao.getFavoriteNames().mapItems { it.toDomain(isFavorite = true) }
     }
 
     override suspend fun toggleFavorite(nameId: Int) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -33,9 +34,7 @@ class DuaRepositoryImpl @Inject constructor(
         flow { seeder.seedIfNeeded(); emitAll(block()) }
 
     override fun getAllCategories(): Flow<List<DuaCategory>> = seededFlow {
-        duaDao.getAllCategories().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        duaDao.getAllCategories().mapItems { it.toDomain() }
     }
 
     override suspend fun getCategoryById(categoryId: String): DuaCategory? {
@@ -44,9 +43,7 @@ class DuaRepositoryImpl @Inject constructor(
     }
 
     override fun getDuasByCategory(categoryId: String): Flow<List<Dua>> = seededFlow {
-        duaDao.getDuasByCategory(categoryId.toIntOrNull() ?: 0).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        duaDao.getDuasByCategory(categoryId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
     override suspend fun getDuaById(duaId: String): Dua? {
@@ -56,9 +53,7 @@ class DuaRepositoryImpl @Inject constructor(
 
     override fun getDuasByOccasion(occasion: DuaOccasion): Flow<List<Dua>> = seededFlow {
         // Since there's no occasion column in the database, return empty list
-        duaDao.searchDuas(occasion.name.lowercase()).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        duaDao.searchDuas(occasion.name.lowercase()).mapItems { it.toDomain() }
     }
 
     override fun searchDuas(query: String): Flow<List<DuaSearchResult>> = seededFlow {
@@ -80,15 +75,11 @@ class DuaRepositoryImpl @Inject constructor(
     }
 
     override fun getAllBookmarks(): Flow<List<DuaBookmark>> {
-        return duaDao.getAllBookmarks().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return duaDao.getAllBookmarks().mapItems { it.toDomain() }
     }
 
     override fun getFavoriteDuas(): Flow<List<DuaBookmark>> {
-        return duaDao.getFavoriteDuas().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return duaDao.getFavoriteDuas().mapItems { it.toDomain() }
     }
 
     override suspend fun getBookmarkByDuaId(duaId: String): DuaBookmark? {
@@ -123,15 +114,11 @@ class DuaRepositoryImpl @Inject constructor(
     }
 
     override fun getProgressForDate(date: Long): Flow<List<DuaProgress>> {
-        return duaDao.getProgressForDate(date).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return duaDao.getProgressForDate(date).mapItems { it.toDomain() }
     }
 
     override fun getProgressHistoryForDua(duaId: String): Flow<List<DuaProgress>> {
-        return duaDao.getProgressHistoryForDua(duaId.toIntOrNull() ?: 0).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return duaDao.getProgressHistoryForDua(duaId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
     override suspend fun incrementDuaProgress(duaId: String, date: Long, targetCount: Int) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/FastingRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/FastingRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.arshadshah.nimaz.domain.model.FastingStats
 import com.arshadshah.nimaz.domain.model.MakeupFast
 import com.arshadshah.nimaz.domain.model.MakeupFastStatus
 import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -26,27 +27,19 @@ class FastingRepositoryImpl @Inject constructor(
     }
 
     override fun getFastRecordsInRange(startDate: Long, endDate: Long): Flow<List<FastRecord>> {
-        return fastingDao.getFastRecordsInRange(startDate, endDate).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getFastRecordsInRange(startDate, endDate).mapItems { it.toDomain() }
     }
 
     override fun getFastRecordsByHijriMonth(hijriMonth: Int): Flow<List<FastRecord>> {
-        return fastingDao.getFastRecordsByHijriMonth(hijriMonth).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getFastRecordsByHijriMonth(hijriMonth).mapItems { it.toDomain() }
     }
 
     override fun getFastRecordsByType(fastType: FastType): Flow<List<FastRecord>> {
-        return fastingDao.getFastRecordsByType(fastType.name.lowercase()).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getFastRecordsByType(fastType.name.lowercase()).mapItems { it.toDomain() }
     }
 
     override fun getFastRecordsByStatus(status: FastStatus): Flow<List<FastRecord>> {
-        return fastingDao.getFastRecordsByStatus(status.name.lowercase()).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getFastRecordsByStatus(status.name.lowercase()).mapItems { it.toDomain() }
     }
 
     override suspend fun insertFastRecord(record: FastRecord) {
@@ -74,15 +67,11 @@ class FastingRepositoryImpl @Inject constructor(
     }
 
     override fun getPendingMakeupFasts(): Flow<List<MakeupFast>> {
-        return fastingDao.getPendingMakeupFasts().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getPendingMakeupFasts().mapItems { it.toDomain() }
     }
 
     override fun getAllMakeupFasts(): Flow<List<MakeupFast>> {
-        return fastingDao.getAllMakeupFasts().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return fastingDao.getAllMakeupFasts().mapItems { it.toDomain() }
     }
 
     override suspend fun getMakeupFastById(id: Long): MakeupFast? {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.repository.HadithRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.time.LocalDate
@@ -36,9 +37,7 @@ class HadithRepositoryImpl @Inject constructor(
     }
 
     override fun getAllBooks(): Flow<List<HadithBook>> {
-        return hadithDao.getAllBooks().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getAllBooks().mapItems { it.toDomain() }
     }
 
     override suspend fun getBookById(bookId: String): HadithBook? {
@@ -101,15 +100,11 @@ class HadithRepositoryImpl @Inject constructor(
         val parts = chapterId.split("_")
         val chapterNum =
             if (parts.size == 2) parts[1].toIntOrNull() ?: 0 else chapterId.toIntOrNull() ?: 0
-        return hadithDao.getHadithsByChapter(chapterNum).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getHadithsByChapter(chapterNum).mapItems { it.toDomain() }
     }
 
     override fun getHadithsByBook(bookId: String): Flow<List<Hadith>> {
-        return hadithDao.getHadithsByBook(bookId.toIntOrNull() ?: 0).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getHadithsByBook(bookId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
     override suspend fun getHadithById(hadithId: String): Hadith? {
@@ -129,9 +124,7 @@ class HadithRepositoryImpl @Inject constructor(
             HadithGrade.MAWDU -> "mawdu"
             HadithGrade.UNKNOWN -> "unknown"
         }
-        return hadithDao.getHadithsByGrade(gradeString).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getHadithsByGrade(gradeString).mapItems { it.toDomain() }
     }
 
     override fun searchHadiths(query: String): Flow<List<HadithSearchResult>> {
@@ -175,15 +168,11 @@ class HadithRepositoryImpl @Inject constructor(
     }
 
     override fun getAllBookmarks(): Flow<List<HadithBookmark>> {
-        return hadithDao.getAllBookmarks().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getAllBookmarks().mapItems { it.toDomain() }
     }
 
     override fun getBookmarksByBook(bookId: String): Flow<List<HadithBookmark>> {
-        return hadithDao.getBookmarksByBook(bookId.toIntOrNull() ?: 0).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return hadithDao.getBookmarksByBook(bookId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
     override suspend fun getBookmarkByHadithId(hadithId: String): HadithBookmark? {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/KhatamRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/KhatamRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.arshadshah.nimaz.domain.model.KhatamConstants
 import com.arshadshah.nimaz.domain.model.KhatamStats
 import com.arshadshah.nimaz.domain.model.KhatamStatus
 import com.arshadshah.nimaz.domain.repository.KhatamRepository
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -49,19 +50,19 @@ class KhatamRepositoryImpl @Inject constructor(
     }
 
     override fun observeInProgressKhatams(): Flow<List<Khatam>> {
-        return khatamDao.observeInProgressKhatams().map { list -> list.map { it.toDomain() } }
+        return khatamDao.observeInProgressKhatams().mapItems { it.toDomain() }
     }
 
     override fun observeCompletedKhatams(): Flow<List<Khatam>> {
-        return khatamDao.observeCompletedKhatams().map { list -> list.map { it.toDomain() } }
+        return khatamDao.observeCompletedKhatams().mapItems { it.toDomain() }
     }
 
     override fun observeAbandonedKhatams(): Flow<List<Khatam>> {
-        return khatamDao.observeAbandonedKhatams().map { list -> list.map { it.toDomain() } }
+        return khatamDao.observeAbandonedKhatams().mapItems { it.toDomain() }
     }
 
     override fun observeAllKhatams(): Flow<List<Khatam>> {
-        return khatamDao.observeAllKhatams().map { list -> list.map { it.toDomain() } }
+        return khatamDao.observeAllKhatams().mapItems { it.toDomain() }
     }
 
     override suspend fun setActiveKhatam(khatamId: Long) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
@@ -16,6 +16,7 @@ import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.map
 import java.time.LocalDate
 import javax.inject.Inject
@@ -48,15 +49,11 @@ class PrayerRepositoryImpl @Inject constructor(
     }
 
     override fun getPrayerRecordsForDate(date: Long): Flow<List<PrayerRecord>> {
-        return prayerDao.getPrayerRecordsForDate(date).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return prayerDao.getPrayerRecordsForDate(date).mapItems { it.toDomain() }
     }
 
     override fun getPrayerRecordsInRange(startDate: Long, endDate: Long): Flow<List<PrayerRecord>> {
-        return prayerDao.getPrayerRecordsInRange(startDate, endDate).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return prayerDao.getPrayerRecordsInRange(startDate, endDate).mapItems { it.toDomain() }
     }
 
     override suspend fun getPrayerRecord(date: Long, prayerName: PrayerName): PrayerRecord? {
@@ -64,15 +61,11 @@ class PrayerRepositoryImpl @Inject constructor(
     }
 
     override fun getPrayerRecordsByStatus(status: PrayerStatus): Flow<List<PrayerRecord>> {
-        return prayerDao.getPrayerRecordsByStatus(status.name.lowercase()).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return prayerDao.getPrayerRecordsByStatus(status.name.lowercase()).mapItems { it.toDomain() }
     }
 
     override fun getMissedPrayersRequiringQada(): Flow<List<PrayerRecord>> {
-        return prayerDao.getMissedPrayersRequiringQada().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return prayerDao.getMissedPrayersRequiringQada().mapItems { it.toDomain() }
     }
 
     override suspend fun insertPrayerRecord(record: PrayerRecord) {
@@ -223,9 +216,7 @@ class PrayerRepositoryImpl @Inject constructor(
 
     // Location operations
     override fun getAllLocations(): Flow<List<Location>> {
-        return locationDao.getAllLocations().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return locationDao.getAllLocations().mapItems { it.toDomain() }
     }
 
     override fun getCurrentLocation(): Flow<Location?> {
@@ -237,9 +228,7 @@ class PrayerRepositoryImpl @Inject constructor(
     }
 
     override fun getFavoriteLocations(): Flow<List<Location>> {
-        return locationDao.getFavoriteLocations().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return locationDao.getFavoriteLocations().mapItems { it.toDomain() }
     }
 
     override suspend fun getLocationById(id: Long): Location? {
@@ -247,9 +236,7 @@ class PrayerRepositoryImpl @Inject constructor(
     }
 
     override fun searchLocations(query: String): Flow<List<Location>> {
-        return locationDao.searchLocations(query).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return locationDao.searchLocations(query).mapItems { it.toDomain() }
     }
 
     override suspend fun insertLocation(location: Location): Long {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import kotlinx.coroutines.flow.Flow
 import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.map
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -30,7 +31,7 @@ class PrayerRepositoryImpl @Inject constructor(
 ) : PrayerRepository {
 
     override fun getTodayPrayerRecords(): Flow<Map<PrayerName, PrayerStatus>> {
-        val todayEpoch = LocalDate.now().toEpochDay() * 86400000L
+        val todayEpoch = LocalDate.now().toUtcMidnightMillis()
         return prayerDao.getPrayerRecordsForDate(todayEpoch).map { entities ->
             entities.associate { PrayerName.fromString(it.prayerName) to PrayerStatus.fromString(it.status) }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.arshadshah.nimaz.data.local.database.entity.ProphetEntity
 import com.arshadshah.nimaz.domain.model.Prophet
 import com.arshadshah.nimaz.domain.repository.ProphetRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
@@ -37,7 +38,7 @@ class ProphetRepositoryImpl @Inject constructor(
     }
 
     override fun getFavoriteProphets(): Flow<List<Prophet>> {
-        return dao.getFavoriteProphets().map { list -> list.map { it.toDomain(isFavorite = true) } }
+        return dao.getFavoriteProphets().mapItems { it.toDomain(isFavorite = true) }
     }
 
     override suspend fun toggleFavorite(prophetId: Int) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
@@ -21,6 +21,7 @@ import com.arshadshah.nimaz.domain.model.QaidaLine
 import com.arshadshah.nimaz.domain.model.QaidaLineContent
 import com.arshadshah.nimaz.domain.model.TokenType
 import com.arshadshah.nimaz.domain.repository.QaidaRepository
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
@@ -34,7 +35,7 @@ class QaidaRepositoryImpl @Inject constructor(
 
     // ── Lessons ───────────────────────────────────────────────────────────
     override fun getLessons(): Flow<List<QaidaLesson>> {
-        return qaidaDao.getAllLessons().map { entities -> entities.map { it.toDomain() } }
+        return qaidaDao.getAllLessons().mapItems { it.toDomain() }
     }
 
     override suspend fun getLesson(lessonId: Int): QaidaLesson? {
@@ -47,7 +48,7 @@ class QaidaRepositoryImpl @Inject constructor(
 
     // ── Letters ───────────────────────────────────────────────────────────
     override fun getLetters(): Flow<List<QaidaLetter>> {
-        return qaidaDao.getAllLetters().map { entities -> entities.map { it.toDomain() } }
+        return qaidaDao.getAllLetters().mapItems { it.toDomain() }
     }
 
     override suspend fun getLetter(letterId: Int): QaidaLetter? {
@@ -61,7 +62,7 @@ class QaidaRepositoryImpl @Inject constructor(
 
     override fun getCellsForLesson(lessonId: Int): Flow<List<QaidaCell>> {
         return qaidaDao.getCellsForLesson(lessonId)
-            .map { entities -> entities.map { it.toDomain() } }
+            .mapItems { it.toDomain() }
     }
 
     override suspend fun getCellCountForLesson(lessonId: Int): Int {
@@ -70,7 +71,7 @@ class QaidaRepositoryImpl @Inject constructor(
 
     // ── Lesson progress ─────────────────────────────────────────────────────
     override fun getAllProgress(): Flow<List<QaidaLessonProgress>> {
-        return qaidaDao.getAllProgress().map { entities -> entities.map { it.toDomain() } }
+        return qaidaDao.getAllProgress().mapItems { it.toDomain() }
     }
 
     override fun observeLessonProgress(lessonId: Int): Flow<QaidaLessonProgress?> {
@@ -92,7 +93,7 @@ class QaidaRepositoryImpl @Inject constructor(
 
     override fun observeCellProgressForLesson(lessonId: Int): Flow<List<QaidaCellProgress>> {
         return qaidaDao.getCellProgressForLesson(lessonId)
-            .map { entities -> entities.map { it.toDomain() } }
+            .mapItems { it.toDomain() }
     }
 
     override suspend fun getCompletedCellCount(lessonId: Int): Int {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -23,6 +23,7 @@ import com.arshadshah.nimaz.domain.repository.QuranRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -35,9 +36,7 @@ class QuranRepositoryImpl @Inject constructor(
 ) : QuranRepository {
 
     override fun getAllSurahs(): Flow<List<Surah>> {
-        return quranDao.getAllSurahs().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.getAllSurahs().mapItems { it.toDomain() }
     }
 
     override suspend fun getSurahByNumber(surahNumber: Int): Surah? {
@@ -49,15 +48,11 @@ class QuranRepositoryImpl @Inject constructor(
             RevelationType.MECCAN -> "meccan"
             RevelationType.MEDINAN -> "medinan"
         }
-        return quranDao.getSurahsByRevelationType(typeString).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.getSurahsByRevelationType(typeString).mapItems { it.toDomain() }
     }
 
     override fun searchSurahs(query: String): Flow<List<Surah>> {
-        return quranDao.searchSurahs(query).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.searchSurahs(query).mapItems { it.toDomain() }
     }
 
     override fun getAyahsBySurah(surahNumber: Int): Flow<List<Ayah>> {
@@ -123,9 +118,7 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     override fun getSajdaAyahs(): Flow<List<Ayah>> {
-        return quranDao.getSajdaAyahs().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.getSajdaAyahs().mapItems { it.toDomain() }
     }
 
     override suspend fun getPageAyahRanges(): List<PageAyahRange> {
@@ -225,9 +218,7 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     override fun getAllBookmarks(): Flow<List<QuranBookmark>> {
-        return quranDao.getAllBookmarks().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.getAllBookmarks().mapItems { it.toDomain() }
     }
 
     override suspend fun getBookmarkByAyahId(ayahId: Int): QuranBookmark? {
@@ -269,9 +260,7 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     override fun getAllFavorites(): Flow<List<QuranFavorite>> {
-        return quranDao.getAllFavorites().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return quranDao.getAllFavorites().mapItems { it.toDomain() }
     }
 
     override fun getFavoriteAyahIds(): Flow<List<Int>> {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/TafseerRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/TafseerRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.arshadshah.nimaz.domain.model.TafseerNote
 import com.arshadshah.nimaz.domain.model.TafseerText
 import com.arshadshah.nimaz.domain.repository.TafseerRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
@@ -26,18 +27,14 @@ class TafseerRepositoryImpl @Inject constructor(
     }
 
     override fun getTafseerForSurah(surahNumber: Int, tafseerId: String): Flow<List<TafseerText>> {
-        return tafseerDao.getTafseerForSurah(surahNumber, tafseerId).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tafseerDao.getTafseerForSurah(surahNumber, tafseerId).mapItems { it.toDomain() }
     }
 
     override fun getHighlightsForAyah(
         ayahId: Int,
         tafseerId: String
     ): Flow<List<TafseerHighlight>> {
-        return tafseerDao.getHighlightsForAyah(ayahId, tafseerId).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tafseerDao.getHighlightsForAyah(ayahId, tafseerId).mapItems { it.toDomain() }
     }
 
     override suspend fun addHighlight(
@@ -84,9 +81,7 @@ class TafseerRepositoryImpl @Inject constructor(
     }
 
     override fun getNotesForAyah(ayahId: Int, tafseerId: String): Flow<List<TafseerNote>> {
-        return tafseerDao.getNotesForAyah(ayahId, tafseerId).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tafseerDao.getNotesForAyah(ayahId, tafseerId).mapItems { it.toDomain() }
     }
 
     override suspend fun addNote(ayahId: Int, tafseerId: String, text: String): Long {

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/TasbihRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/TasbihRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.arshadshah.nimaz.domain.model.TasbihSession
 import com.arshadshah.nimaz.domain.model.TasbihStats
 import com.arshadshah.nimaz.domain.repository.TasbihRepository
 import kotlinx.coroutines.flow.Flow
+import com.arshadshah.nimaz.core.util.mapItems
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -22,28 +23,20 @@ class TasbihRepositoryImpl @Inject constructor(
 ) : TasbihRepository {
 
     override fun getAllPresets(): Flow<List<TasbihPreset>> {
-        return tasbihDao.getAllPresets().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getAllPresets().mapItems { it.toDomain() }
     }
 
     override fun getDefaultPresets(): Flow<List<TasbihPreset>> {
-        return tasbihDao.getDefaultPresets().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getDefaultPresets().mapItems { it.toDomain() }
     }
 
     override fun getCustomPresets(): Flow<List<TasbihPreset>> {
-        return tasbihDao.getCustomPresets().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getCustomPresets().mapItems { it.toDomain() }
     }
 
     override fun getPresetsByCategory(category: TasbihCategory): Flow<List<TasbihPreset>> {
         // No category column in database, filter in memory
-        return tasbihDao.getAllPresets().map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getAllPresets().mapItems { it.toDomain() }
     }
 
     override suspend fun getPresetById(id: Long): TasbihPreset? {
@@ -63,21 +56,15 @@ class TasbihRepositoryImpl @Inject constructor(
     }
 
     override fun getSessionsForDate(date: Long): Flow<List<TasbihSession>> {
-        return tasbihDao.getSessionsForDate(date).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getSessionsForDate(date).mapItems { it.toDomain() }
     }
 
     override fun getSessionsInRange(startDate: Long, endDate: Long): Flow<List<TasbihSession>> {
-        return tasbihDao.getSessionsInRange(startDate, endDate).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getSessionsInRange(startDate, endDate).mapItems { it.toDomain() }
     }
 
     override fun getSessionsForPreset(presetId: Long): Flow<List<TasbihSession>> {
-        return tasbihDao.getSessionsForPreset(presetId).map { entities ->
-            entities.map { it.toDomain() }
-        }
+        return tasbihDao.getSessionsForPreset(presetId).mapItems { it.toDomain() }
     }
 
     override suspend fun getSessionById(id: Long): TasbihSession? {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIcon.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIcon.kt
@@ -80,6 +80,41 @@ fun ContainedIcon(
 }
 
 /**
+ * Icon inside a rounded-square badge with explicit sizing.
+ *
+ * Unlike [ContainedIcon] (which derives its dimensions from [NimazIconSize]
+ * presets), this exposes raw container/icon/corner sizes so it can replace the
+ * many bespoke "Box { Icon }" chips scattered across cards and list items
+ * without changing their appearance.
+ */
+@Composable
+fun IconBadge(
+    imageVector: ImageVector,
+    backgroundColor: Color,
+    iconColor: Color,
+    modifier: Modifier = Modifier,
+    containerSize: Dp = 44.dp,
+    iconSize: Dp = 22.dp,
+    cornerRadius: Dp = 12.dp,
+    contentDescription: String? = null,
+) {
+    Box(
+        modifier = modifier
+            .size(containerSize)
+            .clip(RoundedCornerShape(cornerRadius))
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            tint = iconColor,
+            modifier = Modifier.size(iconSize)
+        )
+    }
+}
+
+/**
  * Prayer icon with prayer-specific color.
  */
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/DuaOfTheMomentCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/DuaOfTheMomentCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
@@ -79,20 +80,13 @@ fun DuaOfTheMomentCard(
                 .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 12.dp)
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(DuaAccent.copy(alpha = 0.2f)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = iconForCategory(categoryLabel),
-                        contentDescription = null,
-                        tint = DuaAccent,
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
+                IconBadge(
+                    imageVector = iconForCategory(categoryLabel),
+                    backgroundColor = DuaAccent.copy(alpha = 0.2f),
+                    iconColor = DuaAccent,
+                    containerSize = 32.dp,
+                    iconSize = 18.dp,
+                )
                 Spacer(modifier = Modifier.width(8.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/FastingStatusCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/FastingStatusCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 /**
@@ -160,20 +161,11 @@ private fun FastingStateBadge(fastingToday: Boolean) {
 
 @Composable
 private fun FastingIconChip() {
-    Box(
-        modifier = Modifier
-            .size(44.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f)),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(
-            imageVector = Icons.Default.LightMode,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(22.dp)
-        )
-    }
+    IconBadge(
+        imageVector = Icons.Default.LightMode,
+        backgroundColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f),
+        iconColor = MaterialTheme.colorScheme.secondary,
+    )
 }
 
 @Preview(showBackground = true, widthDp = 400, name = "Fasting")

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 /**
@@ -76,20 +77,13 @@ fun HadithOfTheDayCard(
                 .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp)
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(HadithAccent.copy(alpha = 0.2f)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Book,
-                        contentDescription = null,
-                        tint = HadithAccent,
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
+                IconBadge(
+                    imageVector = Icons.Default.Book,
+                    backgroundColor = HadithAccent.copy(alpha = 0.2f),
+                    iconColor = HadithAccent,
+                    containerSize = 32.dp,
+                    iconSize = 18.dp,
+                )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(R.string.hadith_of_the_day),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @Composable
@@ -67,20 +68,12 @@ fun NimazSettingsItem(
             val resolvedTint =
                 if (tintIcon) iconTint else MaterialTheme.colorScheme.onSurfaceVariant
 
-            Box(
-                modifier = Modifier
-                    .size(42.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(resolvedBackground),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = resolvedTint,
-                    modifier = Modifier.size(22.dp)
-                )
-            }
+            IconBadge(
+                imageVector = icon,
+                backgroundColor = resolvedBackground,
+                iconColor = resolvedTint,
+                containerSize = 42.dp,
+            )
             Spacer(modifier = Modifier.width(15.dp))
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
@@ -93,24 +94,15 @@ fun PrayerTimeCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // Prayer Icon
-                Box(
-                    modifier = Modifier
-                        .size(44.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(
-                            prayerColor.copy(
-                                alpha = if (prayer.isPassed && !isActive) 0.12f else 0.2f
-                            )
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = getPrayerIcon(prayer.type),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(26.dp)
-                    )
-                }
+                IconBadge(
+                    imageVector = getPrayerIcon(prayer.type),
+                    backgroundColor = prayerColor.copy(
+                        alpha = if (prayer.isPassed && !isActive) 0.12f else 0.2f
+                    ),
+                    iconColor = MaterialTheme.colorScheme.onSurface,
+                    containerSize = 44.dp,
+                    iconSize = 26.dp,
+                )
 
                 Spacer(modifier = Modifier.width(14.dp))
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
@@ -73,10 +73,10 @@ import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.PrayerTrackerEvent
 import com.arshadshah.nimaz.presentation.viewmodel.PrayerTrackerViewModel
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -451,7 +451,7 @@ private fun CalendarSection(
         onNextMonth = { onMonthChange(displayedMonth.plusMonths(1)) },
         selectionStyle = SelectionStyle.BORDER,
         dayStateProvider = { date ->
-            val epoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+            val epoch = date.toUtcMidnightMillis()
             val badgeColor = prayerStatusMap[epoch]
             CalendarDayState(
                 indicatorColor = if (date.isBefore(today) && badgeColor != null) badgeColor else null,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -20,8 +20,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
-import java.time.ZoneOffset
 import javax.inject.Inject
 
 data class DuaCollectionUiState(
@@ -315,7 +315,7 @@ class DuaViewModel @Inject constructor(
     }
 
     private fun getTodayEpoch(): Long {
-        return LocalDate.now().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        return LocalDate.now().toUtcMidnightMillis()
     }
 
     fun isDuaFavorite(duaId: String) = duaRepository.isDuaFavorite(duaId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -25,9 +25,9 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import java.time.Duration
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -323,7 +323,7 @@ class FastingViewModel @Inject constructor(
     private fun selectDate(date: LocalDate) {
         _trackerState.update { it.copy(selectedDate = date, isLoading = true) }
 
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             val record = fastingRepository.getFastRecordForDate(dateEpoch)
@@ -338,7 +338,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun startFast(date: LocalDate, fastType: FastType) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             val now = System.currentTimeMillis()
@@ -365,7 +365,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun completeFast(date: LocalDate) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             fastingRepository.updateFastStatus(dateEpoch, FastStatus.FASTED)
@@ -375,7 +375,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun breakFast(date: LocalDate) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             fastingRepository.updateFastStatus(dateEpoch, FastStatus.NOT_FASTED)
@@ -385,7 +385,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun missFast(date: LocalDate, reason: String?) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
@@ -426,7 +426,7 @@ class FastingViewModel @Inject constructor(
             when (currentRecord.status) {
                 FastStatus.FASTED -> breakFast(date)
                 FastStatus.NOT_FASTED -> {
-                    val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+                    val dateEpoch = date.toUtcMidnightMillis()
                     viewModelScope.launch {
                         fastingRepository.updateFastStatus(dateEpoch, FastStatus.FASTED)
                         selectDate(date)
@@ -459,8 +459,8 @@ class FastingViewModel @Inject constructor(
         val startDate = LocalDate.of(year, month, 1)
         val endDate = startDate.plusMonths(1).minusDays(1)
 
-        val startEpoch = startDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val endEpoch = endDate.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val startEpoch = startDate.toUtcMidnightMillis()
+        val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         calendarJob = viewModelScope.launch {
             fastingRepository.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
@@ -482,9 +482,9 @@ class FastingViewModel @Inject constructor(
                 val ramadanStart = HijriDateCalculator.getFirstDayOfRamadan(hijriToday.year)
                 val ramadanEnd = HijriDateCalculator.getLastDayOfRamadan(hijriToday.year)
 
-                val startEpoch = ramadanStart.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+                val startEpoch = ramadanStart.toUtcMidnightMillis()
                 val endEpoch =
-                    ramadanEnd.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+                    ramadanEnd.plusDays(1).toUtcMidnightMillis()
 
                 fastingRepository.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
                     val fasted = records.count { it.status == FastStatus.FASTED }
@@ -574,8 +574,8 @@ class FastingViewModel @Inject constructor(
             FastingStatsPeriod.ALL_TIME -> now.minusYears(10) to now
         }
 
-        val startEpoch = startDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val endEpoch = endDate.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val startEpoch = startDate.toUtcMidnightMillis()
+        val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
             val stats = fastingRepository.getFastingStats(startEpoch, endEpoch)
@@ -594,7 +594,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun openFastSheet(date: LocalDate) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
@@ -623,7 +623,7 @@ class FastingViewModel @Inject constructor(
         exemptionReason: ExemptionReason?,
         note: String
     ) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
@@ -684,7 +684,7 @@ class FastingViewModel @Inject constructor(
     }
 
     private fun deleteFastRecord(date: LocalDate) {
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
             fastingRepository.deleteFastRecordByDate(dateEpoch)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -42,6 +42,8 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import java.time.DayOfWeek
+import com.arshadshah.nimaz.core.util.MILLIS_PER_DAY
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 import java.time.LocalTime
 import javax.inject.Inject
@@ -155,8 +157,8 @@ class HomeViewModel @Inject constructor(
     private fun observeFastingStatus() {
         viewModelScope.launch {
             val today = LocalDate.now()
-            val startOfDay = today.toEpochDay() * 86400000L
-            val endOfDay = startOfDay + 86400000L - 1
+            val startOfDay = today.toUtcMidnightMillis()
+            val endOfDay = startOfDay + MILLIS_PER_DAY - 1
 
             fastingDao.getFastRecordsInRange(startOfDay, endOfDay).collect { records ->
                 val todayRecord = records.firstOrNull()
@@ -318,7 +320,7 @@ class HomeViewModel @Inject constructor(
 
         viewModelScope.launch {
             val prayerName = PrayerName.valueOf(prayerType.name)
-            val todayEpoch = LocalDate.now().toEpochDay() * 86400000L
+            val todayEpoch = LocalDate.now().toUtcMidnightMillis()
             val currentStatus = _prayerRecords.value[prayerName] ?: PrayerStatus.NOT_PRAYED
             val newStatus =
                 if (currentStatus == PrayerStatus.PRAYED) PrayerStatus.NOT_PRAYED else PrayerStatus.PRAYED

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
-import java.time.ZoneOffset
 import javax.inject.Inject
 
 data class PrayerTrackerUiState(
@@ -168,7 +168,7 @@ class PrayerTrackerViewModel @Inject constructor(
     private fun selectDate(date: LocalDate) {
         _trackerState.update { it.copy(selectedDate = date, isLoading = true) }
 
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
 
         // Cancel previous date's Flow collection before starting new one
         dateRecordsJob?.cancel()
@@ -200,7 +200,7 @@ class PrayerTrackerViewModel @Inject constructor(
         isJamaah: Boolean
     ) {
         val date = _trackerState.value.selectedDate
-        val dateEpoch = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val dateEpoch = date.toUtcMidnightMillis()
         val prayedAt = if (status == PrayerStatus.PRAYED || status == PrayerStatus.LATE) {
             System.currentTimeMillis()
         } else null
@@ -250,14 +250,14 @@ class PrayerTrackerViewModel @Inject constructor(
             StatsPeriod.ALL_TIME -> now.minusYears(10) to now
         }
 
-        val startEpoch = startDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val endEpoch = endDate.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val currentEpoch = now.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val startEpoch = startDate.toUtcMidnightMillis()
+        val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
+        val currentEpoch = now.toUtcMidnightMillis()
 
         // Always load monthly stats
         val monthStart = now.minusMonths(1)
-        val monthStartEpoch = monthStart.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val monthEndEpoch = now.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val monthStartEpoch = monthStart.toUtcMidnightMillis()
+        val monthEndEpoch = now.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
             val stats = prayerRepository.getPrayerStats(startEpoch, endEpoch)
@@ -300,8 +300,8 @@ class PrayerTrackerViewModel @Inject constructor(
     private fun loadHistory(startDate: LocalDate, endDate: LocalDate) {
         _historyState.update { it.copy(startDate = startDate, endDate = endDate, isLoading = true) }
 
-        val startEpoch = startDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
-        val endEpoch = endDate.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        val startEpoch = startDate.toUtcMidnightMillis()
+        val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
             prayerRepository.getPrayerRecordsInRange(startEpoch, endEpoch).collect { records ->

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -26,8 +26,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
-import java.time.ZoneOffset
 import javax.inject.Inject
 
 data class TasbihPresetsUiState(
@@ -675,7 +675,7 @@ class TasbihViewModel @Inject constructor(
     }
 
     private fun getTodayEpoch(): Long {
-        return LocalDate.now().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000
+        return LocalDate.now().toUtcMidnightMillis()
     }
 
     companion object {

--- a/app/src/main/java/com/arshadshah/nimaz/widget/WidgetUpdateScheduler.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/WidgetUpdateScheduler.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.SystemClock
 import android.util.Log
 import androidx.glance.appwidget.updateAll
+import com.arshadshah.nimaz.widget.core.formatWidgetCountdown
 import com.arshadshah.nimaz.widget.nextprayer.NextPrayerWidget
 import com.arshadshah.nimaz.widget.prayertimes.PrayerTimesWidget
 import kotlinx.coroutines.CoroutineScope
@@ -68,20 +69,8 @@ object WidgetUpdateScheduler {
      */
     fun computeCountdown(targetEpochMillis: Long): String {
         if (targetEpochMillis <= 0L) return "—"
-        val now = System.currentTimeMillis()
-        val diff = targetEpochMillis - now
-        if (diff <= 0L) return "—"
-
-        val totalSeconds = diff / 1000
-        val hours = totalSeconds / 3600
-        val minutes = (totalSeconds % 3600) / 60
-        val seconds = totalSeconds % 60
-
-        return when {
-            hours > 0 -> "${hours}h ${minutes}m"
-            minutes > 0 -> "${minutes}m ${seconds}s"
-            else -> "${seconds}s"
-        }
+        val diff = targetEpochMillis - System.currentTimeMillis()
+        return formatWidgetCountdown(diff / 1000)
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/JsonGlanceStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/JsonGlanceStateDefinition.kt
@@ -1,0 +1,82 @@
+package com.arshadshah.nimaz.widget.core
+
+import android.content.Context
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStoreFile
+import androidx.glance.state.GlanceStateDefinition
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Base [GlanceStateDefinition] that persists a JSON-serializable widget state to
+ * a DataStore file.
+ *
+ * Every widget package used to declare an almost identical ~60-line state
+ * definition (the same serializer boilerplate, the same DataStore wiring). They
+ * now extend this class and only supply their file name, serializer, default
+ * value and a short label used in corruption messages.
+ *
+ * @param fileName     DataStore file name (without extension).
+ * @param serializer   kotlinx-serialization serializer for the state type.
+ * @param defaultValue value returned before anything has been written.
+ * @param dataLabel    human-readable label used in [CorruptionException] messages.
+ */
+abstract class JsonGlanceStateDefinition<T>(
+    private val fileName: String,
+    serializer: KSerializer<T>,
+    defaultValue: T,
+    dataLabel: String,
+) : GlanceStateDefinition<T> {
+
+    private val itemSerializer = JsonItemSerializer(serializer, defaultValue, dataLabel)
+
+    override suspend fun getDataStore(context: Context, fileKey: String): DataStore<T> =
+        getOrCreateDataStore(context, fileName, itemSerializer)
+
+    override fun getLocation(context: Context, fileKey: String): File =
+        context.dataStoreFile(fileName)
+
+    private class JsonItemSerializer<T>(
+        private val serializer: KSerializer<T>,
+        override val defaultValue: T,
+        private val dataLabel: String,
+    ) : Serializer<T> {
+
+        override suspend fun readFrom(input: InputStream): T = try {
+            Json.decodeFromString(serializer, input.readBytes().decodeToString())
+        } catch (e: SerializationException) {
+            throw CorruptionException("Could not read $dataLabel data: ${e.message}")
+        }
+
+        override suspend fun writeTo(t: T, output: OutputStream) {
+            output.use {
+                it.write(Json.encodeToString(serializer, t).toByteArray())
+            }
+        }
+    }
+
+    private companion object {
+        // A DataStore must be a process-wide singleton per file; the `by dataStore`
+        // delegate guaranteed this previously, so we keep one instance per file name.
+        private val dataStores = ConcurrentHashMap<String, DataStore<*>>()
+
+        @Suppress("UNCHECKED_CAST")
+        fun <T> getOrCreateDataStore(
+            context: Context,
+            fileName: String,
+            serializer: Serializer<T>,
+        ): DataStore<T> = dataStores.getOrPut(fileName) {
+            DataStoreFactory.create(serializer = serializer) {
+                context.applicationContext.dataStoreFile(fileName)
+            }
+        } as DataStore<T>
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetFormatters.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetFormatters.kt
@@ -1,0 +1,34 @@
+package com.arshadshah.nimaz.widget.core
+
+/**
+ * 12-hour clock formatting shared by the prayer widgets.
+ *
+ * @param includeAmPm when true, appends " AM"/" PM" (used by the next-prayer
+ *        widget); when false, returns a bare "h:mm" (used by the prayer-times
+ *        grid).
+ */
+fun formatWidgetTime(hour: Int, minute: Int, includeAmPm: Boolean = false): String {
+    val displayHour = if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
+    return if (includeAmPm) {
+        val amPm = if (hour >= 12) "PM" else "AM"
+        String.format("%d:%02d %s", displayHour, minute, amPm)
+    } else {
+        String.format("%d:%02d", displayHour, minute)
+    }
+}
+
+/**
+ * Format a remaining duration (in whole seconds) as a compact countdown such as
+ * "2h 30m", "15m 42s" or "30s". Non-positive durations render as an em dash.
+ */
+fun formatWidgetCountdown(totalSeconds: Long): String {
+    if (totalSeconds <= 0L) return "—"
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return when {
+        hours > 0 -> "${hours}h ${minutes}m"
+        minutes > 0 -> "${minutes}m ${seconds}s"
+        else -> "${seconds}s"
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetStateUpdater.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetStateUpdater.kt
@@ -1,0 +1,33 @@
+package com.arshadshah.nimaz.widget.core
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.appwidget.updateAll
+import androidx.glance.state.GlanceStateDefinition
+
+/**
+ * Persist [newState] for every entry in [glanceIds] through [definition], then
+ * trigger a recomposition of [widget].
+ *
+ * Replaces the identical private `setWidgetState` that lived in every widget
+ * worker.
+ */
+suspend fun <T> updateWidgetState(
+    context: Context,
+    widget: GlanceAppWidget,
+    definition: GlanceStateDefinition<T>,
+    glanceIds: List<GlanceId>,
+    newState: T,
+) {
+    glanceIds.forEach { glanceId ->
+        updateAppWidgetState(
+            context = context,
+            definition = definition,
+            glanceId = glanceId,
+            updateState = { newState },
+        )
+    }
+    widget.updateAll(context)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt
@@ -1,0 +1,81 @@
+package com.arshadshah.nimaz.widget.core
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceModifier
+import androidx.glance.LocalContext
+import androidx.glance.action.Action
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.CircularProgressIndicator
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.arshadshah.nimaz.R
+
+/**
+ * The four colour providers every widget reads from `res/color`. Previously each
+ * widget re-declared these four lines; they now share a single palette.
+ */
+data class WidgetPalette(
+    val background: ColorProvider = ColorProvider(R.color.widget_background),
+    val text: ColorProvider = ColorProvider(R.color.widget_text),
+    val textSecondary: ColorProvider = ColorProvider(R.color.widget_text_secondary),
+    val primary: ColorProvider = ColorProvider(R.color.widget_primary),
+)
+
+/**
+ * Full-bleed, centered, tappable container shared by the widgets' loading and
+ * error states.
+ */
+@Composable
+fun WidgetMessageBox(
+    background: ColorProvider,
+    onClick: Action,
+    cornerRadius: Dp = 16.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(background)
+            .cornerRadius(cornerRadius)
+            .clickable(onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+/**
+ * The identical "spinner + Loading…" state used by every widget. Only the corner
+ * radius and tap target vary between widgets, so those are parameters.
+ */
+@Composable
+fun WidgetLoadingBox(
+    background: ColorProvider,
+    textSecondary: ColorProvider,
+    onClick: Action,
+    cornerRadius: Dp = 16.dp,
+) {
+    val context = LocalContext.current
+    WidgetMessageBox(background = background, onClick = onClick, cornerRadius = cornerRadius) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            Text(
+                text = context.getString(R.string.widget_loading),
+                style = TextStyle(color = textSecondary, fontSize = 12.sp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetWork.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetWork.kt
@@ -1,0 +1,50 @@
+package com.arshadshah.nimaz.widget.core
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.time.Duration
+
+/**
+ * Shared WorkManager plumbing for the widget workers.
+ *
+ * Each worker used to carry an identical companion object with
+ * `enqueuePeriodicWork` / `enqueueImmediateWork` / `cancel`. They now delegate
+ * to these helpers and supply only their unique work names and refresh interval.
+ */
+object WidgetWork {
+
+    inline fun <reified W : CoroutineWorker> enqueuePeriodic(
+        context: Context,
+        uniqueWorkName: String,
+        interval: Duration,
+        force: Boolean = false,
+    ) {
+        val request = PeriodicWorkRequestBuilder<W>(interval).build()
+        val policy = if (force) {
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+        } else {
+            ExistingPeriodicWorkPolicy.KEEP
+        }
+        WorkManager.getInstance(context)
+            .enqueueUniquePeriodicWork(uniqueWorkName, policy, request)
+    }
+
+    inline fun <reified W : CoroutineWorker> enqueueImmediate(
+        context: Context,
+        uniqueWorkName: String,
+    ) {
+        val request = OneTimeWorkRequestBuilder<W>().build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(uniqueWorkName, ExistingWorkPolicy.REPLACE, request)
+    }
+
+    fun cancel(context: Context, vararg uniqueWorkNames: String) {
+        val manager = WorkManager.getInstance(context)
+        uniqueWorkNames.forEach { manager.cancelUniqueWork(it) }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarStateDefinition.kt
@@ -1,59 +1,10 @@
 package com.arshadshah.nimaz.widget.hijricalendar
 
-import android.content.Context
-import androidx.datastore.core.CorruptionException
-import androidx.datastore.core.DataStore
-import androidx.datastore.core.Serializer
-import androidx.datastore.dataStore
-import androidx.datastore.dataStoreFile
-import androidx.glance.state.GlanceStateDefinition
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
+import com.arshadshah.nimaz.widget.core.JsonGlanceStateDefinition
 
-object HijriCalendarStateDefinition : GlanceStateDefinition<HijriCalendarWidgetState> {
-
-    private const val DATA_STORE_FILENAME = "hijri_calendar_widget"
-
-    private val Context.datastore by dataStore(
-        DATA_STORE_FILENAME,
-        HijriCalendarWidgetStateSerializer
-    )
-
-    object HijriCalendarWidgetStateSerializer : Serializer<HijriCalendarWidgetState> {
-
-        override val defaultValue: HijriCalendarWidgetState =
-            HijriCalendarWidgetState.Success(HijriCalendarData())
-
-        override suspend fun readFrom(input: InputStream): HijriCalendarWidgetState = try {
-            Json.decodeFromString(
-                HijriCalendarWidgetState.serializer(),
-                input.readBytes().decodeToString()
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Could not read HijriCalendar data: ${e.message}")
-        }
-
-        override suspend fun writeTo(t: HijriCalendarWidgetState, output: OutputStream) {
-            output.use {
-                it.write(
-                    Json.encodeToString(HijriCalendarWidgetState.serializer(), t)
-                        .toByteArray()
-                )
-            }
-        }
-    }
-
-    override suspend fun getDataStore(
-        context: Context,
-        fileKey: String,
-    ): DataStore<HijriCalendarWidgetState> {
-        return context.datastore
-    }
-
-    override fun getLocation(context: Context, fileKey: String): File {
-        return context.dataStoreFile(DATA_STORE_FILENAME)
-    }
-}
+object HijriCalendarStateDefinition : JsonGlanceStateDefinition<HijriCalendarWidgetState>(
+    fileName = "hijri_calendar_widget",
+    serializer = HijriCalendarWidgetState.serializer(),
+    defaultValue = HijriCalendarWidgetState.Success(HijriCalendarData()),
+    dataLabel = "HijriCalendar",
+)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
@@ -41,6 +41,8 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
+import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class HijriCalendarWidget : GlanceAppWidget() {
 
@@ -85,25 +87,12 @@ private fun HijriCalendarContent(
     val primaryColor = ColorProvider(R.color.widget_primary)
 
     when (state) {
-        is HijriCalendarWidgetState.Loading -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(20.dp)
-                    .clickable(actionStartActivity(openCalendarIntent)),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = GlanceModifier.height(8.dp))
-                    Text(
-                        text = context.getString(R.string.widget_loading),
-                        style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                    )
-                }
-            }
-        }
+        is HijriCalendarWidgetState.Loading -> WidgetLoadingBox(
+            background = backgroundColor,
+            textSecondary = textSecondary,
+            onClick = actionStartActivity(openCalendarIntent),
+            cornerRadius = 20.dp,
+        )
 
         is HijriCalendarWidgetState.Success -> {
             HijriCalendarSuccessContent(
@@ -116,20 +105,15 @@ private fun HijriCalendarContent(
             )
         }
 
-        is HijriCalendarWidgetState.Error -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(20.dp)
-                    .clickable(actionStartActivity(openCalendarIntent)),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = context.getString(R.string.widget_tap_to_refresh),
-                    style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                )
-            }
+        is HijriCalendarWidgetState.Error -> WidgetMessageBox(
+            background = backgroundColor,
+            onClick = actionStartActivity(openCalendarIntent),
+            cornerRadius = 20.dp,
+        ) {
+            Text(
+                text = context.getString(R.string.widget_tap_to_refresh),
+                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
@@ -3,17 +3,12 @@ package com.arshadshah.nimaz.widget.hijricalendar
 import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.widget.core.WidgetWork
+import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
@@ -30,48 +25,24 @@ class HijriCalendarWorker @AssistedInject constructor(
     companion object {
         private const val UNIQUE_WORK_NAME = "HijriCalendarWorker"
         private const val ONE_TIME_WORK_NAME = "HijriCalendarWorkerOneTime"
+        private val REFRESH_INTERVAL: Duration = Duration.ofHours(6)
 
-        fun enqueuePeriodicWork(context: Context, force: Boolean = false) {
-            val manager = WorkManager.getInstance(context)
-            val request = PeriodicWorkRequestBuilder<HijriCalendarWorker>(
-                Duration.ofHours(6)
-            ).build()
+        fun enqueuePeriodicWork(context: Context, force: Boolean = false) =
+            WidgetWork.enqueuePeriodic<HijriCalendarWorker>(
+                context, UNIQUE_WORK_NAME, REFRESH_INTERVAL, force
+            )
 
-            val policy = if (force) {
-                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
-            } else {
-                ExistingPeriodicWorkPolicy.KEEP
-            }
+        fun enqueueImmediateWork(context: Context) =
+            WidgetWork.enqueueImmediate<HijriCalendarWorker>(context, ONE_TIME_WORK_NAME)
 
-            manager.enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, policy, request)
-        }
-
-        fun enqueueImmediateWork(context: Context) {
-            val manager = WorkManager.getInstance(context)
-            val request = OneTimeWorkRequestBuilder<HijriCalendarWorker>().build()
-            manager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
-        }
-
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
-            WorkManager.getInstance(context).cancelUniqueWork(ONE_TIME_WORK_NAME)
-        }
+        fun cancel(context: Context) =
+            WidgetWork.cancel(context, UNIQUE_WORK_NAME, ONE_TIME_WORK_NAME)
     }
 
     private suspend fun setWidgetState(
         glanceIds: List<GlanceId>,
         newState: HijriCalendarWidgetState
-    ) {
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(
-                context = context,
-                definition = HijriCalendarStateDefinition,
-                glanceId = glanceId,
-                updateState = { newState }
-            )
-        }
-        HijriCalendarWidget().updateAll(context)
-    }
+    ) = updateWidgetState(context, HijriCalendarWidget(), HijriCalendarStateDefinition, glanceIds, newState)
 
     override suspend fun doWork(): Result {
         val manager = GlanceAppWidgetManager(context)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateStateDefinition.kt
@@ -1,59 +1,10 @@
 package com.arshadshah.nimaz.widget.hijridate
 
-import android.content.Context
-import androidx.datastore.core.CorruptionException
-import androidx.datastore.core.DataStore
-import androidx.datastore.core.Serializer
-import androidx.datastore.dataStore
-import androidx.datastore.dataStoreFile
-import androidx.glance.state.GlanceStateDefinition
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
+import com.arshadshah.nimaz.widget.core.JsonGlanceStateDefinition
 
-object HijriDateStateDefinition : GlanceStateDefinition<HijriDateWidgetState> {
-
-    private const val DATA_STORE_FILENAME = "hijri_date_widget"
-
-    private val Context.datastore by dataStore(
-        DATA_STORE_FILENAME,
-        HijriDateWidgetStateSerializer
-    )
-
-    object HijriDateWidgetStateSerializer : Serializer<HijriDateWidgetState> {
-
-        override val defaultValue: HijriDateWidgetState =
-            HijriDateWidgetState.Success(HijriDateData())
-
-        override suspend fun readFrom(input: InputStream): HijriDateWidgetState = try {
-            Json.decodeFromString(
-                HijriDateWidgetState.serializer(),
-                input.readBytes().decodeToString()
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Could not read HijriDate data: ${e.message}")
-        }
-
-        override suspend fun writeTo(t: HijriDateWidgetState, output: OutputStream) {
-            output.use {
-                it.write(
-                    Json.encodeToString(HijriDateWidgetState.serializer(), t)
-                        .toByteArray()
-                )
-            }
-        }
-    }
-
-    override suspend fun getDataStore(
-        context: Context,
-        fileKey: String,
-    ): DataStore<HijriDateWidgetState> {
-        return context.datastore
-    }
-
-    override fun getLocation(context: Context, fileKey: String): File {
-        return context.dataStoreFile(DATA_STORE_FILENAME)
-    }
-}
+object HijriDateStateDefinition : JsonGlanceStateDefinition<HijriDateWidgetState>(
+    fileName = "hijri_date_widget",
+    serializer = HijriDateWidgetState.serializer(),
+    defaultValue = HijriDateWidgetState.Success(HijriDateData()),
+    dataLabel = "HijriDate",
+)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
@@ -31,6 +31,8 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
+import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class HijriDateWidget : GlanceAppWidget() {
 
@@ -56,25 +58,11 @@ private fun HijriDateContent(state: HijriDateWidgetState) {
     val primaryColor = ColorProvider(R.color.widget_primary)
 
     when (state) {
-        is HijriDateWidgetState.Loading -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = GlanceModifier.height(8.dp))
-                    Text(
-                        text = context.getString(R.string.widget_loading),
-                        style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                    )
-                }
-            }
-        }
+        is HijriDateWidgetState.Loading -> WidgetLoadingBox(
+            background = backgroundColor,
+            textSecondary = textSecondary,
+            onClick = actionStartActivity<MainActivity>(),
+        )
 
         is HijriDateWidgetState.Success -> {
             HijriDateSuccessContent(
@@ -86,20 +74,14 @@ private fun HijriDateContent(state: HijriDateWidgetState) {
             )
         }
 
-        is HijriDateWidgetState.Error -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = context.getString(R.string.widget_tap_to_refresh),
-                    style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                )
-            }
+        is HijriDateWidgetState.Error -> WidgetMessageBox(
+            background = backgroundColor,
+            onClick = actionStartActivity<MainActivity>(),
+        ) {
+            Text(
+                text = context.getString(R.string.widget_tap_to_refresh),
+                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
@@ -3,17 +3,12 @@ package com.arshadshah.nimaz.widget.hijridate
 import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.widget.core.WidgetWork
+import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
@@ -30,48 +25,24 @@ class HijriDateWorker @AssistedInject constructor(
     companion object {
         private const val UNIQUE_WORK_NAME = "HijriDateWorker"
         private const val ONE_TIME_WORK_NAME = "HijriDateWorkerOneTime"
+        private val REFRESH_INTERVAL: Duration = Duration.ofHours(6)
 
-        fun enqueuePeriodicWork(context: Context, force: Boolean = false) {
-            val manager = WorkManager.getInstance(context)
-            val request = PeriodicWorkRequestBuilder<HijriDateWorker>(
-                Duration.ofHours(6)
-            ).build()
+        fun enqueuePeriodicWork(context: Context, force: Boolean = false) =
+            WidgetWork.enqueuePeriodic<HijriDateWorker>(
+                context, UNIQUE_WORK_NAME, REFRESH_INTERVAL, force
+            )
 
-            val policy = if (force) {
-                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
-            } else {
-                ExistingPeriodicWorkPolicy.KEEP
-            }
+        fun enqueueImmediateWork(context: Context) =
+            WidgetWork.enqueueImmediate<HijriDateWorker>(context, ONE_TIME_WORK_NAME)
 
-            manager.enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, policy, request)
-        }
-
-        fun enqueueImmediateWork(context: Context) {
-            val manager = WorkManager.getInstance(context)
-            val request = OneTimeWorkRequestBuilder<HijriDateWorker>().build()
-            manager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
-        }
-
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
-            WorkManager.getInstance(context).cancelUniqueWork(ONE_TIME_WORK_NAME)
-        }
+        fun cancel(context: Context) =
+            WidgetWork.cancel(context, UNIQUE_WORK_NAME, ONE_TIME_WORK_NAME)
     }
 
     private suspend fun setWidgetState(
         glanceIds: List<GlanceId>,
         newState: HijriDateWidgetState
-    ) {
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(
-                context = context,
-                definition = HijriDateStateDefinition,
-                glanceId = glanceId,
-                updateState = { newState }
-            )
-        }
-        HijriDateWidget().updateAll(context)
-    }
+    ) = updateWidgetState(context, HijriDateWidget(), HijriDateStateDefinition, glanceIds, newState)
 
     override suspend fun doWork(): Result {
         val manager = GlanceAppWidgetManager(context)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerStateDefinition.kt
@@ -1,59 +1,10 @@
 package com.arshadshah.nimaz.widget.nextprayer
 
-import android.content.Context
-import androidx.datastore.core.CorruptionException
-import androidx.datastore.core.DataStore
-import androidx.datastore.core.Serializer
-import androidx.datastore.dataStore
-import androidx.datastore.dataStoreFile
-import androidx.glance.state.GlanceStateDefinition
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
+import com.arshadshah.nimaz.widget.core.JsonGlanceStateDefinition
 
-object NextPrayerStateDefinition : GlanceStateDefinition<NextPrayerWidgetState> {
-
-    private const val DATA_STORE_FILENAME = "next_prayer_widget"
-
-    private val Context.datastore by dataStore(
-        DATA_STORE_FILENAME,
-        NextPrayerWidgetStateSerializer
-    )
-
-    object NextPrayerWidgetStateSerializer : Serializer<NextPrayerWidgetState> {
-
-        override val defaultValue: NextPrayerWidgetState =
-            NextPrayerWidgetState.Success(NextPrayerData())
-
-        override suspend fun readFrom(input: InputStream): NextPrayerWidgetState = try {
-            Json.decodeFromString(
-                NextPrayerWidgetState.serializer(),
-                input.readBytes().decodeToString()
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Could not read NextPrayer data: ${e.message}")
-        }
-
-        override suspend fun writeTo(t: NextPrayerWidgetState, output: OutputStream) {
-            output.use {
-                it.write(
-                    Json.encodeToString(NextPrayerWidgetState.serializer(), t)
-                        .toByteArray()
-                )
-            }
-        }
-    }
-
-    override suspend fun getDataStore(
-        context: Context,
-        fileKey: String,
-    ): DataStore<NextPrayerWidgetState> {
-        return context.datastore
-    }
-
-    override fun getLocation(context: Context, fileKey: String): File {
-        return context.dataStoreFile(DATA_STORE_FILENAME)
-    }
-}
+object NextPrayerStateDefinition : JsonGlanceStateDefinition<NextPrayerWidgetState>(
+    fileName = "next_prayer_widget",
+    serializer = NextPrayerWidgetState.serializer(),
+    defaultValue = NextPrayerWidgetState.Success(NextPrayerData()),
+    dataLabel = "NextPrayer",
+)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
@@ -34,6 +34,8 @@ import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
+import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
+import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class NextPrayerWidget : GlanceAppWidget() {
 
@@ -59,25 +61,11 @@ private fun NextPrayerContent(state: NextPrayerWidgetState) {
     val primaryColor = ColorProvider(R.color.widget_primary)
 
     when (state) {
-        is NextPrayerWidgetState.Loading -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = GlanceModifier.height(8.dp))
-                    Text(
-                        text = context.getString(R.string.widget_loading),
-                        style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                    )
-                }
-            }
-        }
+        is NextPrayerWidgetState.Loading -> WidgetLoadingBox(
+            background = backgroundColor,
+            textSecondary = textSecondary,
+            onClick = actionStartActivity<MainActivity>(),
+        )
 
         is NextPrayerWidgetState.Success -> {
             NextPrayerSuccessContent(
@@ -89,22 +77,14 @@ private fun NextPrayerContent(state: NextPrayerWidgetState) {
             )
         }
 
-        is NextPrayerWidgetState.Error -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = context.getString(R.string.widget_tap_to_setup),
-                        style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                    )
-                }
-            }
+        is NextPrayerWidgetState.Error -> WidgetMessageBox(
+            background = backgroundColor,
+            onClick = actionStartActivity<MainActivity>(),
+        ) {
+            Text(
+                text = context.getString(R.string.widget_tap_to_setup),
+                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
@@ -3,18 +3,15 @@ package com.arshadshah.nimaz.widget.nextprayer
 import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.widget.core.WidgetWork
+import com.arshadshah.nimaz.widget.core.formatWidgetCountdown
+import com.arshadshah.nimaz.widget.core.formatWidgetTime
+import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
@@ -34,49 +31,25 @@ class NextPrayerWorker @AssistedInject constructor(
     companion object {
         private const val UNIQUE_WORK_NAME = "NextPrayerWorker"
         private const val ONE_TIME_WORK_NAME = "NextPrayerWorkerOneTime"
+        // WorkManager minimum interval is 15 minutes; per-minute updates use AlarmManager.
+        private val REFRESH_INTERVAL: Duration = Duration.ofMinutes(15)
 
-        fun enqueuePeriodicWork(context: Context, force: Boolean = false) {
-            val manager = WorkManager.getInstance(context)
-            // WorkManager minimum interval is 15 minutes; per-minute updates use AlarmManager
-            val request = PeriodicWorkRequestBuilder<NextPrayerWorker>(
-                Duration.ofMinutes(15)
-            ).build()
+        fun enqueuePeriodicWork(context: Context, force: Boolean = false) =
+            WidgetWork.enqueuePeriodic<NextPrayerWorker>(
+                context, UNIQUE_WORK_NAME, REFRESH_INTERVAL, force
+            )
 
-            val policy = if (force) {
-                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
-            } else {
-                ExistingPeriodicWorkPolicy.KEEP
-            }
+        fun enqueueImmediateWork(context: Context) =
+            WidgetWork.enqueueImmediate<NextPrayerWorker>(context, ONE_TIME_WORK_NAME)
 
-            manager.enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, policy, request)
-        }
-
-        fun enqueueImmediateWork(context: Context) {
-            val manager = WorkManager.getInstance(context)
-            val request = OneTimeWorkRequestBuilder<NextPrayerWorker>().build()
-            manager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
-        }
-
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
-            WorkManager.getInstance(context).cancelUniqueWork(ONE_TIME_WORK_NAME)
-        }
+        fun cancel(context: Context) =
+            WidgetWork.cancel(context, UNIQUE_WORK_NAME, ONE_TIME_WORK_NAME)
     }
 
     private suspend fun setWidgetState(
         glanceIds: List<GlanceId>,
         newState: NextPrayerWidgetState
-    ) {
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(
-                context = context,
-                definition = NextPrayerStateDefinition,
-                glanceId = glanceId,
-                updateState = { newState }
-            )
-        }
-        NextPrayerWidget().updateAll(context)
-    }
+    ) = updateWidgetState(context, NextPrayerWidget(), NextPrayerStateDefinition, glanceIds, newState)
 
     override suspend fun doWork(): Result {
         val manager = GlanceAppWidgetManager(context)
@@ -103,21 +76,15 @@ class NextPrayerWorker @AssistedInject constructor(
             val data = if (nextPrayer != null) {
                 val prayerLocalTime = nextPrayer.time.toLocalDateTime(timeZone)
                 val epochMillis = nextPrayer.time.toEpochMilliseconds()
-                val diff: kotlin.time.Duration = nextPrayer.time - currentTime
-                val totalSeconds = diff.inWholeSeconds
-                val hours = totalSeconds / 3600
-                val minutes = (totalSeconds % 3600) / 60
-                val seconds = totalSeconds % 60
-
-                val countdown = when {
-                    hours > 0 -> "${hours}h ${minutes}m"
-                    minutes > 0 -> "${minutes}m ${seconds}s"
-                    else -> "${seconds}s"
-                }
+                val countdown = formatWidgetCountdown((nextPrayer.time - currentTime).inWholeSeconds)
 
                 NextPrayerData(
                     prayerName = nextPrayer.type.displayName,
-                    prayerTime = formatTime(prayerLocalTime.hour, prayerLocalTime.minute),
+                    prayerTime = formatWidgetTime(
+                        prayerLocalTime.hour,
+                        prayerLocalTime.minute,
+                        includeAmPm = true
+                    ),
                     countdown = countdown,
                     isValid = true,
                     nextPrayerEpochMillis = epochMillis
@@ -131,15 +98,12 @@ class NextPrayerWorker @AssistedInject constructor(
 
                 if (tomorrowFajr != null) {
                     val epochMillis = tomorrowFajr.time.toEpochMilliseconds()
-                    val diff: kotlin.time.Duration = tomorrowFajr.time - currentTime
-                    val totalSeconds = diff.inWholeSeconds
-                    val hours = totalSeconds / 3600
-                    val minutes = (totalSeconds % 3600) / 60
-
                     NextPrayerData(
                         prayerName = "Fajr",
                         prayerTime = "Tomorrow",
-                        countdown = "${hours}h ${minutes}m",
+                        countdown = formatWidgetCountdown(
+                            (tomorrowFajr.time - currentTime).inWholeSeconds
+                        ),
                         isValid = true,
                         nextPrayerEpochMillis = epochMillis
                     )
@@ -159,11 +123,5 @@ class NextPrayerWorker @AssistedInject constructor(
             setWidgetState(glanceIds, NextPrayerWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }
-    }
-
-    private fun formatTime(hour: Int, minute: Int): String {
-        val h = if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
-        val amPm = if (hour >= 12) "PM" else "AM"
-        return String.format("%d:%02d %s", h, minute, amPm)
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesStateDefinition.kt
@@ -1,59 +1,10 @@
 package com.arshadshah.nimaz.widget.prayertimes
 
-import android.content.Context
-import androidx.datastore.core.CorruptionException
-import androidx.datastore.core.DataStore
-import androidx.datastore.core.Serializer
-import androidx.datastore.dataStore
-import androidx.datastore.dataStoreFile
-import androidx.glance.state.GlanceStateDefinition
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
+import com.arshadshah.nimaz.widget.core.JsonGlanceStateDefinition
 
-object PrayerTimesStateDefinition : GlanceStateDefinition<PrayerTimesWidgetState> {
-
-    private const val DATA_STORE_FILENAME = "prayer_times_widget"
-
-    private val Context.datastore by dataStore(
-        DATA_STORE_FILENAME,
-        PrayerTimesWidgetStateSerializer
-    )
-
-    object PrayerTimesWidgetStateSerializer : Serializer<PrayerTimesWidgetState> {
-
-        override val defaultValue: PrayerTimesWidgetState =
-            PrayerTimesWidgetState.Success(PrayerTimesData())
-
-        override suspend fun readFrom(input: InputStream): PrayerTimesWidgetState = try {
-            Json.decodeFromString(
-                PrayerTimesWidgetState.serializer(),
-                input.readBytes().decodeToString()
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Could not read PrayerTimes data: ${e.message}")
-        }
-
-        override suspend fun writeTo(t: PrayerTimesWidgetState, output: OutputStream) {
-            output.use {
-                it.write(
-                    Json.encodeToString(PrayerTimesWidgetState.serializer(), t)
-                        .toByteArray()
-                )
-            }
-        }
-    }
-
-    override suspend fun getDataStore(
-        context: Context,
-        fileKey: String,
-    ): DataStore<PrayerTimesWidgetState> {
-        return context.datastore
-    }
-
-    override fun getLocation(context: Context, fileKey: String): File {
-        return context.dataStoreFile(DATA_STORE_FILENAME)
-    }
-}
+object PrayerTimesStateDefinition : JsonGlanceStateDefinition<PrayerTimesWidgetState>(
+    fileName = "prayer_times_widget",
+    serializer = PrayerTimesWidgetState.serializer(),
+    defaultValue = PrayerTimesWidgetState.Success(PrayerTimesData()),
+    dataLabel = "PrayerTimes",
+)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
@@ -34,6 +34,8 @@ import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
+import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
+import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class PrayerTimesWidget : GlanceAppWidget() {
 
@@ -59,25 +61,11 @@ private fun PrayerTimesContent(state: PrayerTimesWidgetState) {
     val primaryColor = ColorProvider(R.color.widget_primary)
 
     when (state) {
-        is PrayerTimesWidgetState.Loading -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = GlanceModifier.height(8.dp))
-                    Text(
-                        text = context.getString(R.string.widget_loading),
-                        style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                    )
-                }
-            }
-        }
+        is PrayerTimesWidgetState.Loading -> WidgetLoadingBox(
+            background = backgroundColor,
+            textSecondary = textSecondary,
+            onClick = actionStartActivity<MainActivity>(),
+        )
 
         is PrayerTimesWidgetState.Success -> {
             PrayerTimesSuccessContent(
@@ -89,20 +77,14 @@ private fun PrayerTimesContent(state: PrayerTimesWidgetState) {
             )
         }
 
-        is PrayerTimesWidgetState.Error -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = context.getString(R.string.widget_tap_to_setup),
-                    style = TextStyle(color = textSecondary, fontSize = 12.sp)
-                )
-            }
+        is PrayerTimesWidgetState.Error -> WidgetMessageBox(
+            background = backgroundColor,
+            onClick = actionStartActivity<MainActivity>(),
+        ) {
+            Text(
+                text = context.getString(R.string.widget_tap_to_setup),
+                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
@@ -3,20 +3,16 @@ package com.arshadshah.nimaz.widget.prayertimes
 import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.widget.core.WidgetWork
+import com.arshadshah.nimaz.widget.core.formatWidgetTime
+import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
@@ -36,48 +32,24 @@ class PrayerTimesWorker @AssistedInject constructor(
     companion object {
         private const val UNIQUE_WORK_NAME = "PrayerTimesWorker"
         private const val ONE_TIME_WORK_NAME = "PrayerTimesWorkerOneTime"
+        private val REFRESH_INTERVAL: Duration = Duration.ofMinutes(15)
 
-        fun enqueuePeriodicWork(context: Context, force: Boolean = false) {
-            val manager = WorkManager.getInstance(context)
-            val request = PeriodicWorkRequestBuilder<PrayerTimesWorker>(
-                Duration.ofMinutes(15)
-            ).build()
+        fun enqueuePeriodicWork(context: Context, force: Boolean = false) =
+            WidgetWork.enqueuePeriodic<PrayerTimesWorker>(
+                context, UNIQUE_WORK_NAME, REFRESH_INTERVAL, force
+            )
 
-            val policy = if (force) {
-                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
-            } else {
-                ExistingPeriodicWorkPolicy.KEEP
-            }
+        fun enqueueImmediateWork(context: Context) =
+            WidgetWork.enqueueImmediate<PrayerTimesWorker>(context, ONE_TIME_WORK_NAME)
 
-            manager.enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, policy, request)
-        }
-
-        fun enqueueImmediateWork(context: Context) {
-            val manager = WorkManager.getInstance(context)
-            val request = OneTimeWorkRequestBuilder<PrayerTimesWorker>().build()
-            manager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
-        }
-
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
-            WorkManager.getInstance(context).cancelUniqueWork(ONE_TIME_WORK_NAME)
-        }
+        fun cancel(context: Context) =
+            WidgetWork.cancel(context, UNIQUE_WORK_NAME, ONE_TIME_WORK_NAME)
     }
 
     private suspend fun setWidgetState(
         glanceIds: List<GlanceId>,
         newState: PrayerTimesWidgetState
-    ) {
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(
-                context = context,
-                definition = PrayerTimesStateDefinition,
-                glanceId = glanceId,
-                updateState = { newState }
-            )
-        }
-        PrayerTimesWidget().updateAll(context)
-    }
+    ) = updateWidgetState(context, PrayerTimesWidget(), PrayerTimesStateDefinition, glanceIds, newState)
 
     override suspend fun doWork(): Result {
         val manager = GlanceAppWidgetManager(context)
@@ -115,6 +87,12 @@ class PrayerTimesWorker @AssistedInject constructor(
                 return prayerLocalTime.time < localTime.time
             }
 
+            fun formatPrayer(prayerTime: com.arshadshah.nimaz.domain.model.PrayerTime?): String =
+                prayerTime?.let {
+                    val local = it.time.toLocalDateTime(timeZone)
+                    formatWidgetTime(local.hour, local.minute)
+                } ?: "—"
+
             val nextPrayer = prayerTimes.firstOrNull { prayerTime ->
                 prayerTime.type != PrayerType.SUNRISE &&
                         prayerTime.time.toLocalDateTime(timeZone).time > localTime.time
@@ -139,36 +117,11 @@ class PrayerTimesWorker @AssistedInject constructor(
                 hijriDate = "${hijriDate.day} ${hijriDate.monthName}",
                 nextPrayerName = nextPrayer?.type?.displayName ?: "—",
                 timeUntilNext = timeUntilNext,
-                fajrTime = fajr?.let {
-                    formatTime(
-                        it.time.toLocalDateTime(timeZone).hour,
-                        it.time.toLocalDateTime(timeZone).minute
-                    )
-                } ?: "—",
-                dhuhrTime = dhuhr?.let {
-                    formatTime(
-                        it.time.toLocalDateTime(timeZone).hour,
-                        it.time.toLocalDateTime(timeZone).minute
-                    )
-                } ?: "—",
-                asrTime = asr?.let {
-                    formatTime(
-                        it.time.toLocalDateTime(timeZone).hour,
-                        it.time.toLocalDateTime(timeZone).minute
-                    )
-                } ?: "—",
-                maghribTime = maghrib?.let {
-                    formatTime(
-                        it.time.toLocalDateTime(timeZone).hour,
-                        it.time.toLocalDateTime(timeZone).minute
-                    )
-                } ?: "—",
-                ishaTime = isha?.let {
-                    formatTime(
-                        it.time.toLocalDateTime(timeZone).hour,
-                        it.time.toLocalDateTime(timeZone).minute
-                    )
-                } ?: "—",
+                fajrTime = formatPrayer(fajr),
+                dhuhrTime = formatPrayer(dhuhr),
+                asrTime = formatPrayer(asr),
+                maghribTime = formatPrayer(maghrib),
+                ishaTime = formatPrayer(isha),
                 fajrPassed = isPassed(fajr),
                 dhuhrPassed = isPassed(dhuhr),
                 asrPassed = isPassed(asr),
@@ -183,10 +136,5 @@ class PrayerTimesWorker @AssistedInject constructor(
             setWidgetState(glanceIds, PrayerTimesWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }
-    }
-
-    private fun formatTime(hour: Int, minute: Int): String {
-        val h = if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
-        return String.format("%d:%02d", h, minute)
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerStateDefinition.kt
@@ -1,59 +1,10 @@
 package com.arshadshah.nimaz.widget.prayertracker
 
-import android.content.Context
-import androidx.datastore.core.CorruptionException
-import androidx.datastore.core.DataStore
-import androidx.datastore.core.Serializer
-import androidx.datastore.dataStore
-import androidx.datastore.dataStoreFile
-import androidx.glance.state.GlanceStateDefinition
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
+import com.arshadshah.nimaz.widget.core.JsonGlanceStateDefinition
 
-object PrayerTrackerStateDefinition : GlanceStateDefinition<PrayerTrackerWidgetState> {
-
-    private const val DATA_STORE_FILENAME = "prayer_tracker_widget"
-
-    private val Context.datastore by dataStore(
-        DATA_STORE_FILENAME,
-        PrayerTrackerWidgetStateSerializer
-    )
-
-    object PrayerTrackerWidgetStateSerializer : Serializer<PrayerTrackerWidgetState> {
-
-        override val defaultValue: PrayerTrackerWidgetState =
-            PrayerTrackerWidgetState.Success(PrayerTrackerData())
-
-        override suspend fun readFrom(input: InputStream): PrayerTrackerWidgetState = try {
-            Json.decodeFromString(
-                PrayerTrackerWidgetState.serializer(),
-                input.readBytes().decodeToString()
-            )
-        } catch (e: SerializationException) {
-            throw CorruptionException("Could not read PrayerTracker data: ${e.message}")
-        }
-
-        override suspend fun writeTo(t: PrayerTrackerWidgetState, output: OutputStream) {
-            output.use {
-                it.write(
-                    Json.encodeToString(PrayerTrackerWidgetState.serializer(), t)
-                        .toByteArray()
-                )
-            }
-        }
-    }
-
-    override suspend fun getDataStore(
-        context: Context,
-        fileKey: String,
-    ): DataStore<PrayerTrackerWidgetState> {
-        return context.datastore
-    }
-
-    override fun getLocation(context: Context, fileKey: String): File {
-        return context.dataStoreFile(DATA_STORE_FILENAME)
-    }
-}
+object PrayerTrackerStateDefinition : JsonGlanceStateDefinition<PrayerTrackerWidgetState>(
+    fileName = "prayer_tracker_widget",
+    serializer = PrayerTrackerWidgetState.serializer(),
+    defaultValue = PrayerTrackerWidgetState.Success(PrayerTrackerData()),
+    dataLabel = "PrayerTracker",
+)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
@@ -40,6 +40,7 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 
 class PrayerTrackerWidget : GlanceAppWidget() {
@@ -250,7 +251,7 @@ private fun togglePrayerStatus(context: Context, prayerName: String) {
             val prayerDao = entryPoint.prayerDao()
 
             val today = LocalDate.now()
-            val todayEpoch = today.toEpochDay() * 86400000L
+            val todayEpoch = today.toUtcMidnightMillis()
 
             // Get current record
             val currentRecord = prayerDao.getPrayerRecord(todayEpoch, prayerName)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
@@ -34,6 +34,8 @@ import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.widget.WidgetEntryPoint
+import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
+import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -63,30 +65,11 @@ private fun PrayerTrackerContent(context: Context, state: PrayerTrackerWidgetSta
     val primaryColor = ColorProvider(R.color.widget_primary)
 
     when (state) {
-        is PrayerTrackerWidgetState.Loading -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = GlanceModifier.height(8.dp))
-                    Text(
-                        text = context.getString(R.string.widget_loading),
-                        style = TextStyle(
-                            color = textSecondary,
-                            fontSize = 12.sp
-                        )
-                    )
-                }
-            }
-        }
+        is PrayerTrackerWidgetState.Loading -> WidgetLoadingBox(
+            background = backgroundColor,
+            textSecondary = textSecondary,
+            onClick = actionStartActivity<MainActivity>(),
+        )
 
         is PrayerTrackerWidgetState.Success -> {
             PrayerTrackerSuccessContent(
@@ -99,34 +82,28 @@ private fun PrayerTrackerContent(context: Context, state: PrayerTrackerWidgetSta
             )
         }
 
-        is PrayerTrackerWidgetState.Error -> {
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxSize()
-                    .background(backgroundColor)
-                    .cornerRadius(16.dp)
-                    .clickable(actionStartActivity<MainActivity>()),
-                contentAlignment = Alignment.Center
+        is PrayerTrackerWidgetState.Error -> WidgetMessageBox(
+            background = backgroundColor,
+            onClick = actionStartActivity<MainActivity>(),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = context.getString(R.string.widget_error_loading),
-                        style = TextStyle(
-                            color = textSecondary,
-                            fontSize = 12.sp
-                        )
+                Text(
+                    text = context.getString(R.string.widget_error_loading),
+                    style = TextStyle(
+                        color = textSecondary,
+                        fontSize = 12.sp
                     )
-                    Spacer(modifier = GlanceModifier.height(4.dp))
-                    Text(
-                        text = context.getString(R.string.widget_tap_to_retry),
-                        style = TextStyle(
-                            color = primaryColor,
-                            fontSize = 10.sp
-                        )
+                )
+                Spacer(modifier = GlanceModifier.height(4.dp))
+                Text(
+                    text = context.getString(R.string.widget_tap_to_retry),
+                    style = TextStyle(
+                        color = primaryColor,
+                        fontSize = 10.sp
                     )
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
@@ -3,17 +3,12 @@ package com.arshadshah.nimaz.widget.prayertracker
 import android.content.Context
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.widget.core.WidgetWork
+import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
@@ -29,48 +24,24 @@ class PrayerTrackerWorker @AssistedInject constructor(
     companion object {
         private const val UNIQUE_WORK_NAME = "PrayerTrackerWorker"
         private const val ONE_TIME_WORK_NAME = "PrayerTrackerWorkerOneTime"
+        private val REFRESH_INTERVAL: Duration = Duration.ofMinutes(30)
 
-        fun enqueuePeriodicWork(context: Context, force: Boolean = false) {
-            val manager = WorkManager.getInstance(context)
-            val request = PeriodicWorkRequestBuilder<PrayerTrackerWorker>(
-                Duration.ofMinutes(30)
-            ).build()
+        fun enqueuePeriodicWork(context: Context, force: Boolean = false) =
+            WidgetWork.enqueuePeriodic<PrayerTrackerWorker>(
+                context, UNIQUE_WORK_NAME, REFRESH_INTERVAL, force
+            )
 
-            val policy = if (force) {
-                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
-            } else {
-                ExistingPeriodicWorkPolicy.KEEP
-            }
+        fun enqueueImmediateWork(context: Context) =
+            WidgetWork.enqueueImmediate<PrayerTrackerWorker>(context, ONE_TIME_WORK_NAME)
 
-            manager.enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, policy, request)
-        }
-
-        fun enqueueImmediateWork(context: Context) {
-            val manager = WorkManager.getInstance(context)
-            val request = OneTimeWorkRequestBuilder<PrayerTrackerWorker>().build()
-            manager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
-        }
-
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
-            WorkManager.getInstance(context).cancelUniqueWork(ONE_TIME_WORK_NAME)
-        }
+        fun cancel(context: Context) =
+            WidgetWork.cancel(context, UNIQUE_WORK_NAME, ONE_TIME_WORK_NAME)
     }
 
     private suspend fun setWidgetState(
         glanceIds: List<GlanceId>,
         newState: PrayerTrackerWidgetState
-    ) {
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(
-                context = context,
-                definition = PrayerTrackerStateDefinition,
-                glanceId = glanceId,
-                updateState = { newState }
-            )
-        }
-        PrayerTrackerWidget().updateAll(context)
-    }
+    ) = updateWidgetState(context, PrayerTrackerWidget(), PrayerTrackerStateDefinition, glanceIds, newState)
 
     override suspend fun doWork(): Result {
         val manager = GlanceAppWidgetManager(context)

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
@@ -12,6 +12,7 @@ import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import java.time.LocalDate
 
 @HiltWorker
@@ -53,7 +54,7 @@ class PrayerTrackerWorker @AssistedInject constructor(
 
         return try {
             val today = LocalDate.now()
-            val todayEpoch = today.toEpochDay() * 86400000L
+            val todayEpoch = today.toUtcMidnightMillis()
             val records = prayerDao.getPrayerRecordsForDateSync(todayEpoch)
             val recordMap = records.associate { it.prayerName to it.status }
 


### PR DESCRIPTION
The five widget packages (next prayer, prayer times, hijri date, prayer
tracker, hijri calendar) each carried near-identical boilerplate. Extract the
shared pieces into a new widget/core package and have every widget reuse them:

- JsonGlanceStateDefinition: generic JSON-backed GlanceStateDefinition base,
  replacing five ~60-line state definitions (serializer + DataStore wiring).
- WidgetWork: shared WorkManager enqueue/cancel helpers, replacing the
  identical companion objects in all five workers.
- updateWidgetState: shared "persist state + updateAll" helper, replacing the
  identical private setWidgetState in every worker.
- WidgetUi: shared colour palette plus WidgetLoadingBox / WidgetMessageBox,
  replacing the copy-pasted loading and error boxes.
- WidgetFormatters: shared 12-hour time and countdown formatting, unifying the
  duplicated formatTime helpers and WidgetUpdateScheduler.computeCountdown.

No behaviour change: DataStore file names/locations, work names, refresh
intervals and rendered output are all preserved. Net ~250 fewer lines.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XMwM3D13xvXXA4mHVDuSZj