### PR TITLE
refactor(compose): centralise duplicated names screens and Quran/Hadith palettes

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBanners.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/QuranBanners.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @Composable
@@ -38,10 +39,10 @@ internal fun JuzPageBanner(
             .clip(RoundedCornerShape(20.dp))
             .background(
                 Brush.linearGradient(
-                    listOf(Color(0xFF115E59), Color(0xFF042F2E))
+                    listOf(NimazColors.QuranColors.CardGradientStart, NimazColors.QuranColors.CardGradientEnd)
                 )
             )
-            .border(1.dp, Color(0xFF0F766E), RoundedCornerShape(20.dp))
+            .border(1.dp, NimazColors.QuranColors.CardBorder, RoundedCornerShape(20.dp))
             .padding(25.dp)
     ) {
         Column(
@@ -52,14 +53,14 @@ internal fun JuzPageBanner(
                 text = title,
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color(0xFFEAB308)
+                color = NimazColors.QuranColors.CardAccentGold
             )
             if (subtitle.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = subtitle,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = Color(0xFFEAB308).copy(alpha = 0.8f)
+                    color = NimazColors.QuranColors.CardAccentGold.copy(alpha = 0.8f)
                 )
             }
         }
@@ -84,7 +85,7 @@ internal fun PageSurahSeparator(
                 .fillMaxWidth()
                 .background(
                     Brush.linearGradient(
-                        listOf(Color(0xFF115E59), Color(0xFF042F2E))
+                        listOf(NimazColors.QuranColors.CardGradientStart, NimazColors.QuranColors.CardGradientEnd)
                     )
                 )
                 .padding(vertical = 14.dp, horizontal = 18.dp)
@@ -124,7 +125,7 @@ internal fun PageSurahSeparator(
                     ArabicText(
                         text = surahNameArabic,
                         size = ArabicTextSize.MEDIUM,
-                        color = Color(0xFFEAB308)
+                        color = NimazColors.QuranColors.CardAccentGold
                     )
                 }
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.IconBadge
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 /**
@@ -159,10 +160,10 @@ fun HadithOfTheDayCard(
 @Composable
 private fun GradeChip(grade: String) {
     val color = when (grade.trim().lowercase()) {
-        "sahih" -> Color(0xFF4CAF50)
-        "hasan" -> Color(0xFF8BC34A)
-        "da'if", "daif", "dai'f" -> Color(0xFFFF9800)
-        "mawdu", "mawdu'", "fabricated" -> Color(0xFFF44336)
+        "sahih" -> NimazColors.HadithGradeColors.Sahih
+        "hasan" -> NimazColors.HadithGradeColors.Hasan
+        "da'if", "daif", "dai'f" -> NimazColors.HadithGradeColors.Daif
+        "mawdu", "mawdu'", "fabricated" -> NimazColors.HadithGradeColors.Mawdu
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     Text(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafContinuousText.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafContinuousText.kt
@@ -34,9 +34,10 @@ import com.arshadshah.nimaz.presentation.components.atoms.formatAyahEndMarker
 import com.arshadshah.nimaz.presentation.components.atoms.getDisplayArabicText
 import androidx.compose.ui.text.font.FontFamily
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
-private val MushafLineColor = Color(0xFF0F766E).copy(alpha = 0.5f)
+private val MushafLineColor = NimazColors.QuranColors.CardBorder.copy(alpha = 0.5f)
 
 /**
  * Core component that renders continuous Arabic text with clickable ayah spans.

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafSurahHeader.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafSurahHeader.kt
@@ -28,13 +28,14 @@ import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.BISMILLAH_TEXT
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
-// Theme colors for Mushaf header (matching QuranReaderScreen patterns)
-private val MushafHeaderGradientStart = Color(0xFF115E59)
-private val MushafHeaderGradientEnd = Color(0xFF042F2E)
-private val MushafHeaderBorder = Color(0xFF0F766E)
-private val MushafGoldColor = Color(0xFFEAB308)
+// Theme colors for Mushaf header — shared Quran card palette (see NimazColors.QuranColors)
+private val MushafHeaderGradientStart = NimazColors.QuranColors.CardGradientStart
+private val MushafHeaderGradientEnd = NimazColors.QuranColors.CardGradientEnd
+private val MushafHeaderBorder = NimazColors.QuranColors.CardBorder
+private val MushafGoldColor = NimazColors.QuranColors.CardAccentGold
 
 /**
  * Decorative surah header shown when a new surah starts on a Mushaf page.

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranContinueReadingCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranContinueReadingCard.kt
@@ -32,6 +32,7 @@ import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -64,15 +65,15 @@ internal fun ContinueReadingCard(
                 .background(
                     brush = Brush.linearGradient(
                         colors = listOf(
-                            Color(0xFF115E59),
-                            Color(0xFF042F2E)
+                            NimazColors.QuranColors.CardGradientStart,
+                            NimazColors.QuranColors.CardGradientEnd
                         )
                     ),
                     shape = RoundedCornerShape(20.dp)
                 )
                 .border(
                     width = 1.dp,
-                    color = Color(0xFF0F766E),
+                    color = NimazColors.QuranColors.CardBorder,
                     shape = RoundedCornerShape(20.dp)
                 )
         ) {
@@ -84,7 +85,7 @@ internal fun ContinueReadingCard(
                 Text(
                     text = stringResource(R.string.quran_home_continue_reading),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color(0xFF2DD4BF),
+                    color = NimazColors.QuranColors.CardAccentCyan,
                     letterSpacing = 1.5.sp,
                     fontWeight = FontWeight.Medium
                 )
@@ -105,7 +106,7 @@ internal fun ContinueReadingCard(
                     ArabicText(
                         text = surahName.nameArabic,
                         size = ArabicTextSize.MEDIUM,
-                        color = Color(0xFFEAB308)
+                        color = NimazColors.QuranColors.CardAccentGold
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -149,7 +150,7 @@ internal fun ContinueReadingCard(
                                 .fillMaxWidth(progressFraction)
                                 .height(6.dp)
                                 .clip(RoundedCornerShape(3.dp))
-                                .background(Color(0xFFEAB308))
+                                .background(NimazColors.QuranColors.CardAccentGold)
                         )
                     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranKhatamProgressCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranKhatamProgressCard.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -35,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.Khatam
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -143,8 +143,8 @@ internal fun KhatamProgressCard(
                             .background(
                                 brush = Brush.horizontalGradient(
                                     colors = listOf(
-                                        Color(0xFF14B8A6),
-                                        Color(0xFFEAB308)
+                                        NimazColors.QuranColors.CardAccentTeal,
+                                        NimazColors.QuranColors.CardAccentGold
                                     )
                                 )
                             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBanner.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBanner.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @Composable
@@ -49,10 +50,10 @@ internal fun SurahBanner(
             .clip(RoundedCornerShape(20.dp))
             .background(
                 Brush.linearGradient(
-                    listOf(Color(0xFF115E59), Color(0xFF042F2E))
+                    listOf(NimazColors.QuranColors.CardGradientStart, NimazColors.QuranColors.CardGradientEnd)
                 )
             )
-            .border(1.dp, Color(0xFF0F766E), RoundedCornerShape(20.dp))
+            .border(1.dp, NimazColors.QuranColors.CardBorder, RoundedCornerShape(20.dp))
             .padding(25.dp)
     ) {
         Column(
@@ -62,7 +63,7 @@ internal fun SurahBanner(
             ArabicText(
                 text = surahNameArabic,
                 size = ArabicTextSize.EXTRA_LARGE,
-                color = Color(0xFFEAB308)
+                color = NimazColors.QuranColors.CardAccentGold
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -71,13 +72,13 @@ internal fun SurahBanner(
                 text = surahNameEnglish,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.SemiBold,
-                color = Color(0xFFEAB308)
+                color = NimazColors.QuranColors.CardAccentGold
             )
 
             Text(
                 text = surahMeaning,
                 style = MaterialTheme.typography.bodySmall,
-                color = Color(0xFFEAB308).copy(alpha = 0.8f)
+                color = NimazColors.QuranColors.CardAccentGold.copy(alpha = 0.8f)
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -113,7 +114,7 @@ internal fun SurahBanner(
                 ArabicText(
                     text = "\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u0651\u064E\u0647\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0652\u0645\u064E\u0670\u0646\u0650 \u0671\u0644\u0631\u0651\u064E\u062D\u0650\u064A\u0645\u0650",
                     size = ArabicTextSize.LARGE,
-                    color = Color(0xFFEAB308)
+                    color = NimazColors.QuranColors.CardAccentGold
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponents.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponents.kt
@@ -44,6 +44,7 @@ import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.StatItem
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @Composable
@@ -58,7 +59,7 @@ internal fun HeroHeader(
             .background(
                 Brush.verticalGradient(
                     colors = listOf(
-                        Color(0xFF115E59),
+                        NimazColors.QuranColors.CardGradientStart,
                         MaterialTheme.colorScheme.background
                     )
                 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranVerseOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranVerseOfTheDayCard.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.sp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 /**
@@ -63,15 +64,15 @@ internal fun VerseOfTheDayCard(
                 .background(
                     brush = Brush.linearGradient(
                         colors = listOf(
-                            Color(0xFF115E59),
-                            Color(0xFF042F2E)
+                            NimazColors.QuranColors.CardGradientStart,
+                            NimazColors.QuranColors.CardGradientEnd
                         )
                     ),
                     shape = RoundedCornerShape(20.dp)
                 )
                 .border(
                     width = 1.dp,
-                    color = Color(0xFF0F766E),
+                    color = NimazColors.QuranColors.CardBorder,
                     shape = RoundedCornerShape(20.dp)
                 )
         ) {
@@ -84,14 +85,14 @@ internal fun VerseOfTheDayCard(
                     Icon(
                         imageVector = Icons.Default.AutoStories,
                         contentDescription = null,
-                        tint = Color(0xFFEAB308),
+                        tint = NimazColors.QuranColors.CardAccentGold,
                         modifier = Modifier.size(16.dp)
                     )
                     Spacer(modifier = Modifier.size(8.dp))
                     Text(
                         text = stringResource(R.string.quran_home_verse_of_the_day),
                         style = MaterialTheme.typography.labelSmall,
-                        color = Color(0xFF2DD4BF),
+                        color = NimazColors.QuranColors.CardAccentCyan,
                         letterSpacing = 1.5.sp,
                         fontWeight = FontWeight.Medium
                     )
@@ -123,7 +124,7 @@ internal fun VerseOfTheDayCard(
                     text = reference,
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFFEAB308)
+                    color = NimazColors.QuranColors.CardAccentGold
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafPage.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafPage.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
@@ -50,11 +49,12 @@ import com.arshadshah.nimaz.presentation.components.molecules.sampleFatihahAyahs
 import com.arshadshah.nimaz.presentation.components.molecules.sampleSurahBaqarah
 import com.arshadshah.nimaz.presentation.components.molecules.sampleSurahFatihah
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
-private val MushafFrameColor = Color(0xFF0F766E)
-private val MushafFrameColorLight = Color(0xFF14B8A6)
-private val MushafGoldAccent = Color(0xFFEAB308)
+private val MushafFrameColor = NimazColors.QuranColors.CardBorder
+private val MushafFrameColorLight = NimazColors.QuranColors.CardAccentTeal
+private val MushafGoldAccent = NimazColors.QuranColors.CardAccentGold
 
 /**
  * Main Mushaf page component.

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranSurahInfoSections.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranSurahInfoSections.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -161,7 +162,10 @@ internal fun BottomActions(
                         .clip(RoundedCornerShape(14.dp))
                         .background(
                             Brush.linearGradient(
-                                colors = listOf(Color(0xFF14B8A6), Color(0xFF0F766E))
+                                colors = listOf(
+                                    NimazColors.QuranColors.CardAccentTeal,
+                                    NimazColors.QuranColors.CardBorder
+                                )
                             )
                         )
                         .clickable(onClick = onStartReading)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/templates/NameScreenScaffolds.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/templates/NameScreenScaffolds.kt
@@ -1,0 +1,211 @@
+package com.arshadshah.nimaz.presentation.components.templates
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
+import com.arshadshah.nimaz.presentation.components.molecules.FavoriteFab
+import com.arshadshah.nimaz.presentation.components.molecules.NameFilterRow
+import com.arshadshah.nimaz.presentation.components.molecules.NamesAccent
+import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
+import com.arshadshah.nimaz.presentation.theme.NimazSpacing
+
+/**
+ * Shared scaffold for the three "names" list screens (Asma ul Husna, Asma un
+ * Nabi, Prophets). These previously copy-pasted an identical search-bar +
+ * favourites-filter + loading + list + empty-state structure; only the data
+ * source, accent, strings and the per-item card differed.
+ *
+ * @param itemContent renders a single row (e.g. a [com.arshadshah.nimaz.presentation.components.molecules.NameCard]).
+ * @param emptyTitle title shown when the (unfiltered) list is empty; the
+ *        favourites-only empty state always uses [R.string.no_favorites_yet].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> SearchableNameListScreen(
+    title: String,
+    searchHint: String,
+    searchQuery: String,
+    showFavoritesOnly: Boolean,
+    isLoading: Boolean,
+    items: List<T>,
+    accent: NamesAccent,
+    emptyTitle: String,
+    itemKey: (T) -> Any,
+    onNavigateBack: () -> Unit,
+    onSearch: (String) -> Unit,
+    onClearSearch: () -> Unit,
+    onToggleFavoritesFilter: () -> Unit,
+    itemContent: @Composable (T) -> Unit,
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            NimazBackTopAppBar(
+                title = title,
+                onBackClick = onNavigateBack
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            NimazSearchBar(
+                query = searchQuery,
+                onQueryChange = onSearch,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
+                placeholder = searchHint,
+                showClearButton = searchQuery.isNotEmpty(),
+                onClear = onClearSearch,
+                onSearch = onSearch
+            )
+
+            NameFilterRow(
+                showFavoritesOnly = showFavoritesOnly,
+                onShowAll = onToggleFavoritesFilter,
+                onShowFavorites = onToggleFavoritesFilter,
+                accent = accent,
+                allLabel = stringResource(R.string.all),
+                favoritesLabel = stringResource(R.string.favorites),
+                modifier = Modifier.padding(
+                    horizontal = NimazSpacing.Large,
+                    vertical = NimazSpacing.ExtraSmall
+                )
+            )
+
+            if (isLoading) {
+                NimazLoadingState()
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        horizontal = NimazSpacing.Large,
+                        vertical = NimazSpacing.Small
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
+                ) {
+                    items(
+                        items = items,
+                        key = { itemKey(it) }
+                    ) { item ->
+                        itemContent(item)
+                    }
+
+                    if (items.isEmpty()) {
+                        item {
+                            NimazEmptyState(
+                                title = if (showFavoritesOnly) {
+                                    stringResource(R.string.no_favorites_yet)
+                                } else {
+                                    emptyTitle
+                                },
+                                message = "",
+                                icon = Icons.Filled.Favorite,
+                                iconTint = accent.contentTint,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 48.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Shared scaffold for the three "names" detail screens. These previously
+ * copy-pasted an identical top-bar + favourite FAB + loading + scrollable
+ * section list. Only the loaded item, title, accent and the body sections
+ * differed.
+ *
+ * The body [content] receives the non-null loaded [item]; a trailing spacer for
+ * the FAB is appended automatically.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> NameDetailScaffold(
+    item: T?,
+    isLoading: Boolean,
+    title: String,
+    accent: NamesAccent,
+    isFavorite: (T) -> Boolean,
+    onNavigateBack: () -> Unit,
+    onToggleFavorite: (T) -> Unit,
+    content: LazyListScope.(T) -> Unit,
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            NimazBackTopAppBar(
+                title = title,
+                onBackClick = onNavigateBack
+            )
+        },
+        floatingActionButton = {
+            item?.let { loaded ->
+                FavoriteFab(
+                    isFavorite = isFavorite(loaded),
+                    accent = accent,
+                    onClick = { onToggleFavorite(loaded) }
+                )
+            }
+        }
+    ) { paddingValues ->
+        if (isLoading || item == null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentPadding = PaddingValues(
+                    horizontal = NimazSpacing.Large,
+                    vertical = NimazSpacing.Small
+                ),
+                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
+            ) {
+                content(item)
+
+                item {
+                    Spacer(modifier = Modifier.height(72.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/templates/ReaderPagerScaffold.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/templates/ReaderPagerScaffold.kt
@@ -1,0 +1,155 @@
+package com.arshadshah.nimaz.presentation.components.templates
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import kotlinx.coroutines.launch
+
+/**
+ * Shared scaffold for the swipe-through readers (hadith, dua). Both previously
+ * copy-pasted the same pager-state setup, "scroll to the requested index once the
+ * collection loads" effect, loading/empty/content branching, and prev/next page
+ * animation wiring. Only the page content and bottom bar differed.
+ *
+ * The screen keeps ownership of *loading* its data (its own `LaunchedEffect` that
+ * dispatches the load event); this template only owns the pager + chrome.
+ *
+ * @param targetIndex the index the pager should settle on once [items] is loaded.
+ * @param title produces the top-bar title from the currently-visible item (null
+ *        until loaded), so readers whose title tracks the page stay in sync.
+ * @param pageContent renders a single page for the given item.
+ * @param bottomBar renders the per-item action bar; receives the current item,
+ *        the current/total page counts, and ready-made prev/next callbacks.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> ReaderPagerScaffold(
+    items: List<T>,
+    targetIndex: Int,
+    isLoading: Boolean,
+    title: @Composable (currentItem: T?) -> String,
+    onNavigateBack: () -> Unit,
+    onSettingsClick: () -> Unit,
+    settingsContentDescription: String,
+    emptyText: String,
+    itemKey: (T) -> Any,
+    pageContent: @Composable (T) -> Unit,
+    bottomBar: @Composable (item: T, currentPage: Int, pageCount: Int, onPrev: () -> Unit, onNext: () -> Unit) -> Unit,
+    subtitle: String? = null,
+) {
+    val scope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(
+        initialPage = targetIndex.coerceAtLeast(0),
+        pageCount = { items.size }
+    )
+
+    LaunchedEffect(targetIndex, items.size) {
+        if (items.isNotEmpty()) {
+            pagerState.scrollToPage(targetIndex.coerceIn(0, items.lastIndex))
+        }
+    }
+
+    val current = items.getOrNull(pagerState.currentPage)
+
+    Scaffold(
+        topBar = {
+            NimazBackTopAppBar(
+                title = title(current),
+                subtitle = subtitle,
+                onBackClick = onNavigateBack,
+                actions = {
+                    IconButton(onClick = onSettingsClick) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = settingsContentDescription,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            when {
+                isLoading && items.isEmpty() -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                items.isEmpty() -> {
+                    Text(
+                        text = emptyText,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                else -> {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            key = { itemKey(items[it]) }
+                        ) { page ->
+                            pageContent(items[page])
+                        }
+
+                        current?.let { item ->
+                            bottomBar(
+                                item,
+                                pagerState.currentPage,
+                                items.size,
+                                {
+                                    scope.launch {
+                                        pagerState.animateScrollToPage(
+                                            (pagerState.currentPage - 1).coerceAtLeast(0)
+                                        )
+                                    }
+                                },
+                                {
+                                    scope.launch {
+                                        pagerState.animateScrollToPage(
+                                            (pagerState.currentPage + 1).coerceAtMost(items.lastIndex)
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaDetailScreen.kt
@@ -1,54 +1,36 @@
 package com.arshadshah.nimaz.presentation.screens.asma
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.molecules.FavoriteFab
-import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionCard
 import com.arshadshah.nimaz.presentation.components.molecules.NameDetailHeader
+import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionCard
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.templates.NameDetailScaffold
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUlHusnaEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUlHusnaViewModel
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun AsmaUlHusnaDetailScreen(
     nameId: Int,
@@ -62,138 +44,101 @@ fun AsmaUlHusnaDetailScreen(
     val state by viewModel.detailState.collectAsState()
     val accent = NamesAccents.allah()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
-                onBackClick = onNavigateBack
+    NameDetailScaffold(
+        item = state.name,
+        isLoading = state.isLoading,
+        title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
+        accent = accent,
+        isFavorite = { it.isFavorite },
+        onNavigateBack = onNavigateBack,
+        onToggleFavorite = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(it.id)) }
+    ) { name ->
+        // Calligraphic header
+        item {
+            NameDetailHeader(
+                arabicName = name.nameArabic,
+                accent = accent,
+                number = name.id,
+                primaryLabel = name.nameTransliteration,
+                secondaryLabel = name.nameEnglish,
             )
-        },
-        floatingActionButton = {
-            state.name?.let { name ->
-                FavoriteFab(
-                    isFavorite = name.isFavorite,
-                    accent = accent,
-                    onClick = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(name.id)) }
-                )
-            }
         }
-    ) { paddingValues ->
-        if (state.isLoading || state.name == null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val name = state.name!!
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentPadding = PaddingValues(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.Small
-                ),
-                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
-            ) {
-                // Calligraphic header
-                item {
-                    NameDetailHeader(
-                        arabicName = name.nameArabic,
-                        accent = accent,
-                        number = name.id,
-                        primaryLabel = name.nameTransliteration,
-                        secondaryLabel = name.nameEnglish,
-                    )
-                }
 
-                // Meaning Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_meaning),
-                        content = name.meaning
-                    )
-                }
+        // Meaning Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_meaning),
+                content = name.meaning
+            )
+        }
 
-                // Explanation Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_explanation),
-                        content = name.explanation
-                    )
-                }
+        // Explanation Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_explanation),
+                content = name.explanation
+            )
+        }
 
-                // Benefits Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_benefits),
-                        content = name.benefits
-                    )
-                }
+        // Benefits Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_benefits),
+                content = name.benefits
+            )
+        }
 
-                // Quran References
-                if (name.quranReferences.isNotEmpty()) {
-                    item {
-                        NimazCard(
-                            modifier = Modifier.fillMaxWidth(),
-                            style = NimazCardStyle.FILLED,
-                            colors = CardDefaults.cardColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                            )
+        // Quran References
+        if (name.quranReferences.isNotEmpty()) {
+            item {
+                NimazCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    style = NimazCardStyle.FILLED,
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(NimazSpacing.Large),
+                        verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.asma_ul_husna_quran_references),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = accent.contentTint
+                        )
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(NimazSpacing.Small),
+                            verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
                         ) {
-                            Column(
-                                modifier = Modifier.padding(NimazSpacing.Large),
-                                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.asma_ul_husna_quran_references),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = accent.contentTint
-                                )
-                                FlowRow(
-                                    horizontalArrangement = Arrangement.spacedBy(NimazSpacing.Small),
-                                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                                ) {
-                                    name.quranReferences.forEach { reference ->
-                                        AssistChip(
-                                            onClick = {},
-                                            label = {
-                                                Text(
-                                                    text = reference,
-                                                    style = MaterialTheme.typography.bodySmall
-                                                )
-                                            },
-                                            colors = AssistChipDefaults.assistChipColors(
-                                                containerColor = accent.chipContainer,
-                                                labelColor = accent.onChipContainer
-                                            )
+                            name.quranReferences.forEach { reference ->
+                                AssistChip(
+                                    onClick = {},
+                                    label = {
+                                        Text(
+                                            text = reference,
+                                            style = MaterialTheme.typography.bodySmall
                                         )
-                                    }
-                                }
+                                    },
+                                    colors = AssistChipDefaults.assistChipColors(
+                                        containerColor = accent.chipContainer,
+                                        labelColor = accent.onChipContainer
+                                    )
+                                )
                             }
                         }
                     }
                 }
-
-                // Usage in Dua Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_usage_in_dua),
-                        content = name.usageInDua
-                    )
-                }
-
-                // Bottom spacer for FAB
-                item {
-                    Spacer(modifier = Modifier.height(72.dp))
-                }
             }
+        }
+
+        // Usage in Dua Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_usage_in_dua),
+                content = name.usageInDua
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaListScreen.kt
@@ -1,41 +1,17 @@
 package com.arshadshah.nimaz.presentation.screens.asma
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.molecules.NameCard
-import com.arshadshah.nimaz.presentation.components.molecules.NameFilterRow
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.theme.NimazSpacing
+import com.arshadshah.nimaz.presentation.components.templates.SearchableNameListScreen
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUlHusnaEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUlHusnaViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AsmaUlHusnaListScreen(
     onNavigateBack: () -> Unit,
@@ -45,98 +21,32 @@ fun AsmaUlHusnaListScreen(
     val state by viewModel.listState.collectAsState()
     val accent = NamesAccents.allah()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = stringResource(R.string.asma_ul_husna_title),
-                onBackClick = onNavigateBack
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            // Search Bar
-            NimazSearchBar(
-                query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(AsmaUlHusnaEvent.Search(it)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
-                placeholder = stringResource(R.string.asma_ul_husna_search_hint),
-                showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(AsmaUlHusnaEvent.ClearSearch) },
-                onSearch = { viewModel.onEvent(AsmaUlHusnaEvent.Search(it)) }
-            )
-
-            // Filter Chips
-            NameFilterRow(
-                showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavoritesFilter) },
-                accent = accent,
-                allLabel = stringResource(R.string.all),
-                favoritesLabel = stringResource(R.string.favorites),
-                modifier = Modifier.padding(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.ExtraSmall
-                )
-            )
-
-            // Content
-            if (state.isLoading) {
-                NimazLoadingState()
-            } else {
-                val displayList = state.filteredNames
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        horizontal = NimazSpacing.Large,
-                        vertical = NimazSpacing.Small
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                ) {
-                    items(
-                        items = displayList,
-                        key = { it.id }
-                    ) { name ->
-                        NameCard(
-                            number = name.id,
-                            arabicName = name.nameArabic,
-                            primaryLabel = name.nameTransliteration,
-                            secondaryLabel = name.nameEnglish,
-                            isFavorite = name.isFavorite,
-                            accent = accent,
-                            onClick = { onNavigateToDetail(name.id) },
-                            onFavoriteClick = {
-                                viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(name.id))
-                            }
-                        )
-                    }
-
-                    if (displayList.isEmpty()) {
-                        item {
-                            NimazEmptyState(
-                                title = if (state.showFavoritesOnly) {
-                                    stringResource(R.string.no_favorites_yet)
-                                } else {
-                                    stringResource(R.string.asma_ul_husna_no_names_found)
-                                },
-                                message = "",
-                                icon = Icons.Filled.Favorite,
-                                iconTint = accent.contentTint,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 48.dp)
-                            )
-                        }
-                    }
-                }
+    SearchableNameListScreen(
+        title = stringResource(R.string.asma_ul_husna_title),
+        searchHint = stringResource(R.string.asma_ul_husna_search_hint),
+        searchQuery = state.searchQuery,
+        showFavoritesOnly = state.showFavoritesOnly,
+        isLoading = state.isLoading,
+        items = state.filteredNames,
+        accent = accent,
+        emptyTitle = stringResource(R.string.asma_ul_husna_no_names_found),
+        itemKey = { it.id },
+        onNavigateBack = onNavigateBack,
+        onSearch = { viewModel.onEvent(AsmaUlHusnaEvent.Search(it)) },
+        onClearSearch = { viewModel.onEvent(AsmaUlHusnaEvent.ClearSearch) },
+        onToggleFavoritesFilter = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavoritesFilter) }
+    ) { name ->
+        NameCard(
+            number = name.id,
+            arabicName = name.nameArabic,
+            primaryLabel = name.nameTransliteration,
+            secondaryLabel = name.nameEnglish,
+            isFavorite = name.isFavorite,
+            accent = accent,
+            onClick = { onNavigateToDetail(name.id) },
+            onFavoriteClick = {
+                viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(name.id))
             }
-        }
+        )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiDetailScreen.kt
@@ -1,50 +1,19 @@
 package com.arshadshah.nimaz.presentation.screens.asmaunnabi
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.molecules.FavoriteFab
 import com.arshadshah.nimaz.presentation.components.molecules.NameDetailHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionCard
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.theme.NimazSpacing
+import com.arshadshah.nimaz.presentation.components.templates.NameDetailScaffold
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUnNabiEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUnNabiViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AsmaUnNabiDetailScreen(
     nameId: Int,
@@ -58,88 +27,51 @@ fun AsmaUnNabiDetailScreen(
     val state by viewModel.detailState.collectAsState()
     val accent = NamesAccents.prophetNames()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
-                onBackClick = onNavigateBack
+    NameDetailScaffold(
+        item = state.name,
+        isLoading = state.isLoading,
+        title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
+        accent = accent,
+        isFavorite = { it.isFavorite },
+        onNavigateBack = onNavigateBack,
+        onToggleFavorite = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(it.id)) }
+    ) { name ->
+        // Calligraphic header
+        item {
+            NameDetailHeader(
+                arabicName = name.nameArabic,
+                accent = accent,
+                number = name.id,
+                primaryLabel = name.nameTransliteration,
+                secondaryLabel = name.nameEnglish,
             )
-        },
-        floatingActionButton = {
-            state.name?.let { name ->
-                FavoriteFab(
-                    isFavorite = name.isFavorite,
-                    accent = accent,
-                    onClick = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(name.id)) }
-                )
-            }
         }
-    ) { paddingValues ->
-        if (state.isLoading || state.name == null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val name = state.name!!
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentPadding = PaddingValues(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.Small
-                ),
-                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
-            ) {
-                // Calligraphic header
-                item {
-                    NameDetailHeader(
-                        arabicName = name.nameArabic,
-                        accent = accent,
-                        number = name.id,
-                        primaryLabel = name.nameTransliteration,
-                        secondaryLabel = name.nameEnglish,
-                    )
-                }
 
-                // Meaning Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_meaning),
-                        content = name.meaning,
-                        titleColor = accent.contentTint
-                    )
-                }
+        // Meaning Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_meaning),
+                content = name.meaning,
+                titleColor = accent.contentTint
+            )
+        }
 
-                // Explanation Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_ul_husna_explanation),
-                        content = name.explanation,
-                        titleColor = accent.contentTint
-                    )
-                }
+        // Explanation Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_ul_husna_explanation),
+                content = name.explanation,
+                titleColor = accent.contentTint
+            )
+        }
 
-                // Source Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.asma_un_nabi_source),
-                        content = name.source,
-                        titleColor = accent.contentTint
-                    )
-                }
-
-                // Bottom spacer for FAB
-                item {
-                    Spacer(modifier = Modifier.height(72.dp))
-                }
-            }
+        // Source Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.asma_un_nabi_source),
+                content = name.source,
+                titleColor = accent.contentTint
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiListScreen.kt
@@ -1,41 +1,17 @@
 package com.arshadshah.nimaz.presentation.screens.asmaunnabi
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.molecules.NameCard
-import com.arshadshah.nimaz.presentation.components.molecules.NameFilterRow
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.theme.NimazSpacing
+import com.arshadshah.nimaz.presentation.components.templates.SearchableNameListScreen
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUnNabiEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AsmaUnNabiViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AsmaUnNabiListScreen(
     onNavigateBack: () -> Unit,
@@ -45,97 +21,32 @@ fun AsmaUnNabiListScreen(
     val state by viewModel.listState.collectAsState()
     val accent = NamesAccents.prophetNames()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = stringResource(R.string.asma_un_nabi_title),
-                onBackClick = onNavigateBack
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            NimazSearchBar(
-                query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(AsmaUnNabiEvent.Search(it)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
-                placeholder = stringResource(R.string.asma_un_nabi_search_hint),
-                showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(AsmaUnNabiEvent.ClearSearch) },
-                onSearch = { viewModel.onEvent(AsmaUnNabiEvent.Search(it)) }
-            )
-
-            // Filter Chips
-            NameFilterRow(
-                showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavoritesFilter) },
-                accent = accent,
-                allLabel = stringResource(R.string.all),
-                favoritesLabel = stringResource(R.string.favorites),
-                modifier = Modifier.padding(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.ExtraSmall
-                )
-            )
-
-            // Content
-            if (state.isLoading) {
-                NimazLoadingState()
-            } else {
-                val displayList = state.filteredNames
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        horizontal = NimazSpacing.Large,
-                        vertical = NimazSpacing.Small
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                ) {
-                    items(
-                        items = displayList,
-                        key = { it.id }
-                    ) { name ->
-                        NameCard(
-                            number = name.id,
-                            arabicName = name.nameArabic,
-                            primaryLabel = name.nameTransliteration,
-                            secondaryLabel = name.nameEnglish,
-                            isFavorite = name.isFavorite,
-                            accent = accent,
-                            onClick = { onNavigateToDetail(name.id) },
-                            onFavoriteClick = {
-                                viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(name.id))
-                            }
-                        )
-                    }
-
-                    if (displayList.isEmpty()) {
-                        item {
-                            NimazEmptyState(
-                                title = if (state.showFavoritesOnly) {
-                                    stringResource(R.string.no_favorites_yet)
-                                } else {
-                                    stringResource(R.string.asma_un_nabi_no_names_found)
-                                },
-                                message = "",
-                                icon = Icons.Filled.Favorite,
-                                iconTint = accent.contentTint,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 48.dp)
-                            )
-                        }
-                    }
-                }
+    SearchableNameListScreen(
+        title = stringResource(R.string.asma_un_nabi_title),
+        searchHint = stringResource(R.string.asma_un_nabi_search_hint),
+        searchQuery = state.searchQuery,
+        showFavoritesOnly = state.showFavoritesOnly,
+        isLoading = state.isLoading,
+        items = state.filteredNames,
+        accent = accent,
+        emptyTitle = stringResource(R.string.asma_un_nabi_no_names_found),
+        itemKey = { it.id },
+        onNavigateBack = onNavigateBack,
+        onSearch = { viewModel.onEvent(AsmaUnNabiEvent.Search(it)) },
+        onClearSearch = { viewModel.onEvent(AsmaUnNabiEvent.ClearSearch) },
+        onToggleFavoritesFilter = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavoritesFilter) }
+    ) { name ->
+        NameCard(
+            number = name.id,
+            arabicName = name.nameArabic,
+            primaryLabel = name.nameTransliteration,
+            secondaryLabel = name.nameEnglish,
+            isFavorite = name.isFavorite,
+            accent = accent,
+            onClick = { onNavigateToDetail(name.id) },
+            onFavoriteClick = {
+                viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(name.id))
             }
-        }
+        )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -18,8 +17,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -29,15 +26,10 @@ import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,10 +37,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -66,16 +56,15 @@ import com.arshadshah.nimaz.presentation.components.atoms.DuaArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazLabelChip
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPillActionButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazReaderBottomBar
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.templates.ReaderPagerScaffold
 import com.arshadshah.nimaz.presentation.theme.AdaptiveSpacing
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.DuaEvent
 import com.arshadshah.nimaz.presentation.viewmodel.DuaReaderUiState
 import com.arshadshah.nimaz.presentation.viewmodel.DuaViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.TasbihEvent
 import com.arshadshah.nimaz.presentation.viewmodel.TasbihViewModel
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DuaReaderScreen(
     duaId: String,
@@ -86,109 +75,34 @@ fun DuaReaderScreen(
 ) {
     val state by viewModel.readerState.collectAsState()
     val duas = state.duas
-    val scope = rememberCoroutineScope()
-
-    val pagerState = rememberPagerState(
-        initialPage = state.initialIndex.coerceAtLeast(0),
-        pageCount = { duas.size }
-    )
 
     LaunchedEffect(duaId) {
         viewModel.onEvent(DuaEvent.LoadDua(duaId))
     }
 
-    // Jump to the requested dua once the collection has loaded.
-    LaunchedEffect(state.initialIndex, duas.size) {
-        if (duas.isNotEmpty()) {
-            pagerState.scrollToPage(state.initialIndex.coerceIn(0, duas.lastIndex))
-        }
-    }
-
-    val currentDua = duas.getOrNull(pagerState.currentPage)
-
-    Scaffold(
-        topBar = {
-            NimazBackTopAppBar(
-                title = currentDua?.titleEnglish ?: stringResource(R.string.dua_reader_loading),
-                onBackClick = onNavigateBack,
-                actions = {
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(
-                            imageVector = Icons.Default.Settings,
-                            contentDescription = stringResource(R.string.dua_settings),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
+    ReaderPagerScaffold(
+        items = duas,
+        targetIndex = state.initialIndex,
+        isLoading = state.isLoading,
+        title = { current -> current?.titleEnglish ?: stringResource(R.string.dua_reader_loading) },
+        onNavigateBack = onNavigateBack,
+        onSettingsClick = onNavigateToSettings,
+        settingsContentDescription = stringResource(R.string.dua_settings),
+        emptyText = stringResource(R.string.dua_reader_not_found),
+        itemKey = { it.id },
+        pageContent = { dua -> DuaPage(dua = dua, state = state) },
+        bottomBar = { dua, currentPage, pageCount, onPrev, onNext ->
+            DuaReaderBottomBar(
+                dua = dua,
+                viewModel = viewModel,
+                tasbihViewModel = tasbihViewModel,
+                currentPage = currentPage,
+                pageCount = pageCount,
+                onPrev = onPrev,
+                onNext = onNext
             )
-        },
-        containerColor = MaterialTheme.colorScheme.background
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            when {
-                state.isLoading && duas.isEmpty() -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-
-                duas.isEmpty() -> {
-                    Text(
-                        text = stringResource(R.string.dua_reader_not_found),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.Center)
-                    )
-                }
-
-                else -> {
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxWidth(),
-                            key = { duas[it].id }
-                        ) { page ->
-                            DuaPage(dua = duas[page], state = state)
-                        }
-
-                        currentDua?.let { dua ->
-                            DuaReaderBottomBar(
-                                dua = dua,
-                                viewModel = viewModel,
-                                tasbihViewModel = tasbihViewModel,
-                                currentPage = pagerState.currentPage,
-                                pageCount = duas.size,
-                                onPrev = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(
-                                            (pagerState.currentPage - 1).coerceAtLeast(0)
-                                        )
-                                    }
-                                },
-                                onNext = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(
-                                            (pagerState.currentPage + 1).coerceAtMost(duas.lastIndex)
-                                        )
-                                    }
-                                }
-                            )
-                        }
-                    }
-                }
-            }
         }
-    }
+    )
 }
 
 /**
@@ -370,7 +284,7 @@ private fun DuaReaderBottomBar(
             contentDescription = stringResource(R.string.dua_reader_favorite),
             onClick = { viewModel.onEvent(DuaEvent.ToggleFavorite(dua.id, dua.categoryId)) },
             active = isFavorite,
-            activeColor = Color(0xFFEF4444)
+            activeColor = NimazColors.ReaderActionColors.FavoriteActive
         )
         NimazPillActionButton(
             icon = Icons.Default.Add,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
@@ -61,6 +61,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazStatData
 import com.arshadshah.nimaz.presentation.components.organisms.NimazStatsGrid
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.HadithEvent
 import com.arshadshah.nimaz.presentation.viewmodel.HadithViewModel
 
@@ -286,7 +287,7 @@ private fun HadithOfTheDayCard(
                         contentDescription = stringResource(R.string.bookmark),
                         onClick = onBookmarkClick,
                         active = isBookmarked,
-                        activeColor = Color(0xFFEAB308)
+                        activeColor = NimazColors.ReaderActionColors.BookmarkActive
                     )
                     NimazPillActionButton(
                         icon = Icons.Default.Share,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithGradeChip.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithGradeChip.kt
@@ -21,12 +21,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 // Hadith grade colour-coding, shared by the reader and settings preview.
-val SahihGreen = Color(0xFF22C55E)
-val HasanTeal = Color(0xFF0D9488)
-val DaifAmber = Color(0xFFF59E0B)
-val MawduRed = Color(0xFFEF4444)
+// Backed by the single source of truth in NimazColors.HadithGradeColors.
+val SahihGreen = NimazColors.HadithGradeColors.Sahih
+val HasanTeal = NimazColors.HadithGradeColors.Hasan
+val DaifAmber = NimazColors.HadithGradeColors.Daif
+val MawduRed = NimazColors.HadithGradeColors.Mawdu
 
 data class HadithGradeDisplay(val label: String, val color: Color)
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -27,8 +27,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -39,15 +37,10 @@ import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,7 +55,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -80,14 +72,14 @@ import com.arshadshah.nimaz.presentation.components.atoms.HadithArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazLabelChip
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPillActionButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazReaderBottomBar
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.templates.ReaderPagerScaffold
 import com.arshadshah.nimaz.presentation.theme.AdaptiveSpacing
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.HadithEvent
 import com.arshadshah.nimaz.presentation.viewmodel.HadithReaderUiState
 import com.arshadshah.nimaz.presentation.viewmodel.HadithViewModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HadithReaderScreen(
     bookId: String,
@@ -98,12 +90,6 @@ fun HadithReaderScreen(
 ) {
     val state by viewModel.readerState.collectAsState()
     val hadiths = state.hadiths
-    val scope = rememberCoroutineScope()
-
-    val pagerState = rememberPagerState(
-        initialPage = state.currentHadithIndex.coerceAtLeast(0),
-        pageCount = { hadiths.size }
-    )
 
     LaunchedEffect(chapterId, bookId) {
         // If bookId is empty and chapterId isn't a "book_chapter" id, it's a hadithId from search.
@@ -114,99 +100,31 @@ fun HadithReaderScreen(
         }
     }
 
-    LaunchedEffect(state.currentHadithIndex, hadiths.size) {
-        if (hadiths.isNotEmpty()) {
-            pagerState.scrollToPage(state.currentHadithIndex.coerceIn(0, hadiths.lastIndex))
-        }
-    }
-
-    val currentHadith = hadiths.getOrNull(pagerState.currentPage)
-
-    Scaffold(
-        topBar = {
-            NimazBackTopAppBar(
-                title = state.chapter?.nameEnglish ?: stringResource(R.string.loading),
-                subtitle = state.chapter?.let {
-                    stringResource(R.string.hadith_chapter_format, it.chapterNumber)
-                },
-                onBackClick = onNavigateBack,
-                actions = {
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(
-                            imageVector = Icons.Default.Settings,
-                            contentDescription = stringResource(R.string.hadith_settings),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            )
+    ReaderPagerScaffold(
+        items = hadiths,
+        targetIndex = state.currentHadithIndex,
+        isLoading = state.isLoading,
+        title = { state.chapter?.nameEnglish ?: stringResource(R.string.loading) },
+        subtitle = state.chapter?.let {
+            stringResource(R.string.hadith_chapter_format, it.chapterNumber)
         },
-        containerColor = MaterialTheme.colorScheme.background
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            when {
-                state.isLoading && hadiths.isEmpty() -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-
-                hadiths.isEmpty() -> {
-                    Text(
-                        text = stringResource(R.string.no_hadith_found),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.Center)
-                    )
-                }
-
-                else -> {
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxWidth(),
-                            key = { hadiths[it].id }
-                        ) { page ->
-                            HadithPage(hadith = hadiths[page], state = state)
-                        }
-
-                        currentHadith?.let { hadith ->
-                            HadithReaderBottomBar(
-                                hadith = hadith,
-                                viewModel = viewModel,
-                                currentPage = pagerState.currentPage,
-                                pageCount = hadiths.size,
-                                onPrev = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(
-                                            (pagerState.currentPage - 1).coerceAtLeast(0)
-                                        )
-                                    }
-                                },
-                                onNext = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(
-                                            (pagerState.currentPage + 1).coerceAtMost(hadiths.lastIndex)
-                                        )
-                                    }
-                                }
-                            )
-                        }
-                    }
-                }
-            }
+        onNavigateBack = onNavigateBack,
+        onSettingsClick = onNavigateToSettings,
+        settingsContentDescription = stringResource(R.string.hadith_settings),
+        emptyText = stringResource(R.string.no_hadith_found),
+        itemKey = { it.id },
+        pageContent = { hadith -> HadithPage(hadith = hadith, state = state) },
+        bottomBar = { hadith, currentPage, pageCount, onPrev, onNext ->
+            HadithReaderBottomBar(
+                hadith = hadith,
+                viewModel = viewModel,
+                currentPage = currentPage,
+                pageCount = pageCount,
+                onPrev = onPrev,
+                onNext = onNext
+            )
         }
-    }
+    )
 }
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -465,7 +383,7 @@ private fun HadithReaderBottomBar(
                 )
             },
             active = isBookmarked,
-            activeColor = Color(0xFFEAB308)
+            activeColor = NimazColors.ReaderActionColors.BookmarkActive
         )
         NimazPillActionButton(
             icon = Icons.Default.Share,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreen.kt
@@ -1,32 +1,20 @@
 package com.arshadshah.nimaz.presentation.screens.prophets
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Circle
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,7 +22,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -43,17 +30,16 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.molecules.FavoriteFab
 import com.arshadshah.nimaz.presentation.components.molecules.NameDetailHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionCard
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccent
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.templates.NameDetailScaffold
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
 import com.arshadshah.nimaz.presentation.viewmodel.ProphetEvent
 import com.arshadshah.nimaz.presentation.viewmodel.ProphetViewModel
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProphetDetailScreen(
     prophetId: Int,
@@ -67,190 +53,153 @@ fun ProphetDetailScreen(
     val state by viewModel.detailState.collectAsState()
     val accent = NamesAccents.prophets()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = state.prophet?.nameEnglish ?: stringResource(R.string.prophet_detail),
-                onBackClick = onNavigateBack
+    NameDetailScaffold(
+        item = state.prophet,
+        isLoading = state.isLoading,
+        title = state.prophet?.nameEnglish ?: stringResource(R.string.prophet_detail),
+        accent = accent,
+        isFavorite = { it.isFavorite },
+        onNavigateBack = onNavigateBack,
+        onToggleFavorite = { viewModel.onEvent(ProphetEvent.ToggleFavorite(it.id)) }
+    ) { prophet ->
+        // Calligraphic header (no number medallion for prophets)
+        item {
+            NameDetailHeader(
+                arabicName = prophet.nameArabic,
+                accent = accent,
+                number = null,
+                primaryLabel = prophet.nameEnglish,
+                secondaryLabel = prophet.titleEnglish,
             )
-        },
-        floatingActionButton = {
-            state.prophet?.let { prophet ->
-                FavoriteFab(
-                    isFavorite = prophet.isFavorite,
-                    accent = accent,
-                    onClick = { viewModel.onEvent(ProphetEvent.ToggleFavorite(prophet.id)) }
+        }
+
+        // Story Section
+        item {
+            NameDetailSectionCard(
+                title = stringResource(R.string.prophets_story),
+                content = prophet.storySummary,
+                titleColor = accent.contentTint
+            )
+        }
+
+        // Key Lessons Section
+        if (prophet.keyLessons.isNotEmpty()) {
+            item {
+                BulletListCard(
+                    title = stringResource(R.string.prophets_key_lessons),
+                    items = prophet.keyLessons,
+                    accent = accent
                 )
             }
         }
-    ) { paddingValues ->
-        if (state.isLoading || state.prophet == null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val prophet = state.prophet!!
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentPadding = PaddingValues(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.Small
-                ),
-                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
-            ) {
-                // Calligraphic header (no number medallion for prophets)
-                item {
-                    NameDetailHeader(
-                        arabicName = prophet.nameArabic,
-                        accent = accent,
-                        number = null,
-                        primaryLabel = prophet.nameEnglish,
-                        secondaryLabel = prophet.titleEnglish,
+
+        // Quran Mentions
+        if (prophet.quranMentions.isNotEmpty()) {
+            item {
+                NimazCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    style = NimazCardStyle.FILLED,
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                     )
-                }
-
-                // Story Section
-                item {
-                    NameDetailSectionCard(
-                        title = stringResource(R.string.prophets_story),
-                        content = prophet.storySummary,
-                        titleColor = accent.contentTint
-                    )
-                }
-
-                // Key Lessons Section
-                if (prophet.keyLessons.isNotEmpty()) {
-                    item {
-                        BulletListCard(
-                            title = stringResource(R.string.prophets_key_lessons),
-                            items = prophet.keyLessons,
-                            accent = accent
-                        )
-                    }
-                }
-
-                // Quran Mentions
-                if (prophet.quranMentions.isNotEmpty()) {
-                    item {
-                        NimazCard(
-                            modifier = Modifier.fillMaxWidth(),
-                            style = NimazCardStyle.FILLED,
-                            colors = CardDefaults.cardColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                            )
-                        ) {
-                            Column(
-                                modifier = Modifier.padding(NimazSpacing.Large),
-                                verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.prophets_quran_mentions),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = accent.contentTint
-                                )
-                                FlowRow(
-                                    horizontalArrangement = Arrangement.spacedBy(NimazSpacing.Small),
-                                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                                ) {
-                                    prophet.quranMentions.forEach { verse ->
-                                        AssistChip(
-                                            onClick = {},
-                                            label = {
-                                                Text(
-                                                    text = verse,
-                                                    style = MaterialTheme.typography.bodySmall
-                                                )
-                                            },
-                                            colors = AssistChipDefaults.assistChipColors(
-                                                containerColor = accent.chipContainer,
-                                                labelColor = accent.onChipContainer
-                                            )
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Timeline Section
-                item {
-                    NimazCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        style = NimazCardStyle.FILLED,
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                        )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(NimazSpacing.Large),
+                        verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
                     ) {
-                        Column(
-                            modifier = Modifier.padding(NimazSpacing.Large),
-                            verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
+                        Text(
+                            text = stringResource(R.string.prophets_quran_mentions),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = accent.contentTint
+                        )
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(NimazSpacing.Small),
+                            verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
                         ) {
-                            Text(
-                                text = stringResource(R.string.prophets_timeline),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = accent.contentTint
-                            )
-
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween
-                            ) {
-                                TimelineItem(
-                                    label = stringResource(R.string.prophets_era),
-                                    value = prophet.era,
-                                    modifier = Modifier.weight(1f)
-                                )
-                                TimelineItem(
-                                    label = stringResource(R.string.prophets_lineage),
-                                    value = prophet.lineage,
-                                    modifier = Modifier.weight(1f)
-                                )
-                            }
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween
-                            ) {
-                                TimelineItem(
-                                    label = stringResource(R.string.prophets_years_lived),
-                                    value = prophet.yearsLived,
-                                    modifier = Modifier.weight(1f)
-                                )
-                                TimelineItem(
-                                    label = stringResource(R.string.prophets_place),
-                                    value = prophet.placeOfPreaching,
-                                    modifier = Modifier.weight(1f)
+                            prophet.quranMentions.forEach { verse ->
+                                AssistChip(
+                                    onClick = {},
+                                    label = {
+                                        Text(
+                                            text = verse,
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    },
+                                    colors = AssistChipDefaults.assistChipColors(
+                                        containerColor = accent.chipContainer,
+                                        labelColor = accent.onChipContainer
+                                    )
                                 )
                             }
                         }
                     }
                 }
+            }
+        }
 
-                // Miracles Section
-                if (prophet.miracles.isNotEmpty()) {
-                    item {
-                        BulletListCard(
-                            title = stringResource(R.string.prophets_miracles),
-                            items = prophet.miracles,
-                            accent = accent
+        // Timeline Section
+        item {
+            NimazCard(
+                modifier = Modifier.fillMaxWidth(),
+                style = NimazCardStyle.FILLED,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(NimazSpacing.Large),
+                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Medium)
+                ) {
+                    Text(
+                        text = stringResource(R.string.prophets_timeline),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = accent.contentTint
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        TimelineItem(
+                            label = stringResource(R.string.prophets_era),
+                            value = prophet.era,
+                            modifier = Modifier.weight(1f)
+                        )
+                        TimelineItem(
+                            label = stringResource(R.string.prophets_lineage),
+                            value = prophet.lineage,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        TimelineItem(
+                            label = stringResource(R.string.prophets_years_lived),
+                            value = prophet.yearsLived,
+                            modifier = Modifier.weight(1f)
+                        )
+                        TimelineItem(
+                            label = stringResource(R.string.prophets_place),
+                            value = prophet.placeOfPreaching,
+                            modifier = Modifier.weight(1f)
                         )
                     }
                 }
+            }
+        }
 
-                // Bottom spacer for FAB
-                item {
-                    Spacer(modifier = Modifier.height(72.dp))
-                }
+        // Miracles Section
+        if (prophet.miracles.isNotEmpty()) {
+            item {
+                BulletListCard(
+                    title = stringResource(R.string.prophets_miracles),
+                    items = prophet.miracles,
+                    accent = accent
+                )
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetsListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetsListScreen.kt
@@ -1,41 +1,17 @@
 package com.arshadshah.nimaz.presentation.screens.prophets
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.molecules.NameCard
-import com.arshadshah.nimaz.presentation.components.molecules.NameFilterRow
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
-import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
-import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.theme.NimazSpacing
+import com.arshadshah.nimaz.presentation.components.templates.SearchableNameListScreen
 import com.arshadshah.nimaz.presentation.viewmodel.ProphetEvent
 import com.arshadshah.nimaz.presentation.viewmodel.ProphetViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProphetsListScreen(
     onNavigateBack: () -> Unit,
@@ -45,97 +21,34 @@ fun ProphetsListScreen(
     val state by viewModel.listState.collectAsState()
     val accent = NamesAccents.prophets()
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            NimazBackTopAppBar(
-                title = stringResource(R.string.prophets_title),
-                onBackClick = onNavigateBack
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            NimazSearchBar(
-                query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(ProphetEvent.Search(it)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
-                placeholder = stringResource(R.string.prophets_search_hint),
-                showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(ProphetEvent.ClearSearch) }
-            )
-
-            // Filter Chips
-            NameFilterRow(
-                showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(ProphetEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(ProphetEvent.ToggleFavoritesFilter) },
-                accent = accent,
-                allLabel = stringResource(R.string.all),
-                favoritesLabel = stringResource(R.string.favorites),
-                modifier = Modifier.padding(
-                    horizontal = NimazSpacing.Large,
-                    vertical = NimazSpacing.ExtraSmall
-                )
-            )
-
-            if (state.isLoading) {
-                NimazLoadingState()
-            } else {
-                val displayList = state.filteredProphets
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        horizontal = NimazSpacing.Large,
-                        vertical = NimazSpacing.Small
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(NimazSpacing.Small)
-                ) {
-                    items(
-                        items = displayList,
-                        key = { it.id }
-                    ) { prophet ->
-                        NameCard(
-                            number = prophet.id,
-                            arabicName = prophet.nameArabic,
-                            primaryLabel = prophet.nameEnglish,
-                            secondaryLabel = prophet.nameTransliteration,
-                            isFavorite = prophet.isFavorite,
-                            accent = accent,
-                            onClick = { onNavigateToDetail(prophet.id) },
-                            onFavoriteClick = {
-                                viewModel.onEvent(ProphetEvent.ToggleFavorite(prophet.id))
-                            },
-                            titleLabel = prophet.titleEnglish,
-                            eraChip = prophet.era
-                        )
-                    }
-
-                    if (displayList.isEmpty()) {
-                        item {
-                            NimazEmptyState(
-                                title = if (state.showFavoritesOnly) {
-                                    stringResource(R.string.no_favorites_yet)
-                                } else {
-                                    stringResource(R.string.prophets_no_found)
-                                },
-                                message = "",
-                                icon = Icons.Filled.Favorite,
-                                iconTint = accent.contentTint,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 48.dp)
-                            )
-                        }
-                    }
-                }
-            }
-        }
+    SearchableNameListScreen(
+        title = stringResource(R.string.prophets_title),
+        searchHint = stringResource(R.string.prophets_search_hint),
+        searchQuery = state.searchQuery,
+        showFavoritesOnly = state.showFavoritesOnly,
+        isLoading = state.isLoading,
+        items = state.filteredProphets,
+        accent = accent,
+        emptyTitle = stringResource(R.string.prophets_no_found),
+        itemKey = { it.id },
+        onNavigateBack = onNavigateBack,
+        onSearch = { viewModel.onEvent(ProphetEvent.Search(it)) },
+        onClearSearch = { viewModel.onEvent(ProphetEvent.ClearSearch) },
+        onToggleFavoritesFilter = { viewModel.onEvent(ProphetEvent.ToggleFavoritesFilter) }
+    ) { prophet ->
+        NameCard(
+            number = prophet.id,
+            arabicName = prophet.nameArabic,
+            primaryLabel = prophet.nameEnglish,
+            secondaryLabel = prophet.nameTransliteration,
+            isFavorite = prophet.isFavorite,
+            accent = accent,
+            onClick = { onNavigateToDetail(prophet.id) },
+            onFavoriteClick = {
+                viewModel.onEvent(ProphetEvent.ToggleFavorite(prophet.id))
+            },
+            titleLabel = prophet.titleEnglish,
+            eraChip = prophet.era
+        )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -88,6 +88,7 @@ import com.arshadshah.nimaz.presentation.components.organisms.JuzGrid
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.computeJuzHeaderIndices
 import com.arshadshah.nimaz.presentation.components.organisms.pageGridItems
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.viewmodel.QuranEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QuranHomeUiState
@@ -325,8 +326,8 @@ private fun HomeTabContent(
                             .background(
                                 brush = Brush.linearGradient(
                                     colors = listOf(
-                                        Color(0xFF115E59),
-                                        Color(0xFF042F2E)
+                                        NimazColors.QuranColors.CardGradientStart,
+                                        NimazColors.QuranColors.CardGradientEnd
                                     )
                                 ),
                                 shape = RoundedCornerShape(20.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
@@ -145,6 +145,13 @@ object NimazColors {
         val Mawdu = Color(0xFFEF4444)
     }
 
+    // Active-state accents for reader action pills (bookmark / favourite),
+    // shared by the hadith and dua readers and the hadith collection screen.
+    object ReaderActionColors {
+        val BookmarkActive = NimazColors.Gold500   // 0xFFEAB308
+        val FavoriteActive = Color(0xFFEF4444)
+    }
+
     // Zakat Colors
     object ZakatColors {
         val Gold = Color(0xFFFFD700)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
@@ -124,6 +124,25 @@ object NimazColors {
         val SajdaAyah = Color(0xFFE91E63)
         val BookmarkPrimary = Color(0xFFFFC107)
         val BookmarkSecondary = Color(0xFF00BCD4)
+
+        // Shared "dark teal" Quran card theme — used by the surah banners,
+        // verse-of-the-day, continue-reading, khatam and mushaf header/page cards.
+        // Centralised here so the whole Quran surface re-themes from one place.
+        val CardGradientStart = NimazColors.Primary800   // 0xFF115E59
+        val CardGradientEnd = NimazColors.Primary950     // 0xFF042F2E
+        val CardBorder = NimazColors.Primary700          // 0xFF0F766E
+        val CardAccentTeal = NimazColors.Primary         // 0xFF14B8A6
+        val CardAccentCyan = NimazColors.Primary400      // 0xFF2DD4BF
+        val CardAccentGold = NimazColors.Gold500         // 0xFFEAB308
+    }
+
+    // Hadith grade authenticity colours — shared by the reader grade chip and the
+    // hadith-of-the-day card so the same grade reads identically everywhere.
+    object HadithGradeColors {
+        val Sahih = Color(0xFF22C55E)
+        val Hasan = Color(0xFF0D9488)
+        val Daif = Color(0xFFF59E0B)
+        val Mawdu = Color(0xFFEF4444)
     }
 
     // Zakat Colors


### PR DESCRIPTION
Hunt down and eliminate duplication across the compose layer (atoms → screens):

Names feature (screens):
- Add reusable `SearchableNameListScreen` and `NameDetailScaffold` templates
  (presentation/components/templates/NameScreenScaffolds.kt). The three names
  list screens (Asma ul Husna, Asma un Nabi, Prophets) and their three detail
  screens previously copy-pasted an identical search/filter/loading/list and
  top-bar/FAB/loading scaffold; only the data, accent, strings and per-item /
  per-section content differed. Screens now supply just those via the template,
  removing ~400 lines of duplicated scaffolding.

Quran "dark teal" card palette (atoms/molecules/organisms/screens):
- The teal gradient/border/accent literals (0xFF115E59 / 042F2E / 0F766E /
  14B8A6 / 2DD4BF / EAB308) were hardcoded across ~10 Quran files. Add semantic
  tokens to NimazColors.QuranColors (CardGradientStart/End, CardBorder,
  CardAccentTeal/Cyan/Gold) and reference them everywhere so the whole Quran
  surface re-themes from one place.

Hadith grade colours:
- The hadith-of-the-day card hardcoded a grade→colour map that drifted from the
  reader's HadithGradeChip palette despite a comment saying they should match.
  Add NimazColors.HadithGradeColors as the single source of truth and point both
  the card and the chip at it, fixing the inconsistency.

No behavioural changes beyond aligning the hadith-of-the-day grade colours with
the reader (their intended, documented behaviour).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014xQQA6eiJKhFMFGLnFynz4