### PR TITLE
docs: add authoritative architecture guide and agent guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Nimaz — agent guide
+
+Nimaz is an offline-first Android Islamic companion app: **Kotlin + Jetpack Compose**,
+**Clean Architecture** (`presentation → domain → data`) with **MVVM + UDF**, Hilt DI, Room,
+DataStore, type-safe Navigation Compose.
+
+## Read this first
+
+**[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) is the source of truth** for how this app is
+structured (layer patterns, DI, navigation, theming, diagrams, a new-feature recipe, and a
+tech-debt registry of known deviations). Follow it so the architecture does not drift. When
+adding a feature, copy an existing one that follows the patterns — good references:
+`AsmaUlHusna`, `Prophet`, `Khatam`, `Quran`.
+
+## Non-negotiable rules
+
+1. Dependencies point inward: **domain never imports `data`** (no Room entity/DAO/DataStore);
+   presentation never imports entities/DAOs.
+2. ViewModels inject **`XxxUseCases`**, not repositories or DAOs.
+3. ViewModels expose `StateFlow<XxxUiState>` (immutable `data class`) + a single
+   `onEvent(event: XxxEvent)` (sealed interface). No exposed `MutableStateFlow`/`LiveData`.
+4. Repositories return **domain models**; map at the data layer (`Entity.toDomain()` /
+   `Model.toEntity()`).
+5. DI lives in `core/di`: `@Binds` for interface→impl, `@Provides` for `XxxUseCases`,
+   `@Singleton` in `SingletonComponent`.
+6. Navigation is type-safe: add a `@Serializable` `Route` + `composable<Route.X>` in
+   `NavGraph`. (Not every `Route` is a screen — some features are tabs inside a parent
+   screen; validate before wiring.)
+7. No hardcoded `Color(0xFF…)` in screens — use `MaterialTheme.colorScheme.*` / `NimazColors.*`
+   and reuse `presentation/components` (atoms/molecules/organisms).
+
+## Verify before finishing
+
+```bash
+./gradlew :app:compileDebugKotlin     # runs KSP → validates Hilt + Room wiring
+./gradlew :app:testDebugUnitTest
+```
+
+Requires JDK 21 + Android SDK (compileSdk 36); set `sdk.dir` in `local.properties` or
+`ANDROID_HOME`. Develop on a feature branch; do not push to `dev` without explicit approval.
+
+## Known deviations
+
+Some areas intentionally diverge from the canonical patterns (use-case gaps, a Zakat
+clean-arch leak, Calendar's direct DAO use, QaidaReader's missing `onEvent`, etc.). They are
+catalogued in **§9 of `docs/ARCHITECTURE.md`** — do not copy them; fix them per the table.
+</content>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,10 @@ adding a feature, copy an existing one that follows the patterns — good refere
 Requires JDK 21 + Android SDK (compileSdk 36); set `sdk.dir` in `local.properties` or
 `ANDROID_HOME`. Develop on a feature branch; do not push to `dev` without explicit approval.
 
-## Known deviations
+## Known deviations & cleanup backlog
 
-Some areas intentionally diverge from the canonical patterns (use-case gaps, a Zakat
-clean-arch leak, Calendar's direct DAO use, QaidaReader's missing `onEvent`, etc.). They are
-catalogued in **§9 of `docs/ARCHITECTURE.md`** — do not copy them; fix them per the table.
+Resolved vs open deviations are tracked in **§9 of `docs/ARCHITECTURE.md`**. A tick-box backlog
+of clean-architecture anti-patterns to chip away at (with detection commands) lives in
+**[`docs/CLEAN_ARCHITECTURE_CHECKLIST.md`](docs/CLEAN_ARCHITECTURE_CHECKLIST.md)** — do not copy
+open items; fix them and tick the box.
 </content>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,39 @@ DataStore, type-safe Navigation Compose.
 
 ## Read this first
 
-**[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) is the source of truth** for how this app is
-structured (layer patterns, DI, navigation, theming, diagrams, a new-feature recipe, and a
-tech-debt registry of known deviations). Follow it so the architecture does not drift. When
-adding a feature, copy an existing one that follows the patterns — good references:
+The `docs/` folder is the source of truth — read the relevant doc before working, and **keep it
+updated as part of your change** (see "Documentation is part of the work" below):
+
+- **[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** — layer patterns, DI, navigation, theming,
+  diagrams, the new-feature recipe, and the tech-debt registry (§9). The architectural source of truth.
+- **[`docs/NAVIGATION.md`](docs/NAVIGATION.md)** — the complete route graph + route table.
+- **[`docs/SUBSYSTEMS.md`](docs/SUBSYSTEMS.md)** — audio, widgets, background work, notifications,
+  database/migrations, preferences, content seeding, prayer-time calc, sync, init/monitoring.
+- **[`docs/CLEAN_ARCHITECTURE_CHECKLIST.md`](docs/CLEAN_ARCHITECTURE_CHECKLIST.md)** — tick-box
+  anti-pattern backlog with detection commands.
+
+When adding a feature, copy an existing one that follows the patterns — good references:
 `AsmaUlHusna`, `Prophet`, `Khatam`, `Quran`.
+
+> Naming: the app is **Nimaz** and the package is **`com.arshadshah.nimaz`**. The older
+> `docs/nimaz-pro-*.md` files are historical design/planning artifacts (they say "Nimaz Pro" /
+> `com.nimazpro.app`) — treat them as background, not current truth.
+
+## Documentation is part of the work
+
+Docs only stay useful if they track reality. **In every change, update the docs your change
+touches** — this is not optional:
+
+- Add/remove/rename a `Route` → update **`docs/NAVIGATION.md`** (route table *and*, if the
+  high-level map changes, the mermaid diagram; validate it).
+- Change a subsystem (audio, widgets, workers, notifications, DB schema/migrations, DataStore,
+  seeders, prayer-time calc, sync, init/monitoring) → update the relevant section of
+  **`docs/SUBSYSTEMS.md`**.
+- Change a layer pattern, DI convention, or resolve/introduce a deviation → update
+  **`docs/ARCHITECTURE.md`** (and its §9 registry).
+- Fix or discover a clean-architecture anti-pattern → tick / add to
+  **`docs/CLEAN_ARCHITECTURE_CHECKLIST.md`**.
+- Change the DB schema or shipped data → update **`docs/nimaz-pro-data-guide.md`**.
 
 ## Non-negotiable rules
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The app is built with modern Android tooling:
 
 Core content and functionality are designed to remain available without constant network access.
 
+> **Architecture:** see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — the source of truth
+> for layering, patterns, DI, navigation, theming, diagrams, and the new-feature recipe.
+> Agents should also read [`CLAUDE.md`](CLAUDE.md).
+
 ## Main Features
 
 - Prayer times and prayer tracking

--- a/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
@@ -25,7 +25,7 @@ import com.arshadshah.nimaz.core.util.InAppUpdateManager
 import com.arshadshah.nimaz.data.audio.AdhanPlaybackService
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.data.audio.QuranAudioService
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarWidget
@@ -39,7 +39,7 @@ val LocalInAppUpdateManager = staticCompositionLocalOf<InAppUpdateManager?> { nu
 class MainActivity : ComponentActivity() {
 
     @Inject
-    lateinit var preferencesDataStore: PreferencesDataStore
+    lateinit var settingsRepository: SettingsRepository
 
     @Inject
     lateinit var quranAudioManager: QuranAudioManager
@@ -83,16 +83,16 @@ class MainActivity : ComponentActivity() {
         inAppUpdateManager.checkForUpdate()
 
         setContent {
-            val themeModeString by preferencesDataStore.themeMode.collectAsState(initial = "system")
-            val dynamicColor by preferencesDataStore.dynamicColor.collectAsState(initial = false)
-            val hapticEnabled by preferencesDataStore.hapticFeedback.collectAsState(initial = true)
-            val animationsEnabled by preferencesDataStore.animationsEnabled.collectAsState(initial = true)
-            val use24HourFormat by preferencesDataStore.use24HourFormat.collectAsState(initial = false)
-            val useHijriPrimary by preferencesDataStore.useHijriPrimary.collectAsState(initial = false)
-            val showIslamicPatterns by preferencesDataStore.showIslamicPatterns.collectAsState(
+            val themeModeString by settingsRepository.themeMode.collectAsState(initial = "system")
+            val dynamicColor by settingsRepository.dynamicColor.collectAsState(initial = false)
+            val hapticEnabled by settingsRepository.hapticFeedback.collectAsState(initial = true)
+            val animationsEnabled by settingsRepository.animationsEnabled.collectAsState(initial = true)
+            val use24HourFormat by settingsRepository.use24HourFormat.collectAsState(initial = false)
+            val useHijriPrimary by settingsRepository.useHijriPrimary.collectAsState(initial = false)
+            val showIslamicPatterns by settingsRepository.showIslamicPatterns.collectAsState(
                 initial = true
             )
-            val localeCode by preferencesDataStore.appLanguage.collectAsState(initial = "en")
+            val localeCode by settingsRepository.appLanguage.collectAsState(initial = "en")
 
             val themeMode = when (themeModeString) {
                 "light" -> ThemeMode.LIGHT

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -59,6 +59,8 @@ import com.arshadshah.nimaz.domain.usecase.GetAsmaUlHusnaByIdUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAsmaUnNabiByIdUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAvailableTranslatorsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAyahsByJuzUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAyahsBySurahUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSurahByNumberUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAyahsByPageUseCase
 import com.arshadshah.nimaz.domain.usecase.GetCourseProgressUseCase
 import com.arshadshah.nimaz.domain.usecase.GetFavoriteAsmaUlHusnaUseCase
@@ -180,12 +182,46 @@ import com.arshadshah.nimaz.domain.usecase.SearchHadithsUseCase
 import com.arshadshah.nimaz.domain.usecase.SeedMissingDefaultsUseCase
 import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
 import com.arshadshah.nimaz.domain.usecase.ToggleBookmarkUseCase
-import com.arshadshah.nimaz.domain.usecase.ToggleFavoriteUseCase
+import com.arshadshah.nimaz.domain.usecase.ToggleDuaFavoriteUseCase
+import com.arshadshah.nimaz.domain.usecase.ToggleLocationFavoriteUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateFastRecordUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateFastStatusUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateMakeupFastUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdatePresetUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateSessionCountUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteCalculationUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteLocationUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllHistoryUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllLocationsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCurrentLocationUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCurrentStreakUseCase
+import com.arshadshah.nimaz.domain.usecase.GetFavoriteLocationsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetLongestStreakUseCase
+import com.arshadshah.nimaz.domain.usecase.GetMissedPrayersRequiringQadaUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPrayerRecordsForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPrayerRecordsInRangeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPrayerStatsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPrayerTimesForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTodayPrayerRecordsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTotalPaidUseCase
+import com.arshadshah.nimaz.domain.usecase.InsertCalculationUseCase
+import com.arshadshah.nimaz.domain.usecase.InsertLocationUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkAsPaidUseCase
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.SetCurrentLocationUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdatePrayerStatusUseCase
+import com.arshadshah.nimaz.domain.usecase.ZakatUseCases
+import com.arshadshah.nimaz.domain.usecase.TafseerUseCases
+import com.arshadshah.nimaz.domain.usecase.GetTafseerForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHighlightsForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.AddHighlightUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateHighlightUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteHighlightUseCase
+import com.arshadshah.nimaz.domain.usecase.GetNotesForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.AddNoteUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateNoteUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteNoteUseCase
+import com.arshadshah.nimaz.domain.usecase.ExportAnnotationsUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -341,6 +377,8 @@ object UseCaseModule {
     ): QuranUseCases {
         return QuranUseCases(
             getSurahList = GetSurahListUseCase(repository),
+            getSurahByNumber = GetSurahByNumberUseCase(repository),
+            getAyahsBySurah = GetAyahsBySurahUseCase(repository),
             getSurahWithAyahs = GetSurahWithAyahsUseCase(repository),
             getAyahsByJuz = GetAyahsByJuzUseCase(repository),
             getAyahsByPage = GetAyahsByPageUseCase(repository),
@@ -511,7 +549,7 @@ object UseCaseModule {
             getProgressForDate = GetProgressForDateUseCase(repository),
             isDuaFavorite = IsDuaFavoriteUseCase(repository),
             searchDuas = SearchDuasUseCase(repository),
-            toggleFavorite = ToggleFavoriteUseCase(repository)
+            toggleFavorite = ToggleDuaFavoriteUseCase(repository)
         )
     }
     @Provides
@@ -559,6 +597,63 @@ object UseCaseModule {
             markMakeupFastCompleted = MarkMakeupFastCompletedUseCase(repository),
             markFidyaPaid = MarkFidyaPaidUseCase(repository),
             getTotalFidyaPaid = GetTotalFidyaPaidUseCase(repository)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun providePrayerUseCases(
+        repository: PrayerRepository
+    ): PrayerUseCases {
+        return PrayerUseCases(
+            getPrayerRecordsForDate = GetPrayerRecordsForDateUseCase(repository),
+            getPrayerRecordsInRange = GetPrayerRecordsInRangeUseCase(repository),
+            getTodayPrayerRecords = GetTodayPrayerRecordsUseCase(repository),
+            updatePrayerStatus = UpdatePrayerStatusUseCase(repository),
+            getPrayerTimesForDate = GetPrayerTimesForDateUseCase(repository),
+            getCurrentStreak = GetCurrentStreakUseCase(repository),
+            getLongestStreak = GetLongestStreakUseCase(repository),
+            getMissedPrayersRequiringQada = GetMissedPrayersRequiringQadaUseCase(repository),
+            getPrayerStats = GetPrayerStatsUseCase(repository),
+            getCurrentLocation = GetCurrentLocationUseCase(repository),
+            getAllLocations = GetAllLocationsUseCase(repository),
+            getFavoriteLocations = GetFavoriteLocationsUseCase(repository),
+            insertLocation = InsertLocationUseCase(repository),
+            deleteLocation = DeleteLocationUseCase(repository),
+            setCurrentLocation = SetCurrentLocationUseCase(repository),
+            toggleFavorite = ToggleLocationFavoriteUseCase(repository)
+        )
+    }
+    @Provides
+    @Singleton
+    fun provideZakatUseCases(
+        repository: ZakatRepository
+    ): ZakatUseCases {
+        return ZakatUseCases(
+            getAllHistory = GetAllHistoryUseCase(repository),
+            insertCalculation = InsertCalculationUseCase(repository),
+            markAsPaid = MarkAsPaidUseCase(repository),
+            getTotalPaid = GetTotalPaidUseCase(repository),
+            deleteCalculation = DeleteCalculationUseCase(repository)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideTafseerUseCases(
+        repository: TafseerRepository
+    ): TafseerUseCases {
+        return TafseerUseCases(
+            getTafseerForAyah = GetTafseerForAyahUseCase(repository),
+            getHighlightsForAyah = GetHighlightsForAyahUseCase(repository),
+            addHighlight = AddHighlightUseCase(repository),
+            updateHighlight = UpdateHighlightUseCase(repository),
+            deleteHighlight = DeleteHighlightUseCase(repository),
+            getNotesForAyah = GetNotesForAyahUseCase(repository),
+            addNote = AddNoteUseCase(repository),
+            updateNote = UpdateNoteUseCase(repository),
+            deleteNote = DeleteNoteUseCase(repository),
+            exportAnnotations = ExportAnnotationsUseCase(repository)
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -124,6 +124,68 @@ import com.arshadshah.nimaz.domain.usecase.UnlockNextLessonUseCase
 import com.arshadshah.nimaz.domain.usecase.UnmarkAyahReadUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateQuranBookmarkUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateReadingPositionUseCase
+import com.arshadshah.nimaz.domain.usecase.CompleteSessionUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteCustomPresetUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteFastRecordByDateUseCase
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.FastingUseCases
+import com.arshadshah.nimaz.domain.usecase.GetActiveSessionUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllBookmarksUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllBooksUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllCategoriesUseCase
+import com.arshadshah.nimaz.domain.usecase.GetAllMakeupFastsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetBookByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCategoryByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetChapterByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetChaptersByBookUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCompletedSessionsInRangeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetCustomPresetsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDefaultPresetsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDuaByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDuasByCategoryUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDuasByOccasionUseCase
+import com.arshadshah.nimaz.domain.usecase.GetFastRecordForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetFastRecordsInRangeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetFastingStatsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetFavoriteDuasUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithByNumberUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithOfTheDayUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithsByChapterUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithsByGradeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetMakeupFastCountForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPendingMakeupFastsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetPresetByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetProgressForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetRamadanFastedCountUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSessionByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSessionsForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSessionsInRangeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTasbihStatsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTotalCountInRangeUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTotalFidyaPaidUseCase
+import com.arshadshah.nimaz.domain.usecase.GetVoluntaryFastCountUseCase
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.arshadshah.nimaz.domain.usecase.InsertFastRecordUseCase
+import com.arshadshah.nimaz.domain.usecase.InsertMakeupFastUseCase
+import com.arshadshah.nimaz.domain.usecase.InsertPresetUseCase
+import com.arshadshah.nimaz.domain.usecase.InsertSessionUseCase
+import com.arshadshah.nimaz.domain.usecase.IsDuaFavoriteUseCase
+import com.arshadshah.nimaz.domain.usecase.IsHadithBookmarkedUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkFidyaPaidUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkMakeupFastCompletedUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchDuasUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchHadithsInBookUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchHadithsUseCase
+import com.arshadshah.nimaz.domain.usecase.SeedMissingDefaultsUseCase
+import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
+import com.arshadshah.nimaz.domain.usecase.ToggleBookmarkUseCase
+import com.arshadshah.nimaz.domain.usecase.ToggleFavoriteUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateFastRecordUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateFastStatusUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateMakeupFastUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdatePresetUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateSessionCountUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -406,6 +468,97 @@ object UseCaseModule {
             getCourseProgress = GetCourseProgressUseCase(repository),
             resetProgress = ResetQaidaProgressUseCase(repository),
             observeCompletedCells = ObserveCompletedCellsUseCase(repository)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideTasbihUseCases(
+        repository: TasbihRepository
+    ): TasbihUseCases {
+        return TasbihUseCases(
+            getDefaultPresets = GetDefaultPresetsUseCase(repository),
+            getCustomPresets = GetCustomPresetsUseCase(repository),
+            getPresetById = GetPresetByIdUseCase(repository),
+            insertPreset = InsertPresetUseCase(repository),
+            updatePreset = UpdatePresetUseCase(repository),
+            deleteCustomPreset = DeleteCustomPresetUseCase(repository),
+            seedMissingDefaults = SeedMissingDefaultsUseCase(repository),
+            getSessionsForDate = GetSessionsForDateUseCase(repository),
+            getSessionsInRange = GetSessionsInRangeUseCase(repository),
+            getActiveSession = GetActiveSessionUseCase(repository),
+            getSessionById = GetSessionByIdUseCase(repository),
+            insertSession = InsertSessionUseCase(repository),
+            updateSessionCount = UpdateSessionCountUseCase(repository),
+            completeSession = CompleteSessionUseCase(repository),
+            getTasbihStats = GetTasbihStatsUseCase(repository),
+            getTotalCountInRange = GetTotalCountInRangeUseCase(repository),
+            getCompletedSessionsInRange = GetCompletedSessionsInRangeUseCase(repository)
+        )
+    }
+    @Provides
+    @Singleton
+    fun provideDuaUseCases(
+        repository: DuaRepository
+    ): DuaUseCases {
+        return DuaUseCases(
+            getAllCategories = GetAllCategoriesUseCase(repository),
+            getCategoryById = GetCategoryByIdUseCase(repository),
+            getDuaById = GetDuaByIdUseCase(repository),
+            getDuasByCategory = GetDuasByCategoryUseCase(repository),
+            getDuasByOccasion = GetDuasByOccasionUseCase(repository),
+            getFavoriteDuas = GetFavoriteDuasUseCase(repository),
+            getProgressForDate = GetProgressForDateUseCase(repository),
+            isDuaFavorite = IsDuaFavoriteUseCase(repository),
+            searchDuas = SearchDuasUseCase(repository),
+            toggleFavorite = ToggleFavoriteUseCase(repository)
+        )
+    }
+    @Provides
+    @Singleton
+    fun provideHadithUseCases(
+        repository: HadithRepository
+    ): HadithUseCases {
+        return HadithUseCases(
+            getAllBooks = GetAllBooksUseCase(repository),
+            getBookById = GetBookByIdUseCase(repository),
+            getChaptersByBook = GetChaptersByBookUseCase(repository),
+            getChapterById = GetChapterByIdUseCase(repository),
+            getHadithsByChapter = GetHadithsByChapterUseCase(repository),
+            getHadithById = GetHadithByIdUseCase(repository),
+            getHadithByNumber = GetHadithByNumberUseCase(repository),
+            getHadithsByGrade = GetHadithsByGradeUseCase(repository),
+            getHadithOfTheDay = GetHadithOfTheDayUseCase(repository),
+            searchHadiths = SearchHadithsUseCase(repository),
+            searchHadithsInBook = SearchHadithsInBookUseCase(repository),
+            getAllBookmarks = GetAllBookmarksUseCase(repository),
+            isHadithBookmarked = IsHadithBookmarkedUseCase(repository),
+            toggleBookmark = ToggleBookmarkUseCase(repository)
+        )
+    }
+    @Provides
+    @Singleton
+    fun provideFastingUseCases(
+        repository: FastingRepository
+    ): FastingUseCases {
+        return FastingUseCases(
+            getFastRecordForDate = GetFastRecordForDateUseCase(repository),
+            getFastRecordsInRange = GetFastRecordsInRangeUseCase(repository),
+            insertFastRecord = InsertFastRecordUseCase(repository),
+            updateFastRecord = UpdateFastRecordUseCase(repository),
+            updateFastStatus = UpdateFastStatusUseCase(repository),
+            deleteFastRecordByDate = DeleteFastRecordByDateUseCase(repository),
+            getRamadanFastedCount = GetRamadanFastedCountUseCase(repository),
+            getVoluntaryFastCount = GetVoluntaryFastCountUseCase(repository),
+            getFastingStats = GetFastingStatsUseCase(repository),
+            getAllMakeupFasts = GetAllMakeupFastsUseCase(repository),
+            getPendingMakeupFasts = GetPendingMakeupFastsUseCase(repository),
+            getMakeupFastCountForDate = GetMakeupFastCountForDateUseCase(repository),
+            insertMakeupFast = InsertMakeupFastUseCase(repository),
+            updateMakeupFast = UpdateMakeupFastUseCase(repository),
+            markMakeupFastCompleted = MarkMakeupFastCompletedUseCase(repository),
+            markFidyaPaid = MarkFidyaPaidUseCase(repository),
+            getTotalFidyaPaid = GetTotalFidyaPaidUseCase(repository)
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -16,6 +16,7 @@ import com.arshadshah.nimaz.data.local.qaida.AndroidQaidaAssetReader
 import com.arshadshah.nimaz.data.local.qaida.DataStoreQaidaContentVersionStore
 import com.arshadshah.nimaz.data.local.qaida.QaidaAssetReader
 import com.arshadshah.nimaz.data.local.qaida.QaidaContentVersionStore
+import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.data.repository.AsmaUlHusnaRepositoryImpl
 import com.arshadshah.nimaz.data.repository.AsmaUnNabiRepositoryImpl
 import com.arshadshah.nimaz.data.repository.DuaRepositoryImpl
@@ -32,6 +33,7 @@ import com.arshadshah.nimaz.data.repository.TafseerRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TasbihRepositoryImpl
 import com.arshadshah.nimaz.data.repository.ZakatRepositoryImpl
 import com.arshadshah.nimaz.domain.repository.AsmaUlHusnaRepository
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.repository.AsmaUnNabiRepository
 import com.arshadshah.nimaz.domain.repository.DuaRepository
 import com.arshadshah.nimaz.domain.repository.FastingRepository
@@ -380,6 +382,12 @@ abstract class RepositoryModule {
     abstract fun bindIslamicEventRepository(
         islamicEventRepositoryImpl: IslamicEventRepositoryImpl
     ): IslamicEventRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSettingsRepository(
+        preferencesDataStore: PreferencesDataStore
+    ): SettingsRepository
 }
 
 @Module

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -22,6 +22,7 @@ import com.arshadshah.nimaz.data.repository.DuaRepositoryImpl
 import com.arshadshah.nimaz.data.repository.FastingRepositoryImpl
 import com.arshadshah.nimaz.data.repository.HadithRepositoryImpl
 import com.arshadshah.nimaz.data.repository.HelpRepositoryImpl
+import com.arshadshah.nimaz.data.repository.IslamicEventRepositoryImpl
 import com.arshadshah.nimaz.data.repository.KhatamRepositoryImpl
 import com.arshadshah.nimaz.data.repository.PrayerRepositoryImpl
 import com.arshadshah.nimaz.data.repository.ProphetRepositoryImpl
@@ -36,6 +37,7 @@ import com.arshadshah.nimaz.domain.repository.DuaRepository
 import com.arshadshah.nimaz.domain.repository.FastingRepository
 import com.arshadshah.nimaz.domain.repository.HadithRepository
 import com.arshadshah.nimaz.domain.repository.HelpRepository
+import com.arshadshah.nimaz.domain.repository.IslamicEventRepository
 import com.arshadshah.nimaz.domain.repository.KhatamRepository
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import com.arshadshah.nimaz.domain.repository.ProphetRepository
@@ -222,6 +224,12 @@ import com.arshadshah.nimaz.domain.usecase.AddNoteUseCase
 import com.arshadshah.nimaz.domain.usecase.UpdateNoteUseCase
 import com.arshadshah.nimaz.domain.usecase.DeleteNoteUseCase
 import com.arshadshah.nimaz.domain.usecase.ExportAnnotationsUseCase
+import com.arshadshah.nimaz.domain.usecase.UpdateHadithBookmarkUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteHadithBookmarkUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDuaBookmarksUseCase
+import com.arshadshah.nimaz.domain.usecase.DeleteDuaBookmarkUseCase
+import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
+import com.arshadshah.nimaz.domain.usecase.GetAllIslamicEventsUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -364,6 +372,12 @@ abstract class RepositoryModule {
     abstract fun bindQaidaRepository(
         qaidaRepositoryImpl: QaidaRepositoryImpl
     ): QaidaRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindIslamicEventRepository(
+        islamicEventRepositoryImpl: IslamicEventRepositoryImpl
+    ): IslamicEventRepository
 }
 
 @Module
@@ -549,7 +563,9 @@ object UseCaseModule {
             getProgressForDate = GetProgressForDateUseCase(repository),
             isDuaFavorite = IsDuaFavoriteUseCase(repository),
             searchDuas = SearchDuasUseCase(repository),
-            toggleFavorite = ToggleDuaFavoriteUseCase(repository)
+            toggleFavorite = ToggleDuaFavoriteUseCase(repository),
+            getAllBookmarks = GetDuaBookmarksUseCase(repository),
+            deleteBookmark = DeleteDuaBookmarkUseCase(repository)
         )
     }
     @Provides
@@ -571,7 +587,9 @@ object UseCaseModule {
             searchHadithsInBook = SearchHadithsInBookUseCase(repository),
             getAllBookmarks = GetAllBookmarksUseCase(repository),
             isHadithBookmarked = IsHadithBookmarkedUseCase(repository),
-            toggleBookmark = ToggleBookmarkUseCase(repository)
+            toggleBookmark = ToggleBookmarkUseCase(repository),
+            updateBookmark = UpdateHadithBookmarkUseCase(repository),
+            deleteBookmark = DeleteHadithBookmarkUseCase(repository)
         )
     }
     @Provides
@@ -654,6 +672,16 @@ object UseCaseModule {
             updateNote = UpdateNoteUseCase(repository),
             deleteNote = DeleteNoteUseCase(repository),
             exportAnnotations = ExportAnnotationsUseCase(repository)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideIslamicEventUseCases(
+        repository: IslamicEventRepository
+    ): IslamicEventUseCases {
+        return IslamicEventUseCases(
+            getAllEvents = GetAllIslamicEventsUseCase(repository)
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -230,6 +230,8 @@ import com.arshadshah.nimaz.domain.usecase.GetDuaBookmarksUseCase
 import com.arshadshah.nimaz.domain.usecase.DeleteDuaBookmarkUseCase
 import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
 import com.arshadshah.nimaz.domain.usecase.GetAllIslamicEventsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDailyHadithUseCase
+import com.arshadshah.nimaz.domain.usecase.GetDailyDuaUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -565,7 +567,8 @@ object UseCaseModule {
             searchDuas = SearchDuasUseCase(repository),
             toggleFavorite = ToggleDuaFavoriteUseCase(repository),
             getAllBookmarks = GetDuaBookmarksUseCase(repository),
-            deleteBookmark = DeleteDuaBookmarkUseCase(repository)
+            deleteBookmark = DeleteDuaBookmarkUseCase(repository),
+            getDailyDua = GetDailyDuaUseCase(repository)
         )
     }
     @Provides
@@ -589,7 +592,8 @@ object UseCaseModule {
             isHadithBookmarked = IsHadithBookmarkedUseCase(repository),
             toggleBookmark = ToggleBookmarkUseCase(repository),
             updateBookmark = UpdateHadithBookmarkUseCase(repository),
-            deleteBookmark = DeleteHadithBookmarkUseCase(repository)
+            deleteBookmark = DeleteHadithBookmarkUseCase(repository),
+            getDailyHadith = GetDailyHadithUseCase(repository)
         )
     }
     @Provides

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
@@ -102,9 +102,6 @@ sealed interface Route {
     @Serializable
     data object FastingStats : Route
 
-    @Serializable
-    data object MakeupFasts : Route
-
     // Tasbih screens
     @Serializable
     data object TasbihHome : Route

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanPlaybackService
@@ -92,6 +93,8 @@ class BootReceiver : BroadcastReceiver() {
                     preReminderMinutes = preReminderMinutes
                 )
             } catch (e: Exception) {
+                CrashReporter.log("BootReceiver reschedule failed")
+                CrashReporter.recordException(e)
                 e.printStackTrace()
             }
         }
@@ -120,6 +123,8 @@ class BootReceiver : BroadcastReceiver() {
                     preReminderMinutes = preReminderMinutes
                 )
             } catch (e: Exception) {
+                CrashReporter.log("BootReceiver markMissedPrayersAndReschedule failed")
+                CrashReporter.recordException(e)
                 e.printStackTrace()
             }
         }
@@ -296,6 +301,7 @@ class BootReceiver : BroadcastReceiver() {
                 )
             } catch (e: Exception) {
                 e.printStackTrace()
+                CrashReporter.recordException(e)
                 showEnhancedPrayerNotification(
                     context,
                     prayerName,
@@ -511,6 +517,7 @@ class BootReceiver : BroadcastReceiver() {
 
             } catch (e: Exception) {
                 e.printStackTrace()
+                CrashReporter.recordException(e)
                 AppAnalytics.logError("daily_summary", e.javaClass.simpleName, e.message)
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerTimesPdfExporter.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerTimesPdfExporter.kt
@@ -12,6 +12,7 @@ import android.graphics.pdf.PdfDocument
 import androidx.core.content.FileProvider
 import androidx.core.content.res.ResourcesCompat
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.model.IslamicEventType
 import com.arshadshah.nimaz.domain.model.IslamicEvents
 import java.io.File
@@ -155,7 +156,7 @@ object PrayerTimesPdfExporter {
                 (27 + tileSize - pad).toInt()
             )
             logo.draw(c)
-        }
+        }.onFailure { CrashReporter.recordException(it) }
         val title = Paint().apply {
             isAntiAlias = true; color = Color.WHITE; typeface = bold; textSize = 25f
         }

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/TajweedParser.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/TajweedParser.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.presentation.theme.NimazColors.TajweedColors
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -135,6 +136,7 @@ object TajweedParser {
                 }
             }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             // If parsing fails, return the raw text without colors
             buildAnnotatedString {
                 append(stripJson(tajweedText))
@@ -154,6 +156,7 @@ object TajweedParser {
             val segments = json.decodeFromString<List<TajweedSegment>>(tajweedText)
             segments.joinToString("") { it.t }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             stripJson(tajweedText)
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanAudioManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.MediaPlayer
 import android.net.Uri
 import android.util.Log
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -135,6 +136,7 @@ class AdhanAudioManager @Inject constructor(
                 isId3 || isMpegSync || isWav
             }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             false
         }
     }
@@ -185,6 +187,7 @@ class AdhanAudioManager @Inject constructor(
             _isPlaying.value = true
             _currentlyPlaying.value = sound
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             e.printStackTrace()
             _isPlaying.value = false
             _currentlyPlaying.value = null
@@ -310,12 +313,14 @@ class AdhanAudioManager @Inject constructor(
                             updateDownloadState(sound, DownloadState.Completed)
                             return@withContext true
                         } catch (e: Exception) {
+                            CrashReporter.recordException(e)
                             lastError = "Failed to save file: ${e.message}"
                             tempFile.delete()
                             outputFile.delete()
                         }
                     }
                 } catch (e: Exception) {
+                    CrashReporter.recordException(e)
                     lastError = e.message ?: "Download failed"
                     Log.e(TAG, "Download attempt $attempt failed for $fileName: $lastError")
                     tempFile.delete()
@@ -503,6 +508,7 @@ class AdhanAudioManager @Inject constructor(
             updateDownloadState(AdhanSound.SIMPLE_BEEP, DownloadState.Completed)
             true
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             e.printStackTrace()
             updateDownloadState(
                 AdhanSound.SIMPLE_BEEP,

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadService.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -170,6 +171,7 @@ class AdhanDownloadService : Service() {
                 ensureBeepExists()
                 showCompletionNotification(sound.displayName, results)
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 Log.e(TAG, "Download service error", e)
                 showErrorNotification()
             } finally {
@@ -186,6 +188,7 @@ class AdhanDownloadService : Service() {
                 ensureBeepExists()
                 showCompletionNotification(sound.displayName, results)
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 Log.e(TAG, "Download service error", e)
                 showErrorNotification()
             } finally {

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -54,6 +55,7 @@ class AdhanDownloadWorker @AssistedInject constructor(
 
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             Log.e(TAG, "Background adhan download failed", e)
             if (runAttemptCount < MAX_RETRIES) Result.retry() else Result.failure()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanPlaybackService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanPlaybackService.kt
@@ -21,6 +21,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import javax.inject.Inject
@@ -269,6 +270,7 @@ class AdhanPlaybackService : Service() {
                 startForeground(notifId, createPlaybackNotification(prayerName))
             }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             e.printStackTrace()
             stopPlayback()
             stopSelf()

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -453,7 +454,8 @@ class QuranAudioManager @Inject constructor(
                             retriever.extractMetadata(
                                 MediaMetadataRetriever.METADATA_KEY_DURATION
                             )?.toLongOrNull() ?: 0L
-                        } catch (_: Exception) {
+                        } catch (e: Exception) {
+                            CrashReporter.recordException(e)
                             0L
                         } finally {
                             retriever.release()
@@ -499,6 +501,7 @@ class QuranAudioManager @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 _audioState.update {
                     it.copy(
                         isPreparing = false,
@@ -779,7 +782,10 @@ class QuranAudioManager @Inject constructor(
                     }
                 }
                 // All retries failed
-                lastException?.let { destination.delete() }
+                lastException?.let {
+                    CrashReporter.recordException(it)
+                    destination.delete()
+                }
             }
         } finally {
             downloadingFiles.remove(key)

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -156,7 +156,7 @@ abstract class NimazDatabase : RoomDatabase() {
         // Current Room schema version. Keep in sync with @Database(version = ...)
         // above. Exposed so crash reports can be tagged with the schema version,
         // which makes migration-related crashes far easier to diagnose.
-        const val SCHEMA_VERSION = 16
+        const val SCHEMA_VERSION = 17
 
         // Tables that gained an `updatedAt` column in schema v10/v11.
         private val UPDATED_AT_TABLES = listOf(

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -67,6 +67,13 @@ import com.arshadshah.nimaz.data.local.database.entity.TasbihSessionEntity
 import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
 import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
 
+/**
+ * Single source of truth for the database schema version. Bump this (and add a
+ * migration) for any schema change — it drives both the Room `@Database(version = …)`
+ * annotation below and `NimazDatabase.SCHEMA_VERSION` (used to tag crash reports).
+ */
+const val NIMAZ_DATABASE_VERSION = 17
+
 @Database(
     entities = [
         // Quran
@@ -129,7 +136,7 @@ import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
         LocationEntity::class,
         IslamicEventEntity::class
     ],
-    version = 17,
+    version = NIMAZ_DATABASE_VERSION,
     exportSchema = true
 )
 abstract class NimazDatabase : RoomDatabase() {
@@ -153,10 +160,10 @@ abstract class NimazDatabase : RoomDatabase() {
     companion object {
         const val DATABASE_NAME = "nimaz_database"
 
-        // Current Room schema version. Keep in sync with @Database(version = ...)
-        // above. Exposed so crash reports can be tagged with the schema version,
-        // which makes migration-related crashes far easier to diagnose.
-        const val SCHEMA_VERSION = 17
+        // Exposed so crash reports can be tagged with the schema version, which
+        // makes migration-related crashes far easier to diagnose. Derived from the
+        // single source of truth so it can never drift from @Database(version = …).
+        const val SCHEMA_VERSION = NIMAZ_DATABASE_VERSION
 
         // Tables that gained an `updatedAt` column in schema v10/v11.
         private val UPDATED_AT_TABLES = listOf(

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -15,7 +15,7 @@ import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
 import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
 import kotlinx.coroutines.flow.Flow
 
-data class PageAyahRange(
+data class PageAyahRangeRow(
     val page: Int,
     val minAyahId: Int,
     val maxAyahId: Int,
@@ -57,7 +57,7 @@ interface QuranDao {
     fun getAyahsByPage(pageNumber: Int): Flow<List<AyahEntity>>
 
     @Query("SELECT page, MIN(id) AS minAyahId, MAX(id) AS maxAyahId, COUNT(id) AS ayahCount FROM ayahs GROUP BY page ORDER BY page ASC")
-    suspend fun getPageAyahRanges(): List<PageAyahRange>
+    suspend fun getPageAyahRanges(): List<PageAyahRangeRow>
 
     @Query("SELECT * FROM ayahs WHERE sajda_type IS NOT NULL ORDER BY id ASC")
     fun getSajdaAyahs(): Flow<List<AyahEntity>>

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,7 +26,7 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 @Singleton
 class PreferencesDataStore @Inject constructor(
     private val context: Context
-) {
+) : SettingsRepository {
     private val dataStore = context.dataStore
 
     /** Observe a preference, falling back to [default] when it has not been set. */
@@ -163,161 +165,161 @@ class PreferencesDataStore @Inject constructor(
         val LOCATION_NAME = stringPreferencesKey("location_name")
     }
 
-    suspend fun clearAllData() {
+    override suspend fun clearAllData() {
         dataStore.edit { it.clear() }
     }
 
     // Onboarding
-    val onboardingCompleted: Flow<Boolean> = preference(PreferencesKeys.ONBOARDING_COMPLETED, false)
+    override val onboardingCompleted: Flow<Boolean> = preference(PreferencesKeys.ONBOARDING_COMPLETED, false)
 
-    suspend fun setOnboardingCompleted(completed: Boolean) =
+    override suspend fun setOnboardingCompleted(completed: Boolean) =
         put(PreferencesKeys.ONBOARDING_COMPLETED, completed)
 
     // Theme
-    val themeMode: Flow<String> = preference(PreferencesKeys.THEME_MODE, "system")
+    override val themeMode: Flow<String> = preference(PreferencesKeys.THEME_MODE, "system")
 
-    suspend fun setThemeMode(mode: String) = put(PreferencesKeys.THEME_MODE, mode)
+    override suspend fun setThemeMode(mode: String) = put(PreferencesKeys.THEME_MODE, mode)
 
-    val dynamicColor: Flow<Boolean> = preference(PreferencesKeys.DYNAMIC_COLOR, false)
+    override val dynamicColor: Flow<Boolean> = preference(PreferencesKeys.DYNAMIC_COLOR, false)
 
-    suspend fun setDynamicColor(enabled: Boolean) = put(PreferencesKeys.DYNAMIC_COLOR, enabled)
+    override suspend fun setDynamicColor(enabled: Boolean) = put(PreferencesKeys.DYNAMIC_COLOR, enabled)
 
     // Appearance
-    val showIslamicPatterns: Flow<Boolean> = preference(PreferencesKeys.SHOW_ISLAMIC_PATTERNS, true)
+    override val showIslamicPatterns: Flow<Boolean> = preference(PreferencesKeys.SHOW_ISLAMIC_PATTERNS, true)
 
-    suspend fun setShowIslamicPatterns(enabled: Boolean) =
+    override suspend fun setShowIslamicPatterns(enabled: Boolean) =
         put(PreferencesKeys.SHOW_ISLAMIC_PATTERNS, enabled)
 
-    val animationsEnabled: Flow<Boolean> = preference(PreferencesKeys.ANIMATIONS_ENABLED, true)
+    override val animationsEnabled: Flow<Boolean> = preference(PreferencesKeys.ANIMATIONS_ENABLED, true)
 
-    suspend fun setAnimationsEnabled(enabled: Boolean) =
+    override suspend fun setAnimationsEnabled(enabled: Boolean) =
         put(PreferencesKeys.ANIMATIONS_ENABLED, enabled)
 
     // Display
-    val showCountdown: Flow<Boolean> = preference(PreferencesKeys.SHOW_COUNTDOWN, true)
+    override val showCountdown: Flow<Boolean> = preference(PreferencesKeys.SHOW_COUNTDOWN, true)
 
-    suspend fun setShowCountdown(enabled: Boolean) = put(PreferencesKeys.SHOW_COUNTDOWN, enabled)
+    override suspend fun setShowCountdown(enabled: Boolean) = put(PreferencesKeys.SHOW_COUNTDOWN, enabled)
 
-    val showQuickActions: Flow<Boolean> = preference(PreferencesKeys.SHOW_QUICK_ACTIONS, true)
+    override val showQuickActions: Flow<Boolean> = preference(PreferencesKeys.SHOW_QUICK_ACTIONS, true)
 
-    suspend fun setShowQuickActions(enabled: Boolean) =
+    override suspend fun setShowQuickActions(enabled: Boolean) =
         put(PreferencesKeys.SHOW_QUICK_ACTIONS, enabled)
 
-    val hapticFeedback: Flow<Boolean> = preference(PreferencesKeys.HAPTIC_FEEDBACK, true)
+    override val hapticFeedback: Flow<Boolean> = preference(PreferencesKeys.HAPTIC_FEEDBACK, true)
 
-    suspend fun setHapticFeedback(enabled: Boolean) = put(PreferencesKeys.HAPTIC_FEEDBACK, enabled)
+    override suspend fun setHapticFeedback(enabled: Boolean) = put(PreferencesKeys.HAPTIC_FEEDBACK, enabled)
 
-    val use24HourFormat: Flow<Boolean> = preference(PreferencesKeys.USE_24_HOUR_FORMAT, false)
+    override val use24HourFormat: Flow<Boolean> = preference(PreferencesKeys.USE_24_HOUR_FORMAT, false)
 
-    suspend fun setUse24HourFormat(enabled: Boolean) =
+    override suspend fun setUse24HourFormat(enabled: Boolean) =
         put(PreferencesKeys.USE_24_HOUR_FORMAT, enabled)
 
-    val useHijriPrimary: Flow<Boolean> = preference(PreferencesKeys.USE_HIJRI_PRIMARY, false)
+    override val useHijriPrimary: Flow<Boolean> = preference(PreferencesKeys.USE_HIJRI_PRIMARY, false)
 
-    suspend fun setUseHijriPrimary(enabled: Boolean) =
+    override suspend fun setUseHijriPrimary(enabled: Boolean) =
         put(PreferencesKeys.USE_HIJRI_PRIMARY, enabled)
 
     // Language
-    val appLanguage: Flow<String> = preference(PreferencesKeys.APP_LANGUAGE, "en")
+    override val appLanguage: Flow<String> = preference(PreferencesKeys.APP_LANGUAGE, "en")
 
-    suspend fun setAppLanguage(language: String) = put(PreferencesKeys.APP_LANGUAGE, language)
+    override suspend fun setAppLanguage(language: String) = put(PreferencesKeys.APP_LANGUAGE, language)
 
     // Help content version (0 = never seeded)
-    val helpContentVersion: Flow<Int> = preference(PreferencesKeys.HELP_CONTENT_VERSION, 0)
+    override val helpContentVersion: Flow<Int> = preference(PreferencesKeys.HELP_CONTENT_VERSION, 0)
 
-    suspend fun setHelpContentVersion(version: Int) =
+    override suspend fun setHelpContentVersion(version: Int) =
         put(PreferencesKeys.HELP_CONTENT_VERSION, version)
 
     // Hadith backfill version (0 = never applied)
-    val hadithBackfillVersion: Flow<Int> = preference(PreferencesKeys.HADITH_BACKFILL_VERSION, 0)
+    override val hadithBackfillVersion: Flow<Int> = preference(PreferencesKeys.HADITH_BACKFILL_VERSION, 0)
 
-    suspend fun setHadithBackfillVersion(version: Int) =
+    override suspend fun setHadithBackfillVersion(version: Int) =
         put(PreferencesKeys.HADITH_BACKFILL_VERSION, version)
 
     // Tasbih counter style — true = bead strand, false = classic circle.
-    val tasbihBeadMode: Flow<Boolean> = preference(PreferencesKeys.TASBIH_BEAD_MODE, false)
+    override val tasbihBeadMode: Flow<Boolean> = preference(PreferencesKeys.TASBIH_BEAD_MODE, false)
 
-    suspend fun setTasbihBeadMode(enabled: Boolean) = put(PreferencesKeys.TASBIH_BEAD_MODE, enabled)
+    override suspend fun setTasbihBeadMode(enabled: Boolean) = put(PreferencesKeys.TASBIH_BEAD_MODE, enabled)
 
     // Tasbih bead design — stable key of the chosen BeadDesign (default "wood").
-    val tasbihBeadDesign: Flow<String> = preference(PreferencesKeys.TASBIH_BEAD_DESIGN, "wood")
+    override val tasbihBeadDesign: Flow<String> = preference(PreferencesKeys.TASBIH_BEAD_DESIGN, "wood")
 
-    suspend fun setTasbihBeadDesign(key: String) = put(PreferencesKeys.TASBIH_BEAD_DESIGN, key)
+    override suspend fun setTasbihBeadDesign(key: String) = put(PreferencesKeys.TASBIH_BEAD_DESIGN, key)
 
     // Currently selected tasbih preset id (-1 = free count). Shared across screens
     // so the Choose-Dhikr picker can drive the counter on a separate back-stack entry.
-    val tasbihSelectedPresetId: Flow<Long> = preference(PreferencesKeys.TASBIH_SELECTED_PRESET, -1L)
+    override val tasbihSelectedPresetId: Flow<Long> = preference(PreferencesKeys.TASBIH_SELECTED_PRESET, -1L)
 
-    suspend fun setTasbihSelectedPresetId(id: Long) =
+    override suspend fun setTasbihSelectedPresetId(id: Long) =
         put(PreferencesKeys.TASBIH_SELECTED_PRESET, id)
 
     // Versioned runtime seed of new default presets (prepackaged DB only has the
     // original five). Bump the latest version in the VM when new defaults are added.
-    val tasbihPresetSeedVersion: Flow<Int> =
+    override val tasbihPresetSeedVersion: Flow<Int> =
         preference(PreferencesKeys.TASBIH_PRESET_SEED_VERSION, 0)
 
-    suspend fun setTasbihPresetSeedVersion(version: Int) =
+    override suspend fun setTasbihPresetSeedVersion(version: Int) =
         put(PreferencesKeys.TASBIH_PRESET_SEED_VERSION, version)
 
     // Favourite preset ids (stored as strings).
-    val tasbihFavorites: Flow<Set<String>> =
+    override val tasbihFavorites: Flow<Set<String>> =
         preference(PreferencesKeys.TASBIH_FAVORITES, emptySet())
 
-    suspend fun setTasbihFavorites(ids: Set<String>) = put(PreferencesKeys.TASBIH_FAVORITES, ids)
+    override suspend fun setTasbihFavorites(ids: Set<String>) = put(PreferencesKeys.TASBIH_FAVORITES, ids)
 
     // Bead strand handedness — false = right-handed (beads advance right→left),
     // true = left-handed (beads advance left→right).
-    val tasbihLeftHanded: Flow<Boolean> = preference(PreferencesKeys.TASBIH_LEFT_HANDED, false)
+    override val tasbihLeftHanded: Flow<Boolean> = preference(PreferencesKeys.TASBIH_LEFT_HANDED, false)
 
-    suspend fun setTasbihLeftHanded(enabled: Boolean) =
+    override suspend fun setTasbihLeftHanded(enabled: Boolean) =
         put(PreferencesKeys.TASBIH_LEFT_HANDED, enabled)
 
     // Dua content version (0 = never seeded)
-    val duaContentVersion: Flow<Int> = preference(PreferencesKeys.DUA_CONTENT_VERSION, 0)
+    override val duaContentVersion: Flow<Int> = preference(PreferencesKeys.DUA_CONTENT_VERSION, 0)
 
-    suspend fun setDuaContentVersion(version: Int) =
+    override suspend fun setDuaContentVersion(version: Int) =
         put(PreferencesKeys.DUA_CONTENT_VERSION, version)
 
     // Qaida content version (0 = never seeded)
-    val qaidaContentVersion: Flow<Int> = preference(PreferencesKeys.QAIDA_CONTENT_VERSION, 0)
+    override val qaidaContentVersion: Flow<Int> = preference(PreferencesKeys.QAIDA_CONTENT_VERSION, 0)
 
-    suspend fun setQaidaContentVersion(version: Int) =
+    override suspend fun setQaidaContentVersion(version: Int) =
         put(PreferencesKeys.QAIDA_CONTENT_VERSION, version)
 
-    val arabicFontSize: Flow<String> = preference(PreferencesKeys.ARABIC_FONT_SIZE, "medium")
+    override val arabicFontSize: Flow<String> = preference(PreferencesKeys.ARABIC_FONT_SIZE, "medium")
 
-    suspend fun setArabicFontSize(size: String) = put(PreferencesKeys.ARABIC_FONT_SIZE, size)
+    override suspend fun setArabicFontSize(size: String) = put(PreferencesKeys.ARABIC_FONT_SIZE, size)
 
     // Prayer Settings
-    val calculationMethod: Flow<String> =
+    override val calculationMethod: Flow<String> =
         preference(PreferencesKeys.CALCULATION_METHOD, "MUSLIM_WORLD_LEAGUE")
 
-    suspend fun setCalculationMethod(method: String) =
+    override suspend fun setCalculationMethod(method: String) =
         put(PreferencesKeys.CALCULATION_METHOD, method)
 
-    val asrCalculation: Flow<String> = preference(PreferencesKeys.ASR_CALCULATION, "standard")
+    override val asrCalculation: Flow<String> = preference(PreferencesKeys.ASR_CALCULATION, "standard")
 
-    suspend fun setAsrCalculation(calculation: String) =
+    override suspend fun setAsrCalculation(calculation: String) =
         put(PreferencesKeys.ASR_CALCULATION, calculation)
 
-    val highLatitudeRule: Flow<String> =
+    override val highLatitudeRule: Flow<String> =
         preference(PreferencesKeys.HIGH_LATITUDE_RULE, "MIDDLE_OF_NIGHT")
 
-    suspend fun setHighLatitudeRule(rule: String) = put(PreferencesKeys.HIGH_LATITUDE_RULE, rule)
+    override suspend fun setHighLatitudeRule(rule: String) = put(PreferencesKeys.HIGH_LATITUDE_RULE, rule)
 
-    val currentLocationId: Flow<Long?> = preference(PreferencesKeys.CURRENT_LOCATION_ID)
+    override val currentLocationId: Flow<Long?> = preference(PreferencesKeys.CURRENT_LOCATION_ID)
 
-    suspend fun setCurrentLocationId(id: Long) = put(PreferencesKeys.CURRENT_LOCATION_ID, id)
+    override suspend fun setCurrentLocationId(id: Long) = put(PreferencesKeys.CURRENT_LOCATION_ID, id)
 
     // Prayer Adjustments
-    val fajrAdjustment: Flow<Int> = preference(PreferencesKeys.FAJR_ADJUSTMENT, 0)
-    val sunriseAdjustment: Flow<Int> = preference(PreferencesKeys.SUNRISE_ADJUSTMENT, 0)
-    val dhuhrAdjustment: Flow<Int> = preference(PreferencesKeys.DHUHR_ADJUSTMENT, 0)
-    val asrAdjustment: Flow<Int> = preference(PreferencesKeys.ASR_ADJUSTMENT, 0)
-    val maghribAdjustment: Flow<Int> = preference(PreferencesKeys.MAGHRIB_ADJUSTMENT, 0)
-    val ishaAdjustment: Flow<Int> = preference(PreferencesKeys.ISHA_ADJUSTMENT, 0)
+    override val fajrAdjustment: Flow<Int> = preference(PreferencesKeys.FAJR_ADJUSTMENT, 0)
+    override val sunriseAdjustment: Flow<Int> = preference(PreferencesKeys.SUNRISE_ADJUSTMENT, 0)
+    override val dhuhrAdjustment: Flow<Int> = preference(PreferencesKeys.DHUHR_ADJUSTMENT, 0)
+    override val asrAdjustment: Flow<Int> = preference(PreferencesKeys.ASR_ADJUSTMENT, 0)
+    override val maghribAdjustment: Flow<Int> = preference(PreferencesKeys.MAGHRIB_ADJUSTMENT, 0)
+    override val ishaAdjustment: Flow<Int> = preference(PreferencesKeys.ISHA_ADJUSTMENT, 0)
 
-    suspend fun setPrayerAdjustment(prayer: String, minutes: Int) {
+    override suspend fun setPrayerAdjustment(prayer: String, minutes: Int) {
         dataStore.edit { prefs ->
             val key = when (prayer.lowercase()) {
                 "fajr" -> PreferencesKeys.FAJR_ADJUSTMENT
@@ -333,36 +335,36 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Notifications
-    val prayerNotificationsEnabled: Flow<Boolean> =
+    override val prayerNotificationsEnabled: Flow<Boolean> =
         preference(PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED, true)
 
-    suspend fun setPrayerNotificationsEnabled(enabled: Boolean) =
+    override suspend fun setPrayerNotificationsEnabled(enabled: Boolean) =
         put(PreferencesKeys.PRAYER_NOTIFICATIONS_ENABLED, enabled)
 
-    val adhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ADHAN_ENABLED, false)
+    override val adhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ADHAN_ENABLED, false)
 
-    suspend fun setAdhanEnabled(enabled: Boolean) = put(PreferencesKeys.ADHAN_ENABLED, enabled)
+    override suspend fun setAdhanEnabled(enabled: Boolean) = put(PreferencesKeys.ADHAN_ENABLED, enabled)
 
-    val selectedAdhanSound: Flow<String> =
+    override val selectedAdhanSound: Flow<String> =
         preference(PreferencesKeys.SELECTED_ADHAN_SOUND, "MISHARY")
 
-    suspend fun setSelectedAdhanSound(sound: String) =
+    override suspend fun setSelectedAdhanSound(sound: String) =
         put(PreferencesKeys.SELECTED_ADHAN_SOUND, sound)
 
-    val fajrNotificationEnabled: Flow<Boolean> =
+    override val fajrNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.FAJR_NOTIFICATION_ENABLED, true)
-    val sunriseNotificationEnabled: Flow<Boolean> =
+    override val sunriseNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.SUNRISE_NOTIFICATION_ENABLED, false)
-    val dhuhrNotificationEnabled: Flow<Boolean> =
+    override val dhuhrNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.DHUHR_NOTIFICATION_ENABLED, true)
-    val asrNotificationEnabled: Flow<Boolean> =
+    override val asrNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.ASR_NOTIFICATION_ENABLED, true)
-    val maghribNotificationEnabled: Flow<Boolean> =
+    override val maghribNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.MAGHRIB_NOTIFICATION_ENABLED, true)
-    val ishaNotificationEnabled: Flow<Boolean> =
+    override val ishaNotificationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.ISHA_NOTIFICATION_ENABLED, true)
 
-    suspend fun setPrayerNotificationEnabled(prayer: String, enabled: Boolean) {
+    override suspend fun setPrayerNotificationEnabled(prayer: String, enabled: Boolean) {
         dataStore.edit { prefs ->
             val key = when (prayer.lowercase()) {
                 "fajr" -> PreferencesKeys.FAJR_NOTIFICATION_ENABLED
@@ -378,13 +380,13 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Per-prayer adhan enabled
-    val fajrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.FAJR_ADHAN_ENABLED, true)
-    val dhuhrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.DHUHR_ADHAN_ENABLED, true)
-    val asrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ASR_ADHAN_ENABLED, true)
-    val maghribAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.MAGHRIB_ADHAN_ENABLED, true)
-    val ishaAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ISHA_ADHAN_ENABLED, true)
+    override val fajrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.FAJR_ADHAN_ENABLED, true)
+    override val dhuhrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.DHUHR_ADHAN_ENABLED, true)
+    override val asrAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ASR_ADHAN_ENABLED, true)
+    override val maghribAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.MAGHRIB_ADHAN_ENABLED, true)
+    override val ishaAdhanEnabled: Flow<Boolean> = preference(PreferencesKeys.ISHA_ADHAN_ENABLED, true)
 
-    suspend fun setPrayerAdhanEnabled(prayer: String, enabled: Boolean) {
+    override suspend fun setPrayerAdhanEnabled(prayer: String, enabled: Boolean) {
         dataStore.edit { prefs ->
             val key = when (prayer.lowercase()) {
                 "fajr" -> PreferencesKeys.FAJR_ADHAN_ENABLED
@@ -402,7 +404,7 @@ class PreferencesDataStore @Inject constructor(
      * Check if adhan is enabled for a specific prayer.
      * Sunrise always returns false (uses beep only).
      */
-    fun isAdhanEnabledForPrayer(prayer: String): Flow<Boolean> {
+    override fun isAdhanEnabledForPrayer(prayer: String): Flow<Boolean> {
         return when (prayer.lowercase()) {
             "fajr" -> fajrAdhanEnabled
             "dhuhr" -> dhuhrAdhanEnabled
@@ -414,177 +416,177 @@ class PreferencesDataStore @Inject constructor(
         }
     }
 
-    val adhanRespectDnd: Flow<Boolean> = preference(PreferencesKeys.ADHAN_RESPECT_DND, true)
+    override val adhanRespectDnd: Flow<Boolean> = preference(PreferencesKeys.ADHAN_RESPECT_DND, true)
 
-    suspend fun setAdhanRespectDnd(enabled: Boolean) =
+    override suspend fun setAdhanRespectDnd(enabled: Boolean) =
         put(PreferencesKeys.ADHAN_RESPECT_DND, enabled)
 
-    val notificationVibration: Flow<Boolean> =
+    override val notificationVibration: Flow<Boolean> =
         preference(PreferencesKeys.NOTIFICATION_VIBRATION, true)
 
-    suspend fun setNotificationVibration(enabled: Boolean) =
+    override suspend fun setNotificationVibration(enabled: Boolean) =
         put(PreferencesKeys.NOTIFICATION_VIBRATION, enabled)
 
-    val notificationReminderMinutes: Flow<Int> =
+    override val notificationReminderMinutes: Flow<Int> =
         preference(PreferencesKeys.NOTIFICATION_REMINDER_MINUTES, 15)
 
-    suspend fun setNotificationReminderMinutes(minutes: Int) =
+    override suspend fun setNotificationReminderMinutes(minutes: Int) =
         put(PreferencesKeys.NOTIFICATION_REMINDER_MINUTES, minutes)
 
-    val showReminderBefore: Flow<Boolean> = preference(PreferencesKeys.SHOW_REMINDER_BEFORE, true)
+    override val showReminderBefore: Flow<Boolean> = preference(PreferencesKeys.SHOW_REMINDER_BEFORE, true)
 
-    suspend fun setShowReminderBefore(enabled: Boolean) =
+    override suspend fun setShowReminderBefore(enabled: Boolean) =
         put(PreferencesKeys.SHOW_REMINDER_BEFORE, enabled)
 
-    val persistentNotification: Flow<Boolean> =
+    override val persistentNotification: Flow<Boolean> =
         preference(PreferencesKeys.PERSISTENT_NOTIFICATION, false)
 
-    suspend fun setPersistentNotification(enabled: Boolean) =
+    override suspend fun setPersistentNotification(enabled: Boolean) =
         put(PreferencesKeys.PERSISTENT_NOTIFICATION, enabled)
 
     // Quran Settings
-    val quranTranslatorId: Flow<String> =
+    override val quranTranslatorId: Flow<String> =
         preference(PreferencesKeys.QURAN_TRANSLATOR_ID, "sahih_international")
 
-    suspend fun setQuranTranslatorId(translatorId: String) =
+    override suspend fun setQuranTranslatorId(translatorId: String) =
         put(PreferencesKeys.QURAN_TRANSLATOR_ID, translatorId)
 
-    val showTranslation: Flow<Boolean> = preference(PreferencesKeys.SHOW_TRANSLATION, true)
+    override val showTranslation: Flow<Boolean> = preference(PreferencesKeys.SHOW_TRANSLATION, true)
 
-    suspend fun setShowTranslation(show: Boolean) = put(PreferencesKeys.SHOW_TRANSLATION, show)
+    override suspend fun setShowTranslation(show: Boolean) = put(PreferencesKeys.SHOW_TRANSLATION, show)
 
-    val showTransliteration: Flow<Boolean> =
+    override val showTransliteration: Flow<Boolean> =
         preference(PreferencesKeys.SHOW_TRANSLITERATION, false)
 
-    suspend fun setShowTransliteration(show: Boolean) =
+    override suspend fun setShowTransliteration(show: Boolean) =
         put(PreferencesKeys.SHOW_TRANSLITERATION, show)
 
-    val selectedReciterId: Flow<String?> = preference(PreferencesKeys.SELECTED_RECITER_ID)
+    override val selectedReciterId: Flow<String?> = preference(PreferencesKeys.SELECTED_RECITER_ID)
 
-    suspend fun setSelectedReciterId(reciterId: String?) {
+    override suspend fun setSelectedReciterId(reciterId: String?) {
         dataStore.edit {
             if (reciterId != null) it[PreferencesKeys.SELECTED_RECITER_ID] = reciterId
             else it.remove(PreferencesKeys.SELECTED_RECITER_ID)
         }
     }
 
-    val quranArabicFont: Flow<String> = preference(PreferencesKeys.QURAN_ARABIC_FONT, "amiri")
+    override val quranArabicFont: Flow<String> = preference(PreferencesKeys.QURAN_ARABIC_FONT, "amiri")
 
-    suspend fun setQuranArabicFont(fontId: String) =
+    override suspend fun setQuranArabicFont(fontId: String) =
         put(PreferencesKeys.QURAN_ARABIC_FONT, fontId)
 
-    val quranArabicFontSize: Flow<Float> =
+    override val quranArabicFontSize: Flow<Float> =
         preference(PreferencesKeys.QURAN_ARABIC_FONT_SIZE, 28f)
 
-    suspend fun setQuranArabicFontSize(size: Float) =
+    override suspend fun setQuranArabicFontSize(size: Float) =
         put(PreferencesKeys.QURAN_ARABIC_FONT_SIZE, size)
 
-    val quranTranslationFontSize: Flow<Float> =
+    override val quranTranslationFontSize: Flow<Float> =
         preference(PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setQuranTranslationFontSize(size: Float) =
+    override suspend fun setQuranTranslationFontSize(size: Float) =
         put(PreferencesKeys.QURAN_TRANSLATION_FONT_SIZE, size)
 
-    val continuousReading: Flow<Boolean> = preference(PreferencesKeys.CONTINUOUS_READING, true)
+    override val continuousReading: Flow<Boolean> = preference(PreferencesKeys.CONTINUOUS_READING, true)
 
-    suspend fun setContinuousReading(enabled: Boolean) =
+    override suspend fun setContinuousReading(enabled: Boolean) =
         put(PreferencesKeys.CONTINUOUS_READING, enabled)
 
-    val keepScreenOn: Flow<Boolean> = preference(PreferencesKeys.KEEP_SCREEN_ON, true)
+    override val keepScreenOn: Flow<Boolean> = preference(PreferencesKeys.KEEP_SCREEN_ON, true)
 
-    suspend fun setKeepScreenOn(enabled: Boolean) = put(PreferencesKeys.KEEP_SCREEN_ON, enabled)
+    override suspend fun setKeepScreenOn(enabled: Boolean) = put(PreferencesKeys.KEEP_SCREEN_ON, enabled)
 
-    val showTajweed: Flow<Boolean> = preference(PreferencesKeys.SHOW_TAJWEED, false)
+    override val showTajweed: Flow<Boolean> = preference(PreferencesKeys.SHOW_TAJWEED, false)
 
-    suspend fun setShowTajweed(enabled: Boolean) = put(PreferencesKeys.SHOW_TAJWEED, enabled)
+    override suspend fun setShowTajweed(enabled: Boolean) = put(PreferencesKeys.SHOW_TAJWEED, enabled)
 
     // Dua Settings
-    val duaArabicFont: Flow<String> = preference(PreferencesKeys.DUA_ARABIC_FONT, "amiri")
+    override val duaArabicFont: Flow<String> = preference(PreferencesKeys.DUA_ARABIC_FONT, "amiri")
 
-    suspend fun setDuaArabicFont(fontId: String) = put(PreferencesKeys.DUA_ARABIC_FONT, fontId)
+    override suspend fun setDuaArabicFont(fontId: String) = put(PreferencesKeys.DUA_ARABIC_FONT, fontId)
 
-    val duaArabicFontSize: Flow<Float> = preference(PreferencesKeys.DUA_ARABIC_FONT_SIZE, 28f)
+    override val duaArabicFontSize: Flow<Float> = preference(PreferencesKeys.DUA_ARABIC_FONT_SIZE, 28f)
 
-    suspend fun setDuaArabicFontSize(size: Float) =
+    override suspend fun setDuaArabicFontSize(size: Float) =
         put(PreferencesKeys.DUA_ARABIC_FONT_SIZE, size)
 
-    val duaTranslationFontSize: Flow<Float> =
+    override val duaTranslationFontSize: Flow<Float> =
         preference(PreferencesKeys.DUA_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setDuaTranslationFontSize(size: Float) =
+    override suspend fun setDuaTranslationFontSize(size: Float) =
         put(PreferencesKeys.DUA_TRANSLATION_FONT_SIZE, size)
 
-    val duaShowArabic: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_ARABIC, true)
+    override val duaShowArabic: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_ARABIC, true)
 
-    suspend fun setDuaShowArabic(show: Boolean) = put(PreferencesKeys.DUA_SHOW_ARABIC, show)
+    override suspend fun setDuaShowArabic(show: Boolean) = put(PreferencesKeys.DUA_SHOW_ARABIC, show)
 
-    val duaShowTransliteration: Flow<Boolean> =
+    override val duaShowTransliteration: Flow<Boolean> =
         preference(PreferencesKeys.DUA_SHOW_TRANSLITERATION, true)
 
-    suspend fun setDuaShowTransliteration(show: Boolean) =
+    override suspend fun setDuaShowTransliteration(show: Boolean) =
         put(PreferencesKeys.DUA_SHOW_TRANSLITERATION, show)
 
-    val duaShowTranslation: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_TRANSLATION, true)
+    override val duaShowTranslation: Flow<Boolean> = preference(PreferencesKeys.DUA_SHOW_TRANSLATION, true)
 
-    suspend fun setDuaShowTranslation(show: Boolean) =
+    override suspend fun setDuaShowTranslation(show: Boolean) =
         put(PreferencesKeys.DUA_SHOW_TRANSLATION, show)
 
     // Hadith Settings
-    val hadithArabicFont: Flow<String> = preference(PreferencesKeys.HADITH_ARABIC_FONT, "amiri")
+    override val hadithArabicFont: Flow<String> = preference(PreferencesKeys.HADITH_ARABIC_FONT, "amiri")
 
-    suspend fun setHadithArabicFont(fontId: String) =
+    override suspend fun setHadithArabicFont(fontId: String) =
         put(PreferencesKeys.HADITH_ARABIC_FONT, fontId)
 
-    val hadithArabicFontSize: Flow<Float> =
+    override val hadithArabicFontSize: Flow<Float> =
         preference(PreferencesKeys.HADITH_ARABIC_FONT_SIZE, 24f)
 
-    suspend fun setHadithArabicFontSize(size: Float) =
+    override suspend fun setHadithArabicFontSize(size: Float) =
         put(PreferencesKeys.HADITH_ARABIC_FONT_SIZE, size)
 
-    val hadithTranslationFontSize: Flow<Float> =
+    override val hadithTranslationFontSize: Flow<Float> =
         preference(PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE, 16f)
 
-    suspend fun setHadithTranslationFontSize(size: Float) =
+    override suspend fun setHadithTranslationFontSize(size: Float) =
         put(PreferencesKeys.HADITH_TRANSLATION_FONT_SIZE, size)
 
-    val hadithShowArabic: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_ARABIC, true)
+    override val hadithShowArabic: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_ARABIC, true)
 
-    suspend fun setHadithShowArabic(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_ARABIC, show)
+    override suspend fun setHadithShowArabic(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_ARABIC, show)
 
-    val hadithShowTranslation: Flow<Boolean> =
+    override val hadithShowTranslation: Flow<Boolean> =
         preference(PreferencesKeys.HADITH_SHOW_TRANSLATION, true)
 
-    suspend fun setHadithShowTranslation(show: Boolean) =
+    override suspend fun setHadithShowTranslation(show: Boolean) =
         put(PreferencesKeys.HADITH_SHOW_TRANSLATION, show)
 
-    val hadithShowGrade: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_GRADE, true)
+    override val hadithShowGrade: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_GRADE, true)
 
-    suspend fun setHadithShowGrade(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_GRADE, show)
+    override suspend fun setHadithShowGrade(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_GRADE, show)
 
-    val hadithShowChain: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_CHAIN, true)
+    override val hadithShowChain: Flow<Boolean> = preference(PreferencesKeys.HADITH_SHOW_CHAIN, true)
 
-    suspend fun setHadithShowChain(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_CHAIN, show)
+    override suspend fun setHadithShowChain(show: Boolean) = put(PreferencesKeys.HADITH_SHOW_CHAIN, show)
 
     // Tasbih Settings
-    val tasbihVibrationEnabled: Flow<Boolean> =
+    override val tasbihVibrationEnabled: Flow<Boolean> =
         preference(PreferencesKeys.TASBIH_VIBRATION_ENABLED, true)
 
-    suspend fun setTasbihVibrationEnabled(enabled: Boolean) =
+    override suspend fun setTasbihVibrationEnabled(enabled: Boolean) =
         put(PreferencesKeys.TASBIH_VIBRATION_ENABLED, enabled)
 
-    val tasbihSoundEnabled: Flow<Boolean> = preference(PreferencesKeys.TASBIH_SOUND_ENABLED, true)
+    override val tasbihSoundEnabled: Flow<Boolean> = preference(PreferencesKeys.TASBIH_SOUND_ENABLED, true)
 
-    suspend fun setTasbihSoundEnabled(enabled: Boolean) =
+    override suspend fun setTasbihSoundEnabled(enabled: Boolean) =
         put(PreferencesKeys.TASBIH_SOUND_ENABLED, enabled)
 
     // Location
-    val latitude: Flow<Double> = preference(PreferencesKeys.LATITUDE, 0.0)
+    override val latitude: Flow<Double> = preference(PreferencesKeys.LATITUDE, 0.0)
 
-    val longitude: Flow<Double> = preference(PreferencesKeys.LONGITUDE, 0.0)
+    override val longitude: Flow<Double> = preference(PreferencesKeys.LONGITUDE, 0.0)
 
-    val locationName: Flow<String> = preference(PreferencesKeys.LOCATION_NAME, "")
+    override val locationName: Flow<String> = preference(PreferencesKeys.LOCATION_NAME, "")
 
-    suspend fun updateLocation(latitude: Double, longitude: Double, name: String) {
+    override suspend fun updateLocation(latitude: Double, longitude: Double, name: String) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.LATITUDE] = latitude
             preferences[PreferencesKeys.LONGITUDE] = longitude
@@ -593,7 +595,7 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Export all preferences as key-value map for sync
-    suspend fun exportAllPreferences(): Map<String, String> {
+    override suspend fun exportAllPreferences(): Map<String, String> {
         val preferences = dataStore.data.first()
         return preferences.asMap().map { (key, value) ->
             key.name to value.toString()
@@ -601,7 +603,7 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Import preferences from sync payload
-    suspend fun importPreferences(prefsMap: Map<String, String>) {
+    override suspend fun importPreferences(prefsMap: Map<String, String>) {
         dataStore.edit { preferences ->
             prefsMap.forEach { (key, value) ->
                 when {
@@ -636,7 +638,7 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // Combined user preferences
-    val userPreferences: Flow<UserPreferences> = dataStore.data.map { preferences ->
+    override val userPreferences: Flow<UserPreferences> = dataStore.data.map { preferences ->
         UserPreferences(
             onboardingCompleted = preferences[PreferencesKeys.ONBOARDING_COMPLETED] ?: false,
             themeMode = preferences[PreferencesKeys.THEME_MODE] ?: "system",
@@ -656,18 +658,3 @@ class PreferencesDataStore @Inject constructor(
         )
     }
 }
-
-data class UserPreferences(
-    val onboardingCompleted: Boolean,
-    val themeMode: String,
-    val dynamicColor: Boolean,
-    val appLanguage: String,
-    val calculationMethod: String,
-    val asrCalculation: String,
-    val latitude: Double,
-    val longitude: Double,
-    val locationName: String,
-    val prayerNotificationsEnabled: Boolean,
-    val quranTranslatorId: String,
-    val showTranslation: Boolean
-)

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.database.dao.AsmaUlHusnaDao
 import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaEntity
 import com.arshadshah.nimaz.domain.model.AsmaUlHusna
@@ -54,6 +55,7 @@ class AsmaUlHusnaRepositoryImpl @Inject constructor(
             val jsonArray = JSONArray(quranReferences)
             (0 until jsonArray.length()).map { jsonArray.getString(it) }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             emptyList()
         }
         return AsmaUlHusna(

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
@@ -46,6 +46,12 @@ class DuaRepositoryImpl @Inject constructor(
         duaDao.getDuasByCategory(categoryId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
+    override suspend fun getDuasByCategoryOnce(categoryId: String): List<Dua> {
+        seeder.seedIfNeeded()
+        return duaDao.getDuasByCategoryOnce(categoryId.toIntOrNull() ?: return emptyList())
+            .map { it.toDomain() }
+    }
+
     override suspend fun getDuaById(duaId: String): Dua? {
         seeder.seedIfNeeded()
         return duaDao.getDuaById(duaId.toIntOrNull() ?: return null)?.toDomain()

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.data.repository
 
 import com.arshadshah.nimaz.data.local.database.dao.HadithDao
+import com.arshadshah.nimaz.data.local.hadith.HadithBackfillSeeder
 import com.arshadshah.nimaz.data.local.database.entity.HadithBookEntity
 import com.arshadshah.nimaz.data.local.database.entity.HadithBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.HadithEntity
@@ -22,8 +23,19 @@ import javax.inject.Singleton
 
 @Singleton
 class HadithRepositoryImpl @Inject constructor(
-    private val hadithDao: HadithDao
+    private val hadithDao: HadithDao,
+    private val backfillSeeder: HadithBackfillSeeder
 ) : HadithRepository {
+
+    override suspend fun getHadithCount(): Int {
+        backfillSeeder.seedIfNeeded()
+        return hadithDao.getHadithCount()
+    }
+
+    override suspend fun getHadithByOffset(offset: Int): Hadith? {
+        backfillSeeder.seedIfNeeded()
+        return hadithDao.getHadithByOffset(offset)?.toDomain()
+    }
 
     override suspend fun getHadithOfTheDay(): Hadith? {
         val totalHadiths = hadithDao.getHadithCount()

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/HelpRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/HelpRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.database.dao.HelpDao
 import com.arshadshah.nimaz.data.local.database.entity.HelpStringEntity
 import com.arshadshah.nimaz.data.local.help.HelpContentSeeder
@@ -47,7 +48,7 @@ class HelpRepositoryImpl @Inject constructor(
         if (raw.isNullOrBlank()) emptyList()
         else runCatching {
             helpJson.decodeFromString(ListSerializer(String.serializer()), raw)
-        }.getOrDefault(emptyList())
+        }.onFailure { CrashReporter.recordException(it) }.getOrDefault(emptyList())
 
     /** Seed once, then emit DB-backed flows. */
     private fun <T> seededFlow(block: () -> Flow<T>): Flow<T> =

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/IslamicEventRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/IslamicEventRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.mapItems
 import com.arshadshah.nimaz.data.local.database.dao.IslamicEventDao
 import com.arshadshah.nimaz.data.local.database.entity.IslamicEventEntity
@@ -30,7 +31,8 @@ private fun IslamicEventEntity.toDomain(): IslamicEvent {
         hijriDay = hijriDay,
         eventType = try {
             IslamicEventType.valueOf(eventType.uppercase())
-        } catch (_: IllegalArgumentException) {
+        } catch (e: IllegalArgumentException) {
+            CrashReporter.recordException(e)
             IslamicEventType.HOLIDAY
         },
         isHoliday = isHoliday == 1,

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/IslamicEventRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/IslamicEventRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.core.util.mapItems
+import com.arshadshah.nimaz.data.local.database.dao.IslamicEventDao
+import com.arshadshah.nimaz.data.local.database.entity.IslamicEventEntity
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import com.arshadshah.nimaz.domain.model.IslamicEventType
+import com.arshadshah.nimaz.domain.repository.IslamicEventRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IslamicEventRepositoryImpl @Inject constructor(
+    private val islamicEventDao: IslamicEventDao
+) : IslamicEventRepository {
+
+    override fun getAllEvents(): Flow<List<IslamicEvent>> {
+        return islamicEventDao.getAllEvents().mapItems { it.toDomain() }
+    }
+}
+
+private fun IslamicEventEntity.toDomain(): IslamicEvent {
+    return IslamicEvent(
+        id = id.toString(),
+        nameArabic = nameArabic,
+        nameEnglish = nameEnglish,
+        description = description,
+        hijriMonth = hijriMonth,
+        hijriDay = hijriDay,
+        eventType = try {
+            IslamicEventType.valueOf(eventType.uppercase())
+        } catch (_: IllegalArgumentException) {
+            IslamicEventType.HOLIDAY
+        },
+        isHoliday = isHoliday == 1,
+        isFastingDay = eventType.equals("fast", ignoreCase = true),
+        isNightOfPower = eventType.equals("night", ignoreCase = true),
+        gregorianDate = null,
+        year = null,
+        notes = null,
+        priority = 0
+    )
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.database.dao.ProphetDao
 import com.arshadshah.nimaz.data.local.database.entity.ProphetEntity
 import com.arshadshah.nimaz.domain.model.Prophet
@@ -54,6 +55,7 @@ class ProphetRepositoryImpl @Inject constructor(
             val jsonArray = JSONArray(json)
             (0 until jsonArray.length()).map { jsonArray.getString(it) }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             emptyList()
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QaidaRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.database.dao.QaidaDao
 import com.arshadshah.nimaz.data.local.database.entity.QaidaCellEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaCellProgressEntity
@@ -123,6 +124,7 @@ class QaidaRepositoryImpl @Inject constructor(
             val jsonArray = JSONArray(json)
             (0 until jsonArray.length()).map { jsonArray.getString(it) }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             emptyList()
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.data.repository
 
-import com.arshadshah.nimaz.data.local.database.dao.PageAyahRange
+import com.arshadshah.nimaz.data.local.database.dao.PageAyahRangeRow
+import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.data.local.database.dao.QuranDao
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
@@ -122,7 +123,7 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPageAyahRanges(): List<PageAyahRange> {
-        return quranDao.getPageAyahRanges()
+        return quranDao.getPageAyahRanges().map { it.toDomain() }
     }
 
     override fun getSurahWithAyahs(surahNumber: Int, translatorId: String?): Flow<SurahWithAyahs?> {
@@ -394,6 +395,15 @@ class QuranRepositoryImpl @Inject constructor(
             totalAyahsRead = totalAyahsRead,
             currentKhatmaCount = currentKhatmaCount,
             updatedAt = updatedAt
+        )
+    }
+
+    private fun PageAyahRangeRow.toDomain(): PageAyahRange {
+        return PageAyahRange(
+            page = page,
+            minAyahId = minAyahId,
+            maxAyahId = maxAyahId,
+            ayahCount = ayahCount
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.mapItems
 import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
 import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
@@ -43,7 +44,9 @@ private fun ZakatHistoryEntity.toDomain() = ZakatHistoryEntry(
     totalLiabilities = totalLiabilities,
     netWorth = netWorth,
     zakatDue = zakatDue,
-    nisabType = runCatching { NisabType.valueOf(nisabType) }.getOrDefault(NisabType.GOLD),
+    nisabType = runCatching { NisabType.valueOf(nisabType) }
+        .onFailure { CrashReporter.recordException(it) }
+        .getOrDefault(NisabType.GOLD),
     nisabValue = nisabValue,
     isPaid = isPaid,
     paidAt = paidAt,

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/ZakatRepositoryImpl.kt
@@ -1,7 +1,10 @@
 package com.arshadshah.nimaz.data.repository
 
+import com.arshadshah.nimaz.core.util.mapItems
 import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
 import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
 import com.arshadshah.nimaz.domain.repository.ZakatRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -12,12 +15,12 @@ class ZakatRepositoryImpl @Inject constructor(
     private val zakatDao: ZakatDao
 ) : ZakatRepository {
 
-    override fun getAllHistory(): Flow<List<ZakatHistoryEntity>> {
-        return zakatDao.getAllHistory()
+    override fun getAllHistory(): Flow<List<ZakatHistoryEntry>> {
+        return zakatDao.getAllHistory().mapItems { it.toDomain() }
     }
 
-    override suspend fun insertCalculation(entry: ZakatHistoryEntity): Long {
-        return zakatDao.insertCalculation(entry)
+    override suspend fun insertCalculation(entry: ZakatHistoryEntry): Long {
+        return zakatDao.insertCalculation(entry.toEntity())
     }
 
     override suspend fun markAsPaid(id: Long, paidAt: Long) {
@@ -32,3 +35,31 @@ class ZakatRepositoryImpl @Inject constructor(
         zakatDao.deleteCalculation(id)
     }
 }
+
+private fun ZakatHistoryEntity.toDomain() = ZakatHistoryEntry(
+    id = id,
+    calculatedAt = calculatedAt,
+    totalAssets = totalAssets,
+    totalLiabilities = totalLiabilities,
+    netWorth = netWorth,
+    zakatDue = zakatDue,
+    nisabType = runCatching { NisabType.valueOf(nisabType) }.getOrDefault(NisabType.GOLD),
+    nisabValue = nisabValue,
+    isPaid = isPaid,
+    paidAt = paidAt,
+    notes = notes
+)
+
+private fun ZakatHistoryEntry.toEntity() = ZakatHistoryEntity(
+    id = id,
+    calculatedAt = calculatedAt,
+    totalAssets = totalAssets,
+    totalLiabilities = totalLiabilities,
+    netWorth = netWorth,
+    zakatDue = zakatDue,
+    nisabType = nisabType.name,
+    nisabValue = nisabValue,
+    isPaid = isPaid,
+    paidAt = paidAt,
+    notes = notes
+)

--- a/app/src/main/java/com/arshadshah/nimaz/data/sync/NearbyConnectionsManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/sync/NearbyConnectionsManager.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.data.sync
 
 import android.content.Context
 import android.util.Log
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.google.android.gms.nearby.Nearby
 import com.google.android.gms.nearby.connection.AdvertisingOptions
 import com.google.android.gms.nearby.connection.ConnectionInfo
@@ -186,6 +187,7 @@ class NearbyConnectionsManager @Inject constructor(
                                         ConnectionState.Error("No data handler registered")
                                 }
                         } catch (e: Exception) {
+                            CrashReporter.recordException(e)
                             Log.e(TAG, "BYTES data payload: decompression failed", e)
                             _connectionState.value =
                                 ConnectionState.Error("Failed to decompress: ${e.message}")
@@ -240,6 +242,7 @@ class NearbyConnectionsManager @Inject constructor(
                                         ConnectionState.Error("No data handler registered")
                                 }
                         } catch (e: Exception) {
+                            CrashReporter.recordException(e)
                             Log.e(TAG, "STREAM ${payload.id}: read failed", e)
                             _connectionState.value =
                                 ConnectionState.Error("Failed to read data: ${e.message}")

--- a/app/src/main/java/com/arshadshah/nimaz/data/sync/SyncSignal.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/sync/SyncSignal.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.data.sync
 
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -53,7 +54,8 @@ sealed class SyncSignal {
 
         fun decode(bytes: ByteArray): SyncSignal? = try {
             json.decodeFromString(serializer(), String(bytes, Charsets.UTF_8))
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            CrashReporter.recordException(e)
             null
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/DuaModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/DuaModels.kt
@@ -10,6 +10,13 @@ data class DuaCategory(
     val duaCount: Int
 )
 
+/** A single dua chosen for "dua of the day", with its category label/icon. */
+data class DailyDuaSelection(
+    val dua: Dua,
+    val categoryName: String,
+    val categoryIcon: String?
+)
+
 data class Dua(
     val id: String,
     val categoryId: String,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranModels.kt
@@ -56,6 +56,14 @@ data class QuranBookmark(
     val updatedAt: Long
 )
 
+/** The span of ayah ids that make up a single mushaf page. */
+data class PageAyahRange(
+    val page: Int,
+    val minAyahId: Int,
+    val maxAyahId: Int,
+    val ayahCount: Int
+)
+
 data class ReadingProgress(
     val lastReadSurah: Int,
     val lastReadAyah: Int,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/SettingsModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/SettingsModels.kt
@@ -1,0 +1,17 @@
+package com.arshadshah.nimaz.domain.model
+
+/** Combined snapshot of the most commonly-read user preferences. */
+data class UserPreferences(
+    val onboardingCompleted: Boolean,
+    val themeMode: String,
+    val dynamicColor: Boolean,
+    val appLanguage: String,
+    val calculationMethod: String,
+    val asrCalculation: String,
+    val latitude: Double,
+    val longitude: Double,
+    val locationName: String,
+    val prayerNotificationsEnabled: Boolean,
+    val quranTranslatorId: String,
+    val showTranslation: Boolean
+)

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/ZakatModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/ZakatModels.kt
@@ -17,6 +17,21 @@ data class ZakatCalculation(
     val note: String? = null
 )
 
+/** A persisted zakat calculation record, including payment status. */
+data class ZakatHistoryEntry(
+    val id: Long = 0,
+    val calculatedAt: Long,
+    val totalAssets: Double,
+    val totalLiabilities: Double,
+    val netWorth: Double,
+    val zakatDue: Double,
+    val nisabType: NisabType,
+    val nisabValue: Double,
+    val isPaid: Boolean = false,
+    val paidAt: Long? = null,
+    val notes: String? = null
+)
+
 data class ZakatAssets(
     val cashOnHand: Double = 0.0,
     val bankBalance: Double = 0.0,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/DuaRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/DuaRepository.kt
@@ -15,6 +15,7 @@ interface DuaRepository {
 
     // Dua operations
     fun getDuasByCategory(categoryId: String): Flow<List<Dua>>
+    suspend fun getDuasByCategoryOnce(categoryId: String): List<Dua>
     suspend fun getDuaById(duaId: String): Dua?
     fun getDuasByOccasion(occasion: DuaOccasion): Flow<List<Dua>>
 

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
@@ -41,6 +41,10 @@ interface HadithRepository {
     suspend fun updateBookmark(bookmark: HadithBookmark)
     suspend fun deleteBookmark(hadithId: String)
 
+    // Daily content (seeds the backfill before reading)
+    suspend fun getHadithCount(): Int
+    suspend fun getHadithByOffset(offset: Int): Hadith?
+
     // Data initialization
     suspend fun initializeHadithData()
     suspend fun isDataInitialized(): Boolean

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/IslamicEventRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/IslamicEventRepository.kt
@@ -1,0 +1,8 @@
+package com.arshadshah.nimaz.domain.repository
+
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import kotlinx.coroutines.flow.Flow
+
+interface IslamicEventRepository {
+    fun getAllEvents(): Flow<List<IslamicEvent>>
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
@@ -1,6 +1,6 @@
 package com.arshadshah.nimaz.domain.repository
 
-import com.arshadshah.nimaz.data.local.database.dao.PageAyahRange
+import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.QuranBookmark
 import com.arshadshah.nimaz.domain.model.QuranFavorite

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
@@ -1,0 +1,158 @@
+package com.arshadshah.nimaz.domain.repository
+
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * App-wide user settings/preferences. Implemented by the DataStore-backed
+ * PreferencesDataStore in the data layer; presentation depends on this interface.
+ */
+interface SettingsRepository {
+    suspend fun clearAllData()
+    val onboardingCompleted: Flow<Boolean>
+    suspend fun setOnboardingCompleted(completed: Boolean)
+    val themeMode: Flow<String>
+    suspend fun setThemeMode(mode: String)
+    val dynamicColor: Flow<Boolean>
+    suspend fun setDynamicColor(enabled: Boolean)
+    val showIslamicPatterns: Flow<Boolean>
+    suspend fun setShowIslamicPatterns(enabled: Boolean)
+    val animationsEnabled: Flow<Boolean>
+    suspend fun setAnimationsEnabled(enabled: Boolean)
+    val showCountdown: Flow<Boolean>
+    suspend fun setShowCountdown(enabled: Boolean)
+    val showQuickActions: Flow<Boolean>
+    suspend fun setShowQuickActions(enabled: Boolean)
+    val hapticFeedback: Flow<Boolean>
+    suspend fun setHapticFeedback(enabled: Boolean)
+    val use24HourFormat: Flow<Boolean>
+    suspend fun setUse24HourFormat(enabled: Boolean)
+    val useHijriPrimary: Flow<Boolean>
+    suspend fun setUseHijriPrimary(enabled: Boolean)
+    val appLanguage: Flow<String>
+    suspend fun setAppLanguage(language: String)
+    val helpContentVersion: Flow<Int>
+    suspend fun setHelpContentVersion(version: Int)
+    val hadithBackfillVersion: Flow<Int>
+    suspend fun setHadithBackfillVersion(version: Int)
+    val tasbihBeadMode: Flow<Boolean>
+    suspend fun setTasbihBeadMode(enabled: Boolean)
+    val tasbihBeadDesign: Flow<String>
+    suspend fun setTasbihBeadDesign(key: String)
+    val tasbihSelectedPresetId: Flow<Long>
+    suspend fun setTasbihSelectedPresetId(id: Long)
+    val tasbihPresetSeedVersion: Flow<Int>
+    suspend fun setTasbihPresetSeedVersion(version: Int)
+    val tasbihFavorites: Flow<Set<String>>
+    suspend fun setTasbihFavorites(ids: Set<String>)
+    val tasbihLeftHanded: Flow<Boolean>
+    suspend fun setTasbihLeftHanded(enabled: Boolean)
+    val duaContentVersion: Flow<Int>
+    suspend fun setDuaContentVersion(version: Int)
+    val qaidaContentVersion: Flow<Int>
+    suspend fun setQaidaContentVersion(version: Int)
+    val arabicFontSize: Flow<String>
+    suspend fun setArabicFontSize(size: String)
+    val calculationMethod: Flow<String>
+    suspend fun setCalculationMethod(method: String)
+    val asrCalculation: Flow<String>
+    suspend fun setAsrCalculation(calculation: String)
+    val highLatitudeRule: Flow<String>
+    suspend fun setHighLatitudeRule(rule: String)
+    val currentLocationId: Flow<Long?>
+    suspend fun setCurrentLocationId(id: Long)
+    val fajrAdjustment: Flow<Int>
+    val sunriseAdjustment: Flow<Int>
+    val dhuhrAdjustment: Flow<Int>
+    val asrAdjustment: Flow<Int>
+    val maghribAdjustment: Flow<Int>
+    val ishaAdjustment: Flow<Int>
+    suspend fun setPrayerAdjustment(prayer: String, minutes: Int)
+    val prayerNotificationsEnabled: Flow<Boolean>
+    suspend fun setPrayerNotificationsEnabled(enabled: Boolean)
+    val adhanEnabled: Flow<Boolean>
+    suspend fun setAdhanEnabled(enabled: Boolean)
+    val selectedAdhanSound: Flow<String>
+    suspend fun setSelectedAdhanSound(sound: String)
+    val fajrNotificationEnabled: Flow<Boolean>
+    val sunriseNotificationEnabled: Flow<Boolean>
+    val dhuhrNotificationEnabled: Flow<Boolean>
+    val asrNotificationEnabled: Flow<Boolean>
+    val maghribNotificationEnabled: Flow<Boolean>
+    val ishaNotificationEnabled: Flow<Boolean>
+    suspend fun setPrayerNotificationEnabled(prayer: String, enabled: Boolean)
+    val fajrAdhanEnabled: Flow<Boolean>
+    val dhuhrAdhanEnabled: Flow<Boolean>
+    val asrAdhanEnabled: Flow<Boolean>
+    val maghribAdhanEnabled: Flow<Boolean>
+    val ishaAdhanEnabled: Flow<Boolean>
+    suspend fun setPrayerAdhanEnabled(prayer: String, enabled: Boolean)
+    fun isAdhanEnabledForPrayer(prayer: String): Flow<Boolean>
+    val adhanRespectDnd: Flow<Boolean>
+    suspend fun setAdhanRespectDnd(enabled: Boolean)
+    val notificationVibration: Flow<Boolean>
+    suspend fun setNotificationVibration(enabled: Boolean)
+    val notificationReminderMinutes: Flow<Int>
+    suspend fun setNotificationReminderMinutes(minutes: Int)
+    val showReminderBefore: Flow<Boolean>
+    suspend fun setShowReminderBefore(enabled: Boolean)
+    val persistentNotification: Flow<Boolean>
+    suspend fun setPersistentNotification(enabled: Boolean)
+    val quranTranslatorId: Flow<String>
+    suspend fun setQuranTranslatorId(translatorId: String)
+    val showTranslation: Flow<Boolean>
+    suspend fun setShowTranslation(show: Boolean)
+    val showTransliteration: Flow<Boolean>
+    suspend fun setShowTransliteration(show: Boolean)
+    val selectedReciterId: Flow<String?>
+    suspend fun setSelectedReciterId(reciterId: String?)
+    val quranArabicFont: Flow<String>
+    suspend fun setQuranArabicFont(fontId: String)
+    val quranArabicFontSize: Flow<Float>
+    suspend fun setQuranArabicFontSize(size: Float)
+    val quranTranslationFontSize: Flow<Float>
+    suspend fun setQuranTranslationFontSize(size: Float)
+    val continuousReading: Flow<Boolean>
+    suspend fun setContinuousReading(enabled: Boolean)
+    val keepScreenOn: Flow<Boolean>
+    suspend fun setKeepScreenOn(enabled: Boolean)
+    val showTajweed: Flow<Boolean>
+    suspend fun setShowTajweed(enabled: Boolean)
+    val duaArabicFont: Flow<String>
+    suspend fun setDuaArabicFont(fontId: String)
+    val duaArabicFontSize: Flow<Float>
+    suspend fun setDuaArabicFontSize(size: Float)
+    val duaTranslationFontSize: Flow<Float>
+    suspend fun setDuaTranslationFontSize(size: Float)
+    val duaShowArabic: Flow<Boolean>
+    suspend fun setDuaShowArabic(show: Boolean)
+    val duaShowTransliteration: Flow<Boolean>
+    suspend fun setDuaShowTransliteration(show: Boolean)
+    val duaShowTranslation: Flow<Boolean>
+    suspend fun setDuaShowTranslation(show: Boolean)
+    val hadithArabicFont: Flow<String>
+    suspend fun setHadithArabicFont(fontId: String)
+    val hadithArabicFontSize: Flow<Float>
+    suspend fun setHadithArabicFontSize(size: Float)
+    val hadithTranslationFontSize: Flow<Float>
+    suspend fun setHadithTranslationFontSize(size: Float)
+    val hadithShowArabic: Flow<Boolean>
+    suspend fun setHadithShowArabic(show: Boolean)
+    val hadithShowTranslation: Flow<Boolean>
+    suspend fun setHadithShowTranslation(show: Boolean)
+    val hadithShowGrade: Flow<Boolean>
+    suspend fun setHadithShowGrade(show: Boolean)
+    val hadithShowChain: Flow<Boolean>
+    suspend fun setHadithShowChain(show: Boolean)
+    val tasbihVibrationEnabled: Flow<Boolean>
+    suspend fun setTasbihVibrationEnabled(enabled: Boolean)
+    val tasbihSoundEnabled: Flow<Boolean>
+    suspend fun setTasbihSoundEnabled(enabled: Boolean)
+    val latitude: Flow<Double>
+    val longitude: Flow<Double>
+    val locationName: Flow<String>
+    suspend fun updateLocation(latitude: Double, longitude: Double, name: String)
+    suspend fun exportAllPreferences(): Map<String, String>
+    suspend fun importPreferences(prefsMap: Map<String, String>)
+    val userPreferences: Flow<UserPreferences>
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/ZakatRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/ZakatRepository.kt
@@ -1,11 +1,11 @@
 package com.arshadshah.nimaz.domain.repository
 
-import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
 import kotlinx.coroutines.flow.Flow
 
 interface ZakatRepository {
-    fun getAllHistory(): Flow<List<ZakatHistoryEntity>>
-    suspend fun insertCalculation(entry: ZakatHistoryEntity): Long
+    fun getAllHistory(): Flow<List<ZakatHistoryEntry>>
+    suspend fun insertCalculation(entry: ZakatHistoryEntry): Long
     suspend fun markAsPaid(id: Long, paidAt: Long)
     suspend fun getTotalPaid(): Double
     suspend fun deleteCalculation(id: Long)

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
@@ -1,0 +1,64 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaBookmark
+import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.domain.model.DuaProgress
+import com.arshadshah.nimaz.domain.model.DuaSearchResult
+import com.arshadshah.nimaz.domain.repository.DuaRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class DuaUseCases(
+    val getAllCategories: GetAllCategoriesUseCase,
+    val getCategoryById: GetCategoryByIdUseCase,
+    val getDuaById: GetDuaByIdUseCase,
+    val getDuasByCategory: GetDuasByCategoryUseCase,
+    val getDuasByOccasion: GetDuasByOccasionUseCase,
+    val getFavoriteDuas: GetFavoriteDuasUseCase,
+    val getProgressForDate: GetProgressForDateUseCase,
+    val isDuaFavorite: IsDuaFavoriteUseCase,
+    val searchDuas: SearchDuasUseCase,
+    val toggleFavorite: ToggleFavoriteUseCase
+)
+
+class GetAllCategoriesUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(): Flow<List<DuaCategory>> = repository.getAllCategories()
+}
+
+class GetCategoryByIdUseCase @Inject constructor(private val repository: DuaRepository) {
+    suspend operator fun invoke(categoryId: String): DuaCategory? = repository.getCategoryById(categoryId)
+}
+
+class GetDuaByIdUseCase @Inject constructor(private val repository: DuaRepository) {
+    suspend operator fun invoke(duaId: String): Dua? = repository.getDuaById(duaId)
+}
+
+class GetDuasByCategoryUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(categoryId: String): Flow<List<Dua>> = repository.getDuasByCategory(categoryId)
+}
+
+class GetDuasByOccasionUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(occasion: DuaOccasion): Flow<List<Dua>> = repository.getDuasByOccasion(occasion)
+}
+
+class GetFavoriteDuasUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(): Flow<List<DuaBookmark>> = repository.getFavoriteDuas()
+}
+
+class GetProgressForDateUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(date: Long): Flow<List<DuaProgress>> = repository.getProgressForDate(date)
+}
+
+class IsDuaFavoriteUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(duaId: String): Flow<Boolean> = repository.isDuaFavorite(duaId)
+}
+
+class SearchDuasUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(query: String): Flow<List<DuaSearchResult>> = repository.searchDuas(query)
+}
+
+class ToggleFavoriteUseCase @Inject constructor(private val repository: DuaRepository) {
+    suspend operator fun invoke(duaId: String, categoryId: String) = repository.toggleFavorite(duaId, categoryId)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.domain.usecase
 
+import com.arshadshah.nimaz.domain.model.DailyDuaSelection
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.DuaCategory
@@ -22,7 +23,8 @@ data class DuaUseCases(
     val searchDuas: SearchDuasUseCase,
     val toggleFavorite: ToggleDuaFavoriteUseCase,
     val getAllBookmarks: GetDuaBookmarksUseCase,
-    val deleteBookmark: DeleteDuaBookmarkUseCase
+    val deleteBookmark: DeleteDuaBookmarkUseCase,
+    val getDailyDua: GetDailyDuaUseCase
 )
 
 class GetAllCategoriesUseCase @Inject constructor(private val repository: DuaRepository) {
@@ -71,4 +73,37 @@ class GetDuaBookmarksUseCase @Inject constructor(private val repository: DuaRepo
 
 class DeleteDuaBookmarkUseCase @Inject constructor(private val repository: DuaRepository) {
     suspend operator fun invoke(duaId: String) = repository.deleteBookmark(duaId)
+}
+
+/**
+ * "Dua of the day": picks the adhkar category appropriate to the time of day, then
+ * rotates the specific dua within it daily. [hourOfDay] and [dayOfYear] are passed
+ * in so the use case stays pure/testable.
+ */
+class GetDailyDuaUseCase @Inject constructor(private val repository: DuaRepository) {
+    suspend operator fun invoke(hourOfDay: Int, dayOfYear: Int): DailyDuaSelection? {
+        val categoryId = categoryIdForHour(hourOfDay)
+        val category = repository.getCategoryById(categoryId) ?: return null
+        val duas = repository.getDuasByCategoryOnce(categoryId)
+        if (duas.isEmpty()) return null
+        val index = (dayOfYear % duas.size).coerceIn(0, duas.size - 1)
+        return DailyDuaSelection(
+            dua = duas[index],
+            categoryName = category.nameEnglish,
+            categoryIcon = category.iconName
+        )
+    }
+
+    // Adhkar category ids from the prepopulated `dua_categories` table.
+    private fun categoryIdForHour(hour: Int): String = when (hour) {
+        in 4..15 -> CATEGORY_MORNING
+        in 16..20 -> CATEGORY_EVENING
+        else -> CATEGORY_BEFORE_SLEEP
+    }
+
+    private companion object {
+        const val CATEGORY_MORNING = "1"
+        const val CATEGORY_EVENING = "2"
+        const val CATEGORY_BEFORE_SLEEP = "5"
+    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
@@ -20,7 +20,9 @@ data class DuaUseCases(
     val getProgressForDate: GetProgressForDateUseCase,
     val isDuaFavorite: IsDuaFavoriteUseCase,
     val searchDuas: SearchDuasUseCase,
-    val toggleFavorite: ToggleDuaFavoriteUseCase
+    val toggleFavorite: ToggleDuaFavoriteUseCase,
+    val getAllBookmarks: GetDuaBookmarksUseCase,
+    val deleteBookmark: DeleteDuaBookmarkUseCase
 )
 
 class GetAllCategoriesUseCase @Inject constructor(private val repository: DuaRepository) {
@@ -61,4 +63,12 @@ class SearchDuasUseCase @Inject constructor(private val repository: DuaRepositor
 
 class ToggleDuaFavoriteUseCase @Inject constructor(private val repository: DuaRepository) {
     suspend operator fun invoke(duaId: String, categoryId: String) = repository.toggleFavorite(duaId, categoryId)
+}
+
+class GetDuaBookmarksUseCase @Inject constructor(private val repository: DuaRepository) {
+    operator fun invoke(): Flow<List<DuaBookmark>> = repository.getAllBookmarks()
+}
+
+class DeleteDuaBookmarkUseCase @Inject constructor(private val repository: DuaRepository) {
+    suspend operator fun invoke(duaId: String) = repository.deleteBookmark(duaId)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
@@ -20,7 +20,7 @@ data class DuaUseCases(
     val getProgressForDate: GetProgressForDateUseCase,
     val isDuaFavorite: IsDuaFavoriteUseCase,
     val searchDuas: SearchDuasUseCase,
-    val toggleFavorite: ToggleFavoriteUseCase
+    val toggleFavorite: ToggleDuaFavoriteUseCase
 )
 
 class GetAllCategoriesUseCase @Inject constructor(private val repository: DuaRepository) {
@@ -59,6 +59,6 @@ class SearchDuasUseCase @Inject constructor(private val repository: DuaRepositor
     operator fun invoke(query: String): Flow<List<DuaSearchResult>> = repository.searchDuas(query)
 }
 
-class ToggleFavoriteUseCase @Inject constructor(private val repository: DuaRepository) {
+class ToggleDuaFavoriteUseCase @Inject constructor(private val repository: DuaRepository) {
     suspend operator fun invoke(duaId: String, categoryId: String) = repository.toggleFavorite(duaId, categoryId)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/FastingUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/FastingUseCases.kt
@@ -1,0 +1,102 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastingStats
+import com.arshadshah.nimaz.domain.model.MakeupFast
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class FastingUseCases(
+    val getFastRecordForDate: GetFastRecordForDateUseCase,
+    val getFastRecordsInRange: GetFastRecordsInRangeUseCase,
+    val insertFastRecord: InsertFastRecordUseCase,
+    val updateFastRecord: UpdateFastRecordUseCase,
+    val updateFastStatus: UpdateFastStatusUseCase,
+    val deleteFastRecordByDate: DeleteFastRecordByDateUseCase,
+    val getRamadanFastedCount: GetRamadanFastedCountUseCase,
+    val getVoluntaryFastCount: GetVoluntaryFastCountUseCase,
+    val getFastingStats: GetFastingStatsUseCase,
+    val getAllMakeupFasts: GetAllMakeupFastsUseCase,
+    val getPendingMakeupFasts: GetPendingMakeupFastsUseCase,
+    val getMakeupFastCountForDate: GetMakeupFastCountForDateUseCase,
+    val insertMakeupFast: InsertMakeupFastUseCase,
+    val updateMakeupFast: UpdateMakeupFastUseCase,
+    val markMakeupFastCompleted: MarkMakeupFastCompletedUseCase,
+    val markFidyaPaid: MarkFidyaPaidUseCase,
+    val getTotalFidyaPaid: GetTotalFidyaPaidUseCase
+)
+
+class GetFastRecordForDateUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(date: Long): FastRecord? = repository.getFastRecordForDate(date)
+}
+
+class GetFastRecordsInRangeUseCase @Inject constructor(private val repository: FastingRepository) {
+    operator fun invoke(startDate: Long, endDate: Long): Flow<List<FastRecord>> =
+        repository.getFastRecordsInRange(startDate, endDate)
+}
+
+class InsertFastRecordUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(record: FastRecord) = repository.insertFastRecord(record)
+}
+
+class UpdateFastRecordUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(record: FastRecord) = repository.updateFastRecord(record)
+}
+
+class UpdateFastStatusUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(date: Long, status: FastStatus) =
+        repository.updateFastStatus(date, status)
+}
+
+class DeleteFastRecordByDateUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(date: Long) = repository.deleteFastRecordByDate(date)
+}
+
+class GetRamadanFastedCountUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(): Int = repository.getRamadanFastedCount()
+}
+
+class GetVoluntaryFastCountUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(): Int = repository.getVoluntaryFastCount()
+}
+
+class GetFastingStatsUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(startDate: Long, endDate: Long): FastingStats =
+        repository.getFastingStats(startDate, endDate)
+}
+
+class GetAllMakeupFastsUseCase @Inject constructor(private val repository: FastingRepository) {
+    operator fun invoke(): Flow<List<MakeupFast>> = repository.getAllMakeupFasts()
+}
+
+class GetPendingMakeupFastsUseCase @Inject constructor(private val repository: FastingRepository) {
+    operator fun invoke(): Flow<List<MakeupFast>> = repository.getPendingMakeupFasts()
+}
+
+class GetMakeupFastCountForDateUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(originalDate: Long): Int =
+        repository.getMakeupFastCountForDate(originalDate)
+}
+
+class InsertMakeupFastUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(makeupFast: MakeupFast) = repository.insertMakeupFast(makeupFast)
+}
+
+class UpdateMakeupFastUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(makeupFast: MakeupFast) = repository.updateMakeupFast(makeupFast)
+}
+
+class MarkMakeupFastCompletedUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(id: Long, completedDate: Long) =
+        repository.markMakeupFastCompleted(id, completedDate)
+}
+
+class MarkFidyaPaidUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(id: Long, amount: Double) = repository.markFidyaPaid(id, amount)
+}
+
+class GetTotalFidyaPaidUseCase @Inject constructor(private val repository: FastingRepository) {
+    suspend operator fun invoke(): Double = repository.getTotalFidyaPaid()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
@@ -1,0 +1,87 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithBook
+import com.arshadshah.nimaz.domain.model.HadithBookmark
+import com.arshadshah.nimaz.domain.model.HadithChapter
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.domain.model.HadithSearchResult
+import com.arshadshah.nimaz.domain.repository.HadithRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class HadithUseCases(
+    val getAllBooks: GetAllBooksUseCase,
+    val getBookById: GetBookByIdUseCase,
+    val getChaptersByBook: GetChaptersByBookUseCase,
+    val getChapterById: GetChapterByIdUseCase,
+    val getHadithsByChapter: GetHadithsByChapterUseCase,
+    val getHadithById: GetHadithByIdUseCase,
+    val getHadithByNumber: GetHadithByNumberUseCase,
+    val getHadithsByGrade: GetHadithsByGradeUseCase,
+    val getHadithOfTheDay: GetHadithOfTheDayUseCase,
+    val searchHadiths: SearchHadithsUseCase,
+    val searchHadithsInBook: SearchHadithsInBookUseCase,
+    val getAllBookmarks: GetAllBookmarksUseCase,
+    val isHadithBookmarked: IsHadithBookmarkedUseCase,
+    val toggleBookmark: ToggleBookmarkUseCase
+)
+
+class GetAllBooksUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(): Flow<List<HadithBook>> = repository.getAllBooks()
+}
+
+class GetBookByIdUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(bookId: String): HadithBook? = repository.getBookById(bookId)
+}
+
+class GetChaptersByBookUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(bookId: String): Flow<List<HadithChapter>> = repository.getChaptersByBook(bookId)
+}
+
+class GetChapterByIdUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(chapterId: String): HadithChapter? = repository.getChapterById(chapterId)
+}
+
+class GetHadithsByChapterUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(chapterId: String): Flow<List<Hadith>> = repository.getHadithsByChapter(chapterId)
+}
+
+class GetHadithByIdUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(hadithId: String): Hadith? = repository.getHadithById(hadithId)
+}
+
+class GetHadithByNumberUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(bookId: String, hadithNumber: Int): Hadith? =
+        repository.getHadithByNumber(bookId, hadithNumber)
+}
+
+class GetHadithsByGradeUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(grade: HadithGrade): Flow<List<Hadith>> = repository.getHadithsByGrade(grade)
+}
+
+class GetHadithOfTheDayUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(): Hadith? = repository.getHadithOfTheDay()
+}
+
+class SearchHadithsUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(query: String): Flow<List<HadithSearchResult>> = repository.searchHadiths(query)
+}
+
+class SearchHadithsInBookUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(bookId: String, query: String): Flow<List<HadithSearchResult>> =
+        repository.searchHadithsInBook(bookId, query)
+}
+
+class GetAllBookmarksUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(): Flow<List<HadithBookmark>> = repository.getAllBookmarks()
+}
+
+class IsHadithBookmarkedUseCase @Inject constructor(private val repository: HadithRepository) {
+    operator fun invoke(hadithId: String): Flow<Boolean> = repository.isHadithBookmarked(hadithId)
+}
+
+class ToggleBookmarkUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(hadithId: String, bookId: String, hadithNumber: Int) =
+        repository.toggleBookmark(hadithId, bookId, hadithNumber)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
@@ -24,7 +24,9 @@ data class HadithUseCases(
     val searchHadithsInBook: SearchHadithsInBookUseCase,
     val getAllBookmarks: GetAllBookmarksUseCase,
     val isHadithBookmarked: IsHadithBookmarkedUseCase,
-    val toggleBookmark: ToggleBookmarkUseCase
+    val toggleBookmark: ToggleBookmarkUseCase,
+    val updateBookmark: UpdateHadithBookmarkUseCase,
+    val deleteBookmark: DeleteHadithBookmarkUseCase
 )
 
 class GetAllBooksUseCase @Inject constructor(private val repository: HadithRepository) {
@@ -84,4 +86,12 @@ class IsHadithBookmarkedUseCase @Inject constructor(private val repository: Hadi
 class ToggleBookmarkUseCase @Inject constructor(private val repository: HadithRepository) {
     suspend operator fun invoke(hadithId: String, bookId: String, hadithNumber: Int) =
         repository.toggleBookmark(hadithId, bookId, hadithNumber)
+}
+
+class UpdateHadithBookmarkUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(bookmark: HadithBookmark) = repository.updateBookmark(bookmark)
+}
+
+class DeleteHadithBookmarkUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(hadithId: String) = repository.deleteBookmark(hadithId)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
@@ -26,7 +26,8 @@ data class HadithUseCases(
     val isHadithBookmarked: IsHadithBookmarkedUseCase,
     val toggleBookmark: ToggleBookmarkUseCase,
     val updateBookmark: UpdateHadithBookmarkUseCase,
-    val deleteBookmark: DeleteHadithBookmarkUseCase
+    val deleteBookmark: DeleteHadithBookmarkUseCase,
+    val getDailyHadith: GetDailyHadithUseCase
 )
 
 class GetAllBooksUseCase @Inject constructor(private val repository: HadithRepository) {
@@ -94,4 +95,19 @@ class UpdateHadithBookmarkUseCase @Inject constructor(private val repository: Ha
 
 class DeleteHadithBookmarkUseCase @Inject constructor(private val repository: HadithRepository) {
     suspend operator fun invoke(hadithId: String) = repository.deleteBookmark(hadithId)
+}
+
+/**
+ * Deterministic "hadith of the day": scatters each day across the whole collection
+ * with a Knuth multiplicative hash so consecutive days land on very different
+ * hadiths, while the same day always yields the same one. [epochDay] is passed in
+ * (e.g. `LocalDate.now().toEpochDay()`) so the use case stays pure/testable.
+ */
+class GetDailyHadithUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(epochDay: Long): Hadith? {
+        val total = repository.getHadithCount()
+        if (total == 0) return null
+        val offset = Math.floorMod(epochDay * 2654435761L, total.toLong()).toInt()
+        return repository.getHadithByOffset(offset)
+    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/IslamicEventUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/IslamicEventUseCases.kt
@@ -1,0 +1,14 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import com.arshadshah.nimaz.domain.repository.IslamicEventRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class IslamicEventUseCases(
+    val getAllEvents: GetAllIslamicEventsUseCase
+)
+
+class GetAllIslamicEventsUseCase @Inject constructor(private val repository: IslamicEventRepository) {
+    operator fun invoke(): Flow<List<IslamicEvent>> = repository.getAllEvents()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/PrayerUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/PrayerUseCases.kt
@@ -1,0 +1,106 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStats
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerTimes
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import javax.inject.Inject
+
+data class PrayerUseCases(
+    val getPrayerRecordsForDate: GetPrayerRecordsForDateUseCase,
+    val getPrayerRecordsInRange: GetPrayerRecordsInRangeUseCase,
+    val getTodayPrayerRecords: GetTodayPrayerRecordsUseCase,
+    val updatePrayerStatus: UpdatePrayerStatusUseCase,
+    val getPrayerTimesForDate: GetPrayerTimesForDateUseCase,
+    val getCurrentStreak: GetCurrentStreakUseCase,
+    val getLongestStreak: GetLongestStreakUseCase,
+    val getMissedPrayersRequiringQada: GetMissedPrayersRequiringQadaUseCase,
+    val getPrayerStats: GetPrayerStatsUseCase,
+    val getCurrentLocation: GetCurrentLocationUseCase,
+    val getAllLocations: GetAllLocationsUseCase,
+    val getFavoriteLocations: GetFavoriteLocationsUseCase,
+    val insertLocation: InsertLocationUseCase,
+    val deleteLocation: DeleteLocationUseCase,
+    val setCurrentLocation: SetCurrentLocationUseCase,
+    val toggleFavorite: ToggleLocationFavoriteUseCase
+)
+
+class GetPrayerRecordsForDateUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(date: Long): Flow<List<PrayerRecord>> =
+        repository.getPrayerRecordsForDate(date)
+}
+
+class GetPrayerRecordsInRangeUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(startDate: Long, endDate: Long): Flow<List<PrayerRecord>> =
+        repository.getPrayerRecordsInRange(startDate, endDate)
+}
+
+class GetTodayPrayerRecordsUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(): Flow<Map<PrayerName, PrayerStatus>> =
+        repository.getTodayPrayerRecords()
+}
+
+class UpdatePrayerStatusUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(
+        date: Long,
+        prayerName: PrayerName,
+        status: PrayerStatus,
+        prayedAt: Long?,
+        isJamaah: Boolean
+    ) = repository.updatePrayerStatus(date, prayerName, status, prayedAt, isJamaah)
+}
+
+class GetPrayerTimesForDateUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(date: LocalDate, location: Location): PrayerTimes =
+        repository.getPrayerTimesForDate(date, location)
+}
+
+class GetCurrentStreakUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(currentDate: Long): Int = repository.getCurrentStreak(currentDate)
+}
+
+class GetLongestStreakUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(): Int = repository.getLongestStreak()
+}
+
+class GetMissedPrayersRequiringQadaUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(): Flow<List<PrayerRecord>> = repository.getMissedPrayersRequiringQada()
+}
+
+class GetPrayerStatsUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(startDate: Long, endDate: Long): PrayerStats =
+        repository.getPrayerStats(startDate, endDate)
+}
+
+class GetCurrentLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(): Flow<Location?> = repository.getCurrentLocation()
+}
+
+class GetAllLocationsUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(): Flow<List<Location>> = repository.getAllLocations()
+}
+
+class GetFavoriteLocationsUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(): Flow<List<Location>> = repository.getFavoriteLocations()
+}
+
+class InsertLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(location: Location): Long = repository.insertLocation(location)
+}
+
+class DeleteLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(location: Location) = repository.deleteLocation(location)
+}
+
+class SetCurrentLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(id: Long) = repository.setCurrentLocation(id)
+}
+
+class ToggleLocationFavoriteUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(id: Long) = repository.toggleFavorite(id)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
@@ -185,9 +185,25 @@ class GetVerseOfTheDayUseCase @Inject constructor(
     }
 }
 
+class GetSurahByNumberUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(surahNumber: Int): Surah? =
+        repository.getSurahByNumber(surahNumber)
+}
+
+class GetAyahsBySurahUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    operator fun invoke(surahNumber: Int): Flow<List<Ayah>> =
+        repository.getAyahsBySurah(surahNumber)
+}
+
 // Wrapper class for all Quran use cases
 data class QuranUseCases(
     val getSurahList: GetSurahListUseCase,
+    val getSurahByNumber: GetSurahByNumberUseCase,
+    val getAyahsBySurah: GetAyahsBySurahUseCase,
     val getSurahWithAyahs: GetSurahWithAyahsUseCase,
     val getAyahsByJuz: GetAyahsByJuzUseCase,
     val getAyahsByPage: GetAyahsByPageUseCase,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
@@ -1,6 +1,6 @@
 package com.arshadshah.nimaz.domain.usecase
 
-import com.arshadshah.nimaz.data.local.database.dao.PageAyahRange
+import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.QuranBookmark
 import com.arshadshah.nimaz.domain.model.QuranFavorite

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/TafseerUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/TafseerUseCases.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.TafseerHighlight
+import com.arshadshah.nimaz.domain.model.TafseerNote
+import com.arshadshah.nimaz.domain.model.TafseerText
+import com.arshadshah.nimaz.domain.repository.TafseerRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class TafseerUseCases(
+    val getTafseerForAyah: GetTafseerForAyahUseCase,
+    val getHighlightsForAyah: GetHighlightsForAyahUseCase,
+    val addHighlight: AddHighlightUseCase,
+    val updateHighlight: UpdateHighlightUseCase,
+    val deleteHighlight: DeleteHighlightUseCase,
+    val getNotesForAyah: GetNotesForAyahUseCase,
+    val addNote: AddNoteUseCase,
+    val updateNote: UpdateNoteUseCase,
+    val deleteNote: DeleteNoteUseCase,
+    val exportAnnotations: ExportAnnotationsUseCase
+)
+
+class GetTafseerForAyahUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(ayahId: Int, tafseerId: String): TafseerText? =
+        repository.getTafseerForAyah(ayahId, tafseerId)
+}
+
+class GetHighlightsForAyahUseCase @Inject constructor(private val repository: TafseerRepository) {
+    operator fun invoke(ayahId: Int, tafseerId: String): Flow<List<TafseerHighlight>> =
+        repository.getHighlightsForAyah(ayahId, tafseerId)
+}
+
+class AddHighlightUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(
+        ayahId: Int,
+        tafseerId: String,
+        startOffset: Int,
+        endOffset: Int,
+        color: String,
+        note: String? = null
+    ): Long = repository.addHighlight(ayahId, tafseerId, startOffset, endOffset, color, note)
+}
+
+class UpdateHighlightUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(highlight: TafseerHighlight) = repository.updateHighlight(highlight)
+}
+
+class DeleteHighlightUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(highlightId: Long) = repository.deleteHighlight(highlightId)
+}
+
+class GetNotesForAyahUseCase @Inject constructor(private val repository: TafseerRepository) {
+    operator fun invoke(ayahId: Int, tafseerId: String): Flow<List<TafseerNote>> =
+        repository.getNotesForAyah(ayahId, tafseerId)
+}
+
+class AddNoteUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(ayahId: Int, tafseerId: String, text: String): Long =
+        repository.addNote(ayahId, tafseerId, text)
+}
+
+class UpdateNoteUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(note: TafseerNote) = repository.updateNote(note)
+}
+
+class DeleteNoteUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(noteId: Long) = repository.deleteNote(noteId)
+}
+
+class ExportAnnotationsUseCase @Inject constructor(private val repository: TafseerRepository) {
+    suspend operator fun invoke(): String = repository.exportAnnotations()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/TasbihUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/TasbihUseCases.kt
@@ -1,0 +1,102 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.arshadshah.nimaz.domain.model.TasbihSession
+import com.arshadshah.nimaz.domain.model.TasbihStats
+import com.arshadshah.nimaz.domain.repository.TasbihRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class TasbihUseCases(
+    val getDefaultPresets: GetDefaultPresetsUseCase,
+    val getCustomPresets: GetCustomPresetsUseCase,
+    val getPresetById: GetPresetByIdUseCase,
+    val insertPreset: InsertPresetUseCase,
+    val updatePreset: UpdatePresetUseCase,
+    val deleteCustomPreset: DeleteCustomPresetUseCase,
+    val seedMissingDefaults: SeedMissingDefaultsUseCase,
+    val getSessionsForDate: GetSessionsForDateUseCase,
+    val getSessionsInRange: GetSessionsInRangeUseCase,
+    val getActiveSession: GetActiveSessionUseCase,
+    val getSessionById: GetSessionByIdUseCase,
+    val insertSession: InsertSessionUseCase,
+    val updateSessionCount: UpdateSessionCountUseCase,
+    val completeSession: CompleteSessionUseCase,
+    val getTasbihStats: GetTasbihStatsUseCase,
+    val getTotalCountInRange: GetTotalCountInRangeUseCase,
+    val getCompletedSessionsInRange: GetCompletedSessionsInRangeUseCase
+)
+
+class GetDefaultPresetsUseCase @Inject constructor(private val repository: TasbihRepository) {
+    operator fun invoke(): Flow<List<TasbihPreset>> = repository.getDefaultPresets()
+}
+
+class GetCustomPresetsUseCase @Inject constructor(private val repository: TasbihRepository) {
+    operator fun invoke(): Flow<List<TasbihPreset>> = repository.getCustomPresets()
+}
+
+class GetPresetByIdUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(id: Long): TasbihPreset? = repository.getPresetById(id)
+}
+
+class InsertPresetUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(preset: TasbihPreset): Long = repository.insertPreset(preset)
+}
+
+class UpdatePresetUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(preset: TasbihPreset) = repository.updatePreset(preset)
+}
+
+class DeleteCustomPresetUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(id: Long) = repository.deleteCustomPreset(id)
+}
+
+class SeedMissingDefaultsUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke() = repository.seedMissingDefaults()
+}
+
+class GetSessionsForDateUseCase @Inject constructor(private val repository: TasbihRepository) {
+    operator fun invoke(date: Long): Flow<List<TasbihSession>> = repository.getSessionsForDate(date)
+}
+
+class GetSessionsInRangeUseCase @Inject constructor(private val repository: TasbihRepository) {
+    operator fun invoke(startDate: Long, endDate: Long): Flow<List<TasbihSession>> =
+        repository.getSessionsInRange(startDate, endDate)
+}
+
+class GetActiveSessionUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(): TasbihSession? = repository.getActiveSession()
+}
+
+class GetSessionByIdUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(id: Long): TasbihSession? = repository.getSessionById(id)
+}
+
+class InsertSessionUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(session: TasbihSession): Long = repository.insertSession(session)
+}
+
+class UpdateSessionCountUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(id: Long, count: Int, laps: Int) =
+        repository.updateSessionCount(id, count, laps)
+}
+
+class CompleteSessionUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(id: Long, completedAt: Long, duration: Long) =
+        repository.completeSession(id, completedAt, duration)
+}
+
+class GetTasbihStatsUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(startDate: Long, endDate: Long): TasbihStats =
+        repository.getTasbihStats(startDate, endDate)
+}
+
+class GetTotalCountInRangeUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(startDate: Long, endDate: Long): Int =
+        repository.getTotalCountInRange(startDate, endDate)
+}
+
+class GetCompletedSessionsInRangeUseCase @Inject constructor(private val repository: TasbihRepository) {
+    suspend operator fun invoke(startDate: Long, endDate: Long): Int =
+        repository.getCompletedSessionsInRange(startDate, endDate)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ZakatUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ZakatUseCases.kt
@@ -1,0 +1,34 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
+import com.arshadshah.nimaz.domain.repository.ZakatRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+data class ZakatUseCases(
+    val getAllHistory: GetAllHistoryUseCase,
+    val insertCalculation: InsertCalculationUseCase,
+    val markAsPaid: MarkAsPaidUseCase,
+    val getTotalPaid: GetTotalPaidUseCase,
+    val deleteCalculation: DeleteCalculationUseCase
+)
+
+class GetAllHistoryUseCase @Inject constructor(private val repository: ZakatRepository) {
+    operator fun invoke(): Flow<List<ZakatHistoryEntry>> = repository.getAllHistory()
+}
+
+class InsertCalculationUseCase @Inject constructor(private val repository: ZakatRepository) {
+    suspend operator fun invoke(entry: ZakatHistoryEntry): Long = repository.insertCalculation(entry)
+}
+
+class MarkAsPaidUseCase @Inject constructor(private val repository: ZakatRepository) {
+    suspend operator fun invoke(id: Long, paidAt: Long) = repository.markAsPaid(id, paidAt)
+}
+
+class GetTotalPaidUseCase @Inject constructor(private val repository: ZakatRepository) {
+    suspend operator fun invoke(): Double = repository.getTotalPaid()
+}
+
+class DeleteCalculationUseCase @Inject constructor(private val repository: ZakatRepository) {
+    suspend operator fun invoke(id: Long) = repository.deleteCalculation(id)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranPageGrid.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranPageGrid.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.arshadshah.nimaz.data.local.database.dao.PageAyahRange
+import com.arshadshah.nimaz.domain.model.PageAyahRange
 
 /**
  * Pre-computes the LazyColumn item index for each Juz header (1..30).

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.HijriDateCalculator.getHijriMonthName
@@ -257,9 +258,9 @@ private fun CalendarSection(
                     MaterialTheme.colorScheme.primary,
                     stringResource(R.string.month_start)
                 ),
-                CalendarLegendItem(Color(0xFFEAB308), stringResource(R.string.eid)),
-                CalendarLegendItem(Color(0xFF22C55E), stringResource(R.string.holy_night)),
-                CalendarLegendItem(Color(0xFFA855F7), stringResource(R.string.fasting))
+                CalendarLegendItem(NimazColors.Gold500, stringResource(R.string.eid)),
+                CalendarLegendItem(NimazColors.Success, stringResource(R.string.holy_night)),
+                CalendarLegendItem(NimazColors.Purple, stringResource(R.string.fasting))
             )
         )
     }
@@ -270,9 +271,9 @@ private fun CalendarSection(
 private fun getEventDotColor(events: List<IslamicEvent>): Color? {
     val primaryEvent = events.firstOrNull() ?: return null
     return when (primaryEvent.eventType) {
-        IslamicEventType.HOLIDAY -> Color(0xFFEAB308)
-        IslamicEventType.NIGHT -> Color(0xFF22C55E)
-        IslamicEventType.FAST -> Color(0xFFA855F7)
-        IslamicEventType.HISTORICAL -> Color(0xFF22C55E)
+        IslamicEventType.HOLIDAY -> NimazColors.Gold500
+        IslamicEventType.NIGHT -> NimazColors.Success
+        IslamicEventType.FAST -> NimazColors.Purple
+        IslamicEventType.HISTORICAL -> NimazColors.Success
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.TasbihCategory
@@ -370,7 +371,7 @@ private fun DuaReaderBottomBar(
             contentDescription = stringResource(R.string.dua_reader_favorite),
             onClick = { viewModel.onEvent(DuaEvent.ToggleFavorite(dua.id, dua.categoryId)) },
             active = isFavorite,
-            activeColor = Color(0xFFEF4444)
+            activeColor = NimazColors.PrayerColors.Maghrib
         )
         NimazPillActionButton(
             icon = Icons.Default.Add,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.DuaCategory
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -376,14 +377,14 @@ private fun AdhkarListItem(
 @Composable
 private fun getCategoryColor(categoryId: String): Color {
     return when (categoryId.hashCode() % 8) {
-        0 -> Color(0xFFFBBF24) // morning/gold
-        1 -> Color(0xFF6366F1) // evening/indigo
-        2 -> Color(0xFF8B5CF6) // sleep/purple
+        0 -> NimazColors.Amber // morning/gold
+        1 -> NimazColors.PrayerColors.Fajr // evening/indigo
+        2 -> NimazColors.PrayerColors.Isha // sleep/purple
         3 -> MaterialTheme.colorScheme.primary // prayer/teal
-        4 -> Color(0xFFF97316) // travel/orange
-        5 -> Color(0xFF22C55E) // food/green
-        6 -> Color(0xFFEF4444) // protection/red
-        7 -> Color(0xFFEC4899) // forgiveness/pink
+        4 -> NimazColors.PrayerColors.Asr // travel/orange
+        5 -> NimazColors.Success // food/green
+        6 -> NimazColors.PrayerColors.Maghrib // protection/red
+        7 -> NimazColors.Pink // forgiveness/pink
         else -> MaterialTheme.colorScheme.primary
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
@@ -86,9 +86,9 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAdjusters
 
 // Color constants for makeup fasts
-private val OrangeAccent = Color(0xFFF97316)
-private val OrangeDark = Color(0xFFEA580C)
-private val GreenAccent = Color(0xFF22C55E)
+private val OrangeAccent = NimazColors.PrayerColors.Asr
+private val OrangeDark = NimazColors.OrangeDark
+private val GreenAccent = NimazColors.Success
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -467,8 +467,8 @@ private fun RamadanMissedFastsTracker(
         Surface(
             modifier = modifier.fillMaxWidth(),
             shape = RoundedCornerShape(14.dp),
-            color = Color(0xFFEF4444).copy(alpha = 0.1f),
-            border = BorderStroke(1.dp, Color(0xFFEF4444).copy(alpha = 0.3f))
+            color = NimazColors.PrayerColors.Maghrib.copy(alpha = 0.1f),
+            border = BorderStroke(1.dp, NimazColors.PrayerColors.Maghrib.copy(alpha = 0.3f))
         ) {
             Row(
                 modifier = Modifier.padding(15.dp),
@@ -479,14 +479,14 @@ private fun RamadanMissedFastsTracker(
                     modifier = Modifier
                         .size(40.dp)
                         .clip(RoundedCornerShape(10.dp))
-                        .background(Color(0xFFEF4444).copy(alpha = 0.2f)),
+                        .background(NimazColors.PrayerColors.Maghrib.copy(alpha = 0.2f)),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = "$unloggedDays",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        color = Color(0xFFEF4444)
+                        color = NimazColors.PrayerColors.Maghrib
                     )
                 }
                 Column(modifier = Modifier.weight(1f)) {
@@ -639,7 +639,7 @@ private fun TodayFastSection(
                                 text = suhoorTime,
                                 style = MaterialTheme.typography.titleLarge,
                                 fontWeight = FontWeight.Bold,
-                                color = Color(0xFF818CF8) // Indigo for suhoor
+                                color = NimazColors.IndigoLight // Indigo for suhoor
                             )
                             Spacer(modifier = Modifier.height(5.dp))
                             Text(
@@ -731,7 +731,7 @@ private fun FastingCalendarSection(
     val legendItems = remember(ramadanDaysInMonth, fastedLabel, missedLabel, ramadanLabel) {
         buildList {
             add(CalendarLegendItem(NimazColors.FastingColors.Fasted, fastedLabel))
-            add(CalendarLegendItem(Color(0xFFEF4444), missedLabel))
+            add(CalendarLegendItem(NimazColors.PrayerColors.Maghrib, missedLabel))
             if (ramadanDaysInMonth.isNotEmpty()) {
                 add(CalendarLegendItem(NimazColors.FastingColors.Ramadan, ramadanLabel))
             }
@@ -753,7 +753,7 @@ private fun FastingCalendarSection(
                 CalendarDayState(
                     indicatorColor = when {
                         record?.status == FastStatus.FASTED -> NimazColors.FastingColors.Fasted
-                        record?.status == FastStatus.MAKEUP_DUE -> Color(0xFFEF4444)
+                        record?.status == FastStatus.MAKEUP_DUE -> NimazColors.PrayerColors.Maghrib
                         else -> null
                     },
                     backgroundColor = if (isRamadanDay)
@@ -893,7 +893,7 @@ private fun RecommendedFastsSection(
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             RecommendedFastCard(
                 icon = Icons.Default.CalendarMonth,
-                iconBgColor = Color(0xFF3B82F6).copy(alpha = 0.2f),
+                iconBgColor = NimazColors.Info.copy(alpha = 0.2f),
                 name = stringResource(R.string.fasting_monday),
                 description = stringResource(R.string.fasting_sunnah_desc),
                 nextDate = mondayText,
@@ -902,7 +902,7 @@ private fun RecommendedFastsSection(
             )
             RecommendedFastCard(
                 icon = Icons.Default.CalendarMonth,
-                iconBgColor = Color(0xFFA855F7).copy(alpha = 0.2f),
+                iconBgColor = NimazColors.Purple.copy(alpha = 0.2f),
                 name = stringResource(R.string.fasting_thursday),
                 description = stringResource(R.string.fasting_sunnah_desc),
                 nextDate = thursdayText,
@@ -951,7 +951,7 @@ private fun RecommendedFastsSection(
                 }
                 RecommendedFastCard(
                     icon = Icons.Default.NightsStay,
-                    iconBgColor = Color(0xFF10B981).copy(alpha = 0.2f),
+                    iconBgColor = NimazColors.Emerald.copy(alpha = 0.2f),
                     name = fast.name,
                     description = fast.description,
                     nextDate = dateText,
@@ -1465,8 +1465,8 @@ private fun LegendItemPreview() {
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier.padding(16.dp)
         ) {
-            NimazLegendItem(color = Color(0xFF22C55E), label = "Fasted")
-            NimazLegendItem(color = Color(0xFFEF4444), label = "Missed")
+            NimazLegendItem(color = NimazColors.Success, label = "Fasted")
+            NimazLegendItem(color = NimazColors.PrayerColors.Maghrib, label = "Missed")
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.formatGrouped
 import com.arshadshah.nimaz.domain.model.Hadith
@@ -224,7 +225,7 @@ private fun HadithOfTheDayCard(
                 Box(
                     modifier = Modifier
                         .clip(RoundedCornerShape(100))
-                        .background(Color(0xFFEAB308).copy(alpha = 0.16f))
+                        .background(NimazColors.Gold500.copy(alpha = 0.16f))
                         .padding(horizontal = 12.dp, vertical = 5.dp)
                 ) {
                     Row(
@@ -234,13 +235,13 @@ private fun HadithOfTheDayCard(
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = null,
-                            tint = Color(0xFFCA8A04),
+                            tint = NimazColors.GoldDark,
                             modifier = Modifier.size(14.dp)
                         )
                         Text(
                             text = stringResource(R.string.hadith_of_the_day),
                             style = MaterialTheme.typography.labelSmall,
-                            color = Color(0xFFCA8A04),
+                            color = NimazColors.GoldDark,
                             fontWeight = FontWeight.SemiBold
                         )
                     }
@@ -286,7 +287,7 @@ private fun HadithOfTheDayCard(
                         contentDescription = stringResource(R.string.bookmark),
                         onClick = onBookmarkClick,
                         active = isBookmarked,
-                        activeColor = Color(0xFFEAB308)
+                        activeColor = NimazColors.Gold500
                     )
                     NimazPillActionButton(
                         icon = Icons.Default.Share,
@@ -398,12 +399,12 @@ private fun BookCard(
 @Composable
 private fun getBookGradient(bookId: String): List<Color> {
     return when (bookId.lowercase()) {
-        "bukhari" -> listOf(Color(0xFF22C55E), Color(0xFF16A34A))
-        "muslim" -> listOf(Color(0xFF3B82F6), Color(0xFF2563EB))
-        "tirmidhi" -> listOf(Color(0xFFA855F7), Color(0xFF9333EA))
-        "nasai" -> listOf(Color(0xFFF97316), Color(0xFFEA580C))
-        "abudawud" -> listOf(Color(0xFFEC4899), Color(0xFFDB2777))
-        "ibnmajah" -> listOf(Color(0xFF14B8A6), Color(0xFF0D9488))
-        else -> listOf(Color(0xFF14B8A6), Color(0xFF0D9488))
+        "bukhari" -> NimazColors.HadithCollectionColors.Bukhari
+        "muslim" -> NimazColors.HadithCollectionColors.Muslim
+        "tirmidhi" -> NimazColors.HadithCollectionColors.Tirmidhi
+        "nasai" -> NimazColors.HadithCollectionColors.Nasai
+        "abudawud" -> NimazColors.HadithCollectionColors.AbuDawud
+        "ibnmajah" -> NimazColors.HadithCollectionColors.IbnMajah
+        else -> NimazColors.HadithCollectionColors.Default
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithGradeChip.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithGradeChip.kt
@@ -19,14 +19,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.HadithGrade
 
 // Hadith grade colour-coding, shared by the reader and settings preview.
-val SahihGreen = Color(0xFF22C55E)
-val HasanTeal = Color(0xFF0D9488)
-val DaifAmber = Color(0xFFF59E0B)
-val MawduRed = Color(0xFFEF4444)
+val SahihGreen = NimazColors.Success
+val HasanTeal = NimazColors.Primary600
+val DaifAmber = NimazColors.Warning
+val MawduRed = NimazColors.PrayerColors.Maghrib
 
 data class HadithGradeDisplay(val label: String, val color: Color)
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.Hadith
 import com.arshadshah.nimaz.presentation.components.atoms.HadithArabicText
@@ -465,7 +466,7 @@ private fun HadithReaderBottomBar(
                 )
             },
             active = isBookmarked,
-            activeColor = Color(0xFFEAB308)
+            activeColor = NimazColors.Gold500
         )
         NimazPillActionButton(
             icon = Icons.Default.Share,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpContentUi.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpContentUi.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.domain.model.HelpItem
 import com.arshadshah.nimaz.domain.model.HelpStep
 import com.arshadshah.nimaz.domain.model.HelpTopic
@@ -70,13 +71,13 @@ fun helpIcon(key: String?): ImageVector = when (key) {
 
 @Composable
 fun helpColor(key: String): Color = when (key) {
-    "indigo" -> Color(0xFF6366F1)
-    "gold" -> Color(0xFFEAB308)
-    "teal" -> Color(0xFF14B8A6)
-    "green" -> Color(0xFF22C55E)
-    "violet" -> Color(0xFF8B5CF6)
-    "orange" -> Color(0xFFF97316)
-    "sky" -> Color(0xFF0EA5E9)
+    "indigo" -> NimazColors.PrayerColors.Fajr
+    "gold" -> NimazColors.Gold500
+    "teal" -> NimazColors.Primary
+    "green" -> NimazColors.Success
+    "violet" -> NimazColors.PrayerColors.Isha
+    "orange" -> NimazColors.PrayerColors.Asr
+    "sky" -> NimazColors.Sky
     else -> MaterialTheme.colorScheme.primary
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpGuideScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpGuideScreen.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.screens.help
 
 import androidx.compose.ui.res.stringResource
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -146,7 +147,7 @@ private fun HelpGuideHero(guide: HelpGuideDetail) {
 
 @Composable
 private fun HelpGuideDone() {
-    val green = Color(0xFF22C55E)
+    val green = NimazColors.Success
     NimazCard(style = NimazCardStyle.OUTLINED) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
@@ -177,7 +177,7 @@ fun OnboardingScreen(
     val pagerState = rememberPagerState(pageCount = { totalPages })
 
     Scaffold(
-        containerColor = Color(0xFF061A1C),
+        containerColor = NimazColors.OnboardingBgTop,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { paddingValues ->
         // Let the illuminated background bleed all the way up behind the status
@@ -333,7 +333,7 @@ fun OnboardingScreen(
                             },
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = IllumGold,
-                                contentColor = Color(0xFF0A2A2A)
+                                contentColor = NimazColors.OnboardingBgBottom
                             )
                         ) {
                             Text(
@@ -602,7 +602,7 @@ private fun PermissionCard(
                     onClick = onRequest,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = IllumGold,
-                        contentColor = Color(0xFF0A2A2A)
+                        contentColor = NimazColors.OnboardingBgBottom
                     ),
                     modifier = Modifier.height(if (compact) 36.dp else 40.dp),
                     contentPadding = ButtonDefaults.ContentPadding

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
@@ -587,10 +587,10 @@ private fun EventTag(event: IslamicEvent) {
 }
 
 private fun eventAccent(type: IslamicEventType): Color = when (type) {
-    IslamicEventType.HOLIDAY -> Color(0xFFEAB308)
-    IslamicEventType.NIGHT -> Color(0xFF8B5CF6)
-    IslamicEventType.FAST -> Color(0xFF14B8A6)
-    IslamicEventType.HISTORICAL -> Color(0xFF6366F1)
+    IslamicEventType.HOLIDAY -> NimazColors.Gold500
+    IslamicEventType.NIGHT -> NimazColors.PrayerColors.Isha
+    IslamicEventType.FAST -> NimazColors.Primary
+    IslamicEventType.HISTORICAL -> NimazColors.PrayerColors.Fajr
 }
 
 /** Fast length from a formatted Fajr → Maghrib pair ("h:mm a"); null if unparseable. */

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreen.kt
@@ -234,8 +234,8 @@ private fun InsightsSection(
             if (percent < 90 && totalPrayers > 0) {
                 InsightCard(
                     icon = Icons.Default.Warning,
-                    iconBackgroundColor = Color(0xFFF97316).copy(alpha = 0.2f),
-                    iconTint = Color(0xFFF97316),
+                    iconBackgroundColor = NimazColors.PrayerColors.Asr.copy(alpha = 0.2f),
+                    iconTint = NimazColors.PrayerColors.Asr,
                     title = stringResource(R.string.prayer_insight_needs_attention, name),
                     description = stringResource(R.string.prayer_insight_needs_attention_desc, name, percent)
                 )
@@ -248,8 +248,8 @@ private fun InsightsSection(
             val overallPercent = (stats.totalPrayed.toFloat() / totalPrayers * 100).toInt()
             InsightCard(
                 icon = Icons.AutoMirrored.Filled.TrendingUp,
-                iconBackgroundColor = Color(0xFF22C55E).copy(alpha = 0.2f),
-                iconTint = Color(0xFF22C55E),
+                iconBackgroundColor = NimazColors.Success.copy(alpha = 0.2f),
+                iconTint = NimazColors.Success,
                 title = stringResource(R.string.prayer_insight_overall, overallPercent),
                 description = stringResource(R.string.prayer_insight_overall_desc, stats.totalPrayed, totalPrayers)
             )
@@ -331,8 +331,8 @@ private fun InsightCardWarningPreview() {
     NimazTheme {
         InsightCard(
             icon = Icons.Default.Warning,
-            iconBackgroundColor = Color(0xFFF97316).copy(alpha = 0.2f),
-            iconTint = Color(0xFFF97316),
+            iconBackgroundColor = NimazColors.PrayerColors.Asr.copy(alpha = 0.2f),
+            iconTint = NimazColors.PrayerColors.Asr,
             title = "Fajr needs attention",
             description = "Your Fajr completion is at 65%. Try setting an alarm to improve."
         )
@@ -345,8 +345,8 @@ private fun InsightCardTrendPreview() {
     NimazTheme {
         InsightCard(
             icon = Icons.AutoMirrored.Filled.TrendingUp,
-            iconBackgroundColor = Color(0xFF22C55E).copy(alpha = 0.2f),
-            iconTint = Color(0xFF22C55E),
+            iconBackgroundColor = NimazColors.Success.copy(alpha = 0.2f),
+            iconTint = NimazColors.Success,
             title = "Overall completion: 85%",
             description = "You've completed 120 out of 140 prayers. Keep going!"
         )
@@ -359,8 +359,8 @@ private fun InsightCardBestPreview() {
     NimazTheme {
         InsightCard(
             icon = Icons.Default.Lightbulb,
-            iconBackgroundColor = Color(0xFF3B82F6).copy(alpha = 0.2f),
-            iconTint = Color(0xFF3B82F6),
+            iconBackgroundColor = NimazColors.Info.copy(alpha = 0.2f),
+            iconTint = NimazColors.Info,
             title = "Best prayer: Maghrib",
             description = "You consistently complete Maghrib at 98%."
         )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreen.kt
@@ -279,8 +279,8 @@ private fun QadaTabContent(viewModel: PrayerTrackerViewModel) {
 
 @Composable
 private fun QadaSummaryCard(totalMissed: Int) {
-    val warningOrange = Color(0xFFF97316)
-    val warningOrangeDark = Color(0xFFEA580C)
+    val warningOrange = NimazColors.PrayerColors.Asr
+    val warningOrangeDark = NimazColors.OrangeDark
 
     Box(
         modifier = Modifier
@@ -348,8 +348,8 @@ private fun QadaSummaryCard(totalMissed: Int) {
 
 @Composable
 private fun StreakCard(currentStreak: Int) {
-    val goldDark = Color(0xFFCA8A04)
-    val goldLight = Color(0xFFEAB308)
+    val goldDark = NimazColors.GoldDark
+    val goldLight = NimazColors.Gold500
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -382,7 +382,7 @@ private fun StreakCard(currentStreak: Int) {
                         Icon(
                             imageVector = Icons.Default.LocalFireDepartment,
                             contentDescription = null,
-                            tint = Color(0xFF1C1917),
+                            tint = NimazColors.Neutral900,
                             modifier = Modifier.size(24.dp)
                         )
                     }
@@ -390,7 +390,7 @@ private fun StreakCard(currentStreak: Int) {
                         text = stringResource(R.string.current_streak),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
-                        color = Color(0xFF1C1917)
+                        color = NimazColors.Neutral900
                     )
                 }
                 Spacer(modifier = Modifier.height(10.dp))
@@ -398,13 +398,13 @@ private fun StreakCard(currentStreak: Int) {
                     text = "$currentStreak",
                     fontSize = 48.sp,
                     fontWeight = FontWeight.Bold,
-                    color = Color(0xFF1C1917),
+                    color = NimazColors.Neutral900,
                     lineHeight = 48.sp
                 )
                 Text(
                     text = stringResource(R.string.consecutive_days_all_prayers),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = Color(0xFF1C1917).copy(alpha = 0.8f)
+                    color = NimazColors.Neutral900.copy(alpha = 0.8f)
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/QadaPrayersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/QadaPrayersScreen.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.screens.prayer
 
 import androidx.compose.ui.res.stringResource
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -116,8 +117,8 @@ fun QadaPrayersScreen(
 
 @Composable
 private fun QadaSummaryCard(totalMissed: Int) {
-    val warningOrange = Color(0xFFF97316)
-    val warningOrangeDark = Color(0xFFEA580C)
+    val warningOrange = NimazColors.PrayerColors.Asr
+    val warningOrangeDark = NimazColors.OrangeDark
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaHomeScreen.kt
@@ -31,6 +31,7 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
 import com.arshadshah.nimaz.presentation.components.molecules.QaidaCourseHeader
 import com.arshadshah.nimaz.presentation.components.organisms.QaidaCoursePath
+import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderViewModel
 
 /**
@@ -123,7 +124,7 @@ fun QaidaHomeScreen(
             cancelText = stringResource(R.string.cancel),
             titleIcon = Icons.Filled.RestartAlt,
             isDestructive = true,
-            onConfirm = { viewModel.resetJourney() },
+            onConfirm = { viewModel.onEvent(QaidaReaderEvent.ResetJourney) },
             onDismiss = { showResetDialog = false },
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaLettersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaLettersScreen.kt
@@ -28,6 +28,7 @@ import com.arshadshah.nimaz.domain.model.QaidaLetter
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
 import com.arshadshah.nimaz.presentation.components.organisms.QaidaLetterBoard
 import com.arshadshah.nimaz.presentation.components.organisms.QaidaLetterDetailSheet
+import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderViewModel
 
 /**
@@ -74,7 +75,7 @@ fun QaidaLettersScreen(
             ) {
                 QaidaLetterDetailSheet(
                     letter = letter,
-                    onPlay = viewModel::playLetter,
+                    onPlay = { viewModel.onEvent(QaidaReaderEvent.PlayLetter(it)) },
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qaida/QaidaReaderScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.domain.model.LessonStatus
 import com.arshadshah.nimaz.presentation.components.organisms.QaidaCelebrationOverlay
 import com.arshadshah.nimaz.presentation.components.organisms.QaidaLessonLines
+import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QaidaReaderViewModel
 
 /**
@@ -42,7 +43,7 @@ fun QaidaReaderScreen(
     onNavigateBack: () -> Unit,
     viewModel: QaidaReaderViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(lessonId) { viewModel.selectLesson(lessonId) }
+    LaunchedEffect(lessonId) { viewModel.onEvent(QaidaReaderEvent.SelectLesson(lessonId)) }
 
     val content by viewModel.lessonContent.collectAsStateWithLifecycle()
     val playing by viewModel.playingCell.collectAsStateWithLifecycle()
@@ -102,8 +103,8 @@ fun QaidaReaderScreen(
                     content = c,
                     playingCellId = playing?.id,
                     showTransliteration = showTransliteration,
-                    onCellTap = viewModel::onCellTapped,
-                    onPlayLine = viewModel::playLine,
+                    onCellTap = { viewModel.onEvent(QaidaReaderEvent.CellTapped(it)) },
+                    onPlayLine = { viewModel.onEvent(QaidaReaderEvent.PlayLine(it)) },
                     completedCellIds = completedCellIds,
                 )
             }
@@ -115,7 +116,7 @@ fun QaidaReaderScreen(
                 unlockedTitle = unlockedTitle,
                 onNext = {
                     showCelebration = false
-                    viewModel.nextLesson()
+                    viewModel.onEvent(QaidaReaderEvent.NextLesson)
                 },
                 onMap = onNavigateBack,
             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.QuranBookmark
 import com.arshadshah.nimaz.domain.model.QuranFavorite
@@ -325,8 +326,8 @@ private fun HomeTabContent(
                             .background(
                                 brush = Brush.linearGradient(
                                     colors = listOf(
-                                        Color(0xFF115E59),
-                                        Color(0xFF042F2E)
+                                        NimazColors.Primary800,
+                                        NimazColors.Primary950
                                     )
                                 ),
                                 shape = RoundedCornerShape(20.dp)
@@ -340,7 +341,7 @@ private fun HomeTabContent(
                             Icon(
                                 imageVector = Icons.Default.PlayArrow,
                                 contentDescription = null,
-                                tint = Color(0xFFEAB308),
+                                tint = NimazColors.Gold500,
                                 modifier = Modifier.size(48.dp)
                             )
                             Spacer(modifier = Modifier.height(12.dp))
@@ -354,7 +355,7 @@ private fun HomeTabContent(
                             Text(
                                 text = stringResource(R.string.quran_home_begin_journey),
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = Color(0xFFD4D4D4)
+                                color = NimazColors.Gray300
                             )
                         }
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.screens.settings
 
 import androidx.compose.ui.res.stringResource
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -156,7 +157,7 @@ private fun ThemeSelectionCard(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color(0xFF0C0A09))
+                        .background(NimazColors.Neutral950)
                 ) {
                     ThemePreviewContent(contentColor = Color.White)
                 }
@@ -171,9 +172,9 @@ private fun ThemeSelectionCard(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color(0xFFF5F5F4))
+                        .background(NimazColors.Neutral100)
                 ) {
-                    ThemePreviewContent(contentColor = Color(0xFF0C0A09))
+                    ThemePreviewContent(contentColor = NimazColors.Neutral950)
                 }
             }
             ThemePreviewOption(
@@ -187,7 +188,7 @@ private fun ThemeSelectionCard(
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         val w = size.width
                         val h = size.height
-                        drawRect(color = Color(0xFF0C0A09))
+                        drawRect(color = NimazColors.Neutral950)
                         drawPath(
                             path = androidx.compose.ui.graphics.Path().apply {
                                 moveTo(w, 0f)
@@ -195,7 +196,7 @@ private fun ThemeSelectionCard(
                                 lineTo(0f, h)
                                 close()
                             },
-                            color = Color(0xFFF5F5F4)
+                            color = NimazColors.Neutral100
                         )
                     }
                 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.data.audio.DownloadState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBanner
@@ -73,11 +74,11 @@ import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
 
 // Prayer accent colors matching the HTML prototype
-private val FajrColor = Color(0xFF6366F1)
-private val DhuhrColor = Color(0xFFEAB308)
-private val AsrColor = Color(0xFFF97316)
-private val MaghribColor = Color(0xFFEF4444)
-private val IshaColor = Color(0xFF8B5CF6)
+private val FajrColor = NimazColors.PrayerColors.Fajr
+private val DhuhrColor = NimazColors.Gold500
+private val AsrColor = NimazColors.PrayerColors.Asr
+private val MaghribColor = NimazColors.PrayerColors.Maghrib
+private val IshaColor = NimazColors.PrayerColors.Isha
 
 private data class PrayerNotificationData(
     val name: String,
@@ -489,7 +490,7 @@ fun NotificationSettingsScreen(
                                         ),
                                         style = MaterialTheme.typography.bodySmall,
                                         color = if (isExempted) MaterialTheme.colorScheme.primary
-                                        else Color(0xFFF59E0B)
+                                        else NimazColors.Warning
                                     )
                                 }
                                 if (isExempted) {
@@ -518,7 +519,7 @@ fun NotificationSettingsScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     shape = RoundedCornerShape(12.dp),
                                     colors = ButtonDefaults.buttonColors(
-                                        containerColor = Color(0xFFF59E0B),
+                                        containerColor = NimazColors.Warning,
                                         contentColor = Color.White
                                     )
                                 ) {
@@ -743,7 +744,7 @@ private fun PrayerNotificationRowEnabledPreview() {
             prayer = PrayerNotificationData(
                 name = "Fajr",
                 key = "fajr",
-                accentColor = Color(0xFF5B8DEF),
+                accentColor = NimazColors.InfoSoft,
                 isEnabled = true,
                 isSoundOn = true
             ),
@@ -762,7 +763,7 @@ private fun PrayerNotificationRowDisabledPreview() {
             prayer = PrayerNotificationData(
                 name = "Dhuhr",
                 key = "dhuhr",
-                accentColor = Color(0xFFFACC15),
+                accentColor = NimazColors.Gold400,
                 isEnabled = false,
                 isSoundOn = false
             ),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreen.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.screens.settings
 
 import androidx.compose.ui.res.stringResource
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -483,7 +484,7 @@ private fun HijriDateWidgetPreview(
 private fun PrayerTrackerWidgetPreview(
     modifier: Modifier = Modifier
 ) {
-    val checkedColor = Color(0xFF22C55E) // Green
+    val checkedColor = NimazColors.Success // Green
     val uncheckedColor = MaterialTheme.colorScheme.surfaceVariant
 
     Box(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
@@ -452,7 +452,7 @@ private fun ZakatResultSummaryCard(
     val goldGradient = Brush.linearGradient(
         colors = listOf(
             NimazColors.ZakatColors.Gold,
-            Color(0xFFCA8A04)
+            NimazColors.ZakatColors.GoldAccent
         )
     )
 
@@ -474,7 +474,7 @@ private fun ZakatResultSummaryCard(
                 Text(
                     text = stringResource(R.string.zakat_due),
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF1C1917).copy(alpha = 0.8f)
+                    color = NimazColors.Neutral900.copy(alpha = 0.8f)
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -485,7 +485,7 @@ private fun ZakatResultSummaryCard(
                         fontWeight = FontWeight.Bold,
                         lineHeight = 36.sp
                     ),
-                    color = Color(0xFF1C1917)
+                    color = NimazColors.Neutral900
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -493,7 +493,7 @@ private fun ZakatResultSummaryCard(
                 Text(
                     text = stringResource(R.string.zakat_rate_subtitle),
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF1C1917).copy(alpha = 0.7f)
+                    color = NimazColors.Neutral900.copy(alpha = 0.7f)
                 )
 
                 Spacer(modifier = Modifier.height(15.dp))
@@ -522,7 +522,7 @@ private fun ZakatResultSummaryCard(
                         }"
                     },
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color(0xFF1C1917).copy(alpha = 0.8f),
+                    color = NimazColors.Neutral900.copy(alpha = 0.8f),
                     textAlign = TextAlign.Center
                 )
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
@@ -153,7 +153,7 @@ private fun TotalPaidSummaryCard(
     val goldGradient = Brush.linearGradient(
         colors = listOf(
             NimazColors.ZakatColors.Gold,
-            Color(0xFFCA8A04)
+            NimazColors.ZakatColors.GoldAccent
         )
     )
 
@@ -175,7 +175,7 @@ private fun TotalPaidSummaryCard(
                 Text(
                     text = stringResource(R.string.zakat_history_total_paid),
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF1C1917).copy(alpha = 0.8f)
+                    color = NimazColors.Neutral900.copy(alpha = 0.8f)
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -185,7 +185,7 @@ private fun TotalPaidSummaryCard(
                     style = MaterialTheme.typography.displaySmall.copy(
                         fontWeight = FontWeight.Bold
                     ),
-                    color = Color(0xFF1C1917)
+                    color = NimazColors.Neutral900
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -193,7 +193,7 @@ private fun TotalPaidSummaryCard(
                 Text(
                     text = pluralStringResource(R.plurals.zakat_calculations_recorded, totalEntries, totalEntries),
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF1C1917).copy(alpha = 0.7f)
+                    color = NimazColors.Neutral900.copy(alpha = 0.7f)
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreen.kt
@@ -51,7 +51,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.ZakatEvent
-import com.arshadshah.nimaz.presentation.viewmodel.ZakatHistoryEntry
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
 import com.arshadshah.nimaz.presentation.viewmodel.ZakatViewModel
 import com.arshadshah.nimaz.core.util.formatCurrency
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
@@ -132,6 +132,9 @@ object NimazColors {
         val Silver = Color(0xFFC0C0C0)
         val Cash = Color(0xFF4CAF50)
         val Investment = Color(0xFF2196F3)
+
+        /** Darker amber-gold accent used on zakat calculator/history surfaces. */
+        val GoldAccent = Color(0xFFCA8A04)
     }
 
     // Tasbih Colors

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
@@ -29,6 +29,9 @@ object NimazColors {
     val SecondaryLight = Gold400
     val SecondaryDark = Color(0xFFFFA000)
     val SecondaryContainer = Color(0xFFFFECB3)
+
+    /** Darker amber-gold accent (e.g. icon tints/labels on gold surfaces). */
+    val GoldDark = Color(0xFFCA8A04)
     val OnSecondary = Color(0xFF000000)
     val OnSecondaryContainer = Color(0xFF3E2723)
 
@@ -135,6 +138,17 @@ object NimazColors {
 
         /** Darker amber-gold accent used on zakat calculator/history surfaces. */
         val GoldAccent = Color(0xFFCA8A04)
+    }
+
+    // Per-collection gradient pairs for the Hadith book cards.
+    object HadithCollectionColors {
+        val Bukhari = listOf(Color(0xFF22C55E), Color(0xFF16A34A))
+        val Muslim = listOf(Color(0xFF3B82F6), Color(0xFF2563EB))
+        val Tirmidhi = listOf(Color(0xFFA855F7), Color(0xFF9333EA))
+        val Nasai = listOf(Color(0xFFF97316), Color(0xFFEA580C))
+        val AbuDawud = listOf(Color(0xFFEC4899), Color(0xFFDB2777))
+        val IbnMajah = listOf(Color(0xFF14B8A6), Color(0xFF0D9488))
+        val Default = IbnMajah
     }
 
     // Tasbih Colors

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/theme/Color.kt
@@ -32,6 +32,24 @@ object NimazColors {
 
     /** Darker amber-gold accent (e.g. icon tints/labels on gold surfaces). */
     val GoldDark = Color(0xFFCA8A04)
+
+    // Semantic / categorical accents used across feature screens (Tailwind-derived).
+    val Success = Color(0xFF22C55E)
+    val Warning = Color(0xFFF59E0B)
+    val Info = Color(0xFF3B82F6)
+    val InfoSoft = Color(0xFF5B8DEF)
+    val Emerald = Color(0xFF10B981)
+    val Sky = Color(0xFF0EA5E9)
+    val Purple = Color(0xFFA855F7)
+    val Pink = Color(0xFFEC4899)
+    val Amber = Color(0xFFFBBF24)
+    val OrangeDark = Color(0xFFEA580C)
+    val IndigoLight = Color(0xFF818CF8)
+    val Gray300 = Color(0xFFD4D4D4)
+
+    // Onboarding illustration background (dark teal gradient).
+    val OnboardingBgTop = Color(0xFF061A1C)
+    val OnboardingBgBottom = Color(0xFF0A2A2A)
     val OnSecondary = Color(0xFF000000)
     val OnSecondaryContainer = Color(0xFF3E2723)
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUlHusnaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUlHusnaViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.AsmaUlHusna
 import com.arshadshah.nimaz.domain.usecase.AsmaUlHusnaUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,6 +53,13 @@ class AsmaUlHusnaViewModel @Inject constructor(
     }
 
     fun onEvent(event: AsmaUlHusnaEvent) {
+        when (event) {
+            is AsmaUlHusnaEvent.LoadDetail -> AppAnalytics.logFeatureUsed("asma_ul_husna", "open_detail")
+            is AsmaUlHusnaEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed("asma_ul_husna", "toggle_favorite")
+            is AsmaUlHusnaEvent.Search -> AppAnalytics.logFeatureUsed("asma_ul_husna", "search")
+            AsmaUlHusnaEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed("asma_ul_husna", "toggle_favorites_filter")
+            else -> {}
+        }
         when (event) {
             is AsmaUlHusnaEvent.LoadDetail -> loadDetail(event.nameId)
             is AsmaUlHusnaEvent.ToggleFavorite -> toggleFavorite(event.nameId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUnNabiViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUnNabiViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.AsmaUnNabi
 import com.arshadshah.nimaz.domain.usecase.AsmaUnNabiUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,6 +53,13 @@ class AsmaUnNabiViewModel @Inject constructor(
     }
 
     fun onEvent(event: AsmaUnNabiEvent) {
+        when (event) {
+            is AsmaUnNabiEvent.LoadDetail -> AppAnalytics.logFeatureUsed("asma_un_nabi", "open_detail")
+            is AsmaUnNabiEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed("asma_un_nabi", "toggle_favorite")
+            is AsmaUnNabiEvent.Search -> AppAnalytics.logFeatureUsed("asma_un_nabi", "search")
+            AsmaUnNabiEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed("asma_un_nabi", "toggle_favorites_filter")
+            else -> {}
+        }
         when (event) {
             is AsmaUnNabiEvent.LoadDetail -> loadDetail(event.nameId)
             is AsmaUnNabiEvent.ToggleFavorite -> toggleFavorite(event.nameId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.HadithBookmark
 import com.arshadshah.nimaz.domain.model.QuranBookmark
@@ -98,6 +99,18 @@ class BookmarksViewModel @Inject constructor(
     }
 
     fun onEvent(event: BookmarksEvent) {
+        when (event) {
+            is BookmarksEvent.SetFilter -> AppAnalytics.logFeatureUsed("bookmarks", "set_filter")
+            is BookmarksEvent.SetSortOrder -> AppAnalytics.logFeatureUsed("bookmarks", "set_sort_order")
+            is BookmarksEvent.Search -> AppAnalytics.logFeatureUsed("bookmarks", "search")
+            is BookmarksEvent.DeleteQuranBookmark -> AppAnalytics.logFeatureUsed("bookmarks", "delete_quran")
+            is BookmarksEvent.DeleteHadithBookmark -> AppAnalytics.logFeatureUsed("bookmarks", "delete_hadith")
+            is BookmarksEvent.DeleteDuaBookmark -> AppAnalytics.logFeatureUsed("bookmarks", "delete_dua")
+            is BookmarksEvent.UpdateQuranBookmarkNote -> AppAnalytics.logFeatureUsed("bookmarks", "update_note")
+            is BookmarksEvent.UpdateHadithBookmarkNote -> AppAnalytics.logFeatureUsed("bookmarks", "update_note")
+            BookmarksEvent.ClearAllBookmarks -> AppAnalytics.logFeatureUsed("bookmarks", "clear_all")
+            else -> {}
+        }
         when (event) {
             is BookmarksEvent.SetFilter -> setFilter(event.type)
             is BookmarksEvent.SetSortOrder -> setSortOrder(event.order)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.HadithBookmark
 import com.arshadshah.nimaz.domain.model.QuranBookmark
-import com.arshadshah.nimaz.domain.repository.DuaRepository
-import com.arshadshah.nimaz.domain.repository.HadithRepository
-import com.arshadshah.nimaz.domain.repository.QuranRepository
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import android.content.Context
 import com.arshadshah.nimaz.R
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -81,9 +81,9 @@ sealed interface BookmarksEvent {
 
 @HiltViewModel
 class BookmarksViewModel @Inject constructor(
-    private val quranRepository: QuranRepository,
-    private val hadithRepository: HadithRepository,
-    private val duaRepository: DuaRepository,
+    private val quranUseCases: QuranUseCases,
+    private val hadithUseCases: HadithUseCases,
+    private val duaUseCases: DuaUseCases,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -121,7 +121,7 @@ class BookmarksViewModel @Inject constructor(
 
     private fun loadQuranBookmarks() {
         viewModelScope.launch {
-            quranRepository.getAllBookmarks().collect { bookmarks ->
+            quranUseCases.getBookmarks().collect { bookmarks ->
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.QURAN } +
                             bookmarks.map { it.toUnified() }
@@ -144,7 +144,7 @@ class BookmarksViewModel @Inject constructor(
 
     private fun loadHadithBookmarks() {
         viewModelScope.launch {
-            hadithRepository.getAllBookmarks().collect { bookmarks ->
+            hadithUseCases.getAllBookmarks().collect { bookmarks ->
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.HADITH } +
                             bookmarks.map { it.toUnified() }
@@ -167,7 +167,7 @@ class BookmarksViewModel @Inject constructor(
 
     private fun loadDuaBookmarks() {
         viewModelScope.launch {
-            duaRepository.getAllBookmarks().collect { bookmarks ->
+            duaUseCases.getAllBookmarks().collect { bookmarks ->
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.DUA } +
                             bookmarks.map { it.toUnified() }
@@ -280,44 +280,44 @@ class BookmarksViewModel @Inject constructor(
 
     private fun deleteQuranBookmark(ayahId: Int) {
         viewModelScope.launch {
-            quranRepository.deleteBookmark(ayahId)
+            quranUseCases.deleteBookmark(ayahId)
         }
     }
 
     private fun deleteHadithBookmark(hadithId: String) {
         viewModelScope.launch {
-            hadithRepository.deleteBookmark(hadithId)
+            hadithUseCases.deleteBookmark(hadithId)
         }
     }
 
     private fun deleteDuaBookmark(duaId: String) {
         viewModelScope.launch {
-            duaRepository.deleteBookmark(duaId)
+            duaUseCases.deleteBookmark(duaId)
         }
     }
 
     private fun updateQuranBookmarkNote(bookmark: QuranBookmark) {
         viewModelScope.launch {
-            quranRepository.updateBookmark(bookmark)
+            quranUseCases.updateBookmark(bookmark)
         }
     }
 
     private fun updateHadithBookmarkNote(bookmark: HadithBookmark) {
         viewModelScope.launch {
-            hadithRepository.updateBookmark(bookmark)
+            hadithUseCases.updateBookmark(bookmark)
         }
     }
 
     private fun clearAllBookmarks() {
         viewModelScope.launch {
             _bookmarksState.value.quranBookmarks.forEach {
-                quranRepository.deleteBookmark(it.ayahId)
+                quranUseCases.deleteBookmark(it.ayahId)
             }
             _bookmarksState.value.hadithBookmarks.forEach {
-                hadithRepository.deleteBookmark(it.hadithId)
+                hadithUseCases.deleteBookmark(it.hadithId)
             }
             _bookmarksState.value.duaBookmarks.forEach {
-                duaRepository.deleteBookmark(it.duaId)
+                duaUseCases.deleteBookmark(it.duaId)
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.domain.model.CalendarDay
 import com.arshadshah.nimaz.domain.model.CalendarMonth
@@ -96,6 +98,8 @@ class CalendarViewModel @Inject constructor(
                 loadToday()
                 loadUpcomingEvents()
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("calendar", "load_events", e.message)
                 _calendarState.update {
                     it.copy(
                         error = "Failed to load events: ${e.message}",
@@ -107,6 +111,12 @@ class CalendarViewModel @Inject constructor(
     }
 
     fun onEvent(event: CalendarEvent) {
+        when (event) {
+            is CalendarEvent.SelectDate -> AppAnalytics.logFeatureUsed("calendar", "select_date")
+            is CalendarEvent.SetViewMode -> AppAnalytics.logFeatureUsed("calendar", "set_view_mode")
+            is CalendarEvent.NavigateToYear -> AppAnalytics.logFeatureUsed("calendar", "navigate_year")
+            else -> {}
+        }
         when (event) {
             is CalendarEvent.SelectDate -> selectDate(event.date)
             is CalendarEvent.NavigateToMonth -> navigateToMonth(event.month, event.year)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
@@ -3,13 +3,11 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
-import com.arshadshah.nimaz.data.local.database.dao.IslamicEventDao
-import com.arshadshah.nimaz.data.local.database.entity.IslamicEventEntity
 import com.arshadshah.nimaz.domain.model.CalendarDay
 import com.arshadshah.nimaz.domain.model.CalendarMonth
 import com.arshadshah.nimaz.domain.model.HijriDate
 import com.arshadshah.nimaz.domain.model.IslamicEvent
-import com.arshadshah.nimaz.domain.model.IslamicEventType
+import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,7 +68,7 @@ sealed interface CalendarEvent {
 
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
-    private val islamicEventDao: IslamicEventDao
+    private val islamicEventUseCases: IslamicEventUseCases
 ) : ViewModel() {
 
     private var cachedEvents: List<IslamicEvent> = emptyList()
@@ -94,9 +92,7 @@ class CalendarViewModel @Inject constructor(
     private fun loadEventsFromDatabase() {
         viewModelScope.launch {
             try {
-                cachedEvents = islamicEventDao.getAllEvents()
-                    .first()
-                    .map { it.toDomainModel() }
+                cachedEvents = islamicEventUseCases.getAllEvents().first()
                 loadToday()
                 loadUpcomingEvents()
             } catch (e: Exception) {
@@ -373,25 +369,3 @@ class CalendarViewModel @Inject constructor(
     }
 }
 
-private fun IslamicEventEntity.toDomainModel(): IslamicEvent {
-    return IslamicEvent(
-        id = id.toString(),
-        nameArabic = nameArabic,
-        nameEnglish = nameEnglish,
-        description = description,
-        hijriMonth = hijriMonth,
-        hijriDay = hijriDay,
-        eventType = try {
-            IslamicEventType.valueOf(eventType.uppercase())
-        } catch (_: IllegalArgumentException) {
-            IslamicEventType.HOLIDAY
-        },
-        isHoliday = isHoliday == 1,
-        isFastingDay = eventType.equals("fast", ignoreCase = true),
-        isNightOfPower = eventType.equals("night", ignoreCase = true),
-        gregorianDate = null,
-        year = null,
-        notes = null,
-        priority = 0
-    )
-}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -8,7 +8,7 @@ import com.arshadshah.nimaz.domain.model.DuaCategory
 import com.arshadshah.nimaz.domain.model.DuaOccasion
 import com.arshadshah.nimaz.domain.model.DuaProgress
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
-import com.arshadshah.nimaz.domain.repository.DuaRepository
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
@@ -91,7 +91,7 @@ sealed interface DuaEvent {
 
 @HiltViewModel
 class DuaViewModel @Inject constructor(
-    private val duaRepository: DuaRepository,
+    private val duaUseCases: DuaUseCases,
     private val preferencesDataStore: PreferencesDataStore
 ) : ViewModel() {
 
@@ -152,7 +152,7 @@ class DuaViewModel @Inject constructor(
 
     private fun loadAllCategories() {
         viewModelScope.launch {
-            duaRepository.getAllCategories().collect { categories ->
+            duaUseCases.getAllCategories().collect { categories ->
                 _collectionState.update {
                     it.copy(
                         categories = categories,
@@ -168,10 +168,10 @@ class DuaViewModel @Inject constructor(
         _categoryState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
             try {
-                val category = duaRepository.getCategoryById(categoryId)
+                val category = duaUseCases.getCategoryById(categoryId)
                 _categoryState.update { it.copy(category = category) }
 
-                duaRepository.getDuasByCategory(categoryId).collect { duas ->
+                duaUseCases.getDuasByCategory(categoryId).collect { duas ->
                     _categoryState.update {
                         it.copy(duas = duas, isLoading = false)
                     }
@@ -186,14 +186,14 @@ class DuaViewModel @Inject constructor(
         _readerState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
             try {
-                val dua = duaRepository.getDuaById(duaId)
+                val dua = duaUseCases.getDuaById(duaId)
                 if (dua == null) {
                     _readerState.update { it.copy(isLoading = false, error = "Dua not found") }
                     return@launch
                 }
                 // Load the sibling duas in this collection so the reader can page
                 // through them with a HorizontalPager.
-                duaRepository.getDuasByCategory(dua.categoryId).collect { categoryDuas ->
+                duaUseCases.getDuasByCategory(dua.categoryId).collect { categoryDuas ->
                     val list = categoryDuas.ifEmpty { listOf(dua) }
                     val index = list.indexOfFirst { it.id == duaId }.coerceAtLeast(0)
                     _readerState.update {
@@ -247,7 +247,7 @@ class DuaViewModel @Inject constructor(
     private fun loadDuasByOccasion(occasion: DuaOccasion) {
         _categoryState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
-            duaRepository.getDuasByOccasion(occasion).collect { duas ->
+            duaUseCases.getDuasByOccasion(occasion).collect { duas ->
                 _categoryState.update {
                     it.copy(duas = duas, isLoading = false)
                 }
@@ -263,7 +263,7 @@ class DuaViewModel @Inject constructor(
 
         _searchState.update { it.copy(query = query, isSearching = true) }
         viewModelScope.launch {
-            duaRepository.searchDuas(query).collect { results ->
+            duaUseCases.searchDuas(query).collect { results ->
                 _searchState.update { it.copy(results = results, isSearching = false) }
             }
         }
@@ -286,13 +286,13 @@ class DuaViewModel @Inject constructor(
 
     private fun toggleFavorite(duaId: String, categoryId: String) {
         viewModelScope.launch {
-            duaRepository.toggleFavorite(duaId, categoryId)
+            duaUseCases.toggleFavorite(duaId, categoryId)
         }
     }
 
     private fun loadFavorites() {
         viewModelScope.launch {
-            duaRepository.getFavoriteDuas().collect { favorites ->
+            duaUseCases.getFavoriteDuas().collect { favorites ->
                 _favoritesState.update { it.copy(favorites = favorites, isLoading = false) }
             }
         }
@@ -306,7 +306,7 @@ class DuaViewModel @Inject constructor(
     private fun loadProgressForDate(date: Long) {
         _dailyProgressState.update { it.copy(isLoading = true, date = date) }
         viewModelScope.launch {
-            duaRepository.getProgressForDate(date).collect { progressList ->
+            duaUseCases.getProgressForDate(date).collect { progressList ->
                 _dailyProgressState.update {
                     it.copy(progressList = progressList, isLoading = false)
                 }
@@ -318,5 +318,5 @@ class DuaViewModel @Inject constructor(
         return LocalDate.now().toUtcMidnightMillis()
     }
 
-    fun isDuaFavorite(duaId: String) = duaRepository.isDuaFavorite(duaId)
+    fun isDuaFavorite(duaId: String) = duaUseCases.isDuaFavorite(duaId)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -9,7 +9,7 @@ import com.arshadshah.nimaz.domain.model.DuaOccasion
 import com.arshadshah.nimaz.domain.model.DuaProgress
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.usecase.DuaUseCases
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
 import androidx.compose.ui.text.font.FontFamily
@@ -92,7 +92,7 @@ sealed interface DuaEvent {
 @HiltViewModel
 class DuaViewModel @Inject constructor(
     private val duaUseCases: DuaUseCases,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _collectionState = MutableStateFlow(DuaCollectionUiState())
@@ -214,15 +214,15 @@ class DuaViewModel @Inject constructor(
     private fun observeDuaSettings() {
         viewModelScope.launch {
             val displayFlow = combine(
-                preferencesDataStore.duaArabicFont,
-                preferencesDataStore.duaArabicFontSize,
-                preferencesDataStore.duaTranslationFontSize
+                settingsRepository.duaArabicFont,
+                settingsRepository.duaArabicFontSize,
+                settingsRepository.duaTranslationFontSize
             ) { fontId, arabicSize, transSize -> Triple(fontId, arabicSize, transSize) }
 
             val toggleFlow = combine(
-                preferencesDataStore.duaShowArabic,
-                preferencesDataStore.duaShowTransliteration,
-                preferencesDataStore.duaShowTranslation
+                settingsRepository.duaShowArabic,
+                settingsRepository.duaShowTransliteration,
+                settingsRepository.duaShowTranslation
             ) { showArabic, showTranslit, showTrans -> Triple(showArabic, showTranslit, showTrans) }
 
             combine(displayFlow, toggleFlow) { display, toggles -> display to toggles }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.DuaCategory
@@ -122,6 +124,14 @@ class DuaViewModel @Inject constructor(
 
     fun onEvent(event: DuaEvent) {
         when (event) {
+            is DuaEvent.LoadCategory -> AppAnalytics.logFeatureUsed("dua", "open_category")
+            is DuaEvent.LoadDua -> AppAnalytics.logFeatureUsed("dua", "open_reader")
+            is DuaEvent.LoadDuasByOccasion -> AppAnalytics.logFeatureUsed("dua", "open_occasion")
+            is DuaEvent.Search -> AppAnalytics.logFeatureUsed("dua", "search")
+            is DuaEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed("dua", "toggle_favorite")
+            else -> {}
+        }
+        when (event) {
             is DuaEvent.LoadCategory -> loadCategory(event.categoryId)
             is DuaEvent.LoadDua -> loadDua(event.duaId)
             is DuaEvent.LoadDuasByOccasion -> loadDuasByOccasion(event.occasion)
@@ -177,6 +187,8 @@ class DuaViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("dua", "load_category", e.message)
                 _categoryState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -201,6 +213,8 @@ class DuaViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("dua", "load_dua", e.message)
                 _readerState.update { it.copy(error = e.message, isLoading = false) }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -13,7 +13,7 @@ import com.arshadshah.nimaz.domain.model.FastType
 import com.arshadshah.nimaz.domain.model.FastingStats
 import com.arshadshah.nimaz.domain.model.MakeupFast
 import com.arshadshah.nimaz.domain.model.MakeupFastStatus
-import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.usecase.FastingUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -126,7 +126,7 @@ sealed interface FastingEvent {
 
 @HiltViewModel
 class FastingViewModel @Inject constructor(
-    private val fastingRepository: FastingRepository,
+    private val fastingUseCases: FastingUseCases,
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val preferencesDataStore: PreferencesDataStore
 ) : ViewModel() {
@@ -326,7 +326,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val record = fastingRepository.getFastRecordForDate(dateEpoch)
+            val record = fastingUseCases.getFastRecordForDate(dateEpoch)
             _trackerState.update {
                 it.copy(
                     todayRecord = record,
@@ -358,7 +358,7 @@ class FastingViewModel @Inject constructor(
                 createdAt = now,
                 updatedAt = now
             )
-            fastingRepository.insertFastRecord(record)
+            fastingUseCases.insertFastRecord(record)
             selectDate(date)
             loadStats()
         }
@@ -368,7 +368,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            fastingRepository.updateFastStatus(dateEpoch, FastStatus.FASTED)
+            fastingUseCases.updateFastStatus(dateEpoch, FastStatus.FASTED)
             selectDate(date)
             loadStats()
         }
@@ -378,7 +378,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            fastingRepository.updateFastStatus(dateEpoch, FastStatus.NOT_FASTED)
+            fastingUseCases.updateFastStatus(dateEpoch, FastStatus.NOT_FASTED)
             selectDate(date)
             loadStats()
         }
@@ -388,9 +388,9 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
+            val existingRecord = fastingUseCases.getFastRecordForDate(dateEpoch)
             if (existingRecord != null) {
-                fastingRepository.updateFastStatus(dateEpoch, FastStatus.NOT_FASTED)
+                fastingUseCases.updateFastStatus(dateEpoch, FastStatus.NOT_FASTED)
             } else {
                 val now = System.currentTimeMillis()
                 val hijri = HijriDateCalculator.toHijri(date)
@@ -409,7 +409,7 @@ class FastingViewModel @Inject constructor(
                     createdAt = now,
                     updatedAt = now
                 )
-                fastingRepository.insertFastRecord(record)
+                fastingUseCases.insertFastRecord(record)
             }
             selectDate(date)
             loadStats()
@@ -428,7 +428,7 @@ class FastingViewModel @Inject constructor(
                 FastStatus.NOT_FASTED -> {
                     val dateEpoch = date.toUtcMidnightMillis()
                     viewModelScope.launch {
-                        fastingRepository.updateFastStatus(dateEpoch, FastStatus.FASTED)
+                        fastingUseCases.updateFastStatus(dateEpoch, FastStatus.FASTED)
                         selectDate(date)
                         loadStats()
                     }
@@ -463,7 +463,7 @@ class FastingViewModel @Inject constructor(
         val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         calendarJob = viewModelScope.launch {
-            fastingRepository.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
+            fastingUseCases.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
                 _calendarState.update { it.copy(records = records, isLoading = false) }
             }
         }
@@ -486,7 +486,7 @@ class FastingViewModel @Inject constructor(
                 val endEpoch =
                     ramadanEnd.plusDays(1).toUtcMidnightMillis()
 
-                fastingRepository.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
+                fastingUseCases.getFastRecordsInRange(startEpoch, endEpoch).collect { records ->
                     val fasted = records.count { it.status == FastStatus.FASTED }
                     val missed = records.count { it.status == FastStatus.NOT_FASTED }
 
@@ -517,7 +517,7 @@ class FastingViewModel @Inject constructor(
         makeupPendingJob?.cancel()
         makeupAllJob?.cancel()
         makeupPendingJob = viewModelScope.launch {
-            fastingRepository.getPendingMakeupFasts().collect { pending ->
+            fastingUseCases.getPendingMakeupFasts().collect { pending ->
                 _makeupState.update {
                     it.copy(
                         pendingMakeupFasts = pending,
@@ -527,26 +527,26 @@ class FastingViewModel @Inject constructor(
             }
         }
         makeupAllJob = viewModelScope.launch {
-            fastingRepository.getAllMakeupFasts().collect { all ->
+            fastingUseCases.getAllMakeupFasts().collect { all ->
                 _makeupState.update { it.copy(allMakeupFasts = all) }
             }
         }
         viewModelScope.launch {
-            val totalFidya = fastingRepository.getTotalFidyaPaid()
+            val totalFidya = fastingUseCases.getTotalFidyaPaid()
             _makeupState.update { it.copy(totalFidyaPaid = totalFidya, isLoading = false) }
         }
     }
 
     private fun addMakeupFast(makeupFast: MakeupFast) {
         viewModelScope.launch {
-            fastingRepository.insertMakeupFast(makeupFast)
+            fastingUseCases.insertMakeupFast(makeupFast)
             loadMakeupFasts()
         }
     }
 
     private fun completeMakeupFast(makeupFastId: Long) {
         viewModelScope.launch {
-            fastingRepository.markMakeupFastCompleted(makeupFastId, System.currentTimeMillis())
+            fastingUseCases.markMakeupFastCompleted(makeupFastId, System.currentTimeMillis())
             loadMakeupFasts()
             loadStats()
         }
@@ -554,7 +554,7 @@ class FastingViewModel @Inject constructor(
 
     private fun payFidya(makeupFastId: Long, amount: Double) {
         viewModelScope.launch {
-            fastingRepository.markFidyaPaid(makeupFastId, amount)
+            fastingUseCases.markFidyaPaid(makeupFastId, amount)
             loadMakeupFasts()
         }
     }
@@ -578,9 +578,9 @@ class FastingViewModel @Inject constructor(
         val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val stats = fastingRepository.getFastingStats(startEpoch, endEpoch)
-            val ramadanCount = fastingRepository.getRamadanFastedCount()
-            val voluntaryCount = fastingRepository.getVoluntaryFastCount()
+            val stats = fastingUseCases.getFastingStats(startEpoch, endEpoch)
+            val ramadanCount = fastingUseCases.getRamadanFastedCount()
+            val voluntaryCount = fastingUseCases.getVoluntaryFastCount()
 
             _statsState.update {
                 it.copy(
@@ -597,7 +597,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
+            val existingRecord = fastingUseCases.getFastRecordForDate(dateEpoch)
             val hijri = HijriDateCalculator.toHijri(date)
             val isRamadan = hijri.month == 9
 
@@ -626,7 +626,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val existingRecord = fastingRepository.getFastRecordForDate(dateEpoch)
+            val existingRecord = fastingUseCases.getFastRecordForDate(dateEpoch)
             val now = System.currentTimeMillis()
             val hijri = HijriDateCalculator.toHijri(date)
 
@@ -647,16 +647,16 @@ class FastingViewModel @Inject constructor(
             )
 
             if (existingRecord != null) {
-                fastingRepository.updateFastRecord(record)
+                fastingUseCases.updateFastRecord(record)
             } else {
-                fastingRepository.insertFastRecord(record)
+                fastingUseCases.insertFastRecord(record)
             }
 
             // Auto-create makeup fast for missed/exempted Ramadan days
             if (fastType == FastType.RAMADAN &&
                 (status == FastStatus.NOT_FASTED || status == FastStatus.EXEMPTED)
             ) {
-                val existingMakeupCount = fastingRepository.getMakeupFastCountForDate(dateEpoch)
+                val existingMakeupCount = fastingUseCases.getMakeupFastCountForDate(dateEpoch)
                 if (existingMakeupCount == 0) {
                     val makeupFast = MakeupFast(
                         id = 0,
@@ -670,7 +670,7 @@ class FastingViewModel @Inject constructor(
                         createdAt = now,
                         updatedAt = now
                     )
-                    fastingRepository.insertMakeupFast(makeupFast)
+                    fastingUseCases.insertMakeupFast(makeupFast)
                 }
             }
 
@@ -687,7 +687,7 @@ class FastingViewModel @Inject constructor(
         val dateEpoch = date.toUtcMidnightMillis()
 
         viewModelScope.launch {
-            fastingRepository.deleteFastRecordByDate(dateEpoch)
+            fastingUseCases.deleteFastRecordByDate(dateEpoch)
             _sheetState.update { it.copy(isVisible = false) }
             selectDate(date)
             loadCalendarMonth()
@@ -698,7 +698,7 @@ class FastingViewModel @Inject constructor(
 
     private fun updateMakeupFastRecord(makeupFast: MakeupFast) {
         viewModelScope.launch {
-            fastingRepository.updateMakeupFast(makeupFast)
+            fastingUseCases.updateMakeupFast(makeupFast)
             loadMakeupFasts()
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -222,7 +223,9 @@ class FastingViewModel @Inject constructor(
                     )
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            CrashReporter.recordException(e)
+            AppAnalytics.logError("fasting", "load_prayer_times", e.message)
             // Keep default placeholder times
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.ExemptionReason
 import com.arshadshah.nimaz.domain.model.FastRecord
 import com.arshadshah.nimaz.domain.model.FastStatus
@@ -128,7 +128,7 @@ sealed interface FastingEvent {
 class FastingViewModel @Inject constructor(
     private val fastingUseCases: FastingUseCases,
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _trackerState = MutableStateFlow(FastingTrackerUiState())
@@ -174,8 +174,8 @@ class FastingViewModel @Inject constructor(
     private fun observeLocationAndLoadPrayerTimes() {
         viewModelScope.launch {
             combine(
-                preferencesDataStore.latitude,
-                preferencesDataStore.longitude
+                settingsRepository.latitude,
+                settingsRepository.longitude
             ) { lat, lng -> Pair(lat, lng) }
                 .collect { (lat, lng) ->
                     val latitude = if (lat != 0.0) lat else DEFAULT_LATITUDE

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
@@ -9,7 +9,7 @@ import com.arshadshah.nimaz.domain.model.HadithChapter
 import com.arshadshah.nimaz.domain.model.HadithGrade
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
 import androidx.compose.ui.text.font.FontFamily
@@ -90,7 +90,7 @@ sealed interface HadithEvent {
 @HiltViewModel
 class HadithViewModel @Inject constructor(
     private val hadithUseCases: HadithUseCases,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _collectionState = MutableStateFlow(HadithCollectionUiState())
@@ -330,16 +330,16 @@ class HadithViewModel @Inject constructor(
     private fun observeHadithSettings() {
         viewModelScope.launch {
             val displayFlow = combine(
-                preferencesDataStore.hadithArabicFont,
-                preferencesDataStore.hadithArabicFontSize,
-                preferencesDataStore.hadithTranslationFontSize
+                settingsRepository.hadithArabicFont,
+                settingsRepository.hadithArabicFontSize,
+                settingsRepository.hadithTranslationFontSize
             ) { fontId, arabicSize, transSize -> Triple(fontId, arabicSize, transSize) }
 
             val toggleFlow = combine(
-                preferencesDataStore.hadithShowArabic,
-                preferencesDataStore.hadithShowTranslation,
-                preferencesDataStore.hadithShowGrade,
-                preferencesDataStore.hadithShowChain
+                settingsRepository.hadithShowArabic,
+                settingsRepository.hadithShowTranslation,
+                settingsRepository.hadithShowGrade,
+                settingsRepository.hadithShowChain
             ) { showArabic, showTranslation, showGrade, showChain ->
                 HadithToggles(showArabic, showTranslation, showGrade, showChain)
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
@@ -8,7 +8,7 @@ import com.arshadshah.nimaz.domain.model.HadithBookmark
 import com.arshadshah.nimaz.domain.model.HadithChapter
 import com.arshadshah.nimaz.domain.model.HadithGrade
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
-import com.arshadshah.nimaz.domain.repository.HadithRepository
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
@@ -89,7 +89,7 @@ sealed interface HadithEvent {
 
 @HiltViewModel
 class HadithViewModel @Inject constructor(
-    private val hadithRepository: HadithRepository,
+    private val hadithUseCases: HadithUseCases,
     private val preferencesDataStore: PreferencesDataStore
 ) : ViewModel() {
 
@@ -151,7 +151,7 @@ class HadithViewModel @Inject constructor(
 
     private fun loadAllBooks() {
         viewModelScope.launch {
-            hadithRepository.getAllBooks().collect { books ->
+            hadithUseCases.getAllBooks().collect { books ->
                 _collectionState.update {
                     it.copy(books = books, isLoading = false)
                 }
@@ -161,7 +161,7 @@ class HadithViewModel @Inject constructor(
 
     private fun loadHadithOfTheDay() {
         viewModelScope.launch {
-            val hadith = hadithRepository.getHadithOfTheDay()
+            val hadith = hadithUseCases.getHadithOfTheDay()
             _collectionState.update { it.copy(hadithOfTheDay = hadith) }
         }
     }
@@ -170,10 +170,10 @@ class HadithViewModel @Inject constructor(
         _chaptersState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
             try {
-                val book = hadithRepository.getBookById(bookId)
+                val book = hadithUseCases.getBookById(bookId)
                 _chaptersState.update { it.copy(book = book) }
 
-                hadithRepository.getChaptersByBook(bookId).collect { chapters ->
+                hadithUseCases.getChaptersByBook(bookId).collect { chapters ->
                     _chaptersState.update { state ->
                         state.copy(
                             chapters = chapters,
@@ -192,10 +192,10 @@ class HadithViewModel @Inject constructor(
         _readerState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
             try {
-                val chapter = hadithRepository.getChapterById(chapterId)
+                val chapter = hadithUseCases.getChapterById(chapterId)
                 _readerState.update { it.copy(chapter = chapter) }
 
-                hadithRepository.getHadithsByChapter(chapterId).collect { hadiths ->
+                hadithUseCases.getHadithsByChapter(chapterId).collect { hadiths ->
                     _readerState.update {
                         it.copy(hadiths = hadiths, isLoading = false, currentHadithIndex = 0)
                     }
@@ -210,14 +210,14 @@ class HadithViewModel @Inject constructor(
         _readerState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
             try {
-                val hadith = hadithRepository.getHadithById(hadithId)
+                val hadith = hadithUseCases.getHadithById(hadithId)
                 if (hadith != null) {
                     // Load the chapter containing this hadith to get context
                     val chapterId = "${hadith.bookId}_${hadith.chapterId}"
-                    val chapter = hadithRepository.getChapterById(chapterId)
+                    val chapter = hadithUseCases.getChapterById(chapterId)
 
                     // Get all hadiths in this chapter
-                    hadithRepository.getHadithsByChapter(chapterId).collect { hadiths ->
+                    hadithUseCases.getHadithsByChapter(chapterId).collect { hadiths ->
                         // Find the index of the target hadith
                         val index = hadiths.indexOfFirst { it.id == hadithId }
                         _readerState.update {
@@ -241,7 +241,7 @@ class HadithViewModel @Inject constructor(
     private fun loadHadithByNumber(bookId: String, hadithNumber: Int) {
         viewModelScope.launch {
             try {
-                val hadith = hadithRepository.getHadithByNumber(bookId, hadithNumber)
+                val hadith = hadithUseCases.getHadithByNumber(bookId, hadithNumber)
                 hadith?.let {
                     // Load the chapter containing this hadith
                     loadChapter(it.chapterId)
@@ -265,7 +265,7 @@ class HadithViewModel @Inject constructor(
 
         _searchState.update { it.copy(query = query, isSearching = true) }
         viewModelScope.launch {
-            hadithRepository.searchHadiths(query).collect { results ->
+            hadithUseCases.searchHadiths(query).collect { results ->
                 _searchState.update { it.copy(results = results, isSearching = false) }
             }
         }
@@ -279,7 +279,7 @@ class HadithViewModel @Inject constructor(
 
         _searchState.update { it.copy(query = query, selectedBookId = bookId, isSearching = true) }
         viewModelScope.launch {
-            hadithRepository.searchHadithsInBook(bookId, query).collect { results ->
+            hadithUseCases.searchHadithsInBook(bookId, query).collect { results ->
                 _searchState.update { it.copy(results = results, isSearching = false) }
             }
         }
@@ -301,7 +301,7 @@ class HadithViewModel @Inject constructor(
 
     private fun filterByGrade(grade: HadithGrade) {
         viewModelScope.launch {
-            hadithRepository.getHadithsByGrade(grade).collect { hadiths ->
+            hadithUseCases.getHadithsByGrade(grade).collect { hadiths ->
                 _readerState.update { it.copy(hadiths = hadiths) }
             }
         }
@@ -309,19 +309,19 @@ class HadithViewModel @Inject constructor(
 
     private fun toggleBookmark(hadithId: String, bookId: String, hadithNumber: Int) {
         viewModelScope.launch {
-            hadithRepository.toggleBookmark(hadithId, bookId, hadithNumber)
+            hadithUseCases.toggleBookmark(hadithId, bookId, hadithNumber)
         }
     }
 
     private fun loadBookmarks() {
         viewModelScope.launch {
-            hadithRepository.getAllBookmarks().collect { bookmarks ->
+            hadithUseCases.getAllBookmarks().collect { bookmarks ->
                 _bookmarksState.update { it.copy(bookmarks = bookmarks, isLoading = false) }
             }
         }
     }
 
-    fun isHadithBookmarked(hadithId: String) = hadithRepository.isHadithBookmarked(hadithId)
+    fun isHadithBookmarked(hadithId: String) = hadithUseCases.isHadithBookmarked(hadithId)
 
     /**
      * Reactively mirrors the persisted hadith reading preferences into the reader

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.model.Hadith
 import com.arshadshah.nimaz.domain.model.HadithBook
 import com.arshadshah.nimaz.domain.model.HadithBookmark
@@ -117,6 +119,17 @@ class HadithViewModel @Inject constructor(
 
     fun onEvent(event: HadithEvent) {
         when (event) {
+            is HadithEvent.LoadBook -> AppAnalytics.logFeatureUsed("hadith", "open_book")
+            is HadithEvent.LoadChapter -> AppAnalytics.logFeatureUsed("hadith", "open_reader")
+            is HadithEvent.LoadHadithById -> AppAnalytics.logFeatureUsed("hadith", "open_hadith")
+            is HadithEvent.LoadHadithByNumber -> AppAnalytics.logFeatureUsed("hadith", "open_hadith")
+            is HadithEvent.Search -> AppAnalytics.logFeatureUsed("hadith", "search")
+            is HadithEvent.SearchInBook -> AppAnalytics.logFeatureUsed("hadith", "search_in_book")
+            is HadithEvent.FilterByGrade -> AppAnalytics.logFeatureUsed("hadith", "filter_by_grade")
+            is HadithEvent.ToggleBookmark -> AppAnalytics.logFeatureUsed("hadith", "toggle_bookmark")
+            else -> {}
+        }
+        when (event) {
             is HadithEvent.LoadBook -> loadBook(event.bookId)
             is HadithEvent.LoadChapter -> loadChapter(event.chapterId)
             is HadithEvent.LoadHadithById -> loadHadithById(event.hadithId)
@@ -183,6 +196,8 @@ class HadithViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("hadith", "load_book", e.message)
                 _chaptersState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -201,6 +216,8 @@ class HadithViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("hadith", "load_chapter", e.message)
                 _readerState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -233,6 +250,8 @@ class HadithViewModel @Inject constructor(
                     _readerState.update { it.copy(error = "Hadith not found", isLoading = false) }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("hadith", "load_hadith_by_id", e.message)
                 _readerState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -252,6 +271,8 @@ class HadithViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("hadith", "load_hadith_by_number", e.message)
                 _readerState.update { it.copy(error = e.message) }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
@@ -2,7 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.HelpGuideDetail
 import com.arshadshah.nimaz.domain.model.HelpSearchResult
 import com.arshadshah.nimaz.domain.model.HelpTopic
@@ -56,7 +56,7 @@ sealed interface HelpEvent {
 @HiltViewModel
 class HelpViewModel @Inject constructor(
     private val useCases: HelpUseCases,
-    preferences: PreferencesDataStore
+    preferences: SettingsRepository
 ) : ViewModel() {
 
     private val language: StateFlow<String> = preferences.appLanguage

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.HelpGuideDetail
 import com.arshadshah.nimaz.domain.model.HelpSearchResult
@@ -77,7 +79,11 @@ class HelpViewModel @Inject constructor(
         // Topics re-resolve when the app language changes.
         viewModelScope.launch {
             language.flatMapLatest { lang -> useCases.getTopics(lang) }
-                .catch { e -> _homeState.update { it.copy(isLoading = false, error = e.message) } }
+                .catch { e ->
+                    CrashReporter.recordException(e)
+                    AppAnalytics.logError("help", "load_topics", e.message)
+                    _homeState.update { it.copy(isLoading = false, error = e.message) }
+                }
                 .collect { topics ->
                     _homeState.update {
                         it.copy(
@@ -93,7 +99,11 @@ class HelpViewModel @Inject constructor(
                 .flatMapLatest { (q, lang) ->
                     if (q.isBlank()) flowOf(emptyList()) else useCases.search(q, lang)
                 }
-                .catch { /* keep last results on error */ }
+                .catch { e ->
+                    CrashReporter.recordException(e)
+                    AppAnalytics.logError("help", "search", e.message)
+                    /* keep last results on error */
+                }
                 .collect { results ->
                     _homeState.update {
                         it.copy(
@@ -108,12 +118,20 @@ class HelpViewModel @Inject constructor(
     fun onEvent(event: HelpEvent) {
         when (event) {
             is HelpEvent.Search -> {
+                AppAnalytics.logFeatureUsed("help", "search")
                 query.value = event.query
                 _homeState.update { it.copy(query = event.query) }
             }
 
-            is HelpEvent.LoadTopic -> loadTopic(event.topicId)
-            is HelpEvent.LoadGuide -> loadGuide(event.guideId)
+            is HelpEvent.LoadTopic -> {
+                AppAnalytics.logFeatureUsed("help", "open_topic")
+                loadTopic(event.topicId)
+            }
+
+            is HelpEvent.LoadGuide -> {
+                AppAnalytics.logFeatureUsed("help", "open_guide")
+                loadGuide(event.guideId)
+            }
         }
     }
 
@@ -121,7 +139,11 @@ class HelpViewModel @Inject constructor(
         _topicState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             language.flatMapLatest { lang -> useCases.getTopicDetail(topicId, lang) }
-                .catch { e -> _topicState.update { it.copy(isLoading = false, error = e.message) } }
+                .catch { e ->
+                    CrashReporter.recordException(e)
+                    AppAnalytics.logError("help", "load_topic", e.message)
+                    _topicState.update { it.copy(isLoading = false, error = e.message) }
+                }
                 .collect { detail ->
                     _topicState.update {
                         it.copy(
@@ -137,7 +159,11 @@ class HelpViewModel @Inject constructor(
         _guideState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             language.flatMapLatest { lang -> useCases.getGuide(guideId, lang) }
-                .catch { e -> _guideState.update { it.copy(isLoading = false, error = e.message) } }
+                .catch { e ->
+                    CrashReporter.recordException(e)
+                    AppAnalytics.logError("help", "load_guide", e.message)
+                    _guideState.update { it.copy(isLoading = false, error = e.message) }
+                }
                 .collect { guide ->
                     _guideState.update {
                         it.copy(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -27,7 +27,7 @@ import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -117,7 +117,7 @@ sealed interface HomeEvent {
 class HomeViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val prayerRepository: PrayerRepository,
+    private val prayerUseCases: PrayerUseCases,
     private val preferencesDataStore: PreferencesDataStore,
     private val fastingDao: FastingDao,
     private val hadithDao: HadithDao,
@@ -148,7 +148,7 @@ class HomeViewModel @Inject constructor(
 
     private fun loadPrayerRecords() {
         viewModelScope.launch {
-            prayerRepository.getTodayPrayerRecords().collect { records ->
+            prayerUseCases.getTodayPrayerRecords().collect { records ->
                 _prayerRecords.update { records }
             }
         }
@@ -327,7 +327,7 @@ class HomeViewModel @Inject constructor(
             val prayedAt =
                 if (newStatus == PrayerStatus.PRAYED) System.currentTimeMillis() else null
 
-            prayerRepository.updatePrayerStatus(todayEpoch, prayerName, newStatus, prayedAt, false)
+            prayerUseCases.updatePrayerStatus(todayEpoch, prayerName, newStatus, prayedAt, false)
             _prayerRecords.update { it + (prayerName to newStatus) }
 
             // Update displays with new status

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.FastStatus
@@ -120,7 +120,7 @@ class HomeViewModel @Inject constructor(
     private val fastingUseCases: FastingUseCases,
     private val hadithUseCases: HadithUseCases,
     private val duaUseCases: DuaUseCases,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeUiState())
@@ -321,26 +321,26 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             // Combine location with all prayer calculation settings
             val locationFlow = combine(
-                preferencesDataStore.latitude,
-                preferencesDataStore.longitude,
-                preferencesDataStore.locationName
+                settingsRepository.latitude,
+                settingsRepository.longitude,
+                settingsRepository.locationName
             ) { lat: Double, lng: Double, name: String ->
                 Triple(lat, lng, name)
             }
 
             val calcSettingsFlow = combine(
-                preferencesDataStore.calculationMethod,
-                preferencesDataStore.asrCalculation,
-                preferencesDataStore.highLatitudeRule
+                settingsRepository.calculationMethod,
+                settingsRepository.asrCalculation,
+                settingsRepository.highLatitudeRule
             ) { calc: String, asr: String, high: String ->
                 Triple(calc, asr, high)
             }
 
             val adjustmentsFlow = combine(
-                preferencesDataStore.fajrAdjustment,
-                preferencesDataStore.sunriseAdjustment,
-                preferencesDataStore.dhuhrAdjustment,
-                preferencesDataStore.asrAdjustment,
+                settingsRepository.fajrAdjustment,
+                settingsRepository.sunriseAdjustment,
+                settingsRepository.dhuhrAdjustment,
+                settingsRepository.asrAdjustment,
             ) { fajr, sunrise, dhuhr, asr ->
                 mapOf(
                     PrayerType.FAJR to fajr,
@@ -350,8 +350,8 @@ class HomeViewModel @Inject constructor(
                 )
             }.combine(
                 combine(
-                    preferencesDataStore.maghribAdjustment,
-                    preferencesDataStore.ishaAdjustment
+                    settingsRepository.maghribAdjustment,
+                    settingsRepository.ishaAdjustment
                 ) { maghrib, isha ->
                     mapOf(
                         PrayerType.MAGHRIB to maghrib,
@@ -414,7 +414,7 @@ class HomeViewModel @Inject constructor(
 
     private fun updateLocation(latitude: Double, longitude: Double, name: String) {
         viewModelScope.launch {
-            preferencesDataStore.updateLocation(latitude, longitude, name)
+            settingsRepository.updateLocation(latitude, longitude, name)
             _state.update {
                 it.copy(
                     latitude = latitude,
@@ -617,7 +617,7 @@ class HomeViewModel @Inject constructor(
 
     private fun observeTimeFormat() {
         viewModelScope.launch {
-            preferencesDataStore.use24HourFormat.collect { enabled ->
+            settingsRepository.use24HourFormat.collect { enabled ->
                 use24HourFormat = enabled
                 calculatePrayerTimes() // Recalculate to reformat times
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -14,19 +14,18 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.database.dao.DuaDao
-import com.arshadshah.nimaz.data.local.database.dao.FastingDao
-import com.arshadshah.nimaz.data.local.database.dao.HadithDao
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
-import com.arshadshah.nimaz.data.local.dua.DuaContentSeeder
-import com.arshadshah.nimaz.data.local.hadith.HadithBackfillSeeder
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.FastStatus
 import com.arshadshah.nimaz.domain.model.HadithGrade
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.FastingUseCases
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -118,12 +117,10 @@ class HomeViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val prayerUseCases: PrayerUseCases,
-    private val preferencesDataStore: PreferencesDataStore,
-    private val fastingDao: FastingDao,
-    private val hadithDao: HadithDao,
-    private val duaDao: DuaDao,
-    private val duaContentSeeder: DuaContentSeeder,
-    private val hadithBackfillSeeder: HadithBackfillSeeder
+    private val fastingUseCases: FastingUseCases,
+    private val hadithUseCases: HadithUseCases,
+    private val duaUseCases: DuaUseCases,
+    private val preferencesDataStore: PreferencesDataStore
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeUiState())
@@ -160,9 +157,9 @@ class HomeViewModel @Inject constructor(
             val startOfDay = today.toUtcMidnightMillis()
             val endOfDay = startOfDay + MILLIS_PER_DAY - 1
 
-            fastingDao.getFastRecordsInRange(startOfDay, endOfDay).collect { records ->
+            fastingUseCases.getFastRecordsInRange(startOfDay, endOfDay).collect { records ->
                 val todayRecord = records.firstOrNull()
-                _state.update { it.copy(fastingToday = todayRecord?.status == "fasted") }
+                _state.update { it.copy(fastingToday = todayRecord?.status == FastStatus.FASTED) }
             }
         }
     }
@@ -170,36 +167,20 @@ class HomeViewModel @Inject constructor(
     private fun loadDailyHadith() {
         viewModelScope.launch {
             try {
-                // Fill in any chains of narration that shipped empty in the
-                // prepopulated DB before reading. On an app update the asset is
-                // not re-copied, so the seeder is what reaches existing users.
-                hadithBackfillSeeder.seedIfNeeded()
-                val totalHadiths = hadithDao.getHadithCount()
-                if (totalHadiths == 0) return@launch
-
-                // Spread the daily selection across the whole collection. The
-                // previous approach incremented the offset by one per day, so
-                // consecutive days landed on adjacent (near-identical) hadiths
-                // and barely appeared to change. Multiplying the day index by a
-                // large odd constant (Knuth's multiplicative hash) scatters
-                // each day to a very different part of the database while still
-                // being deterministic: the same day always yields the same
-                // hadith.
-                val daysSinceEpoch = LocalDate.now().toEpochDay()
-                val offset =
-                    Math.floorMod(daysSinceEpoch * 2654435761L, totalHadiths.toLong()).toInt()
-
-                val hadith = hadithDao.getHadithByOffset(offset)
+                // GetDailyHadithUseCase seeds the backfill and applies the Knuth
+                // multiplicative-hash scatter so consecutive days land on very
+                // different hadiths while staying deterministic per day.
+                val hadith = hadithUseCases.getDailyHadith(LocalDate.now().toEpochDay()) ?: return@launch
                 _state.update {
                     it.copy(
-                        dailyHadith = hadith?.textEnglish?.let { text ->
+                        dailyHadith = hadith.textEnglish.let { text ->
                             if (text.length > 150) text.take(150).trimEnd() + "…" else text
                         },
-                        dailyHadithReference = hadith?.reference?.takeIf { ref -> ref.isNotBlank() },
+                        dailyHadithReference = hadith.reference?.takeIf { ref -> ref.isNotBlank() },
                         // Carry the id so tapping the card opens this exact hadith
                         // in the reader, and a short grade label for the card chip.
-                        dailyHadithId = hadith?.id?.toString(),
-                        dailyHadithGrade = shortGradeLabel(hadith?.grade)
+                        dailyHadithId = hadith.id,
+                        dailyHadithGrade = shortGradeLabel(hadith.grade)
                     )
                 }
             } catch (_: Exception) {
@@ -212,8 +193,8 @@ class HomeViewModel @Inject constructor(
      * Short, chip-friendly grade label for the home hadith card (e.g. "Sahih").
      * Returns null for unknown/blank grades so the card simply omits the chip.
      */
-    private fun shortGradeLabel(rawGrade: String?): String? =
-        when (HadithGrade.fromString(rawGrade)) {
+    private fun shortGradeLabel(grade: HadithGrade?): String? =
+        when (grade) {
             HadithGrade.SAHIH -> context.getString(R.string.grade_sahih)
             HadithGrade.HASAN -> context.getString(R.string.grade_hasan)
             HadithGrade.DAIF -> context.getString(R.string.grade_daif)
@@ -228,26 +209,21 @@ class HomeViewModel @Inject constructor(
     private fun loadDailyDua() {
         viewModelScope.launch {
             try {
-                // Ensure newly shipped duas are seeded before reading directly
-                // from the DAO; on an app update the prepopulated DB is not
-                // re-copied, so the seeder is what brings in the new content.
-                duaContentSeeder.seedIfNeeded()
-                val categoryId = duaCategoryForHour(LocalTime.now().hour)
-                val category = duaDao.getCategoryById(categoryId) ?: return@launch
-                val duas = duaDao.getDuasByCategoryOnce(categoryId)
-                if (duas.isEmpty()) return@launch
-
-                val index = (LocalDate.now().dayOfYear % duas.size).coerceIn(0, duas.size - 1)
-                val dua = duas[index]
+                val now = LocalDate.now()
+                val selection = duaUseCases.getDailyDua(
+                    hourOfDay = LocalTime.now().hour,
+                    dayOfYear = now.dayOfYear
+                ) ?: return@launch
+                val dua = selection.dua
                 _state.update {
                     it.copy(
                         dailyDua = DailyDua(
                             title = dua.titleEnglish,
                             arabic = dua.textArabic,
-                            translation = dua.translation,
-                            source = dua.source,
-                            categoryLabel = category.nameEnglish,
-                            categoryIcon = category.icon
+                            translation = dua.textEnglish,
+                            source = dua.reference ?: "",
+                            categoryLabel = selection.categoryName,
+                            categoryIcon = selection.categoryIcon ?: ""
                         )
                     )
                 }
@@ -255,17 +231,6 @@ class HomeViewModel @Inject constructor(
                 // No dua data available
             }
         }
-    }
-
-    /**
-     * Maps the hour of day to a dua category id (matching the prepopulated
-     * `dua_categories` table): morning adhkar through the day, evening adhkar
-     * in the late afternoon, and before-sleep adhkar at night.
-     */
-    private fun duaCategoryForHour(hour: Int): Int = when (hour) {
-        in 4..15 -> DUA_CATEGORY_MORNING
-        in 16..20 -> DUA_CATEGORY_EVENING
-        else -> DUA_CATEGORY_BEFORE_SLEEP
     }
 
     fun onEvent(event: HomeEvent) {
@@ -445,11 +410,6 @@ class HomeViewModel @Inject constructor(
         private const val DEFAULT_LATITUDE = 53.3498
         private const val DEFAULT_LONGITUDE = -6.2603
         private const val DEFAULT_LOCATION_NAME = "Dublin, Ireland"
-
-        // Dua category ids from the prepopulated `dua_categories` table.
-        private const val DUA_CATEGORY_MORNING = 1       // Morning Adhkar
-        private const val DUA_CATEGORY_EVENING = 2       // Evening Adhkar
-        private const val DUA_CATEGORY_BEFORE_SLEEP = 5  // Before Sleep
     }
 
     private fun updateLocation(latitude: Double, longitude: Double, name: String) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -12,6 +12,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -183,7 +185,9 @@ class HomeViewModel @Inject constructor(
                         dailyHadithGrade = shortGradeLabel(hadith.grade)
                     )
                 }
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("home", "load_daily_hadith", e.message)
                 // No hadith data available
             }
         }
@@ -227,13 +231,20 @@ class HomeViewModel @Inject constructor(
                         )
                     )
                 }
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("home", "load_daily_dua", e.message)
                 // No dua data available
             }
         }
     }
 
     fun onEvent(event: HomeEvent) {
+        when (event) {
+            is HomeEvent.UpdateLocation -> AppAnalytics.logFeatureUsed("home", "update_location")
+            is HomeEvent.TogglePrayerStatus -> AppAnalytics.logFeatureUsed("home", "toggle_prayer_status")
+            else -> {}
+        }
         when (event) {
             is HomeEvent.UpdateLocation -> updateLocation(
                 event.latitude,
@@ -599,6 +610,8 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("home", "calculate_prayer_times", e.message)
                 _state.update { it.copy(isLoading = false, error = e.message) }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/KhatamViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/KhatamViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.DailyLogEntry
 import com.arshadshah.nimaz.domain.model.JuzProgressInfo
 import com.arshadshah.nimaz.domain.model.Khatam
@@ -81,6 +82,15 @@ class KhatamViewModel @Inject constructor(
     }
 
     fun onEvent(event: KhatamEvent) {
+        when (event) {
+            is KhatamEvent.SetActiveKhatam -> AppAnalytics.logFeatureUsed("khatam", "set_active")
+            is KhatamEvent.DeleteKhatam -> AppAnalytics.logFeatureUsed("khatam", "delete")
+            is KhatamEvent.AbandonKhatam -> AppAnalytics.logFeatureUsed("khatam", "abandon")
+            is KhatamEvent.ReactivateKhatam -> AppAnalytics.logFeatureUsed("khatam", "reactivate")
+            is KhatamEvent.LoadKhatamDetail -> AppAnalytics.logFeatureUsed("khatam", "open_detail")
+            KhatamEvent.CreateKhatam -> AppAnalytics.logFeatureUsed("khatam", "create")
+            else -> {}
+        }
         when (event) {
             is KhatamEvent.SetActiveKhatam -> setActiveKhatam(event.khatamId)
             is KhatamEvent.DeleteKhatam -> deleteKhatam(event.khatamId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
@@ -9,6 +9,8 @@ import android.os.Build
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -113,13 +115,22 @@ class LocationViewModel @Inject constructor(
                 }
             }
 
-            LocationEvent.Search -> searchLocations(_state.value.searchQuery)
+            LocationEvent.Search -> {
+                AppAnalytics.logFeatureUsed("location", "search")
+                searchLocations(_state.value.searchQuery)
+            }
             LocationEvent.ClearSearch -> _state.update {
                 it.copy(searchQuery = "", searchResults = emptyList())
             }
 
-            is LocationEvent.SelectLocation -> selectLocation(event.location)
-            LocationEvent.UseCurrentGpsLocation -> detectCurrentLocation()
+            is LocationEvent.SelectLocation -> {
+                AppAnalytics.logFeatureUsed("location", "select_location")
+                selectLocation(event.location)
+            }
+            LocationEvent.UseCurrentGpsLocation -> {
+                AppAnalytics.logFeatureUsed("location", "use_gps")
+                detectCurrentLocation()
+            }
             LocationEvent.LoadCurrentLocation -> loadCurrentLocation()
             LocationEvent.DismissError -> _state.update { it.copy(error = null) }
         }
@@ -141,6 +152,8 @@ class LocationViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("location", "load_current", e.message)
                 // Silently fail - location not set
             }
         }
@@ -169,6 +182,8 @@ class LocationViewModel @Inject constructor(
                     _state.update { it.copy(recentLocations = recentLocations) }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("location", "load_recent", e.message)
                 // Silently fail
             }
         }
@@ -185,6 +200,8 @@ class LocationViewModel @Inject constructor(
                 }
                 _state.update { it.copy(searchResults = results, isSearching = false) }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("location", "search", e.message)
                 _state.update {
                     it.copy(
                         isSearching = false,
@@ -233,6 +250,8 @@ class LocationViewModel @Inject constructor(
                 } else null
             }.distinctBy { "${it.name}, ${it.country}" }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
+            AppAnalytics.logError("location", "geocode_search", e.message)
             emptyList()
         }
     }
@@ -279,6 +298,8 @@ class LocationViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("location", "select_location", e.message)
                 _state.update { it.copy(error = "Failed to save location: ${e.message}") }
             }
         }
@@ -327,6 +348,8 @@ class LocationViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("location", "detect_gps", e.message)
                 _state.update {
                     it.copy(
                         isLoadingGps = false,
@@ -405,6 +428,8 @@ class LocationViewModel @Inject constructor(
                 "Unknown Location"
             }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
+            AppAnalytics.logError("location", "reverse_geocode", e.message)
             "Unknown Location"
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
@@ -9,7 +9,7 @@ import android.os.Build
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
@@ -87,7 +87,7 @@ sealed interface LocationEvent {
 @HiltViewModel
 class LocationViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val preferencesDataStore: PreferencesDataStore,
+    private val settingsRepository: SettingsRepository,
     private val prayerUseCases: PrayerUseCases
 ) : ViewModel() {
 
@@ -128,7 +128,7 @@ class LocationViewModel @Inject constructor(
     private fun loadCurrentLocation() {
         viewModelScope.launch {
             try {
-                val prefs = preferencesDataStore.userPreferences.first()
+                val prefs = settingsRepository.userPreferences.first()
                 if (prefs.latitude != 0.0 && prefs.longitude != 0.0) {
                     _state.update {
                         it.copy(
@@ -241,7 +241,7 @@ class LocationViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 // Save to DataStore
-                preferencesDataStore.updateLocation(
+                settingsRepository.updateLocation(
                     latitude = location.latitude,
                     longitude = location.longitude,
                     name = "${location.name}, ${location.country}"
@@ -302,7 +302,7 @@ class LocationViewModel @Inject constructor(
                     }
 
                     // Save location
-                    preferencesDataStore.updateLocation(
+                    settingsRepository.updateLocation(
                         latitude = location.first,
                         longitude = location.second,
                         name = locationName

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/LocationViewModel.kt
@@ -13,7 +13,7 @@ import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -88,7 +88,7 @@ sealed interface LocationEvent {
 class LocationViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val preferencesDataStore: PreferencesDataStore,
-    private val prayerRepository: PrayerRepository
+    private val prayerUseCases: PrayerUseCases
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(LocationUiState())
@@ -149,7 +149,7 @@ class LocationViewModel @Inject constructor(
     private fun loadRecentLocations() {
         viewModelScope.launch {
             try {
-                prayerRepository.getAllLocations().collect { locations ->
+                prayerUseCases.getAllLocations().collect { locations ->
                     val recentLocations = locations
                         .map { location ->
                             SearchLocation(
@@ -264,7 +264,7 @@ class LocationViewModel @Inject constructor(
                     fajrAngle = null,
                     ishaAngle = null
                 )
-                prayerRepository.insertLocation(domainLocation)
+                prayerUseCases.insertLocation(domainLocation)
 
                 // Update state
                 _state.update {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -73,11 +74,13 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
     fun onEvent(event: MonthlyPrayerTimesEvent) {
         when (event) {
             MonthlyPrayerTimesEvent.NextMonth -> {
+                AppAnalytics.logFeatureUsed("monthly_prayer_times", "next_month")
                 _state.update { it.copy(currentMonth = it.currentMonth.plusMonths(1)) }
                 calculateMonth()
             }
 
             MonthlyPrayerTimesEvent.PreviousMonth -> {
+                AppAnalytics.logFeatureUsed("monthly_prayer_times", "previous_month")
                 _state.update { it.copy(currentMonth = it.currentMonth.minusMonths(1)) }
                 calculateMonth()
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
@@ -52,7 +52,7 @@ sealed interface MonthlyPrayerTimesEvent {
 @HiltViewModel
 class MonthlyPrayerTimesViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MonthlyPrayerTimesUiState())
@@ -95,23 +95,23 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
     private fun observeSettings() {
         viewModelScope.launch {
             combine(
-                preferencesDataStore.latitude,
-                preferencesDataStore.longitude,
-                preferencesDataStore.locationName
+                settingsRepository.latitude,
+                settingsRepository.longitude,
+                settingsRepository.locationName
             ) { lat, lng, name -> Triple(lat, lng, name) }
                 .combine(
                     combine(
-                        preferencesDataStore.calculationMethod,
-                        preferencesDataStore.asrCalculation,
-                        preferencesDataStore.highLatitudeRule
+                        settingsRepository.calculationMethod,
+                        settingsRepository.asrCalculation,
+                        settingsRepository.highLatitudeRule
                     ) { calc, asr, high -> Triple(calc, asr, high) }
                 ) { location, calcSettings -> Pair(location, calcSettings) }
                 .combine(
                     combine(
-                        preferencesDataStore.fajrAdjustment,
-                        preferencesDataStore.sunriseAdjustment,
-                        preferencesDataStore.dhuhrAdjustment,
-                        preferencesDataStore.asrAdjustment,
+                        settingsRepository.fajrAdjustment,
+                        settingsRepository.sunriseAdjustment,
+                        settingsRepository.dhuhrAdjustment,
+                        settingsRepository.asrAdjustment,
                     ) { fajr, sunrise, dhuhr, asr ->
                         mapOf(
                             PrayerType.FAJR to fajr,
@@ -121,8 +121,8 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
                         )
                     }.combine(
                         combine(
-                            preferencesDataStore.maghribAdjustment,
-                            preferencesDataStore.ishaAdjustment
+                            settingsRepository.maghribAdjustment,
+                            settingsRepository.ishaAdjustment
                         ) { maghrib, isha ->
                             mapOf(
                                 PrayerType.MAGHRIB to maghrib,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/OnboardingViewModel.kt
@@ -14,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -124,6 +125,8 @@ class OnboardingViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("onboarding", "check_status", e.message)
                 _state.update {
                     it.copy(
                         isLoading = false,
@@ -146,6 +149,7 @@ class OnboardingViewModel @Inject constructor(
                 )
                 _state.update { it.copy(onboardingCompleted = true) }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 _state.update { it.copy(error = e.message) }
                 AppAnalytics.logError("onboarding", e.javaClass.simpleName, e.message)
             }
@@ -251,6 +255,8 @@ class OnboardingViewModel @Inject constructor(
                     _state.update { it.copy(error = "Could not detect location") }
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("onboarding", "detect_location", e.message)
                 _state.update { it.copy(error = "Failed to detect location: ${e.message}") }
             }
         }
@@ -313,6 +319,8 @@ class OnboardingViewModel @Inject constructor(
                 "Unknown Location"
             }
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
+            AppAnalytics.logError("onboarding", "reverse_geocode", e.message)
             "Unknown Location"
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/OnboardingViewModel.kt
@@ -14,7 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -66,7 +66,7 @@ sealed interface OnboardingEvent {
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(OnboardingUiState())
@@ -116,7 +116,7 @@ class OnboardingViewModel @Inject constructor(
     private fun checkOnboardingStatus() {
         viewModelScope.launch {
             try {
-                val completed = preferencesDataStore.onboardingCompleted.first()
+                val completed = settingsRepository.onboardingCompleted.first()
                 _state.update {
                     it.copy(
                         onboardingCompleted = completed,
@@ -137,7 +137,7 @@ class OnboardingViewModel @Inject constructor(
     private fun completeOnboarding() {
         viewModelScope.launch {
             try {
-                preferencesDataStore.setOnboardingCompleted(true)
+                settingsRepository.setOnboardingCompleted(true)
                 val current = _state.value
                 AppAnalytics.logOnboardingCompleted(
                     locationGranted = current.locationPermissionGranted,
@@ -235,7 +235,7 @@ class OnboardingViewModel @Inject constructor(
                     }
 
                     // Save location to DataStore
-                    preferencesDataStore.updateLocation(
+                    settingsRepository.updateLocation(
                         latitude = location.first,
                         longitude = location.second,
                         name = locationName

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -3,7 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
@@ -74,7 +74,7 @@ sealed interface PrayerTimesEvent {
 class PrayerTimesViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val prayerUseCases: PrayerUseCases,
-    private val preferencesDataStore: PreferencesDataStore,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrayerTimesUiState())
@@ -127,23 +127,23 @@ class PrayerTimesViewModel @Inject constructor(
     private fun observeSettings() {
         viewModelScope.launch {
             combine(
-                preferencesDataStore.latitude,
-                preferencesDataStore.longitude,
-                preferencesDataStore.locationName,
+                settingsRepository.latitude,
+                settingsRepository.longitude,
+                settingsRepository.locationName,
             ) { lat, lng, name -> Triple(lat, lng, name) }
                 .combine(
                     combine(
-                        preferencesDataStore.calculationMethod,
-                        preferencesDataStore.asrCalculation,
-                        preferencesDataStore.highLatitudeRule,
+                        settingsRepository.calculationMethod,
+                        settingsRepository.asrCalculation,
+                        settingsRepository.highLatitudeRule,
                     ) { calc, asr, high -> Triple(calc, asr, high) },
                 ) { location, calcSettings -> Pair(location, calcSettings) }
                 .combine(
                     combine(
-                        preferencesDataStore.fajrAdjustment,
-                        preferencesDataStore.sunriseAdjustment,
-                        preferencesDataStore.dhuhrAdjustment,
-                        preferencesDataStore.asrAdjustment,
+                        settingsRepository.fajrAdjustment,
+                        settingsRepository.sunriseAdjustment,
+                        settingsRepository.dhuhrAdjustment,
+                        settingsRepository.asrAdjustment,
                     ) { fajr, sunrise, dhuhr, asr ->
                         mapOf(
                             PrayerType.FAJR to fajr,
@@ -153,8 +153,8 @@ class PrayerTimesViewModel @Inject constructor(
                         )
                     }.combine(
                         combine(
-                            preferencesDataStore.maghribAdjustment,
-                            preferencesDataStore.ishaAdjustment,
+                            settingsRepository.maghribAdjustment,
+                            settingsRepository.ishaAdjustment,
                         ) { maghrib, isha ->
                             mapOf(PrayerType.MAGHRIB to maghrib, PrayerType.ISHA to isha)
                         },

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
@@ -102,6 +103,13 @@ class PrayerTimesViewModel @Inject constructor(
     }
 
     fun onEvent(event: PrayerTimesEvent) {
+        when (event) {
+            PrayerTimesEvent.PreviousDay -> AppAnalytics.logFeatureUsed("prayer_times", "previous_day")
+            PrayerTimesEvent.NextDay -> AppAnalytics.logFeatureUsed("prayer_times", "next_day")
+            PrayerTimesEvent.GoToToday -> AppAnalytics.logFeatureUsed("prayer_times", "go_to_today")
+            is PrayerTimesEvent.TogglePrayer -> AppAnalytics.logFeatureUsed("prayer_times", "toggle_prayer")
+            else -> {}
+        }
         when (event) {
             PrayerTimesEvent.PreviousDay -> changeDay(-1)
             PrayerTimesEvent.NextDay -> changeDay(1)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -11,7 +11,7 @@ import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerTime
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.presentation.components.organisms.MoonPhase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -73,7 +73,7 @@ sealed interface PrayerTimesEvent {
 @HiltViewModel
 class PrayerTimesViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val prayerRepository: PrayerRepository,
+    private val prayerUseCases: PrayerUseCases,
     private val preferencesDataStore: PreferencesDataStore,
 ) : ViewModel() {
 
@@ -244,7 +244,7 @@ class PrayerTimesViewModel @Inject constructor(
         statusJob?.cancel()
         val dateKey = date.toEpochDay() * 86_400_000L
         statusJob = viewModelScope.launch {
-            prayerRepository.getPrayerRecordsForDate(dateKey).collect { records ->
+            prayerUseCases.getPrayerRecordsForDate(dateKey).collect { records ->
                 statuses = records.associate { it.prayerName to it.status }
                 applyTick()
             }
@@ -347,7 +347,7 @@ class PrayerTimesViewModel @Inject constructor(
                 if (current == PrayerStatus.PRAYED) PrayerStatus.NOT_PRAYED else PrayerStatus.PRAYED
             val prayedAt =
                 if (newStatus == PrayerStatus.PRAYED) Instant.now().toEpochMilli() else null
-            prayerRepository.updatePrayerStatus(dateKey, name, newStatus, prayedAt, false)
+            prayerUseCases.updatePrayerStatus(dateKey, name, newStatus, prayedAt, false)
             // getPrayerRecordsForDate re-emits → applyTick refreshes the UI.
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
@@ -9,7 +9,7 @@ import com.arshadshah.nimaz.domain.model.PrayerRecord
 import com.arshadshah.nimaz.domain.model.PrayerStats
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerTimes
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -79,7 +79,7 @@ sealed interface PrayerTrackerEvent {
 
 @HiltViewModel
 class PrayerTrackerViewModel @Inject constructor(
-    private val prayerRepository: PrayerRepository
+    private val prayerUseCases: PrayerUseCases
 ) : ViewModel() {
 
     private val _trackerState = MutableStateFlow(PrayerTrackerUiState())
@@ -151,7 +151,7 @@ class PrayerTrackerViewModel @Inject constructor(
 
     private fun loadCurrentLocation() {
         viewModelScope.launch {
-            prayerRepository.getCurrentLocation().collect { location ->
+            prayerUseCases.getCurrentLocation().collect { location ->
                 currentLocation = location
                 // Reload prayer times if we have a location
                 location?.let {
@@ -176,7 +176,7 @@ class PrayerTrackerViewModel @Inject constructor(
             // Room's reactive Flow ensures cross-screen sync: when HomeScreen or
             // PrayerTracker updates a prayer status via the repository, Room emits
             // the change to all active Flow collectors automatically.
-            prayerRepository.getPrayerRecordsForDate(dateEpoch).collect { records ->
+            prayerUseCases.getPrayerRecordsForDate(dateEpoch).collect { records ->
                 _trackerState.update {
                     it.copy(prayerRecords = records, isLoading = false)
                 }
@@ -190,7 +190,7 @@ class PrayerTrackerViewModel @Inject constructor(
     }
 
     private fun loadPrayerTimes(date: LocalDate, location: Location) {
-        val prayerTimes = prayerRepository.getPrayerTimesForDate(date, location)
+        val prayerTimes = prayerUseCases.getPrayerTimesForDate(date, location)
         _trackerState.update { it.copy(prayerTimes = prayerTimes) }
     }
 
@@ -206,7 +206,7 @@ class PrayerTrackerViewModel @Inject constructor(
         } else null
 
         viewModelScope.launch {
-            prayerRepository.updatePrayerStatus(dateEpoch, prayerName, status, prayedAt, isJamaah)
+            prayerUseCases.updatePrayerStatus(dateEpoch, prayerName, status, prayedAt, isJamaah)
             // Refresh stats after update
             loadStats()
         }
@@ -222,7 +222,7 @@ class PrayerTrackerViewModel @Inject constructor(
 
     private fun markQadaCompleted(record: PrayerRecord) {
         viewModelScope.launch {
-            prayerRepository.updatePrayerStatus(
+            prayerUseCases.updatePrayerStatus(
                 record.date,
                 record.prayerName,
                 PrayerStatus.QADA, // Mark as QADA completed
@@ -260,10 +260,10 @@ class PrayerTrackerViewModel @Inject constructor(
         val monthEndEpoch = now.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
-            val stats = prayerRepository.getPrayerStats(startEpoch, endEpoch)
-            val monthlyStats = prayerRepository.getPrayerStats(monthStartEpoch, monthEndEpoch)
-            val currentStreak = prayerRepository.getCurrentStreak(currentEpoch)
-            val longestStreak = prayerRepository.getLongestStreak()
+            val stats = prayerUseCases.getPrayerStats(startEpoch, endEpoch)
+            val monthlyStats = prayerUseCases.getPrayerStats(monthStartEpoch, monthEndEpoch)
+            val currentStreak = prayerUseCases.getCurrentStreak(currentEpoch)
+            val longestStreak = prayerUseCases.getLongestStreak()
 
             _statsState.update {
                 it.copy(
@@ -279,7 +279,7 @@ class PrayerTrackerViewModel @Inject constructor(
 
     private fun loadQadaPrayers() {
         viewModelScope.launch {
-            prayerRepository.getMissedPrayersRequiringQada().collect { missedPrayers ->
+            prayerUseCases.getMissedPrayersRequiringQada().collect { missedPrayers ->
                 val grouped = missedPrayers.groupBy { record ->
                     val date = LocalDate.ofEpochDay(record.date / (24 * 60 * 60 * 1000))
                     "${date.month.name} ${date.year}"
@@ -304,7 +304,7 @@ class PrayerTrackerViewModel @Inject constructor(
         val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         viewModelScope.launch {
-            prayerRepository.getPrayerRecordsInRange(startEpoch, endEpoch).collect { records ->
+            prayerUseCases.getPrayerRecordsInRange(startEpoch, endEpoch).collect { records ->
                 _historyState.update { it.copy(records = records, isLoading = false) }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ProphetViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ProphetViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.Prophet
 import com.arshadshah.nimaz.domain.usecase.ProphetUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,6 +53,13 @@ class ProphetViewModel @Inject constructor(
     }
 
     fun onEvent(event: ProphetEvent) {
+        when (event) {
+            is ProphetEvent.LoadDetail -> AppAnalytics.logFeatureUsed("prophet", "open_detail")
+            is ProphetEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed("prophet", "toggle_favorite")
+            is ProphetEvent.Search -> AppAnalytics.logFeatureUsed("prophet", "search")
+            ProphetEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed("prophet", "toggle_favorites_filter")
+            else -> {}
+        }
         when (event) {
             is ProphetEvent.LoadDetail -> loadDetail(event.prophetId)
             is ProphetEvent.ToggleFavorite -> toggleFavorite(event.prophetId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
@@ -4,6 +4,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.audio.QaidaAudioManager
 import com.arshadshah.nimaz.data.audio.QaidaAudioState
 import com.arshadshah.nimaz.data.local.qaida.QaidaContentSeeder
@@ -68,6 +70,7 @@ class QaidaReaderViewModel @Inject constructor(
         // QaidaContentSeeder.
         viewModelScope.launch {
             runCatching { contentSeeder.seedIfNeeded() }
+                .onFailure { CrashReporter.recordException(it) }
         }
     }
 
@@ -125,6 +128,15 @@ class QaidaReaderViewModel @Inject constructor(
         }.stateIn(viewModelScope, sharing, null)
 
     fun onEvent(event: QaidaReaderEvent) {
+        when (event) {
+            is QaidaReaderEvent.SelectLesson -> AppAnalytics.logFeatureUsed("qaida", "select_lesson")
+            is QaidaReaderEvent.CellTapped -> AppAnalytics.logFeatureUsed("qaida", "play_cell")
+            is QaidaReaderEvent.PlayLine -> AppAnalytics.logFeatureUsed("qaida", "play_line")
+            is QaidaReaderEvent.PlayLetter -> AppAnalytics.logFeatureUsed("qaida", "play_letter")
+            QaidaReaderEvent.Resume -> AppAnalytics.logFeatureUsed("qaida", "resume")
+            QaidaReaderEvent.ResetJourney -> AppAnalytics.logFeatureUsed("qaida", "reset_journey")
+            else -> {}
+        }
         when (event) {
             is QaidaReaderEvent.SelectLesson -> selectLesson(event.lessonId)
             is QaidaReaderEvent.CellTapped -> onCellTapped(event.cell)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
@@ -27,6 +27,17 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed interface QaidaReaderEvent {
+    data class SelectLesson(val lessonId: Int) : QaidaReaderEvent
+    data class CellTapped(val cell: QaidaCell) : QaidaReaderEvent
+    data class PlayLine(val lineId: Int) : QaidaReaderEvent
+    data class PlayLetter(val letter: QaidaLetter) : QaidaReaderEvent
+    data object NextLesson : QaidaReaderEvent
+    data object PreviousLesson : QaidaReaderEvent
+    data object Resume : QaidaReaderEvent
+    data object ResetJourney : QaidaReaderEvent
+}
+
 /**
  * The state holder behind the Qaida Reader UI (epic #171, sub-issue F of #177).
  *
@@ -113,8 +124,21 @@ class QaidaReaderViewModel @Inject constructor(
                 ?.firstNotNullOfOrNull { line -> line.cells.firstOrNull { it.audioKey == key } }
         }.stateIn(viewModelScope, sharing, null)
 
+    fun onEvent(event: QaidaReaderEvent) {
+        when (event) {
+            is QaidaReaderEvent.SelectLesson -> selectLesson(event.lessonId)
+            is QaidaReaderEvent.CellTapped -> onCellTapped(event.cell)
+            is QaidaReaderEvent.PlayLine -> playLine(event.lineId)
+            is QaidaReaderEvent.PlayLetter -> playLetter(event.letter)
+            QaidaReaderEvent.NextLesson -> nextLesson()
+            QaidaReaderEvent.PreviousLesson -> previousLesson()
+            QaidaReaderEvent.Resume -> resume()
+            QaidaReaderEvent.ResetJourney -> resetJourney()
+        }
+    }
+
     /** Open a lesson, stopping any audio still playing from the previous one. */
-    fun selectLesson(lessonId: Int) {
+    private fun selectLesson(lessonId: Int) {
         if (_selectedLessonId.value == lessonId) return
         audioManager.stop()
         _selectedLessonId.value = lessonId
@@ -124,7 +148,7 @@ class QaidaReaderViewModel @Inject constructor(
      * Handle a token tap: play its clip and mark it heard (which advances the
      * lesson's progress and may unlock the next lesson, per sub-issue E).
      */
-    fun onCellTapped(cell: QaidaCell) {
+    private fun onCellTapped(cell: QaidaCell) {
         audioManager.play(cell.audioKey)
         viewModelScope.launch {
             qaidaUseCases.markCellHeard(cell.lessonId, cell.id)
@@ -132,7 +156,7 @@ class QaidaReaderViewModel @Inject constructor(
     }
 
     /** Play a whole line back-to-back, marking each of its cells heard. */
-    fun playLine(lineId: Int) {
+    private fun playLine(lineId: Int) {
         val line = lessonContent.value?.lines?.firstOrNull { it.line.id == lineId } ?: return
         if (line.cells.isEmpty()) return
         audioManager.playSequence(line.cells.map { it.audioKey })
@@ -142,12 +166,12 @@ class QaidaReaderViewModel @Inject constructor(
     }
 
     /** Play a single letter's clip from the letter explorer (no progress change). */
-    fun playLetter(letter: QaidaLetter) {
+    private fun playLetter(letter: QaidaLetter) {
         audioManager.play(letter.audioKey)
     }
 
     /** Move to the next lesson in display order, if it exists and is not locked. */
-    fun nextLesson() {
+    private fun nextLesson() {
         val lessons = courseProgress.value?.lessons ?: return
         val index = lessons.indexOfFirst { it.lesson.id == _selectedLessonId.value }
         if (index < 0 || index >= lessons.lastIndex) return
@@ -156,7 +180,7 @@ class QaidaReaderViewModel @Inject constructor(
     }
 
     /** Move to the previous lesson in display order, if there is one. */
-    fun previousLesson() {
+    private fun previousLesson() {
         val lessons = courseProgress.value?.lessons ?: return
         val index = lessons.indexOfFirst { it.lesson.id == _selectedLessonId.value }
         if (index <= 0) return
@@ -167,7 +191,7 @@ class QaidaReaderViewModel @Inject constructor(
      * Open the "continue where you left off" lesson: the first unlocked-but-
      * incomplete lesson, falling back to the first lesson if everything is done.
      */
-    fun resume() {
+    private fun resume() {
         val course = courseProgress.value ?: return
         val target = course.nextLessonId ?: course.lessons.firstOrNull()?.lesson?.id
         if (target != null) selectLesson(target)
@@ -178,7 +202,7 @@ class QaidaReaderViewModel @Inject constructor(
      * course rollup is reactive, so the home screen refreshes itself once the
      * rows are cleared. Stops any audio first.
      */
-    fun resetJourney() {
+    private fun resetJourney() {
         audioManager.stop()
         _selectedLessonId.value = null
         viewModelScope.launch {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
@@ -12,6 +12,7 @@ import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.CompassAccuracy
 import com.arshadshah.nimaz.domain.model.CompassData
@@ -283,6 +284,8 @@ class QiblaViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("qibla", "calculate_direction", e.message)
                 _qiblaState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -314,6 +317,8 @@ class QiblaViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("qibla", "set_location", e.message)
                 _qiblaState.update { it.copy(error = e.message, isLoading = false) }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
@@ -12,7 +12,7 @@ import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.CompassAccuracy
 import com.arshadshah.nimaz.domain.model.CompassData
 import com.arshadshah.nimaz.domain.model.Location
@@ -75,7 +75,7 @@ sealed interface QiblaEvent {
 @HiltViewModel
 class QiblaViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val preferencesDataStore: PreferencesDataStore
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _qiblaState = MutableStateFlow(QiblaUiState())
@@ -243,9 +243,9 @@ class QiblaViewModel @Inject constructor(
     private fun observeLocation() {
         viewModelScope.launch {
             combine(
-                preferencesDataStore.latitude,
-                preferencesDataStore.longitude,
-                preferencesDataStore.locationName
+                settingsRepository.latitude,
+                settingsRepository.longitude,
+                settingsRepository.locationName
             ) { lat, lng, name ->
                 Triple(lat, lng, name)
             }.collect { (lat, lng, name) ->

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
@@ -19,7 +19,6 @@ import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.QiblaCalculator
 import com.arshadshah.nimaz.domain.model.QiblaDirection
 import com.arshadshah.nimaz.domain.model.QiblaInfo
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +75,6 @@ sealed interface QiblaEvent {
 @HiltViewModel
 class QiblaViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val prayerRepository: PrayerRepository,
     private val preferencesDataStore: PreferencesDataStore
 ) : ViewModel() {
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -8,7 +8,7 @@ import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.data.audio.AudioState
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.domain.model.PageAyahRange
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.Khatam
 import com.arshadshah.nimaz.domain.model.QuranBookmark
@@ -139,7 +139,7 @@ sealed interface QuranEvent {
 class QuranViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
     val audioManager: QuranAudioManager,
-    private val preferencesDataStore: PreferencesDataStore,
+    private val settingsRepository: SettingsRepository,
     private val khatamUseCases: KhatamUseCases,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -226,7 +226,7 @@ class QuranViewModel @Inject constructor(
             QuranEvent.ToggleTranslation -> {
                 val newValue = !_readerState.value.showTranslation
                 _readerState.update { it.copy(showTranslation = newValue) }
-                viewModelScope.launch { preferencesDataStore.setShowTranslation(newValue) }
+                viewModelScope.launch { settingsRepository.setShowTranslation(newValue) }
             }
 
             QuranEvent.ClearSearch -> {
@@ -258,20 +258,20 @@ class QuranViewModel @Inject constructor(
         viewModelScope.launch {
             // Split into two groups of 4 to use typed combine overloads
             val displayFlow = combine(
-                preferencesDataStore.quranTranslatorId,
-                preferencesDataStore.showTranslation,
-                preferencesDataStore.showTransliteration,
-                preferencesDataStore.quranArabicFontSize,
-                preferencesDataStore.quranArabicFont
+                settingsRepository.quranTranslatorId,
+                settingsRepository.showTranslation,
+                settingsRepository.showTransliteration,
+                settingsRepository.quranArabicFontSize,
+                settingsRepository.quranArabicFont
             ) { translatorId: String, showTrans: Boolean, showTranslit: Boolean, arabicSize: Float, fontId: String ->
                 QuranDisplaySettings(translatorId, showTrans, showTranslit, arabicSize, fontId)
             }
 
             val behaviorFlow = combine(
-                preferencesDataStore.quranTranslationFontSize,
-                preferencesDataStore.continuousReading,
-                preferencesDataStore.keepScreenOn,
-                preferencesDataStore.selectedReciterId
+                settingsRepository.quranTranslationFontSize,
+                settingsRepository.continuousReading,
+                settingsRepository.keepScreenOn,
+                settingsRepository.selectedReciterId
             ) { transSize: Float, continuous: Boolean, keepOn: Boolean, reciter: String? ->
                 QuranBehaviorSettings(transSize, continuous, keepOn, reciter)
             }
@@ -279,7 +279,7 @@ class QuranViewModel @Inject constructor(
             combine(
                 displayFlow,
                 behaviorFlow,
-                preferencesDataStore.showTajweed
+                settingsRepository.showTajweed
             ) { display, behavior, showTajweed ->
                 Triple(display, behavior, showTajweed)
             }.collect { (display, behavior, showTajweed) ->
@@ -415,7 +415,7 @@ class QuranViewModel @Inject constructor(
 
     private fun loadVerseOfTheDay() {
         viewModelScope.launch {
-            val translatorId = preferencesDataStore.quranTranslatorId.first()
+            val translatorId = settingsRepository.quranTranslatorId.first()
             val epochDay = java.time.LocalDate.now().toEpochDay()
             val verse = quranUseCases.getVerseOfTheDay(epochDay, translatorId)
             _homeState.update { it.copy(verseOfTheDay = verse) }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.data.audio.AudioState
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
-import com.arshadshah.nimaz.data.local.database.dao.PageAyahRange
+import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.Khatam

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
@@ -7,9 +7,9 @@ import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.Surah
-import com.arshadshah.nimaz.domain.repository.DuaRepository
-import com.arshadshah.nimaz.domain.repository.HadithRepository
-import com.arshadshah.nimaz.domain.repository.QuranRepository
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -65,9 +65,9 @@ sealed interface SearchEvent {
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val quranRepository: QuranRepository,
-    private val hadithRepository: HadithRepository,
-    private val duaRepository: DuaRepository
+    private val quranUseCases: QuranUseCases,
+    private val hadithUseCases: HadithUseCases,
+    private val duaUseCases: DuaUseCases
 ) : ViewModel() {
 
     private val _searchState = MutableStateFlow(SearchUiState())
@@ -161,7 +161,7 @@ class SearchViewModel @Inject constructor(
 
         // Search Quran (include translations for English search terms)
         viewModelScope.launch {
-            quranRepository.searchQuran(query, "sahih_international").collect { results ->
+            quranUseCases.searchQuran(query, "sahih_international").collect { results ->
                 _searchState.update { state ->
                     val unified =
                         state.allResults.filterNot { it is UnifiedSearchResult.QuranResult } +
@@ -179,7 +179,7 @@ class SearchViewModel @Inject constructor(
 
         // Search Surahs by name
         viewModelScope.launch {
-            quranRepository.searchSurahs(query).collect { surahs ->
+            quranUseCases.getSurahList.search(query).collect { surahs ->
                 _searchState.update { state ->
                     val unified =
                         state.allResults.filterNot { it is UnifiedSearchResult.SurahResult } +
@@ -197,7 +197,7 @@ class SearchViewModel @Inject constructor(
 
         // Search Hadith
         viewModelScope.launch {
-            hadithRepository.searchHadiths(query).collect { results ->
+            hadithUseCases.searchHadiths(query).collect { results ->
                 _searchState.update { state ->
                     val unified =
                         state.allResults.filterNot { it is UnifiedSearchResult.HadithResult } +
@@ -215,7 +215,7 @@ class SearchViewModel @Inject constructor(
 
         // Search Duas
         viewModelScope.launch {
-            duaRepository.searchDuas(query).collect { results ->
+            duaUseCases.searchDuas(query).collect { results ->
                 _searchState.update { state ->
                     val unified =
                         state.allResults.filterNot { it is UnifiedSearchResult.DuaResult } +
@@ -243,7 +243,7 @@ class SearchViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            quranRepository.searchQuran(query, "sahih_international").collect { results ->
+            quranUseCases.searchQuran(query, "sahih_international").collect { results ->
                 val unified = results.map { UnifiedSearchResult.QuranResult(it) }
                 _searchState.update {
                     it.copy(
@@ -258,7 +258,7 @@ class SearchViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            quranRepository.searchSurahs(query).collect { surahs ->
+            quranUseCases.getSurahList.search(query).collect { surahs ->
                 _searchState.update { state ->
                     val surahResults = surahs.map { UnifiedSearchResult.SurahResult(it) }
                     val combined = state.allResults + surahResults
@@ -276,7 +276,7 @@ class SearchViewModel @Inject constructor(
 
     private fun searchHadithOnly(query: String) {
         viewModelScope.launch {
-            hadithRepository.searchHadiths(query).collect { results ->
+            hadithUseCases.searchHadiths(query).collect { results ->
                 val unified = results.map { UnifiedSearchResult.HadithResult(it) }
                 _searchState.update {
                     it.copy(
@@ -293,7 +293,7 @@ class SearchViewModel @Inject constructor(
 
     private fun searchDuaOnly(query: String) {
         viewModelScope.launch {
-            duaRepository.searchDuas(query).collect { results ->
+            duaUseCases.searchDuas(query).collect { results ->
                 val unified = results.map { UnifiedSearchResult.DuaResult(it) }
                 _searchState.update {
                     it.copy(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
@@ -551,6 +552,8 @@ class SettingsViewModel @Inject constructor(
                         // Now play the preview
                         adhanAudioManager.preview(sound, false)
                     } catch (e: Exception) {
+                        CrashReporter.recordException(e)
+                        AppAnalytics.logError("settings", "adhan_preview", e.message)
                         _adhanPreviewError.value = "Failed to play adhan preview: ${e.message}"
                     }
                 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -10,7 +10,7 @@ import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
 import com.arshadshah.nimaz.data.local.database.NimazDatabase
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
@@ -246,7 +246,7 @@ sealed interface SettingsEvent {
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val prayerUseCases: PrayerUseCases,
-    private val preferencesDataStore: PreferencesDataStore,
+    private val settingsRepository: SettingsRepository,
     private val prayerNotificationScheduler: PrayerNotificationScheduler,
     val adhanAudioManager: AdhanAudioManager,
     private val database: NimazDatabase
@@ -368,14 +368,14 @@ class SettingsViewModel @Inject constructor(
                         AppTheme.LIGHT -> "light"
                         AppTheme.DARK -> "dark"
                     }
-                    preferencesDataStore.setThemeMode(modeString)
+                    settingsRepository.setThemeMode(modeString)
                 }
             }
 
             is SettingsEvent.SetLanguage -> {
                 _generalState.update { it.copy(language = event.language) }
                 viewModelScope.launch {
-                    preferencesDataStore.setAppLanguage(event.language.code)
+                    settingsRepository.setAppLanguage(event.language.code)
                     LocaleHelper.setLocale(context, event.language.code)
                     _shouldRestart.value = true
                 }
@@ -383,45 +383,45 @@ class SettingsViewModel @Inject constructor(
 
             is SettingsEvent.SetHijriPrimary -> {
                 _generalState.update { it.copy(useHijriPrimary = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setUseHijriPrimary(event.enabled) }
+                viewModelScope.launch { settingsRepository.setUseHijriPrimary(event.enabled) }
             }
 
             is SettingsEvent.Set24HourFormat -> {
                 _generalState.update { it.copy(use24HourFormat = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setUse24HourFormat(event.enabled) }
+                viewModelScope.launch { settingsRepository.setUse24HourFormat(event.enabled) }
             }
 
             is SettingsEvent.SetShowSeconds -> _generalState.update { it.copy(showSeconds = event.enabled) }
             is SettingsEvent.SetHapticFeedback -> {
                 _generalState.update { it.copy(hapticFeedback = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setHapticFeedback(event.enabled) }
+                viewModelScope.launch { settingsRepository.setHapticFeedback(event.enabled) }
             }
 
             is SettingsEvent.SetShowIslamicPatterns -> {
                 _generalState.update { it.copy(showIslamicPatterns = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowIslamicPatterns(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowIslamicPatterns(event.enabled) }
             }
 
             is SettingsEvent.SetAnimationsEnabled -> {
                 _generalState.update { it.copy(animationsEnabled = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setAnimationsEnabled(event.enabled) }
+                viewModelScope.launch { settingsRepository.setAnimationsEnabled(event.enabled) }
             }
 
             is SettingsEvent.SetShowCountdown -> {
                 _generalState.update { it.copy(showCountdown = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowCountdown(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowCountdown(event.enabled) }
             }
 
             is SettingsEvent.SetShowQuickActions -> {
                 _generalState.update { it.copy(showQuickActions = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowQuickActions(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowQuickActions(event.enabled) }
             }
 
             // Prayer
             is SettingsEvent.SetCalculationMethod -> {
                 _prayerState.update { it.copy(calculationMethod = event.method) }
                 viewModelScope.launch {
-                    preferencesDataStore.setCalculationMethod(event.method.name)
+                    settingsRepository.setCalculationMethod(event.method.name)
                     rescheduleNotifications()
                 }
             }
@@ -429,7 +429,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetAsrMethod -> {
                 _prayerState.update { it.copy(asrMethod = event.method) }
                 viewModelScope.launch {
-                    preferencesDataStore.setAsrCalculation(event.method.name.lowercase())
+                    settingsRepository.setAsrCalculation(event.method.name.lowercase())
                     rescheduleNotifications()
                 }
             }
@@ -437,7 +437,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetHighLatitudeRule -> {
                 _prayerState.update { it.copy(highLatitudeRule = event.rule) }
                 viewModelScope.launch {
-                    preferencesDataStore.setHighLatitudeRule(event.rule.name)
+                    settingsRepository.setHighLatitudeRule(event.rule.name)
                     rescheduleNotifications()
                 }
             }
@@ -455,7 +455,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetPrayerAdjustment -> {
                 updatePrayerAdjustment(event.prayer, event.minutes)
                 viewModelScope.launch {
-                    preferencesDataStore.setPrayerAdjustment(event.prayer, event.minutes)
+                    settingsRepository.setPrayerAdjustment(event.prayer, event.minutes)
                     rescheduleNotifications()
                 }
             }
@@ -464,7 +464,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetNotificationsEnabled -> {
                 _notificationState.update { it.copy(notificationsEnabled = event.enabled) }
                 viewModelScope.launch {
-                    preferencesDataStore.setPrayerNotificationsEnabled(event.enabled)
+                    settingsRepository.setPrayerNotificationsEnabled(event.enabled)
                     rescheduleNotifications()
                 }
             }
@@ -472,7 +472,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetPrayerNotification -> {
                 updatePrayerNotification(event.prayer, event.enabled)
                 viewModelScope.launch {
-                    preferencesDataStore.setPrayerNotificationEnabled(event.prayer, event.enabled)
+                    settingsRepository.setPrayerNotificationEnabled(event.prayer, event.enabled)
                     rescheduleNotifications()
                 }
             }
@@ -480,7 +480,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetAdhanEnabled -> {
                 _notificationState.update { it.copy(adhanEnabled = event.enabled) }
                 viewModelScope.launch {
-                    preferencesDataStore.setAdhanEnabled(event.enabled)
+                    settingsRepository.setAdhanEnabled(event.enabled)
                     rescheduleNotifications()
                 }
             }
@@ -488,24 +488,24 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetPrayerAdhanEnabled -> {
                 updatePrayerAdhanEnabled(event.prayer, event.enabled)
                 viewModelScope.launch {
-                    preferencesDataStore.setPrayerAdhanEnabled(event.prayer, event.enabled)
+                    settingsRepository.setPrayerAdhanEnabled(event.prayer, event.enabled)
                 }
             }
 
             is SettingsEvent.SetVibrationEnabled -> {
                 _notificationState.update { it.copy(vibrationEnabled = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setNotificationVibration(event.enabled) }
+                viewModelScope.launch { settingsRepository.setNotificationVibration(event.enabled) }
             }
 
             is SettingsEvent.SetRespectDnd -> {
                 _notificationState.update { it.copy(respectDnd = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setAdhanRespectDnd(event.enabled) }
+                viewModelScope.launch { settingsRepository.setAdhanRespectDnd(event.enabled) }
             }
 
             is SettingsEvent.SetReminderMinutes -> {
                 _notificationState.update { it.copy(reminderMinutes = event.minutes) }
                 viewModelScope.launch {
-                    preferencesDataStore.setNotificationReminderMinutes(event.minutes)
+                    settingsRepository.setNotificationReminderMinutes(event.minutes)
                     rescheduleNotifications()
                 }
             }
@@ -513,20 +513,20 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetShowReminderBefore -> {
                 _notificationState.update { it.copy(showReminderBefore = event.enabled) }
                 viewModelScope.launch {
-                    preferencesDataStore.setShowReminderBefore(event.enabled)
+                    settingsRepository.setShowReminderBefore(event.enabled)
                     rescheduleNotifications()
                 }
             }
 
             is SettingsEvent.SetPersistentNotification -> {
                 _notificationState.update { it.copy(persistentNotification = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setPersistentNotification(event.enabled) }
+                viewModelScope.launch { settingsRepository.setPersistentNotification(event.enabled) }
             }
 
             is SettingsEvent.SetAdhanSound -> {
                 _notificationState.update { it.copy(selectedAdhanSound = event.sound) }
                 viewModelScope.launch {
-                    preferencesDataStore.setSelectedAdhanSound(event.sound)
+                    settingsRepository.setSelectedAdhanSound(event.sound)
                     // Download the selected adhan if not already downloaded
                     val sound = AdhanSound.fromName(event.sound)
                     if (!adhanAudioManager.isFullyDownloaded(sound)) {
@@ -563,119 +563,119 @@ class SettingsViewModel @Inject constructor(
             // Quran
             is SettingsEvent.SetTranslator -> {
                 _quranState.update { it.copy(selectedTranslatorId = event.translatorId) }
-                viewModelScope.launch { preferencesDataStore.setQuranTranslatorId(event.translatorId) }
+                viewModelScope.launch { settingsRepository.setQuranTranslatorId(event.translatorId) }
             }
 
             is SettingsEvent.SetArabicFont -> {
                 _quranState.update { it.copy(selectedArabicFontId = event.fontId) }
-                viewModelScope.launch { preferencesDataStore.setQuranArabicFont(event.fontId) }
+                viewModelScope.launch { settingsRepository.setQuranArabicFont(event.fontId) }
             }
 
             is SettingsEvent.SetShowTranslation -> {
                 _quranState.update { it.copy(showTranslation = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowTranslation(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowTranslation(event.enabled) }
             }
 
             is SettingsEvent.SetShowTransliteration -> {
                 _quranState.update { it.copy(showTransliteration = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowTransliteration(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowTransliteration(event.enabled) }
             }
 
             is SettingsEvent.SetArabicFontSize -> {
                 _quranState.update { it.copy(arabicFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setQuranArabicFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setQuranArabicFontSize(event.size) }
             }
 
             is SettingsEvent.SetTranslationFontSize -> {
                 _quranState.update { it.copy(translationFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setQuranTranslationFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setQuranTranslationFontSize(event.size) }
             }
 
             is SettingsEvent.SetContinuousReading -> {
                 _quranState.update { it.copy(continuousReading = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setContinuousReading(event.enabled) }
+                viewModelScope.launch { settingsRepository.setContinuousReading(event.enabled) }
             }
 
             is SettingsEvent.SetKeepScreenOn -> {
                 _quranState.update { it.copy(keepScreenOn = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setKeepScreenOn(event.enabled) }
+                viewModelScope.launch { settingsRepository.setKeepScreenOn(event.enabled) }
             }
 
             is SettingsEvent.SetReciter -> {
                 _quranState.update { it.copy(selectedReciterId = event.reciterId) }
-                viewModelScope.launch { preferencesDataStore.setSelectedReciterId(event.reciterId) }
+                viewModelScope.launch { settingsRepository.setSelectedReciterId(event.reciterId) }
             }
 
             is SettingsEvent.SetShowTajweed -> {
                 _quranState.update { it.copy(showTajweed = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setShowTajweed(event.enabled) }
+                viewModelScope.launch { settingsRepository.setShowTajweed(event.enabled) }
             }
 
             // Dua
             is SettingsEvent.SetDuaArabicFont -> {
                 _duaState.update { it.copy(selectedArabicFontId = event.fontId) }
-                viewModelScope.launch { preferencesDataStore.setDuaArabicFont(event.fontId) }
+                viewModelScope.launch { settingsRepository.setDuaArabicFont(event.fontId) }
             }
 
             is SettingsEvent.SetDuaArabicFontSize -> {
                 _duaState.update { it.copy(arabicFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setDuaArabicFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setDuaArabicFontSize(event.size) }
             }
 
             is SettingsEvent.SetDuaTranslationFontSize -> {
                 _duaState.update { it.copy(translationFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setDuaTranslationFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setDuaTranslationFontSize(event.size) }
             }
 
             is SettingsEvent.SetDuaShowArabic -> {
                 _duaState.update { it.copy(showArabic = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setDuaShowArabic(event.enabled) }
+                viewModelScope.launch { settingsRepository.setDuaShowArabic(event.enabled) }
             }
 
             is SettingsEvent.SetDuaShowTransliteration -> {
                 _duaState.update { it.copy(showTransliteration = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setDuaShowTransliteration(event.enabled) }
+                viewModelScope.launch { settingsRepository.setDuaShowTransliteration(event.enabled) }
             }
 
             is SettingsEvent.SetDuaShowTranslation -> {
                 _duaState.update { it.copy(showTranslation = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setDuaShowTranslation(event.enabled) }
+                viewModelScope.launch { settingsRepository.setDuaShowTranslation(event.enabled) }
             }
 
             // Hadith
             is SettingsEvent.SetHadithArabicFont -> {
                 _hadithState.update { it.copy(selectedArabicFontId = event.fontId) }
-                viewModelScope.launch { preferencesDataStore.setHadithArabicFont(event.fontId) }
+                viewModelScope.launch { settingsRepository.setHadithArabicFont(event.fontId) }
             }
 
             is SettingsEvent.SetHadithArabicFontSize -> {
                 _hadithState.update { it.copy(arabicFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setHadithArabicFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setHadithArabicFontSize(event.size) }
             }
 
             is SettingsEvent.SetHadithTranslationFontSize -> {
                 _hadithState.update { it.copy(translationFontSize = event.size) }
-                viewModelScope.launch { preferencesDataStore.setHadithTranslationFontSize(event.size) }
+                viewModelScope.launch { settingsRepository.setHadithTranslationFontSize(event.size) }
             }
 
             is SettingsEvent.SetHadithShowArabic -> {
                 _hadithState.update { it.copy(showArabic = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setHadithShowArabic(event.enabled) }
+                viewModelScope.launch { settingsRepository.setHadithShowArabic(event.enabled) }
             }
 
             is SettingsEvent.SetHadithShowTranslation -> {
                 _hadithState.update { it.copy(showTranslation = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setHadithShowTranslation(event.enabled) }
+                viewModelScope.launch { settingsRepository.setHadithShowTranslation(event.enabled) }
             }
 
             is SettingsEvent.SetHadithShowGrade -> {
                 _hadithState.update { it.copy(showGrade = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setHadithShowGrade(event.enabled) }
+                viewModelScope.launch { settingsRepository.setHadithShowGrade(event.enabled) }
             }
 
             is SettingsEvent.SetHadithShowChain -> {
                 _hadithState.update { it.copy(showChain = event.enabled) }
-                viewModelScope.launch { preferencesDataStore.setHadithShowChain(event.enabled) }
+                viewModelScope.launch { settingsRepository.setHadithShowChain(event.enabled) }
             }
 
             // Location
@@ -736,20 +736,20 @@ class SettingsViewModel @Inject constructor(
     private fun loadSettings() {
         viewModelScope.launch {
             // General settings
-            val theme = when (preferencesDataStore.themeMode.first()) {
+            val theme = when (settingsRepository.themeMode.first()) {
                 "light" -> AppTheme.LIGHT
                 "dark" -> AppTheme.DARK
                 else -> AppTheme.SYSTEM
             }
-            val langCode = preferencesDataStore.appLanguage.first()
+            val langCode = settingsRepository.appLanguage.first()
             val language = AppLanguage.entries.find { it.code == langCode } ?: AppLanguage.ENGLISH
-            val showIslamicPatterns = preferencesDataStore.showIslamicPatterns.first()
-            val animationsEnabled = preferencesDataStore.animationsEnabled.first()
-            val showCountdown = preferencesDataStore.showCountdown.first()
-            val showQuickActions = preferencesDataStore.showQuickActions.first()
-            val hapticFeedback = preferencesDataStore.hapticFeedback.first()
-            val use24Hour = preferencesDataStore.use24HourFormat.first()
-            val useHijri = preferencesDataStore.useHijriPrimary.first()
+            val showIslamicPatterns = settingsRepository.showIslamicPatterns.first()
+            val animationsEnabled = settingsRepository.animationsEnabled.first()
+            val showCountdown = settingsRepository.showCountdown.first()
+            val showQuickActions = settingsRepository.showQuickActions.first()
+            val hapticFeedback = settingsRepository.hapticFeedback.first()
+            val use24Hour = settingsRepository.use24HourFormat.first()
+            val useHijri = settingsRepository.useHijriPrimary.first()
 
             _generalState.update {
                 it.copy(
@@ -766,30 +766,30 @@ class SettingsViewModel @Inject constructor(
             }
 
             // Prayer settings
-            val calcMethodStr = preferencesDataStore.calculationMethod.first()
+            val calcMethodStr = settingsRepository.calculationMethod.first()
             val calcMethod = try {
                 CalculationMethod.valueOf(calcMethodStr)
             } catch (_: Exception) {
                 CalculationMethod.MUSLIM_WORLD_LEAGUE
             }
-            val asrStr = preferencesDataStore.asrCalculation.first()
+            val asrStr = settingsRepository.asrCalculation.first()
             val asrMethod = when (asrStr.lowercase()) {
                 "hanafi" -> AsrJuristicMethod.HANAFI
                 else -> AsrJuristicMethod.STANDARD
             }
-            val highLatStr = preferencesDataStore.highLatitudeRule.first()
+            val highLatStr = settingsRepository.highLatitudeRule.first()
             val highLat = try {
                 HighLatitudeRule.valueOf(highLatStr)
             } catch (_: Exception) {
                 HighLatitudeRule.MIDDLE_OF_NIGHT
             }
 
-            val fajrAdj = preferencesDataStore.fajrAdjustment.first()
-            val sunriseAdj = preferencesDataStore.sunriseAdjustment.first()
-            val dhuhrAdj = preferencesDataStore.dhuhrAdjustment.first()
-            val asrAdj = preferencesDataStore.asrAdjustment.first()
-            val maghribAdj = preferencesDataStore.maghribAdjustment.first()
-            val ishaAdj = preferencesDataStore.ishaAdjustment.first()
+            val fajrAdj = settingsRepository.fajrAdjustment.first()
+            val sunriseAdj = settingsRepository.sunriseAdjustment.first()
+            val dhuhrAdj = settingsRepository.dhuhrAdjustment.first()
+            val asrAdj = settingsRepository.asrAdjustment.first()
+            val maghribAdj = settingsRepository.maghribAdjustment.first()
+            val ishaAdj = settingsRepository.ishaAdjustment.first()
 
             _prayerState.update {
                 it.copy(
@@ -806,27 +806,27 @@ class SettingsViewModel @Inject constructor(
             }
 
             // Notification settings
-            val notifEnabled = preferencesDataStore.prayerNotificationsEnabled.first()
-            val adhanEnabled = preferencesDataStore.adhanEnabled.first()
-            val vibration = preferencesDataStore.notificationVibration.first()
-            val reminderMin = preferencesDataStore.notificationReminderMinutes.first()
-            val showReminder = preferencesDataStore.showReminderBefore.first()
-            val persistent = preferencesDataStore.persistentNotification.first()
-            val respectDnd = preferencesDataStore.adhanRespectDnd.first()
-            val adhanSoundName = preferencesDataStore.selectedAdhanSound.first()
-            val fajrNotif = preferencesDataStore.fajrNotificationEnabled.first()
-            val sunriseNotif = preferencesDataStore.sunriseNotificationEnabled.first()
-            val dhuhrNotif = preferencesDataStore.dhuhrNotificationEnabled.first()
-            val asrNotif = preferencesDataStore.asrNotificationEnabled.first()
-            val maghribNotif = preferencesDataStore.maghribNotificationEnabled.first()
-            val ishaNotif = preferencesDataStore.ishaNotificationEnabled.first()
+            val notifEnabled = settingsRepository.prayerNotificationsEnabled.first()
+            val adhanEnabled = settingsRepository.adhanEnabled.first()
+            val vibration = settingsRepository.notificationVibration.first()
+            val reminderMin = settingsRepository.notificationReminderMinutes.first()
+            val showReminder = settingsRepository.showReminderBefore.first()
+            val persistent = settingsRepository.persistentNotification.first()
+            val respectDnd = settingsRepository.adhanRespectDnd.first()
+            val adhanSoundName = settingsRepository.selectedAdhanSound.first()
+            val fajrNotif = settingsRepository.fajrNotificationEnabled.first()
+            val sunriseNotif = settingsRepository.sunriseNotificationEnabled.first()
+            val dhuhrNotif = settingsRepository.dhuhrNotificationEnabled.first()
+            val asrNotif = settingsRepository.asrNotificationEnabled.first()
+            val maghribNotif = settingsRepository.maghribNotificationEnabled.first()
+            val ishaNotif = settingsRepository.ishaNotificationEnabled.first()
 
             // Per-prayer adhan settings
-            val fajrAdhan = preferencesDataStore.fajrAdhanEnabled.first()
-            val dhuhrAdhan = preferencesDataStore.dhuhrAdhanEnabled.first()
-            val asrAdhan = preferencesDataStore.asrAdhanEnabled.first()
-            val maghribAdhan = preferencesDataStore.maghribAdhanEnabled.first()
-            val ishaAdhan = preferencesDataStore.ishaAdhanEnabled.first()
+            val fajrAdhan = settingsRepository.fajrAdhanEnabled.first()
+            val dhuhrAdhan = settingsRepository.dhuhrAdhanEnabled.first()
+            val asrAdhan = settingsRepository.asrAdhanEnabled.first()
+            val maghribAdhan = settingsRepository.maghribAdhanEnabled.first()
+            val ishaAdhan = settingsRepository.ishaAdhanEnabled.first()
 
             _notificationState.update {
                 it.copy(
@@ -853,16 +853,16 @@ class SettingsViewModel @Inject constructor(
             }
 
             // Quran settings
-            val translatorId = preferencesDataStore.quranTranslatorId.first()
-            val arabicFontId = preferencesDataStore.quranArabicFont.first()
-            val showTranslation = preferencesDataStore.showTranslation.first()
-            val showTransliteration = preferencesDataStore.showTransliteration.first()
-            val arabicFontSize = preferencesDataStore.quranArabicFontSize.first()
-            val translationFontSize = preferencesDataStore.quranTranslationFontSize.first()
-            val continuousReading = preferencesDataStore.continuousReading.first()
-            val keepScreenOn = preferencesDataStore.keepScreenOn.first()
-            val reciterId = preferencesDataStore.selectedReciterId.first()
-            val showTajweed = preferencesDataStore.showTajweed.first()
+            val translatorId = settingsRepository.quranTranslatorId.first()
+            val arabicFontId = settingsRepository.quranArabicFont.first()
+            val showTranslation = settingsRepository.showTranslation.first()
+            val showTransliteration = settingsRepository.showTransliteration.first()
+            val arabicFontSize = settingsRepository.quranArabicFontSize.first()
+            val translationFontSize = settingsRepository.quranTranslationFontSize.first()
+            val continuousReading = settingsRepository.continuousReading.first()
+            val keepScreenOn = settingsRepository.keepScreenOn.first()
+            val reciterId = settingsRepository.selectedReciterId.first()
+            val showTajweed = settingsRepository.showTajweed.first()
 
             _quranState.update {
                 it.copy(
@@ -882,25 +882,25 @@ class SettingsViewModel @Inject constructor(
             // Dua settings
             _duaState.update {
                 it.copy(
-                    selectedArabicFontId = preferencesDataStore.duaArabicFont.first(),
-                    arabicFontSize = preferencesDataStore.duaArabicFontSize.first(),
-                    translationFontSize = preferencesDataStore.duaTranslationFontSize.first(),
-                    showArabic = preferencesDataStore.duaShowArabic.first(),
-                    showTransliteration = preferencesDataStore.duaShowTransliteration.first(),
-                    showTranslation = preferencesDataStore.duaShowTranslation.first()
+                    selectedArabicFontId = settingsRepository.duaArabicFont.first(),
+                    arabicFontSize = settingsRepository.duaArabicFontSize.first(),
+                    translationFontSize = settingsRepository.duaTranslationFontSize.first(),
+                    showArabic = settingsRepository.duaShowArabic.first(),
+                    showTransliteration = settingsRepository.duaShowTransliteration.first(),
+                    showTranslation = settingsRepository.duaShowTranslation.first()
                 )
             }
 
             // Hadith settings
             _hadithState.update {
                 it.copy(
-                    selectedArabicFontId = preferencesDataStore.hadithArabicFont.first(),
-                    arabicFontSize = preferencesDataStore.hadithArabicFontSize.first(),
-                    translationFontSize = preferencesDataStore.hadithTranslationFontSize.first(),
-                    showArabic = preferencesDataStore.hadithShowArabic.first(),
-                    showTranslation = preferencesDataStore.hadithShowTranslation.first(),
-                    showGrade = preferencesDataStore.hadithShowGrade.first(),
-                    showChain = preferencesDataStore.hadithShowChain.first()
+                    selectedArabicFontId = settingsRepository.hadithArabicFont.first(),
+                    arabicFontSize = settingsRepository.hadithArabicFontSize.first(),
+                    translationFontSize = settingsRepository.hadithTranslationFontSize.first(),
+                    showArabic = settingsRepository.hadithShowArabic.first(),
+                    showTranslation = settingsRepository.hadithShowTranslation.first(),
+                    showGrade = settingsRepository.hadithShowGrade.first(),
+                    showChain = settingsRepository.hadithShowChain.first()
                 )
             }
         }
@@ -927,7 +927,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private suspend fun rescheduleNotifications() {
-        val prefs = preferencesDataStore.userPreferences.first()
+        val prefs = settingsRepository.userPreferences.first()
         val lat = prefs.latitude
         val lng = prefs.longitude
         val notifState = _notificationState.value
@@ -1053,7 +1053,7 @@ class SettingsViewModel @Inject constructor(
 
     private fun resetToDefaults() {
         viewModelScope.launch {
-            preferencesDataStore.clearAllData()
+            settingsRepository.clearAllData()
             _generalState.update { GeneralSettingsUiState() }
             _prayerState.update { PrayerSettingsUiState() }
             _notificationState.update { NotificationSettingsUiState() }
@@ -1089,7 +1089,7 @@ class SettingsViewModel @Inject constructor(
             database.tafseerDao().deleteAllUserData()
 
             // Clear DataStore preferences
-            preferencesDataStore.clearAllData()
+            settingsRepository.clearAllData()
 
             // Reset UI state to defaults
             _generalState.update { GeneralSettingsUiState() }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -15,7 +15,7 @@ import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -245,7 +245,7 @@ sealed interface SettingsEvent {
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val prayerRepository: PrayerRepository,
+    private val prayerUseCases: PrayerUseCases,
     private val preferencesDataStore: PreferencesDataStore,
     private val prayerNotificationScheduler: PrayerNotificationScheduler,
     val adhanAudioManager: AdhanAudioManager,
@@ -908,19 +908,19 @@ class SettingsViewModel @Inject constructor(
 
     private fun loadLocations() {
         viewModelScope.launch {
-            prayerRepository.getCurrentLocation().collect { location ->
+            prayerUseCases.getCurrentLocation().collect { location ->
                 _locationState.update { it.copy(currentLocation = location) }
             }
         }
 
         viewModelScope.launch {
-            prayerRepository.getAllLocations().collect { locations ->
+            prayerUseCases.getAllLocations().collect { locations ->
                 _locationState.update { it.copy(savedLocations = locations, isLoading = false) }
             }
         }
 
         viewModelScope.launch {
-            prayerRepository.getFavoriteLocations().collect { favorites ->
+            prayerUseCases.getFavoriteLocations().collect { favorites ->
                 _locationState.update { it.copy(favoriteLocations = favorites) }
             }
         }
@@ -1028,26 +1028,26 @@ class SettingsViewModel @Inject constructor(
 
     private fun setCurrentLocation(location: Location) {
         viewModelScope.launch {
-            val id = prayerRepository.insertLocation(location)
-            prayerRepository.setCurrentLocation(id)
+            val id = prayerUseCases.insertLocation(location)
+            prayerUseCases.setCurrentLocation(id)
         }
     }
 
     private fun addLocation(location: Location) {
         viewModelScope.launch {
-            prayerRepository.insertLocation(location)
+            prayerUseCases.insertLocation(location)
         }
     }
 
     private fun removeLocation(location: Location) {
         viewModelScope.launch {
-            prayerRepository.deleteLocation(location)
+            prayerUseCases.deleteLocation(location)
         }
     }
 
     private fun toggleLocationFavorite(locationId: Long) {
         viewModelScope.launch {
-            prayerRepository.toggleFavorite(locationId)
+            prayerUseCases.toggleFavorite(locationId)
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SyncViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SyncViewModel.kt
@@ -4,6 +4,8 @@ import android.os.Build
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.sync.CancelReason
 import com.arshadshah.nimaz.data.sync.ConnectionState
 import com.arshadshah.nimaz.data.sync.SyncCategory
@@ -224,6 +226,12 @@ class SyncViewModel @Inject constructor(
 
     fun onEvent(event: SyncEvent) {
         when (event) {
+            is SyncEvent.StartSend -> AppAnalytics.logFeatureUsed("sync", "start_send")
+            is SyncEvent.StartReceive -> AppAnalytics.logFeatureUsed("sync", "start_receive")
+            is SyncEvent.Cancel -> AppAnalytics.logFeatureUsed("sync", "cancel")
+            else -> {}
+        }
+        when (event) {
             is SyncEvent.StartSend -> startSend()
             is SyncEvent.StartReceive -> startReceive()
             is SyncEvent.AcceptConnection -> acceptConnection(event.endpointId)
@@ -293,6 +301,8 @@ class SyncViewModel @Inject constructor(
                         )
                     }
                 } catch (e: Exception) {
+                    CrashReporter.recordException(e)
+                    AppAnalytics.logError("sync", "import", e.message)
                     Log.e(TAG, "Import failed!", e)
                     addLogEntry("Import failed: ${e.message}")
                     _uiState.update { it.copy(error = "Import failed: ${e.message}") }
@@ -345,6 +355,8 @@ class SyncViewModel @Inject constructor(
                 connectionsManager.sendData(jsonBytes)
                 Log.d(TAG, "sendData returned — transfer queued")
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("sync", "export", e.message)
                 Log.e(TAG, "Export/send failed!", e)
                 addLogEntry("Export failed: ${e.message}")
                 _uiState.update { it.copy(error = "Export failed: ${e.message}") }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.TafseerHighlight
 import com.arshadshah.nimaz.domain.model.TafseerNote
@@ -63,6 +64,16 @@ class TafseerViewModel @Inject constructor(
     val state: StateFlow<TafseerUiState> = _state.asStateFlow()
 
     fun onEvent(event: TafseerEvent) {
+        when (event) {
+            is TafseerEvent.LoadSurah -> AppAnalytics.logFeatureUsed("tafseer", "open_surah")
+            is TafseerEvent.SwitchSource -> AppAnalytics.logFeatureUsed("tafseer", "switch_source")
+            is TafseerEvent.AddHighlight -> AppAnalytics.logFeatureUsed("tafseer", "add_highlight")
+            is TafseerEvent.DeleteHighlight -> AppAnalytics.logFeatureUsed("tafseer", "delete_highlight")
+            is TafseerEvent.AddNote -> AppAnalytics.logFeatureUsed("tafseer", "add_note")
+            is TafseerEvent.DeleteNote -> AppAnalytics.logFeatureUsed("tafseer", "delete_note")
+            is TafseerEvent.ExportAnnotations -> AppAnalytics.logFeatureUsed("tafseer", "export_annotations")
+            else -> {}
+        }
         when (event) {
             is TafseerEvent.LoadSurah -> loadSurah(event.surahNumber, event.ayahNumber)
             is TafseerEvent.NavigateToAyah -> onAyahChanged(event.index)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
@@ -7,8 +7,8 @@ import com.arshadshah.nimaz.domain.model.TafseerHighlight
 import com.arshadshah.nimaz.domain.model.TafseerNote
 import com.arshadshah.nimaz.domain.model.TafseerSource
 import com.arshadshah.nimaz.domain.model.TafseerText
-import com.arshadshah.nimaz.domain.repository.QuranRepository
-import com.arshadshah.nimaz.domain.repository.TafseerRepository
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.TafseerUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -55,8 +55,8 @@ sealed interface TafseerEvent {
 
 @HiltViewModel
 class TafseerViewModel @Inject constructor(
-    private val tafseerRepository: TafseerRepository,
-    private val quranRepository: QuranRepository
+    private val tafseerUseCases: TafseerUseCases,
+    private val quranUseCases: QuranUseCases
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TafseerUiState())
@@ -91,8 +91,8 @@ class TafseerViewModel @Inject constructor(
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true, surahNumber = surahNumber)
 
-            val surah = quranRepository.getSurahByNumber(surahNumber)
-            val ayahs = quranRepository.getAyahsBySurah(surahNumber).first()
+            val surah = quranUseCases.getSurahByNumber(surahNumber)
+            val ayahs = quranUseCases.getAyahsBySurah(surahNumber).first()
 
             val initialIndex = ayahs.indexOfFirst { it.ayahNumber == ayahNumber }
                 .coerceAtLeast(0)
@@ -129,11 +129,11 @@ class TafseerViewModel @Inject constructor(
         val tafseerId = currentState.selectedSource.id
 
         viewModelScope.launch {
-            val tafseer = tafseerRepository.getTafseerForAyah(ayah.id, tafseerId)
+            val tafseer = tafseerUseCases.getTafseerForAyah(ayah.id, tafseerId)
             // Probe every source so the UI can suggest an alternate one when the
             // selected source has no content for this ayah (seed coverage is partial).
             val available = TafseerSource.entries.filter { source ->
-                tafseerRepository.getTafseerForAyah(ayah.id, source.id)
+                tafseerUseCases.getTafseerForAyah(ayah.id, source.id)
                     ?.text?.isNotBlank() == true
             }.toSet()
             _state.value = _state.value.copy(
@@ -143,13 +143,13 @@ class TafseerViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            tafseerRepository.getHighlightsForAyah(ayah.id, tafseerId).collectLatest { highlights ->
+            tafseerUseCases.getHighlightsForAyah(ayah.id, tafseerId).collectLatest { highlights ->
                 _state.value = _state.value.copy(highlights = highlights)
             }
         }
 
         viewModelScope.launch {
-            tafseerRepository.getNotesForAyah(ayah.id, tafseerId).collectLatest { notes ->
+            tafseerUseCases.getNotesForAyah(ayah.id, tafseerId).collectLatest { notes ->
                 _state.value = _state.value.copy(notes = notes)
             }
         }
@@ -162,7 +162,7 @@ class TafseerViewModel @Inject constructor(
 
         val ayah = ayahs[currentState.currentAyahIndex]
         viewModelScope.launch {
-            tafseerRepository.addHighlight(
+            tafseerUseCases.addHighlight(
                 ayahId = ayah.id,
                 tafseerId = currentState.selectedSource.id,
                 startOffset = startOffset,
@@ -174,14 +174,14 @@ class TafseerViewModel @Inject constructor(
 
     private fun deleteHighlight(highlightId: Long) {
         viewModelScope.launch {
-            tafseerRepository.deleteHighlight(highlightId)
+            tafseerUseCases.deleteHighlight(highlightId)
         }
     }
 
     private fun updateHighlightNote(highlightId: Long, note: String?) {
         val highlight = _state.value.highlights.find { it.id == highlightId } ?: return
         viewModelScope.launch {
-            tafseerRepository.updateHighlight(
+            tafseerUseCases.updateHighlight(
                 highlight.copy(
                     note = note,
                     updatedAt = System.currentTimeMillis()
@@ -197,7 +197,7 @@ class TafseerViewModel @Inject constructor(
 
         val ayah = ayahs[currentState.currentAyahIndex]
         viewModelScope.launch {
-            tafseerRepository.addNote(
+            tafseerUseCases.addNote(
                 ayahId = ayah.id,
                 tafseerId = currentState.selectedSource.id,
                 text = text
@@ -207,19 +207,19 @@ class TafseerViewModel @Inject constructor(
 
     private fun updateNote(note: TafseerNote) {
         viewModelScope.launch {
-            tafseerRepository.updateNote(note)
+            tafseerUseCases.updateNote(note)
         }
     }
 
     private fun deleteNote(noteId: Long) {
         viewModelScope.launch {
-            tafseerRepository.deleteNote(noteId)
+            tafseerUseCases.deleteNote(noteId)
         }
     }
 
     private fun exportAnnotations() {
         viewModelScope.launch {
-            val exported = tafseerRepository.exportAnnotations()
+            val exported = tafseerUseCases.exportAnnotations()
             _state.value = _state.value.copy(exportedText = exported)
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -10,7 +10,7 @@ import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.TasbihCategory
 import com.arshadshah.nimaz.domain.model.TasbihPreset
 import com.arshadshah.nimaz.domain.model.TasbihSession
@@ -103,7 +103,7 @@ sealed interface TasbihEvent {
 @HiltViewModel
 class TasbihViewModel @Inject constructor(
     private val tasbihUseCases: TasbihUseCases,
-    private val preferences: PreferencesDataStore,
+    private val preferences: SettingsRepository,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -15,7 +15,7 @@ import com.arshadshah.nimaz.domain.model.TasbihCategory
 import com.arshadshah.nimaz.domain.model.TasbihPreset
 import com.arshadshah.nimaz.domain.model.TasbihSession
 import com.arshadshah.nimaz.domain.model.TasbihStats
-import com.arshadshah.nimaz.domain.repository.TasbihRepository
+import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
@@ -102,7 +102,7 @@ sealed interface TasbihEvent {
 
 @HiltViewModel
 class TasbihViewModel @Inject constructor(
-    private val tasbihRepository: TasbihRepository,
+    private val tasbihUseCases: TasbihUseCases,
     private val preferences: PreferencesDataStore,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -174,7 +174,7 @@ class TasbihViewModel @Inject constructor(
         // Seed default adhkar added after the prepackaged DB shipped (one-time per version).
         viewModelScope.launch {
             if (preferences.tasbihPresetSeedVersion.first() < LATEST_PRESET_SEED_VERSION) {
-                tasbihRepository.seedMissingDefaults()
+                tasbihUseCases.seedMissingDefaults()
                 preferences.setTasbihPresetSeedVersion(LATEST_PRESET_SEED_VERSION)
             }
         }
@@ -240,7 +240,7 @@ class TasbihViewModel @Inject constructor(
 
     private fun loadPresets() {
         viewModelScope.launch {
-            tasbihRepository.getDefaultPresets().collect { defaults ->
+            tasbihUseCases.getDefaultPresets().collect { defaults ->
                 _presetsState.update {
                     it.copy(
                         defaultPresets = defaults,
@@ -250,7 +250,7 @@ class TasbihViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            tasbihRepository.getCustomPresets().collect { customs ->
+            tasbihUseCases.getCustomPresets().collect { customs ->
                 _presetsState.update {
                     it.copy(
                         customPresets = customs,
@@ -273,7 +273,7 @@ class TasbihViewModel @Inject constructor(
             val duration = completedAt - currentSession.startedAt
 
             viewModelScope.launch {
-                tasbihRepository.completeSession(currentSession.id, completedAt, duration)
+                tasbihUseCases.completeSession(currentSession.id, completedAt, duration)
                 loadHistory()
                 loadStats()
             }
@@ -311,7 +311,7 @@ class TasbihViewModel @Inject constructor(
         }
         if (current == id) return
         viewModelScope.launch {
-            tasbihRepository.getPresetById(id)?.let { selectPreset(it) }
+            tasbihUseCases.getPresetById(id)?.let { selectPreset(it) }
         }
     }
 
@@ -342,7 +342,7 @@ class TasbihViewModel @Inject constructor(
             viewModelScope.launch {
                 val state = _counterState.value
                 // Store the within-lap count; the DB sums currentCount + laps*target.
-                tasbihRepository.updateSessionCount(session.id, state.count, state.laps)
+                tasbihUseCases.updateSessionCount(session.id, state.count, state.laps)
             }
         }
     }
@@ -360,7 +360,7 @@ class TasbihViewModel @Inject constructor(
             val duration = completedAt - currentSession.startedAt
 
             viewModelScope.launch {
-                tasbihRepository.completeSession(currentSession.id, completedAt, duration)
+                tasbihUseCases.completeSession(currentSession.id, completedAt, duration)
                 loadHistory()
                 loadStats()
             }
@@ -394,19 +394,19 @@ class TasbihViewModel @Inject constructor(
 
     private fun createCustomPreset(preset: TasbihPreset) {
         viewModelScope.launch {
-            tasbihRepository.insertPreset(preset)
+            tasbihUseCases.insertPreset(preset)
         }
     }
 
     private fun updateCustomPreset(preset: TasbihPreset) {
         viewModelScope.launch {
-            tasbihRepository.updatePreset(preset)
+            tasbihUseCases.updatePreset(preset)
         }
     }
 
     private fun deleteCustomPreset(presetId: Long) {
         viewModelScope.launch {
-            tasbihRepository.deleteCustomPreset(presetId)
+            tasbihUseCases.deleteCustomPreset(presetId)
         }
     }
 
@@ -439,7 +439,7 @@ class TasbihViewModel @Inject constructor(
         _counterState.value.currentSession?.let { session ->
             viewModelScope.launch {
                 // Store the within-lap count; the DB sums currentCount + laps*target.
-                tasbihRepository.updateSessionCount(
+                tasbihUseCases.updateSessionCount(
                     session.id,
                     _counterState.value.count,
                     _counterState.value.laps
@@ -473,8 +473,8 @@ class TasbihViewModel @Inject constructor(
                 completedAt = null,
                 note = null
             )
-            val sessionId = tasbihRepository.insertSession(session)
-            val insertedSession = tasbihRepository.getSessionById(sessionId)
+            val sessionId = tasbihUseCases.insertSession(session)
+            val insertedSession = tasbihUseCases.getSessionById(sessionId)
 
             _counterState.update {
                 it.copy(
@@ -513,7 +513,7 @@ class TasbihViewModel @Inject constructor(
         // Also update the session in the database if there's an active one
         _counterState.value.currentSession?.let { session ->
             viewModelScope.launch {
-                tasbihRepository.updateSessionCount(session.id, 0, 0)
+                tasbihUseCases.updateSessionCount(session.id, 0, 0)
                 loadStats()
             }
         }
@@ -539,8 +539,8 @@ class TasbihViewModel @Inject constructor(
                 completedAt = null,
                 note = null
             )
-            val sessionId = tasbihRepository.insertSession(session)
-            val insertedSession = tasbihRepository.getSessionById(sessionId)
+            val sessionId = tasbihUseCases.insertSession(session)
+            val insertedSession = tasbihUseCases.getSessionById(sessionId)
 
             _counterState.update {
                 it.copy(
@@ -576,7 +576,7 @@ class TasbihViewModel @Inject constructor(
             val duration = completedAt - session.startedAt
 
             viewModelScope.launch {
-                tasbihRepository.completeSession(session.id, completedAt, duration)
+                tasbihUseCases.completeSession(session.id, completedAt, duration)
 
                 _counterState.update {
                     it.copy(
@@ -607,9 +607,9 @@ class TasbihViewModel @Inject constructor(
 
     private fun checkForActiveSession() {
         viewModelScope.launch {
-            val activeSession = tasbihRepository.getActiveSession()
+            val activeSession = tasbihUseCases.getActiveSession()
             activeSession?.let { session ->
-                val preset = session.presetId?.let { tasbihRepository.getPresetById(it) }
+                val preset = session.presetId?.let { tasbihUseCases.getPresetById(it) }
                 _counterState.update {
                     it.copy(
                         currentSession = session,
@@ -631,12 +631,12 @@ class TasbihViewModel @Inject constructor(
         val weekAgo = today - (7 * 24 * 60 * 60 * 1000)
 
         viewModelScope.launch {
-            tasbihRepository.getSessionsForDate(today).collect { todaySessions ->
+            tasbihUseCases.getSessionsForDate(today).collect { todaySessions ->
                 _historyState.update { it.copy(todaySessions = todaySessions) }
             }
         }
         viewModelScope.launch {
-            tasbihRepository.getSessionsInRange(weekAgo, today + (24 * 60 * 60 * 1000))
+            tasbihUseCases.getSessionsInRange(weekAgo, today + (24 * 60 * 60 * 1000))
                 .collect { weekSessions ->
                     _historyState.update { it.copy(weekSessions = weekSessions, isLoading = false) }
                 }
@@ -649,11 +649,11 @@ class TasbihViewModel @Inject constructor(
         val endOfToday = today + (24 * 60 * 60 * 1000)
 
         viewModelScope.launch {
-            val stats = tasbihRepository.getTasbihStats(weekAgo, endOfToday)
-            val totalToday = tasbihRepository.getTotalCountInRange(today, endOfToday)
-            val totalWeek = tasbihRepository.getTotalCountInRange(weekAgo, endOfToday)
+            val stats = tasbihUseCases.getTasbihStats(weekAgo, endOfToday)
+            val totalToday = tasbihUseCases.getTotalCountInRange(today, endOfToday)
+            val totalWeek = tasbihUseCases.getTotalCountInRange(weekAgo, endOfToday)
             val completedSessions =
-                tasbihRepository.getCompletedSessionsInRange(weekAgo, endOfToday)
+                tasbihUseCases.getCompletedSessionsInRange(weekAgo, endOfToday)
 
             // Calculate base total (excluding current session's count) for real-time display
             val currentSessionCount = _counterState.value.currentSession?.let {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModel.kt
@@ -3,13 +3,13 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
 import com.arshadshah.nimaz.domain.model.NisabType
 import com.arshadshah.nimaz.domain.model.ZakatAssets
 import com.arshadshah.nimaz.domain.model.ZakatCalculation
 import com.arshadshah.nimaz.domain.model.ZakatCalculator
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
 import com.arshadshah.nimaz.domain.model.ZakatLiabilities
-import com.arshadshah.nimaz.domain.repository.ZakatRepository
+import com.arshadshah.nimaz.domain.usecase.ZakatUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,20 +29,6 @@ data class ZakatCalculatorUiState(
     val isCalculating: Boolean = false,
     val showBreakdown: Boolean = false,
     val error: String? = null
-)
-
-data class ZakatHistoryEntry(
-    val id: Long,
-    val calculatedAt: Long,
-    val totalAssets: Double,
-    val totalLiabilities: Double,
-    val netWorth: Double,
-    val zakatDue: Double,
-    val nisabType: NisabType,
-    val nisabValue: Double,
-    val isPaid: Boolean = false,
-    val paidAt: Long? = null,
-    val notes: String? = null
 )
 
 data class ZakatHistoryUiState(
@@ -80,7 +66,7 @@ sealed interface ZakatEvent {
 
 @HiltViewModel
 class ZakatViewModel @Inject constructor(
-    private val zakatRepository: ZakatRepository
+    private val zakatUseCases: ZakatUseCases
 ) : ViewModel() {
 
     private val _calculatorState = MutableStateFlow(ZakatCalculatorUiState())
@@ -239,54 +225,35 @@ class ZakatViewModel @Inject constructor(
         val calculation = _calculatorState.value.calculation ?: return
 
         viewModelScope.launch {
-            val entity = ZakatHistoryEntity(
+            val entry = ZakatHistoryEntry(
                 calculatedAt = calculation.calculatedAt,
                 totalAssets = calculation.totalAssets,
                 totalLiabilities = calculation.totalLiabilities,
                 netWorth = calculation.netWorth,
                 zakatDue = calculation.zakatDue,
-                nisabType = calculation.nisabType.name,
+                nisabType = calculation.nisabType,
                 nisabValue = calculation.nisabValue
             )
-            zakatRepository.insertCalculation(entity)
+            zakatUseCases.insertCalculation(entry)
         }
     }
 
     private fun markAsPaid(entryId: Long) {
         viewModelScope.launch {
-            zakatRepository.markAsPaid(entryId, System.currentTimeMillis())
+            zakatUseCases.markAsPaid(entryId, System.currentTimeMillis())
         }
     }
 
     private fun deleteCalculation(entryId: Long) {
         viewModelScope.launch {
-            zakatRepository.deleteCalculation(entryId)
+            zakatUseCases.deleteCalculation(entryId)
         }
     }
 
     private fun loadHistory() {
         viewModelScope.launch {
-            zakatRepository.getAllHistory().collect { entities ->
-                val entries = entities.map { entity ->
-                    ZakatHistoryEntry(
-                        id = entity.id,
-                        calculatedAt = entity.calculatedAt,
-                        totalAssets = entity.totalAssets,
-                        totalLiabilities = entity.totalLiabilities,
-                        netWorth = entity.netWorth,
-                        zakatDue = entity.zakatDue,
-                        nisabType = try {
-                            NisabType.valueOf(entity.nisabType)
-                        } catch (_: Exception) {
-                            NisabType.GOLD
-                        },
-                        nisabValue = entity.nisabValue,
-                        isPaid = entity.isPaid,
-                        paidAt = entity.paidAt,
-                        notes = entity.notes
-                    )
-                }
-                val totalPaid = zakatRepository.getTotalPaid()
+            zakatUseCases.getAllHistory().collect { entries ->
+                val totalPaid = zakatUseCases.getTotalPaid()
                 _historyState.update {
                     it.copy(
                         history = entries,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ZakatViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.model.NisabType
 import com.arshadshah.nimaz.domain.model.ZakatAssets
 import com.arshadshah.nimaz.domain.model.ZakatCalculation
@@ -204,6 +205,8 @@ class ZakatViewModel @Inject constructor(
                     it.copy(calculation = calculation, isCalculating = false)
                 }
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
+                AppAnalytics.logError("zakat", "calculate", e.message)
                 _calculatorState.update {
                     it.copy(error = e.message, isCalculating = false)
                 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/WidgetUpdateScheduler.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/WidgetUpdateScheduler.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.SystemClock
 import android.util.Log
 import androidx.glance.appwidget.updateAll
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.widget.core.formatWidgetCountdown
 import com.arshadshah.nimaz.widget.nextprayer.NextPrayerWidget
 import com.arshadshah.nimaz.widget.prayertimes.PrayerTimesWidget
@@ -82,11 +83,13 @@ class WidgetTickReceiver : BroadcastReceiver() {
             try {
                 NextPrayerWidget().updateAll(context)
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 Log.e("WidgetTickReceiver", "Failed to update NextPrayerWidget", e)
             }
             try {
                 PrayerTimesWidget().updateAll(context)
             } catch (e: Exception) {
+                CrashReporter.recordException(e)
                 Log.e("WidgetTickReceiver", "Failed to update PrayerTimesWidget", e)
             }
             pendingResult.finish()

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/JsonGlanceStateDefinition.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/JsonGlanceStateDefinition.kt
@@ -7,6 +7,7 @@ import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.Serializer
 import androidx.datastore.dataStoreFile
 import androidx.glance.state.GlanceStateDefinition
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -53,6 +54,7 @@ abstract class JsonGlanceStateDefinition<T>(
         override suspend fun readFrom(input: InputStream): T = try {
             Json.decodeFromString(serializer, input.readBytes().decodeToString())
         } catch (e: SerializationException) {
+            CrashReporter.recordException(e)
             throw CorruptionException("Could not read $dataLabel data: ${e.message}")
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
@@ -6,6 +6,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
@@ -95,6 +96,8 @@ class HijriCalendarWorker @AssistedInject constructor(
             setWidgetState(glanceIds, HijriCalendarWidgetState.Success(data))
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.log("HijriCalendarWorker failed")
+            CrashReporter.recordException(e)
             setWidgetState(glanceIds, HijriCalendarWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
@@ -6,6 +6,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
@@ -74,6 +75,8 @@ class HijriDateWorker @AssistedInject constructor(
             setWidgetState(glanceIds, HijriDateWidgetState.Success(data))
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.log("HijriDateWorker failed")
+            CrashReporter.recordException(e)
             setWidgetState(glanceIds, HijriDateWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
@@ -6,6 +6,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.widget.core.WidgetWork
@@ -120,6 +121,8 @@ class NextPrayerWorker @AssistedInject constructor(
             setWidgetState(glanceIds, NextPrayerWidgetState.Success(data))
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.log("NextPrayerWorker failed")
+            CrashReporter.recordException(e)
             setWidgetState(glanceIds, NextPrayerWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
@@ -6,6 +6,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
@@ -133,6 +134,8 @@ class PrayerTimesWorker @AssistedInject constructor(
             setWidgetState(glanceIds, PrayerTimesWidgetState.Success(data))
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.log("PrayerTimesWorker failed")
+            CrashReporter.recordException(e)
             setWidgetState(glanceIds, PrayerTimesWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
@@ -33,6 +33,7 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.widget.WidgetEntryPoint
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
@@ -285,6 +286,7 @@ private fun togglePrayerStatus(context: Context, prayerName: String) {
             // Trigger widget update
             PrayerTrackerWorker.enqueueImmediateWork(context)
         } catch (e: Exception) {
+            CrashReporter.recordException(e)
             android.util.Log.e("PrayerTrackerWidget", "Failed to toggle prayer status", e)
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
@@ -6,6 +6,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
@@ -79,6 +80,8 @@ class PrayerTrackerWorker @AssistedInject constructor(
             setWidgetState(glanceIds, PrayerTrackerWidgetState.Success(data))
             Result.success()
         } catch (e: Exception) {
+            CrashReporter.log("PrayerTrackerWorker failed")
+            CrashReporter.recordException(e)
             setWidgetState(glanceIds, PrayerTrackerWidgetState.Error(e.message))
             if (runAttemptCount < 3) Result.retry() else Result.failure()
         }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
@@ -2,7 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import app.cash.turbine.test
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.ExemptionReason
 import com.arshadshah.nimaz.domain.model.FastRecord
 import com.arshadshah.nimaz.domain.model.FastStatus
@@ -38,7 +38,7 @@ class FastingViewModelTest {
 
     private lateinit var repository: FastingRepository
     private lateinit var prayerTimeCalculator: PrayerTimeCalculator
-    private lateinit var preferencesDataStore: PreferencesDataStore
+    private lateinit var settingsRepository: SettingsRepository
     private lateinit var viewModel: FastingViewModel
 
     private val now = System.currentTimeMillis()
@@ -49,11 +49,11 @@ class FastingViewModelTest {
 
         repository = mockk(relaxed = true)
         prayerTimeCalculator = mockk(relaxed = true)
-        preferencesDataStore = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
 
         // Provide defaults so ViewModel init doesn't crash
-        every { preferencesDataStore.latitude } returns flowOf(53.3498)
-        every { preferencesDataStore.longitude } returns flowOf(-6.2603)
+        every { settingsRepository.latitude } returns flowOf(53.3498)
+        every { settingsRepository.longitude } returns flowOf(-6.2603)
         coEvery { repository.getFastRecordForDate(any()) } returns null
         every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(emptyList())
         every { repository.getPendingMakeupFasts() } returns flowOf(emptyList())
@@ -74,7 +74,7 @@ class FastingViewModelTest {
     }
 
     private fun createViewModel(): FastingViewModel {
-        return FastingViewModel(buildFastingUseCases(repository), prayerTimeCalculator, preferencesDataStore)
+        return FastingViewModel(buildFastingUseCases(repository), prayerTimeCalculator, settingsRepository)
     }
 
     private fun dateToEpoch(date: LocalDate): Long {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
@@ -74,7 +74,7 @@ class FastingViewModelTest {
     }
 
     private fun createViewModel(): FastingViewModel {
-        return FastingViewModel(repository, prayerTimeCalculator, preferencesDataStore)
+        return FastingViewModel(buildFastingUseCases(repository), prayerTimeCalculator, preferencesDataStore)
     }
 
     private fun dateToEpoch(date: LocalDate): Long {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
 import app.cash.turbine.test
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.HelpTopic
 import com.arshadshah.nimaz.domain.usecase.GetHelpTopicsUseCase
 import com.arshadshah.nimaz.domain.usecase.HelpUseCases
@@ -24,7 +24,7 @@ import org.junit.Test
 class HelpViewModelTest {
     private val dispatcher = StandardTestDispatcher()
     private lateinit var useCases: HelpUseCases
-    private lateinit var prefs: PreferencesDataStore
+    private lateinit var prefs: SettingsRepository
 
     @Before
     fun setUp() {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -78,7 +78,7 @@ class HomeViewModelTest {
     private fun createViewModel() = HomeViewModel(
         context = context,
         prayerTimeCalculator = prayerTimeCalculator,
-        prayerRepository = prayerRepository,
+        prayerUseCases = buildPrayerUseCases(prayerRepository),
         preferencesDataStore = preferencesDataStore,
         fastingDao = fastingDao,
         hadithDao = hadithDao,

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.repository.DuaRepository
@@ -44,7 +44,7 @@ class HomeViewModelTest {
     private lateinit var fastingRepository: FastingRepository
     private lateinit var hadithRepository: HadithRepository
     private lateinit var duaRepository: DuaRepository
-    private lateinit var preferencesDataStore: PreferencesDataStore
+    private lateinit var settingsRepository: SettingsRepository
 
     @Before
     fun setUp() {
@@ -56,7 +56,7 @@ class HomeViewModelTest {
         fastingRepository = mockk(relaxed = true)
         hadithRepository = mockk(relaxed = true)
         duaRepository = mockk(relaxed = true)
-        preferencesDataStore = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
 
         // The today's-records Flow emits synchronously, mirroring Room emitting an
         // initial value during ViewModel init before the rest of the constructor
@@ -76,7 +76,7 @@ class HomeViewModelTest {
         fastingUseCases = buildFastingUseCases(fastingRepository),
         hadithUseCases = buildHadithUseCases(hadithRepository),
         duaUseCases = buildDuaUseCases(duaRepository),
-        preferencesDataStore = preferencesDataStore
+        settingsRepository = settingsRepository
     )
 
     /**

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -4,14 +4,12 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.database.dao.DuaDao
-import com.arshadshah.nimaz.data.local.dua.DuaContentSeeder
-import com.arshadshah.nimaz.data.local.hadith.HadithBackfillSeeder
-import com.arshadshah.nimaz.data.local.database.dao.FastingDao
-import com.arshadshah.nimaz.data.local.database.dao.HadithDao
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.repository.DuaRepository
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.repository.HadithRepository
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -43,12 +41,10 @@ class HomeViewModelTest {
     private lateinit var context: Context
     private lateinit var prayerTimeCalculator: PrayerTimeCalculator
     private lateinit var prayerRepository: PrayerRepository
+    private lateinit var fastingRepository: FastingRepository
+    private lateinit var hadithRepository: HadithRepository
+    private lateinit var duaRepository: DuaRepository
     private lateinit var preferencesDataStore: PreferencesDataStore
-    private lateinit var fastingDao: FastingDao
-    private lateinit var hadithDao: HadithDao
-    private lateinit var duaDao: DuaDao
-    private lateinit var duaContentSeeder: DuaContentSeeder
-    private lateinit var hadithBackfillSeeder: HadithBackfillSeeder
 
     @Before
     fun setUp() {
@@ -57,12 +53,10 @@ class HomeViewModelTest {
         context = ApplicationProvider.getApplicationContext()
         prayerTimeCalculator = mockk(relaxed = true)
         prayerRepository = mockk(relaxed = true)
+        fastingRepository = mockk(relaxed = true)
+        hadithRepository = mockk(relaxed = true)
+        duaRepository = mockk(relaxed = true)
         preferencesDataStore = mockk(relaxed = true)
-        fastingDao = mockk(relaxed = true)
-        hadithDao = mockk(relaxed = true)
-        duaDao = mockk(relaxed = true)
-        duaContentSeeder = mockk(relaxed = true)
-        hadithBackfillSeeder = mockk(relaxed = true)
 
         // The today's-records Flow emits synchronously, mirroring Room emitting an
         // initial value during ViewModel init before the rest of the constructor
@@ -79,12 +73,10 @@ class HomeViewModelTest {
         context = context,
         prayerTimeCalculator = prayerTimeCalculator,
         prayerUseCases = buildPrayerUseCases(prayerRepository),
-        preferencesDataStore = preferencesDataStore,
-        fastingDao = fastingDao,
-        hadithDao = hadithDao,
-        duaDao = duaDao,
-        duaContentSeeder = duaContentSeeder,
-        hadithBackfillSeeder = hadithBackfillSeeder
+        fastingUseCases = buildFastingUseCases(fastingRepository),
+        hadithUseCases = buildHadithUseCases(hadithRepository),
+        duaUseCases = buildDuaUseCases(duaRepository),
+        preferencesDataStore = preferencesDataStore
     )
 
     /**

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModelTest.kt
@@ -107,7 +107,7 @@ class QaidaReaderViewModelTest {
         val vm = createViewModel()
         val cell = cell(id = 11, lessonId = 1, audioKey = "l1_alif")
 
-        vm.onCellTapped(cell)
+        vm.onEvent(QaidaReaderEvent.CellTapped(cell))
         advanceUntilIdle()
 
         verify { audioManager.play("l1_alif") }
@@ -120,7 +120,7 @@ class QaidaReaderViewModelTest {
 
         vm.lessonContent.test {
             assertThat(awaitItem()).isNull() // nothing selected yet
-            vm.selectLesson(1)
+            vm.onEvent(QaidaReaderEvent.SelectLesson(1))
             assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
         }
     }
@@ -131,9 +131,9 @@ class QaidaReaderViewModelTest {
 
         vm.lessonContent.test {
             assertThat(awaitItem()).isNull()
-            vm.selectLesson(1)
+            vm.onEvent(QaidaReaderEvent.SelectLesson(1))
             assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
-            vm.selectLesson(2)
+            vm.onEvent(QaidaReaderEvent.SelectLesson(2))
             assertThat(awaitItem()?.lesson?.id).isEqualTo(2)
         }
 
@@ -149,7 +149,7 @@ class QaidaReaderViewModelTest {
         vm.courseProgress.test {
             awaitItem() // initial null
             awaitItem() // emitted rollup
-            vm.resume()
+            vm.onEvent(QaidaReaderEvent.Resume)
         }
         advanceUntilIdle()
 
@@ -162,10 +162,10 @@ class QaidaReaderViewModelTest {
 
         vm.lessonContent.test {
             assertThat(awaitItem()).isNull()
-            vm.selectLesson(1)
+            vm.onEvent(QaidaReaderEvent.SelectLesson(1))
             assertThat(awaitItem()?.lesson?.id).isEqualTo(1)
 
-            vm.playLine(lineId = 100)
+            vm.onEvent(QaidaReaderEvent.PlayLine(lineId = 100))
             advanceUntilIdle()
 
             verify { audioManager.playSequence(listOf("l1_alif", "l1_baa")) }
@@ -180,7 +180,7 @@ class QaidaReaderViewModelTest {
 
         vm.playingCell.test {
             assertThat(awaitItem()).isNull()
-            vm.selectLesson(1)
+            vm.onEvent(QaidaReaderEvent.SelectLesson(1))
             audioStateFlow.value = QaidaAudioState(currentKey = "l1_baa", isPlaying = true)
             advanceUntilIdle()
             assertThat(expectMostRecentItem()?.id).isEqualTo(12)
@@ -197,8 +197,8 @@ class QaidaReaderViewModelTest {
         vm.courseProgress.test {
             awaitItem()
             awaitItem()
-            vm.selectLesson(1)
-            vm.nextLesson()
+            vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+            vm.onEvent(QaidaReaderEvent.NextLesson)
         }
         advanceUntilIdle()
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
@@ -1,0 +1,48 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.usecase.*
+
+// Test helpers: wrap a (mock) repository in the real use-case wrappers so existing
+// repository-level stubbing continues to drive ViewModel behaviour after the
+// use-case layer was introduced.
+
+fun buildFastingUseCases(repository: FastingRepository) = FastingUseCases(
+    getFastRecordForDate = GetFastRecordForDateUseCase(repository),
+    getFastRecordsInRange = GetFastRecordsInRangeUseCase(repository),
+    insertFastRecord = InsertFastRecordUseCase(repository),
+    updateFastRecord = UpdateFastRecordUseCase(repository),
+    updateFastStatus = UpdateFastStatusUseCase(repository),
+    deleteFastRecordByDate = DeleteFastRecordByDateUseCase(repository),
+    getRamadanFastedCount = GetRamadanFastedCountUseCase(repository),
+    getVoluntaryFastCount = GetVoluntaryFastCountUseCase(repository),
+    getFastingStats = GetFastingStatsUseCase(repository),
+    getAllMakeupFasts = GetAllMakeupFastsUseCase(repository),
+    getPendingMakeupFasts = GetPendingMakeupFastsUseCase(repository),
+    getMakeupFastCountForDate = GetMakeupFastCountForDateUseCase(repository),
+    insertMakeupFast = InsertMakeupFastUseCase(repository),
+    updateMakeupFast = UpdateMakeupFastUseCase(repository),
+    markMakeupFastCompleted = MarkMakeupFastCompletedUseCase(repository),
+    markFidyaPaid = MarkFidyaPaidUseCase(repository),
+    getTotalFidyaPaid = GetTotalFidyaPaidUseCase(repository)
+)
+
+fun buildPrayerUseCases(repository: PrayerRepository) = PrayerUseCases(
+    getPrayerRecordsForDate = GetPrayerRecordsForDateUseCase(repository),
+    getPrayerRecordsInRange = GetPrayerRecordsInRangeUseCase(repository),
+    getTodayPrayerRecords = GetTodayPrayerRecordsUseCase(repository),
+    updatePrayerStatus = UpdatePrayerStatusUseCase(repository),
+    getPrayerTimesForDate = GetPrayerTimesForDateUseCase(repository),
+    getCurrentStreak = GetCurrentStreakUseCase(repository),
+    getLongestStreak = GetLongestStreakUseCase(repository),
+    getMissedPrayersRequiringQada = GetMissedPrayersRequiringQadaUseCase(repository),
+    getPrayerStats = GetPrayerStatsUseCase(repository),
+    getCurrentLocation = GetCurrentLocationUseCase(repository),
+    getAllLocations = GetAllLocationsUseCase(repository),
+    getFavoriteLocations = GetFavoriteLocationsUseCase(repository),
+    insertLocation = InsertLocationUseCase(repository),
+    deleteLocation = DeleteLocationUseCase(repository),
+    setCurrentLocation = SetCurrentLocationUseCase(repository),
+    toggleFavorite = ToggleLocationFavoriteUseCase(repository)
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import com.arshadshah.nimaz.domain.repository.FastingRepository
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.repository.HadithRepository
+import com.arshadshah.nimaz.domain.repository.DuaRepository
 import com.arshadshah.nimaz.domain.usecase.*
 
 // Test helpers: wrap a (mock) repository in the real use-case wrappers so existing
@@ -45,4 +47,40 @@ fun buildPrayerUseCases(repository: PrayerRepository) = PrayerUseCases(
     deleteLocation = DeleteLocationUseCase(repository),
     setCurrentLocation = SetCurrentLocationUseCase(repository),
     toggleFavorite = ToggleLocationFavoriteUseCase(repository)
+)
+
+fun buildHadithUseCases(repository: HadithRepository) = HadithUseCases(
+    getAllBooks = GetAllBooksUseCase(repository),
+    getBookById = GetBookByIdUseCase(repository),
+    getChaptersByBook = GetChaptersByBookUseCase(repository),
+    getChapterById = GetChapterByIdUseCase(repository),
+    getHadithsByChapter = GetHadithsByChapterUseCase(repository),
+    getHadithById = GetHadithByIdUseCase(repository),
+    getHadithByNumber = GetHadithByNumberUseCase(repository),
+    getHadithsByGrade = GetHadithsByGradeUseCase(repository),
+    getHadithOfTheDay = GetHadithOfTheDayUseCase(repository),
+    searchHadiths = SearchHadithsUseCase(repository),
+    searchHadithsInBook = SearchHadithsInBookUseCase(repository),
+    getAllBookmarks = GetAllBookmarksUseCase(repository),
+    isHadithBookmarked = IsHadithBookmarkedUseCase(repository),
+    toggleBookmark = ToggleBookmarkUseCase(repository),
+    updateBookmark = UpdateHadithBookmarkUseCase(repository),
+    deleteBookmark = DeleteHadithBookmarkUseCase(repository),
+    getDailyHadith = GetDailyHadithUseCase(repository)
+)
+
+fun buildDuaUseCases(repository: DuaRepository) = DuaUseCases(
+    getAllCategories = GetAllCategoriesUseCase(repository),
+    getCategoryById = GetCategoryByIdUseCase(repository),
+    getDuaById = GetDuaByIdUseCase(repository),
+    getDuasByCategory = GetDuasByCategoryUseCase(repository),
+    getDuasByOccasion = GetDuasByOccasionUseCase(repository),
+    getFavoriteDuas = GetFavoriteDuasUseCase(repository),
+    getProgressForDate = GetProgressForDateUseCase(repository),
+    isDuaFavorite = IsDuaFavoriteUseCase(repository),
+    searchDuas = SearchDuasUseCase(repository),
+    toggleFavorite = ToggleDuaFavoriteUseCase(repository),
+    getAllBookmarks = GetDuaBookmarksUseCase(repository),
+    deleteBookmark = DeleteDuaBookmarkUseCase(repository),
+    getDailyDua = GetDailyDuaUseCase(repository)
 )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -418,23 +418,35 @@ typed route object.
 
 ## 9. Known deviations & tech-debt registry
 
-These are places where the code currently diverges from the canonical patterns above. They
-are documented so agents **do not copy them** and can fix them intentionally. Status reflects
-validation against the live code.
+This registry tracks divergences from the canonical patterns. Most have now been resolved
+during the architecture-consistency pass; the **Resolved** table is kept as a record so the
+fixes aren't accidentally reverted, and the **Open** table lists what remains. Agents must not
+copy anything listed as Open.
+
+### Resolved (do not regress)
+
+| Area | What was fixed |
+|------|----------------|
+| Use-case layer | `Hadith`, `Dua`, `Fasting`, `Prayer`, `Tasbih`, `Tafseer`, `Zakat` now have `XxxUseCases` wrappers; `PrayerTimes/PrayerTracker/Home/Settings/Location`, `Search`, `Bookmarks` ViewModels inject use cases instead of repositories. |
+| Zakat clean-arch leak | `ZakatRepository` now exposes the `ZakatHistoryEntry` domain model (promoted to `domain/model`); entity↔domain mapping lives in `ZakatRepositoryImpl`. |
+| Calendar layer bypass | New `IslamicEventRepository` (+ impl mapping) and `IslamicEventUseCases`; `CalendarViewModel` no longer touches `IslamicEventDao`. |
+| QaidaReader UDF | `QaidaReaderViewModel` now has a sealed `QaidaReaderEvent` + single `onEvent`; action methods are private; Qaida screens dispatch events. |
+| Dead route | The orphaned `Route.MakeupFasts` declaration was removed (makeup fasts is a tab inside `FastTrackerScreen`). |
+| Theming (Zakat) | Zakat screens use `NimazColors.Neutral900` / `NimazColors.ZakatColors.GoldAccent`; no raw color literals remain there. |
+
+### Open (still to do — do not copy)
 
 | # | Area | Deviation | Canonical fix |
 |---|------|-----------|---------------|
-| 1 | Use-case layer | Several ViewModels inject a repository directly instead of `XxxUseCases`: `Hadith`, `Dua`, `Fasting`, `Prayer` (Times/Tracker + Home/Qibla/Settings consumers), `Tasbih`, `Tafseer`, `Zakat`. | Add an `XxxUseCases` wrapper per feature (§4.2) and inject it instead of the repository. |
-| 2 | Clean-arch leak | `domain/repository/ZakatRepository.kt` imports and exposes the Room `ZakatHistoryEntity` (domain depending on data). A `ZakatCalculation` domain model already exists but is unused. | Change the interface to expose `ZakatCalculation`; map in `ZakatRepositoryImpl` with `toDomain()/toEntity()`. |
-| 3 | Layer bypass | `CalendarViewModel` injects `IslamicEventDao` directly. It is the only ViewModel reaching into the data layer. | Route through an `IslamicEvent`/Calendar repository interface + use case. |
-| 4 | UDF intents | `QaidaReaderViewModel` has no `onEvent(...)`; it exposes ~8 public action methods instead (e.g. `selectLesson`, `playLine`). | Introduce a `QaidaReaderEvent` sealed interface and a single `onEvent` dispatcher. |
-| 5 | Service state leak | `QuranViewModel` re-exposes `AudioManager.audioState` directly to the UI. | Fold the audio state the UI needs into the ViewModel's own `UiState`. |
-| 6 | Dead route | `Route.MakeupFasts` is declared but never wired (makeup fasts is a **tab inside** `FastTrackerScreen` — this is correct UX). The declaration is orphaned. | Remove the unused `Route.MakeupFasts` declaration; keep the tab. |
-| 7 | Theming | Hardcoded `Color(0xFF…)` literals in screens — worst offenders: `zakat/ZakatCalculatorScreen.kt`, `zakat/ZakatHistoryScreen.kt`, `hadith/HadithCollectionScreen.kt`, `tasbih/BeadDesign.kt`. | Move values into `NimazColors` (e.g. add `ZakatColors`, `HadithCollections`, `TasbihBeadStyles`) and reference them. |
+| 1 | Layer bypass | `HomeViewModel` injects `FastingDao`, `HadithDao`, `DuaDao` directly for its "daily hadith / daily dua of the day" features. This logic reads entity-level fields and uses prepopulated-DB integer ids + seeders, so it is **not** a mechanical swap — the domain models differ (`Hadith.grade` is an enum, `DuaCategory.iconName` vs `icon`, String vs Int ids). | Extract `GetDailyHadithUseCase` / `GetDailyDuaUseCase` that own the daily-rotation business logic (and the seeders), returning domain models. Needs runtime/visual validation. |
+| 2 | Theming | Bespoke per-item gradient palettes still hold raw `Color(0xFF…)` literals: `hadith/HadithCollectionScreen.kt` (`getBookGradient`, per-collection pairs) and `tasbih/BeadDesign.kt` (bead style gradients). These are centralized design tokens, not scattered ad-hoc colors. | Relocate into `NimazColors` (e.g. `HadithCollectionColors`, `TasbihBeadStyles`) preserving exact hex; do under visual review. |
 
-> **What is NOT a deviation:** exposing multiple `StateFlow`s from one ViewModel for distinct
-> sub-screens (list/detail) is the accepted house style (see `AsmaUlHusnaViewModel`). Do not
-> "consolidate" these into a single mega-state.
+> **Accepted patterns (NOT deviations):**
+> - Exposing multiple `StateFlow`s from one ViewModel for distinct sub-screens (list/detail) is
+>   the house style (see `AsmaUlHusnaViewModel`). Do **not** "consolidate" them into one mega-state.
+> - Audio-playback ViewModels (`QaidaReaderViewModel`, `QuranViewModel`) expose the audio engine's
+>   `StateFlow` (`audioManager.state`) directly to the UI for live highlight/progress. This is an
+>   intentional, consistent pattern for playback features — not a leak to "fix".
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -437,6 +437,7 @@ copy anything listed as Open.
 | QaidaReader UDF | `QaidaReaderViewModel` now has a sealed `QaidaReaderEvent` + single `onEvent`; action methods are private; Qaida screens dispatch events. |
 | Dead route | The orphaned `Route.MakeupFasts` declaration was removed (makeup fasts is a tab inside `FastTrackerScreen`). |
 | Theming (Zakat) | Zakat screens use `NimazColors.Neutral900` / `NimazColors.ZakatColors.GoldAccent`; no raw color literals remain there. |
+| Domain→data leak (`PageAyahRange`) | Added a `PageAyahRange` domain model; the Room projection is `PageAyahRangeRow` (mapped in `QuranRepositoryImpl`). `domain/` no longer imports anything from `data/`. |
 
 ### Open (still to do — do not copy)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,489 @@
+# Nimaz — Architecture Guide
+
+> **Audience:** developers and AI agents working on this codebase.
+> **Purpose:** this is the *source of truth* for how Nimaz is structured. Follow the
+> canonical patterns described here so that new code stays consistent and the
+> architecture does not drift. When you add a feature, copy an existing feature that
+> follows these patterns (good references are called out below) — do **not** invent a
+> new shape.
+
+App package root: `com.arshadshah.nimaz`
+Source root: `app/src/main/java/com/arshadshah/nimaz/`
+
+---
+
+## 0. Golden rules (read first)
+
+These are the rules most often broken. Keep this checklist in mind for every change.
+
+1. **Dependencies point inward.** `presentation → domain → data`. The **domain layer must
+   never import from `data`** (no Room `*Entity`, no DAO, no DataStore). The presentation
+   layer must not import Room entities or DAOs.
+2. **ViewModels talk to use cases, not repositories or DAOs.** Inject `XxxUseCases`, not
+   `XxxRepository` and never a `XxxDao`.
+3. **One `StateFlow<XxxUiState>` per logical sub-screen, plus a single `onEvent(event)`.**
+   UI state is an immutable `data class`; UI intents are a `sealed interface XxxEvent`.
+   Do **not** expose `MutableStateFlow`, `LiveData`, or `mutableStateOf` from a ViewModel.
+4. **Repositories return domain models, never entities.** Map at the data layer with
+   `Entity.toDomain()` / `Model.toEntity()`.
+5. **DI lives in `core/di`.** Bind interfaces with `@Binds`, construct wrappers with
+   `@Provides`, scope app-wide singletons with `@Singleton` in `SingletonComponent`.
+6. **Navigation is type-safe.** Add a `@Serializable` entry to `Route` and a matching
+   `composable<Route.X>` in `NavGraph`. No raw route strings.
+7. **No hardcoded colors/typography in screens.** Use `MaterialTheme.colorScheme.*` or
+   `NimazColors.*`. Reuse `presentation/components` (atoms/molecules/organisms) instead of
+   re-rolling generic UI.
+8. **Verify before you finish.** `./gradlew :app:compileDebugKotlin` must pass (this runs
+   KSP, so it validates Hilt + Room wiring too).
+
+---
+
+## 1. High-level architecture
+
+Nimaz is an **offline-first** Android app built with **Kotlin + Jetpack Compose**,
+following **Clean Architecture** with **MVVM + UDF** (unidirectional data flow).
+
+```mermaid
+flowchart TD
+    subgraph P["presentation (UI)"]
+        SC["Compose Screens"]
+        VM["ViewModels<br/>StateFlow + onEvent(Event)"]
+        CMP["Components<br/>atoms / molecules / organisms"]
+        TH["theme (NimazTheme, NimazColors)"]
+    end
+    subgraph D["domain (business rules)"]
+        UC["Use Cases<br/>XxxUseCases wrapper"]
+        RI["Repository Interfaces"]
+        DM["Domain Models"]
+    end
+    subgraph DA["data (implementation)"]
+        RImpl["Repository Impls<br/>(toDomain / toEntity mapping)"]
+        DAO["Room DAOs + Entities"]
+        DS["DataStore (preferences)"]
+        AR["Asset Readers / Version Stores"]
+    end
+    SC --> VM
+    SC --> CMP
+    VM --> UC
+    UC --> RI
+    VM -.-> DM
+    UC -.-> DM
+    RImpl -- implements --> RI
+    RImpl --> DAO
+    RImpl --> DS
+    RImpl --> AR
+    RImpl --> DM
+    classDef pres fill:#CCFBF1,stroke:#0D9488,color:#134E4A
+    classDef dom fill:#FEF9C3,stroke:#A16207,color:#451A03
+    classDef dat fill:#E7E5E4,stroke:#57534E,color:#1C1917
+    class SC,VM,CMP,TH pres
+    class UC,RI,DM dom
+    class RImpl,DAO,DS,AR dat
+```
+
+**Why these layers exist:**
+
+| Layer | Responsibility | May depend on |
+|-------|----------------|---------------|
+| `presentation` | Render state, capture user intent | `domain` |
+| `domain` | Business rules, contracts, pure models | nothing (Kotlin + coroutines only) |
+| `data` | Implement contracts, talk to Room/DataStore/assets | `domain` |
+
+### Tech stack (authoritative versions live in `gradle/libs.versions.toml`)
+
+Kotlin · Jetpack Compose (Material 3) · Hilt (DI) · Room (DB) · DataStore (prefs) ·
+Navigation Compose (type-safe) · Coroutines/Flow · Media3 (audio) · Glance (widgets) ·
+WorkManager (background) · Adhan2 (prayer times). Single-activity, Compose-only UI.
+
+---
+
+## 2. Package structure
+
+```text
+com.arshadshah.nimaz/
+├── NimazApp.kt              # @HiltAndroidApp, WorkManager config, AppInitializer
+├── MainActivity.kt          # @AndroidEntryPoint, single activity, setContent { NimazTheme { NavGraph() } }
+│
+├── core/
+│   ├── di/                  # Hilt modules — THE place for DI
+│   │   ├── DatabaseModule.kt        # @Provides DB + every DAO
+│   │   ├── DataStoreModule.kt       # @Provides PreferencesDataStore
+│   │   └── RepositoryModule.kt      # @Binds repos  +  object UseCaseModule { @Provides XxxUseCases }
+│   ├── navigation/          # Routes.kt (sealed Route), NavGraph.kt, deep links
+│   ├── util/                # Extensions, mappers (e.g. mapItems), date utils
+│   ├── init/                # AppInitializer
+│   └── monitoring/          # AppAnalytics, CrashReporter
+│
+├── domain/
+│   ├── model/               # Domain models (e.g. QuranModels.kt, TasbihModels.kt)
+│   ├── repository/          # Repository INTERFACES (one per feature)
+│   └── usecase/             # XxxUseCases.kt (wrapper data class + individual use cases)
+│
+├── data/
+│   ├── local/
+│   │   ├── database/        # NimazDatabase.kt, dao/, entity/
+│   │   ├── datastore/       # PreferencesDataStore
+│   │   └── {dua,hadith,help,qaida}/  # Asset readers + content-version stores
+│   ├── repository/          # Repository IMPLEMENTATIONS (XxxRepositoryImpl)
+│   ├── audio/               # Media3 audio managers/services (Quran, Adhan, Qaida)
+│   └── sync/                # Nearby-connections device-to-device sync
+│
+├── presentation/
+│   ├── screens/<feature>/   # Composable screens grouped by feature
+│   ├── viewmodel/           # All ViewModels (flat package)
+│   ├── components/
+│   │   ├── atoms/           # Smallest reusable UI (NimazCard, NimazBadge, ArabicText…)
+│   │   ├── molecules/       # Composed (PrayerTimeCard, NimazDialog, NimazCalendar…)
+│   │   └── organisms/       # Complex (TopAppBar, MushafPage, HomeHero…)
+│   └── theme/               # NimazTheme, Color.kt (NimazColors), Type, Shape
+│
+└── widget/                  # Glance home-screen widgets (nextprayer, prayertracker, hijridate)
+```
+
+> **Note on the older `docs/nimaz-pro-technical-foundation.md`:** that document uses an
+> aspirational package `com.nimazpro.app`. The **real** package is `com.arshadshah.nimaz`.
+> This guide reflects the code as it actually exists.
+
+---
+
+## 3. Anatomy of a feature (vertical slice)
+
+Every feature is a vertical slice through the three layers. This is the shape to copy.
+
+```mermaid
+flowchart LR
+    subgraph pres["presentation"]
+        VM["XxxViewModel<br/>@HiltViewModel"]
+        ST["XxxUiState (data class)"]
+        EV["XxxEvent (sealed interface)"]
+    end
+    subgraph dom["domain"]
+        UCW["XxxUseCases (data class)"]
+        UC1["GetXxxUseCase"]
+        UC2["ToggleXxxUseCase"]
+        REPO["XxxRepository (interface)"]
+        MODEL["Xxx (domain model)"]
+    end
+    subgraph dat["data"]
+        IMPL["XxxRepositoryImpl<br/>@Singleton @Inject"]
+        DAO["XxxDao (@Dao)"]
+        ENT["XxxEntity (@Entity)"]
+    end
+    subgraph di["core/di"]
+        RM["RepositoryModule (@Binds)"]
+        UM["UseCaseModule (@Provides)"]
+    end
+    VM --> UCW
+    VM --> ST
+    VM --> EV
+    UCW --> UC1
+    UCW --> UC2
+    UC1 --> REPO
+    UC2 --> REPO
+    IMPL -. implements .-> REPO
+    IMPL --> DAO
+    DAO --> ENT
+    IMPL --> MODEL
+    UM -. provides .-> UCW
+    RM -. binds .-> IMPL
+```
+
+**Reference features to copy from:** `AsmaUlHusna`, `Prophet`, `Khatam`, `Quran`
+(these go all the way through the use-case layer correctly).
+
+---
+
+## 4. Layer patterns & conventions
+
+### 4.1 Presentation — ViewModels (MVVM + UDF)
+
+Canonical reference: `presentation/viewmodel/AsmaUlHusnaViewModel.kt`.
+
+Rules:
+- Annotated `@HiltViewModel`, constructor injection only.
+- Inject the feature's **`XxxUseCases`** wrapper (not a repository, never a DAO).
+- Expose immutable state as `StateFlow<XxxUiState>` via `asStateFlow()`. A ViewModel
+  **may** expose more than one `StateFlow` when a feature has genuinely distinct
+  sub-screens (e.g. a list state and a detail state) — that is the established house
+  style. Keep each one an immutable `data class`.
+- Mutate with `_state.update { it.copy(...) }`.
+- All UI intents flow through a single `fun onEvent(event: XxxEvent)` that `when`-dispatches
+  to private functions. `XxxEvent` is a `sealed interface`.
+
+```kotlin
+data class XxxUiState(
+    val items: List<Xxx> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+)
+
+sealed interface XxxEvent {
+    data class Select(val id: Int) : XxxEvent
+    data object Refresh : XxxEvent
+}
+
+@HiltViewModel
+class XxxViewModel @Inject constructor(
+    private val xxxUseCases: XxxUseCases,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(XxxUiState())
+    val state: StateFlow<XxxUiState> = _state.asStateFlow()
+
+    init { observe() }
+
+    fun onEvent(event: XxxEvent) = when (event) {
+        is XxxEvent.Select -> select(event.id)
+        XxxEvent.Refresh   -> refresh()
+    }
+
+    private fun observe() = viewModelScope.launch {
+        xxxUseCases.getAll().collect { items ->
+            _state.update { it.copy(items = items, isLoading = false) }
+        }
+    }
+    // ...
+}
+```
+
+Screens collect with `collectAsStateWithLifecycle()` and call `viewModel.onEvent(...)`.
+
+### 4.2 Domain — use cases
+
+Canonical reference: `domain/usecase/AsmaUlHusnaUseCases.kt`.
+
+- **One file per feature**, named `XxxUseCases.kt`. It contains:
+  - a `data class XxxUseCases(...)` wrapper grouping the feature's use cases, and
+  - one small class per operation, each `@Inject constructor(private val repository: XxxRepository)`
+    with an `operator fun invoke(...)` that delegates to the repository.
+- Use cases hold **business logic** (orchestration, filtering, combining). Trivial
+  pass-throughs are fine and expected — the wrapper gives the ViewModel a single,
+  testable dependency and keeps the repository surface out of the UI.
+
+```kotlin
+data class XxxUseCases(
+    val getAll: GetAllXxxUseCase,
+    val toggleFavorite: ToggleXxxFavoriteUseCase,
+)
+
+class GetAllXxxUseCase @Inject constructor(private val repo: XxxRepository) {
+    operator fun invoke(): Flow<List<Xxx>> = repo.getAll()
+}
+```
+
+### 4.3 Domain — repository interfaces & models
+
+- `domain/repository/XxxRepository.kt` is a **pure Kotlin interface** that exposes only
+  **domain models** and primitives. It must not import anything from `data` (no `*Entity`,
+  no DAO). _(See the Zakat deviation in §9 for the one place this is currently violated.)_
+- `domain/model/XxxModels.kt` holds immutable domain models (and enums/value types). These
+  are what flows up to the UI.
+
+### 4.4 Data — repository implementations & mapping
+
+Canonical reference: `data/repository/TasbihRepositoryImpl.kt`.
+
+- `XxxRepositoryImpl` is `@Singleton`, `@Inject constructor(private val dao: XxxDao)` (and/or
+  DataStore / asset readers), and `: XxxRepository`.
+- **Mapping is the impl's job.** Convert with private extension functions
+  `XxxEntity.toDomain()` and `Xxx.toEntity()`. For flows of lists use the shared
+  `core/util` helper `mapItems { it.toDomain() }`.
+
+```kotlin
+@Singleton
+class XxxRepositoryImpl @Inject constructor(
+    private val dao: XxxDao,
+) : XxxRepository {
+    override fun getAll(): Flow<List<Xxx>> = dao.getAll().mapItems { it.toDomain() }
+    override suspend fun insert(item: Xxx): Long = dao.insert(item.toEntity())
+}
+
+private fun XxxEntity.toDomain() = Xxx(/* ... */)
+private fun Xxx.toEntity() = XxxEntity(/* ... */)
+```
+
+### 4.5 Data — Room
+
+- Single database `NimazDatabase` (`data/local/database/`), shipped **pre-populated** from
+  `app/src/main/assets/database/nimaz_prepopulated.db` via `.createFromAsset(...)`.
+- Entities in `entity/`, DAOs in `dao/`. **Schema changes require a migration** added to the
+  `addMigrations(...)` chain in `DatabaseModule` and a bump of the DB version. Never ship a
+  schema change without a migration (the app relies on the prepackaged DB).
+
+---
+
+## 5. Unidirectional data flow (end-to-end)
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant S as Screen (Compose)
+    participant V as ViewModel
+    participant UC as UseCase
+    participant R as Repository Impl
+    participant SRC as Room DAO / DataStore
+    U->>S: interaction (tap)
+    S->>V: onEvent(XxxEvent.Action)
+    V->>UC: useCases.action(params)
+    UC->>R: repository.action(params)
+    R->>SRC: query / write
+    SRC-->>R: Entity / Flow<Entity>
+    R-->>UC: Domain Model (toDomain)
+    UC-->>V: Domain Model / Flow
+    V->>V: _state.update { it.copy(...) }
+    V-->>S: StateFlow<XxxUiState> emits
+    S-->>U: recomposition
+```
+
+State flows **down** (immutable `UiState`), events flow **up** (`onEvent`). The UI is a
+pure function of state.
+
+---
+
+## 6. Dependency injection (Hilt)
+
+```mermaid
+flowchart TD
+    APP["NimazApp (@HiltAndroidApp)"]
+    SGC["SingletonComponent"]
+    DBM["DatabaseModule<br/>@Provides DB + all DAOs"]
+    DSM["DataStoreModule<br/>@Provides PreferencesDataStore"]
+    RM["RepositoryModule (abstract)<br/>@Binds interface -> impl"]
+    UM["UseCaseModule (object)<br/>@Provides XxxUseCases"]
+    VMS["@HiltViewModel ViewModels"]
+    APP --> SGC
+    SGC --> DBM
+    SGC --> DSM
+    SGC --> RM
+    SGC --> UM
+    DBM --> RM
+    RM --> UM
+    UM --> VMS
+    DSM --> VMS
+    RM --> VMS
+```
+
+Conventions:
+- **All modules live in `core/di`** and install into `SingletonComponent` with `@Singleton`.
+- **`@Binds`** (in the `abstract class RepositoryModule`) for interface→impl bindings.
+- **`@Provides`** (in the `object UseCaseModule` at the bottom of `RepositoryModule.kt`) to
+  construct each `XxxUseCases` wrapper from its repository.
+- Individual use cases use `@Inject constructor`, so they need no module entry — only the
+  wrapper is `@Provides`.
+- DAOs are provided one-per-method from the single `NimazDatabase` instance in `DatabaseModule`.
+
+**Adding a use-case wrapper:** add a `provideXxxUseCases(repository: XxxRepository): XxxUseCases`
+function to `UseCaseModule`, mirroring `provideAsmaUlHusnaUseCases`.
+
+---
+
+## 7. Navigation
+
+Reference: `core/navigation/Routes.kt` and `core/navigation/NavGraph.kt`.
+
+- Routes are a `@Serializable` `sealed interface Route`. `data object` for argument-less
+  destinations, `data class` for ones with typed args (e.g.
+  `data class QuranReader(val surahNumber: Int, val ayahNumber: Int = 1)`).
+- Each route is wired with `composable<Route.X> { backStackEntry -> ... }`; typed args are
+  read with `backStackEntry.toRoute<Route.X>()`.
+- Bottom navigation is the `BottomNavDestination` enum (Home, Quran, Tasbih, Qibla, More).
+- **Not every `Route` is a full-screen destination.** Some features are tabs/sections inside
+  a parent screen. Example: **makeup fasts is a tab inside `FastTrackerScreen`** (driven by
+  `FastingEvent.LoadMakeupFasts`), *not* a standalone screen — so `Route.MakeupFasts` is not
+  wired in `NavGraph`. Validate how a feature is actually surfaced before adding/removing a
+  route. (See §9.)
+
+**Adding a screen:** add the `@Serializable` `Route` entry, add a `composable<Route.X>` in
+`NavGraph`, create the screen under `presentation/screens/<feature>/`, and navigate via the
+typed route object.
+
+---
+
+## 8. Theming & components
+
+- **Colors:** `presentation/theme/Color.kt` exposes the `NimazColors` object (primary teal,
+  gold accent, per-prayer colors, semantic statuses, tajweed colors, etc.). Use
+  `MaterialTheme.colorScheme.*` for themed surfaces, or `NimazColors.*` for brand/semantic
+  values. **Do not** write `Color(0xFF…)` literals in screens — if a needed value is missing,
+  add it to `NimazColors`.
+- **Theme entry:** `NimazTheme { ... }` wraps the app in `MainActivity`; it supplies the
+  Material 3 color scheme, `NimazTypography`, and shapes, and honors `ThemeMode`.
+- **Components follow Atomic Design** (`atoms` → `molecules` → `organisms`). Reuse shared
+  components (e.g. `NimazCard`, `PrayerTimeCard`, `NimazBackTopAppBar`, `NimazEmptyState`,
+  `NimazCalendar`) rather than re-rolling generic UI. Screen-local private composables are
+  fine for **feature-specific** layout that isn't reused elsewhere; promote anything reused
+  across screens into `components/`.
+
+---
+
+## 9. Known deviations & tech-debt registry
+
+These are places where the code currently diverges from the canonical patterns above. They
+are documented so agents **do not copy them** and can fix them intentionally. Status reflects
+validation against the live code.
+
+| # | Area | Deviation | Canonical fix |
+|---|------|-----------|---------------|
+| 1 | Use-case layer | Several ViewModels inject a repository directly instead of `XxxUseCases`: `Hadith`, `Dua`, `Fasting`, `Prayer` (Times/Tracker + Home/Qibla/Settings consumers), `Tasbih`, `Tafseer`, `Zakat`. | Add an `XxxUseCases` wrapper per feature (§4.2) and inject it instead of the repository. |
+| 2 | Clean-arch leak | `domain/repository/ZakatRepository.kt` imports and exposes the Room `ZakatHistoryEntity` (domain depending on data). A `ZakatCalculation` domain model already exists but is unused. | Change the interface to expose `ZakatCalculation`; map in `ZakatRepositoryImpl` with `toDomain()/toEntity()`. |
+| 3 | Layer bypass | `CalendarViewModel` injects `IslamicEventDao` directly. It is the only ViewModel reaching into the data layer. | Route through an `IslamicEvent`/Calendar repository interface + use case. |
+| 4 | UDF intents | `QaidaReaderViewModel` has no `onEvent(...)`; it exposes ~8 public action methods instead (e.g. `selectLesson`, `playLine`). | Introduce a `QaidaReaderEvent` sealed interface and a single `onEvent` dispatcher. |
+| 5 | Service state leak | `QuranViewModel` re-exposes `AudioManager.audioState` directly to the UI. | Fold the audio state the UI needs into the ViewModel's own `UiState`. |
+| 6 | Dead route | `Route.MakeupFasts` is declared but never wired (makeup fasts is a **tab inside** `FastTrackerScreen` — this is correct UX). The declaration is orphaned. | Remove the unused `Route.MakeupFasts` declaration; keep the tab. |
+| 7 | Theming | Hardcoded `Color(0xFF…)` literals in screens — worst offenders: `zakat/ZakatCalculatorScreen.kt`, `zakat/ZakatHistoryScreen.kt`, `hadith/HadithCollectionScreen.kt`, `tasbih/BeadDesign.kt`. | Move values into `NimazColors` (e.g. add `ZakatColors`, `HadithCollections`, `TasbihBeadStyles`) and reference them. |
+
+> **What is NOT a deviation:** exposing multiple `StateFlow`s from one ViewModel for distinct
+> sub-screens (list/detail) is the accepted house style (see `AsmaUlHusnaViewModel`). Do not
+> "consolidate" these into a single mega-state.
+
+---
+
+## 10. Recipe — add a new feature end-to-end
+
+1. **Domain models** — `domain/model/XxxModels.kt` (immutable data classes/enums).
+2. **Repository interface** — `domain/repository/XxxRepository.kt` (domain types only).
+3. **Room** — add `XxxEntity` (`entity/`) and `XxxDao` (`dao/`); register the DAO in
+   `NimazDatabase` and provide it in `DatabaseModule`. Add a migration if the schema changes.
+4. **Repository impl** — `data/repository/XxxRepositoryImpl.kt` with `toDomain()/toEntity()`
+   mapping. Bind it with `@Binds` in `RepositoryModule`.
+5. **Use cases** — `domain/usecase/XxxUseCases.kt` (wrapper + per-operation classes). Provide
+   the wrapper with `@Provides` in `UseCaseModule`.
+6. **ViewModel** — `presentation/viewmodel/XxxViewModel.kt` (`@HiltViewModel`, inject
+   `XxxUseCases`, `StateFlow<XxxUiState>` + sealed `XxxEvent` + `onEvent`).
+7. **Screen** — `presentation/screens/xxx/XxxScreen.kt`, collecting state with
+   `collectAsStateWithLifecycle()` and reusing shared components + theme.
+8. **Navigation** — add `Route.Xxx` and a `composable<Route.Xxx>` in `NavGraph`.
+9. **Tests** — unit-test the ViewModel (fake use cases) and use cases (fake repository);
+   DAO/repository tests where logic warrants. See `app/src/test/...`.
+10. **Verify** — `./gradlew :app:compileDebugKotlin` then `./gradlew :app:testDebugUnitTest`.
+
+---
+
+## 11. Build & verify
+
+```bash
+# Compile (runs KSP → validates Hilt + Room wiring). Fastest correctness gate.
+./gradlew :app:compileDebugKotlin
+
+# Unit tests
+./gradlew :app:testDebugUnitTest      # or: ./gradlew test
+
+# Lint
+./gradlew lint
+
+# Full CI lane (Gradle tests + lint), as run on PRs
+bundle exec fastlane android test
+
+# Debug APK
+./gradlew assembleDebug
+```
+
+Requires JDK 21 and an Android SDK (compileSdk 36). Set `sdk.dir` in `local.properties` or
+`ANDROID_HOME`.
+
+---
+
+*Keep this document in sync with reality.* When you intentionally change a pattern, update
+the relevant section here and the deviation registry in §9 — that is how we prevent drift.
+</content>
+</invoke>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,8 +307,9 @@ private fun Xxx.toEntity() = XxxEntity(/* ... */)
 - Single database `NimazDatabase` (`data/local/database/`), shipped **pre-populated** from
   `app/src/main/assets/database/nimaz_prepopulated.db` via `.createFromAsset(...)`.
 - Entities in `entity/`, DAOs in `dao/`. **Schema changes require a migration** added to the
-  `addMigrations(...)` chain in `DatabaseModule` and a bump of the DB version. Never ship a
-  schema change without a migration (the app relies on the prepackaged DB).
+  `addMigrations(...)` chain in `DatabaseModule` and a bump of the single `NIMAZ_DATABASE_VERSION`
+  constant (in `NimazDatabase.kt`, which drives both `@Database(version)` and `SCHEMA_VERSION`).
+  Never ship a schema change without a migration (the app relies on the prepackaged DB).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -423,6 +423,10 @@ during the architecture-consistency pass; the **Resolved** table is kept as a re
 fixes aren't accidentally reverted, and the **Open** table lists what remains. Agents must not
 copy anything listed as Open.
 
+> For a categorised, tick-box backlog of clean-architecture anti-patterns (with detection
+> commands to re-scan for new instances), see
+> [`CLEAN_ARCHITECTURE_CHECKLIST.md`](CLEAN_ARCHITECTURE_CHECKLIST.md).
+
 ### Resolved (do not regress)
 
 | Area | What was fixed |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -439,6 +439,7 @@ copy anything listed as Open.
 | Theming (Zakat) | Zakat screens use `NimazColors.Neutral900` / `NimazColors.ZakatColors.GoldAccent`; no raw color literals remain there. |
 | Domain→data leak (`PageAyahRange`) | Added a `PageAyahRange` domain model; the Room projection is `PageAyahRangeRow` (mapped in `QuranRepositoryImpl`). `domain/` no longer imports anything from `data/`. |
 | Home daily-content DAO coupling | `HomeViewModel` no longer injects `FastingDao`/`HadithDao`/`DuaDao`. Daily hadith/dua logic extracted to `GetDailyHadithUseCase`/`GetDailyDuaUseCase`; seeding moved into the repositories. No presentation ViewModel injects a DAO or `RepositoryImpl` anymore. |
+| Theming (screens) | Raw `Color(0xFF…)` literals removed from ~20 feature screens into `NimazColors` tokens (exact hex; added `Success`/`Warning`/`Info`/etc. and `HadithCollectionColors`). Only bespoke design-token files remain (`tasbih/BeadDesign.kt`, `TasbihBeads.kt`, `onboarding/OnboardingArt.kt`). |
 
 ### Open (still to do — do not copy)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,6 +438,7 @@ copy anything listed as Open.
 | Dead route | The orphaned `Route.MakeupFasts` declaration was removed (makeup fasts is a tab inside `FastTrackerScreen`). |
 | Theming (Zakat) | Zakat screens use `NimazColors.Neutral900` / `NimazColors.ZakatColors.GoldAccent`; no raw color literals remain there. |
 | Domain→data leak (`PageAyahRange`) | Added a `PageAyahRange` domain model; the Room projection is `PageAyahRangeRow` (mapped in `QuranRepositoryImpl`). `domain/` no longer imports anything from `data/`. |
+| Home daily-content DAO coupling | `HomeViewModel` no longer injects `FastingDao`/`HadithDao`/`DuaDao`. Daily hadith/dua logic extracted to `GetDailyHadithUseCase`/`GetDailyDuaUseCase`; seeding moved into the repositories. No presentation ViewModel injects a DAO or `RepositoryImpl` anymore. |
 
 ### Open (still to do — do not copy)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -440,6 +440,7 @@ copy anything listed as Open.
 | Domain→data leak (`PageAyahRange`) | Added a `PageAyahRange` domain model; the Room projection is `PageAyahRangeRow` (mapped in `QuranRepositoryImpl`). `domain/` no longer imports anything from `data/`. |
 | Home daily-content DAO coupling | `HomeViewModel` no longer injects `FastingDao`/`HadithDao`/`DuaDao`. Daily hadith/dua logic extracted to `GetDailyHadithUseCase`/`GetDailyDuaUseCase`; seeding moved into the repositories. No presentation ViewModel injects a DAO or `RepositoryImpl` anymore. |
 | Theming (screens) | Raw `Color(0xFF…)` literals removed from ~20 feature screens into `NimazColors` tokens (exact hex; added `Success`/`Warning`/`Info`/etc. and `HadithCollectionColors`). Only bespoke design-token files remain (`tasbih/BeadDesign.kt`, `TasbihBeads.kt`, `onboarding/OnboardingArt.kt`). |
+| Preferences abstraction | ViewModels no longer inject the `PreferencesDataStore` data class — they depend on the `domain/repository/SettingsRepository` interface (implemented by `PreferencesDataStore`, bound via `@Binds`). `UserPreferences` moved to `domain/model`. |
 
 ### Open (still to do — do not copy)
 

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -53,10 +53,10 @@ grep -rlnE "private val [a-zA-Z]+: [A-Za-z]+(Dao|RepositoryImpl)" \
   app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/
 ```
 
-- [ ] **`HomeViewModel` injects three DAOs** (`FastingDao`, `HadithDao`, `DuaDao`) for the
-  "daily hadith / daily dua of the day" features. This is entangled with seeders and DB integer
-  ids — **see AP-4** for the proper fix (extract use cases). Removing the DAO injections here
-  resolves both AP-2 and AP-4 for Home.
+- [x] ~~**`HomeViewModel` injects three DAOs** (`FastingDao`, `HadithDao`, `DuaDao`).~~
+  **Resolved.** Home now injects `FastingUseCases`/`HadithUseCases`/`DuaUseCases`; the daily
+  content goes through `GetDailyHadithUseCase`/`GetDailyDuaUseCase` (see AP-4), and seeding moved
+  into the repositories. Home no longer imports any `data.local.database.*`.
 - [x] ~~**`QuranViewModel` imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
 - [x] ~~**`QuranPageGrid` (organism) imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
 
@@ -91,13 +91,12 @@ and call use cases; they shouldn't compute domain results from raw data sources.
 **Why it hurts:** logic isn't reusable or unit-testable in isolation, and the VM grows into a
 god-object.
 
-- [ ] **Home "content of the day" rotation.** `HomeViewModel.loadDailyHadith()` /
-  `loadDailyDua()` pull total counts + offsets from DAOs and compute the daily pick inline
-  (Knuth-hash day scatter, time-of-day category, day-of-year rotation). **Fix:** extract
-  `GetDailyHadithUseCase` and `GetDailyDuaUseCase` (owning the seeders + the selection logic),
-  returning domain models. ⚠️ Behaviour-bearing — validate against the current output (the domain
-  models differ from entities: `Hadith.grade` is an enum, `DuaCategory.iconName` vs `icon`,
-  String vs Int ids), ideally with a runtime/visual check.
+- [x] ~~**Home "content of the day" rotation.**~~ **Resolved.** Extracted
+  `GetDailyHadithUseCase` (Knuth-hash day scatter) and `GetDailyDuaUseCase` (time-of-day category
+  + day-of-year rotation, returning a `DailyDuaSelection` domain model). The seeders moved into
+  the repositories (seed-then-read), and the daily reads use seeded repository methods
+  (`getHadithCount`/`getHadithByOffset`, `getDuasByCategoryOnce`). Behaviour preserved (identical
+  queries/selection math; field mappings verified); full unit suite green.
 - [ ] **General watch:** when a `private fun` in a ViewModel does multi-step computation over
   repository/use-case results (filtering, combining, ranking), consider whether it's a use case.
 

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -115,26 +115,22 @@ grep -rlE 'Color\(0x[0-9A-Fa-f]{6,8}\)' app/src/main/java/com/arshadshah/nimaz/p
  | while read f; do echo "$(grep -coE 'Color\(0x[0-9A-Fa-f]{6,8}\)' "$f")  $f"; done | sort -rn
 ```
 
-Snapshot: **21 screen files** still hold raw literals. Tackle a few per PR (relocate into
-`NimazColors`, preserving exact hex — zero visual change). Top offenders:
+Original snapshot was **21 screen files**. Now down to **3**, and those are accepted
+design-token / illustration files (see below).
 
-- [ ] `fasting/FastTrackerScreen.kt` (15)
-- [ ] `tasbih/BeadDesign.kt` (14 — bespoke bead-style gradients; relocate to a
-  `NimazColors.TasbihBeadStyles` token group, under visual review)
-- [x] ~~`hadith/HadithCollectionScreen.kt` (11)~~ — **Resolved.** `getBookGradient` now reads
-  `NimazColors.HadithCollectionColors`; gold accents use `NimazColors.Gold500` / `NimazColors.GoldDark`.
-- [ ] `prayer/PrayerStatsScreen.kt` (10)
-- [ ] `settings/NotificationSettingsScreen.kt` (9)
-- [ ] `prayer/PrayerTrackerScreen.kt` (8)
-- [ ] `onboarding/OnboardingArt.kt` (8 — illustration art; may legitimately keep brand literals,
-  but prefer named tokens)
-- [ ] `help/HelpContentUi.kt` (7), `dua/DuasCollectionScreen.kt` (7),
-  `calendar/IslamicCalendarScreen.kt` (7)
-- [ ] Remaining lower-count files (run the detect command for the live list):
-  `settings/AppearanceSettingsScreen.kt`, `quran/QuranHomeScreen.kt`,
-  `prayer/MonthlyPrayerTimesScreen.kt`, `hadith/HadithGradeChip.kt`,
-  `onboarding/OnboardingScreen.kt`, …
-- [x] ~~`zakat/ZakatCalculatorScreen.kt`, `zakat/ZakatHistoryScreen.kt`~~ — **resolved**.
+- [x] ~~All 18 feature screens with scattered literals~~ — **Resolved.** Literals across
+  `fasting/FastTrackerScreen`, `prayer/{PrayerStats,PrayerTracker,MonthlyPrayerTimes,QadaPrayers}`,
+  `settings/{Notification,Appearance,Widgets}`, `help/{HelpContentUi,HelpGuide}`,
+  `dua/{DuasCollection,DuaReader}`, `calendar/IslamicCalendar`, `hadith/{HadithCollection,HadithGradeChip,HadithReader}`,
+  `quran/QuranHomeScreen`, `onboarding/OnboardingScreen`, and `zakat/*` were relocated into
+  `NimazColors` (exact hex preserved — zero visual change). New semantic/categorical tokens were
+  added: `Success`, `Warning`, `Info`, `InfoSoft`, `Emerald`, `Sky`, `Purple`, `Pink`, `Amber`,
+  `OrangeDark`, `IndigoLight`, `Gray300`, `OnboardingBg*`, plus `HadithCollectionColors`. Prayer
+  palette usages map to `NimazColors.PrayerColors.*`.
+- [ ] **Accepted (not scattered screen literals) — leave unless a redesign touches them:**
+  `tasbih/BeadDesign.kt` and `tasbih/TasbihBeads.kt` (bespoke bead-style gradient palettes — this
+  *is* their design-token file) and `onboarding/OnboardingArt.kt` (illustration art). If you do
+  tokenize them, add a `NimazColors.TasbihBeadStyles` group under visual review.
 
 > Components (`presentation/components/`) also contain literals; many are intentional gradient
 > stops. Prefer named tokens, but a dedicated design-token file (e.g. `BeadDesign.kt`) holding

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -145,10 +145,13 @@ design-token / illustration files (see below).
 **Why it hurts:** ties many ViewModels to a concrete data/infra class; harder to fake in tests.
 This one is **pervasive and lower priority** — listed so it's tracked, not because it's urgent.
 
-- [ ] **`PreferencesDataStore` injected directly** into many ViewModels (Home, Quran, Settings,
-  Dua, Hadith, Tasbih, Onboarding, Location, …). Consider a `SettingsRepository` /
-  `UserPreferences` domain abstraction so ViewModels depend on an interface, not the DataStore
-  class. Large blast radius — do incrementally or leave as an accepted infra dependency.
+- [x] ~~**`PreferencesDataStore` injected directly** into many ViewModels.~~ **Resolved.**
+  Extracted a `domain/repository/SettingsRepository` interface (147 members); `PreferencesDataStore`
+  now implements it, and `UserPreferences` moved to `domain/model`. All 13 ViewModels + `MainActivity`
+  inject `SettingsRepository`; bound via `@Binds` in `RepositoryModule`. Data-layer consumers
+  (seeders, sync, workers, `AppInitializer`, `BootReceiver`) keep the concrete class.
+  - [ ] **Minor leftover:** `settings/WidgetsScreen.kt` still *instantiates* `PreferencesDataStore(context)`
+    inline (line ~793) instead of going through DI/a ViewModel — convert when that screen is next touched.
 - [ ] **Audio managers expose data-layer `AudioState`.** `QuranViewModel` /
   `QaidaReaderViewModel` surface `audioManager.state` (a `data.audio` type) to the UI. This is an
   **accepted pattern** for playback features (see `ARCHITECTURE.md` §9). If desired, mirror the

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -121,8 +121,8 @@ Snapshot: **21 screen files** still hold raw literals. Tackle a few per PR (relo
 - [ ] `fasting/FastTrackerScreen.kt` (15)
 - [ ] `tasbih/BeadDesign.kt` (14 — bespoke bead-style gradients; relocate to a
   `NimazColors.TasbihBeadStyles` token group, under visual review)
-- [ ] `hadith/HadithCollectionScreen.kt` (11 — `getBookGradient`; relocate to a
-  `NimazColors.HadithCollectionColors` group)
+- [x] ~~`hadith/HadithCollectionScreen.kt` (11)~~ — **Resolved.** `getBookGradient` now reads
+  `NimazColors.HadithCollectionColors`; gold accents use `NimazColors.Gold500` / `NimazColors.GoldDark`.
 - [ ] `prayer/PrayerStatsScreen.kt` (10)
 - [ ] `settings/NotificationSettingsScreen.kt` (9)
 - [ ] `prayer/PrayerTrackerScreen.kt` (8)

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -1,0 +1,194 @@
+# Clean Architecture — Anti-Pattern Checklist
+
+> A **living, tick-box backlog** of clean-architecture violations to chip away at over time.
+> Pair it with [`ARCHITECTURE.md`](ARCHITECTURE.md) (the canonical patterns) and its §9 registry
+> (resolved vs open). Each item is small enough to land in its own PR. When you fix one, check
+> its box and, if it removes the last instance of an anti-pattern, note it in `ARCHITECTURE.md` §9.
+
+**How to use this**
+1. Pick any unchecked box (they're independent — no required order).
+2. Apply the fix, run `./gradlew :app:compileDebugKotlin && ./gradlew :app:testDebugUnitTest`.
+3. Tick the box in the same PR. Re-run the **detection command** for that section to confirm the
+   count dropped (and to catch any new instances that crept in).
+
+Counts below were captured during the architecture-consistency pass — treat them as a starting
+snapshot, not gospel. Re-run the detection commands to refresh.
+
+---
+
+## AP-1 · Domain depends on the data layer
+
+**Rule:** `domain/` must import nothing from `data/` — no Room `*Entity`, no `*Dao`, no
+DAO-defined helper types, no DataStore. The domain layer is pure Kotlin + coroutines.
+
+**Why it hurts:** couples business rules to the database schema; you can't change storage or
+unit-test the domain without Room on the classpath.
+
+**Detect:**
+```bash
+grep -rlnE "import com.arshadshah.nimaz.data\." app/src/main/java/com/arshadshah/nimaz/domain/
+```
+
+- [ ] **`PageAyahRange` leak.** `domain/repository/QuranRepository.kt` and
+  `domain/usecase/QuranUseCases.kt` import `data.local.database.dao.PageAyahRange` (a class
+  declared inside `QuranDao`). **Fix:** add a `PageAyahRange` (or `AyahRange`) model in
+  `domain/model/QuranModels.kt`, have the repository return that, and map from the DAO type in
+  `QuranRepositoryImpl`. Then update `QuranUseCases`, `QuranViewModel`, and `QuranPageGrid`
+  (see AP-2) to the domain type.
+
+---
+
+## AP-2 · Presentation reaches into the data layer
+
+**Rule:** ViewModels, screens, and components import only `domain/` types (+ Compose/UI). No Room
+entities, no DAOs. ViewModels inject `XxxUseCases`, never a `Dao` or `RepositoryImpl`.
+
+**Why it hurts:** the UI becomes coupled to storage details; swapping or refactoring the data
+layer ripples into screens.
+
+**Detect:**
+```bash
+grep -rlnE "import com.arshadshah.nimaz.data.local.database.(dao|entity)" \
+  app/src/main/java/com/arshadshah/nimaz/presentation/
+grep -rlnE "private val [a-zA-Z]+: [A-Za-z]+(Dao|RepositoryImpl)" \
+  app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/
+```
+
+- [ ] **`HomeViewModel` injects three DAOs** (`FastingDao`, `HadithDao`, `DuaDao`) for the
+  "daily hadith / daily dua of the day" features. This is entangled with seeders and DB integer
+  ids — **see AP-4** for the proper fix (extract use cases). Removing the DAO injections here
+  resolves both AP-2 and AP-4 for Home.
+- [ ] **`QuranViewModel` imports `PageAyahRange`** (DAO type). Fixed automatically once AP-1 is
+  done and the VM switches to the domain type.
+- [ ] **`QuranPageGrid` (organism) imports `PageAyahRange`** (DAO type). Same fix as AP-1; a UI
+  component should never reference a DAO-defined type.
+
+---
+
+## AP-3 · Repositories expose Room entities instead of domain models
+
+**Rule:** repository **interfaces** return/accept `domain/model` types only; mapping
+(`Entity.toDomain()` / `Model.toEntity()`) lives in the `*RepositoryImpl`.
+
+**Why it hurts:** leaks persistence shapes up through every layer; a column rename becomes a UI
+change.
+
+**Detect:**
+```bash
+# Domain repository interfaces importing a Room entity:
+grep -rlnE "import com.arshadshah.nimaz.data.local.database.entity" \
+  app/src/main/java/com/arshadshah/nimaz/domain/repository/
+```
+
+- [x] ~~`ZakatRepository` exposed `ZakatHistoryEntity`~~ — **resolved** (now `ZakatHistoryEntry`).
+- [ ] **Audit pass (watchlist).** Re-run the detect command after any new repository lands; keep
+  this at zero. No other current offenders.
+
+---
+
+## AP-4 · Business logic living in ViewModels
+
+**Rule:** orchestration / domain rules belong in use cases. ViewModels translate state ⇄ events
+and call use cases; they shouldn't compute domain results from raw data sources.
+
+**Why it hurts:** logic isn't reusable or unit-testable in isolation, and the VM grows into a
+god-object.
+
+- [ ] **Home "content of the day" rotation.** `HomeViewModel.loadDailyHadith()` /
+  `loadDailyDua()` pull total counts + offsets from DAOs and compute the daily pick inline
+  (Knuth-hash day scatter, time-of-day category, day-of-year rotation). **Fix:** extract
+  `GetDailyHadithUseCase` and `GetDailyDuaUseCase` (owning the seeders + the selection logic),
+  returning domain models. ⚠️ Behaviour-bearing — validate against the current output (the domain
+  models differ from entities: `Hadith.grade` is an enum, `DuaCategory.iconName` vs `icon`,
+  String vs Int ids), ideally with a runtime/visual check.
+- [ ] **General watch:** when a `private fun` in a ViewModel does multi-step computation over
+  repository/use-case results (filtering, combining, ranking), consider whether it's a use case.
+
+---
+
+## AP-5 · Hardcoded colors / dimensions in screens (theme bypass)
+
+**Rule:** use `MaterialTheme.colorScheme.*` or `NimazColors.*`; never raw `Color(0xFF…)` in
+screens. If a value is missing, add a named token to `NimazColors`.
+
+**Why it hurts:** breaks theming/dark-mode, scatters the palette, and makes rebrands impossible.
+
+**Detect (per-file counts, highest first):**
+```bash
+grep -rlE 'Color\(0x[0-9A-Fa-f]{6,8}\)' app/src/main/java/com/arshadshah/nimaz/presentation/screens/ \
+ | while read f; do echo "$(grep -coE 'Color\(0x[0-9A-Fa-f]{6,8}\)' "$f")  $f"; done | sort -rn
+```
+
+Snapshot: **21 screen files** still hold raw literals. Tackle a few per PR (relocate into
+`NimazColors`, preserving exact hex — zero visual change). Top offenders:
+
+- [ ] `fasting/FastTrackerScreen.kt` (15)
+- [ ] `tasbih/BeadDesign.kt` (14 — bespoke bead-style gradients; relocate to a
+  `NimazColors.TasbihBeadStyles` token group, under visual review)
+- [ ] `hadith/HadithCollectionScreen.kt` (11 — `getBookGradient`; relocate to a
+  `NimazColors.HadithCollectionColors` group)
+- [ ] `prayer/PrayerStatsScreen.kt` (10)
+- [ ] `settings/NotificationSettingsScreen.kt` (9)
+- [ ] `prayer/PrayerTrackerScreen.kt` (8)
+- [ ] `onboarding/OnboardingArt.kt` (8 — illustration art; may legitimately keep brand literals,
+  but prefer named tokens)
+- [ ] `help/HelpContentUi.kt` (7), `dua/DuasCollectionScreen.kt` (7),
+  `calendar/IslamicCalendarScreen.kt` (7)
+- [ ] Remaining lower-count files (run the detect command for the live list):
+  `settings/AppearanceSettingsScreen.kt`, `quran/QuranHomeScreen.kt`,
+  `prayer/MonthlyPrayerTimesScreen.kt`, `hadith/HadithGradeChip.kt`,
+  `onboarding/OnboardingScreen.kt`, …
+- [x] ~~`zakat/ZakatCalculatorScreen.kt`, `zakat/ZakatHistoryScreen.kt`~~ — **resolved**.
+
+> Components (`presentation/components/`) also contain literals; many are intentional gradient
+> stops. Prefer named tokens, but a dedicated design-token file (e.g. `BeadDesign.kt`) holding
+> grouped palettes is acceptable — the anti-pattern is *scattered* literals inside screen logic.
+
+---
+
+## AP-6 · Data-layer infrastructure injected straight into ViewModels
+
+**Rule (aspirational):** cross-cutting infrastructure should sit behind a domain abstraction.
+
+**Why it hurts:** ties many ViewModels to a concrete data/infra class; harder to fake in tests.
+This one is **pervasive and lower priority** — listed so it's tracked, not because it's urgent.
+
+- [ ] **`PreferencesDataStore` injected directly** into many ViewModels (Home, Quran, Settings,
+  Dua, Hadith, Tasbih, Onboarding, Location, …). Consider a `SettingsRepository` /
+  `UserPreferences` domain abstraction so ViewModels depend on an interface, not the DataStore
+  class. Large blast radius — do incrementally or leave as an accepted infra dependency.
+- [ ] **Audio managers expose data-layer `AudioState`.** `QuranViewModel` /
+  `QaidaReaderViewModel` surface `audioManager.state` (a `data.audio` type) to the UI. This is an
+  **accepted pattern** for playback features (see `ARCHITECTURE.md` §9). If desired, mirror the
+  fields the UI needs into a domain/UI-state type to drop the `data.audio` import — optional.
+
+---
+
+## AP-7 · General watchlist (no scripted detector — review during PRs)
+
+- [ ] **God ViewModels / mega-state:** a single VM owning many unrelated `StateFlow`s is fine for
+  distinct sub-screens (house style), but watch for one VM serving several *features*.
+- [ ] **`!!` and unsafe casts** on domain/data boundaries — prefer safe mapping + defaults (see
+  the `runCatching { … }.getOrDefault(…)` enum mapping in `ZakatRepositoryImpl`).
+- [ ] **Mapping duplicated across VMs:** if two ViewModels both map the same entity→UI shape,
+  push the mapping down into the repository (`toDomain()`).
+- [ ] **Use cases that only re-expose a repository verbatim across a whole feature:** acceptable
+  (the wrapper is the seam the UI depends on), but if a use case adds no value and the feature is
+  trivial, that's fine — don't over-engineer net-new tiny features.
+
+---
+
+## Quick full re-scan
+
+```bash
+cd app/src/main/java/com/arshadshah/nimaz
+echo "AP-1 domain->data:";      grep -rlnE "import com.arshadshah.nimaz.data\." domain/ || echo "  clean"
+echo "AP-2 presentation->dao/entity:"; grep -rlnE "import com.arshadshah.nimaz.data.local.database.(dao|entity)" presentation/ || echo "  clean"
+echo "AP-2 VM injects Dao/Impl:"; grep -rlnE "private val [a-zA-Z]+: [A-Za-z]+(Dao|RepositoryImpl)" presentation/viewmodel/ || echo "  clean"
+echo "AP-3 domain repo->entity:"; grep -rlnE "import com.arshadshah.nimaz.data.local.database.entity" domain/repository/ || echo "  clean"
+echo "AP-5 screen color literals:"; grep -rlE 'Color\(0x[0-9A-Fa-f]{6,8}\)' presentation/screens/ | wc -l
+```
+
+*Keep this file honest: tick boxes as you go, and add new anti-patterns/instances when you spot
+them.*
+</content>

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -29,12 +29,11 @@ unit-test the domain without Room on the classpath.
 grep -rlnE "import com.arshadshah.nimaz.data\." app/src/main/java/com/arshadshah/nimaz/domain/
 ```
 
-- [ ] **`PageAyahRange` leak.** `domain/repository/QuranRepository.kt` and
-  `domain/usecase/QuranUseCases.kt` import `data.local.database.dao.PageAyahRange` (a class
-  declared inside `QuranDao`). **Fix:** add a `PageAyahRange` (or `AyahRange`) model in
-  `domain/model/QuranModels.kt`, have the repository return that, and map from the DAO type in
-  `QuranRepositoryImpl`. Then update `QuranUseCases`, `QuranViewModel`, and `QuranPageGrid`
-  (see AP-2) to the domain type.
+- [x] ~~**`PageAyahRange` leak.**~~ **Resolved.** Added `PageAyahRange` to
+  `domain/model/QuranModels.kt`; the Room projection was renamed to `PageAyahRangeRow` (kept in
+  `QuranDao`) and `QuranRepositoryImpl` maps row → domain via `toDomain()`. `QuranRepository`,
+  `QuranUseCases`, `QuranViewModel`, and `QuranPageGrid` now use the domain type. `domain/`
+  imports nothing from `data/`.
 
 ---
 
@@ -58,10 +57,8 @@ grep -rlnE "private val [a-zA-Z]+: [A-Za-z]+(Dao|RepositoryImpl)" \
   "daily hadith / daily dua of the day" features. This is entangled with seeders and DB integer
   ids — **see AP-4** for the proper fix (extract use cases). Removing the DAO injections here
   resolves both AP-2 and AP-4 for Home.
-- [ ] **`QuranViewModel` imports `PageAyahRange`** (DAO type). Fixed automatically once AP-1 is
-  done and the VM switches to the domain type.
-- [ ] **`QuranPageGrid` (organism) imports `PageAyahRange`** (DAO type). Same fix as AP-1; a UI
-  component should never reference a DAO-defined type.
+- [x] ~~**`QuranViewModel` imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
+- [x] ~~**`QuranPageGrid` (organism) imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
 
 ---
 

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -1,0 +1,235 @@
+# Nimaz — Navigation Map
+
+> **Single source of truth for the app's navigation graph.** Whenever you add, remove, or
+> rename a `Route`, **update this file in the same change** (the diagram *and* the route table).
+> See [`ARCHITECTURE.md` §7](ARCHITECTURE.md) for the navigation patterns and conventions.
+
+Navigation is **type-safe**: a `@Serializable sealed interface Route`
+(`core/navigation/Routes.kt`) plus `composable<Route.X>` wiring in
+`core/navigation/NavGraph.kt`. Typed arguments are read with
+`backStackEntry.toRoute<Route.X>()`. Bottom navigation is the `BottomNavDestination` enum.
+
+## Graph
+
+```mermaid
+flowchart LR
+    Onboard([Onboarding]) --> Home
+    subgraph BN["Bottom navigation"]
+        Home[Home]
+        QuranHub[Quran]
+        TasbihHub[Tasbih]
+        Qibla[Qibla]
+        More[More]
+    end
+
+    subgraph Q["Quran"]
+        QuranHub --> QuranReader & QuranPage & QuranJuz & QuranSearch & QuranBookmarks
+        QuranReader --> SurahInfo & Tafseer & SelectReciter
+    end
+
+    subgraph Names["Names & Prophets"]
+        AsmaUlHusnaList --> AsmaUlHusnaDetail
+        AsmaUnNabiList --> AsmaUnNabiDetail
+        ProphetsList --> ProphetDetail
+    end
+
+    subgraph Kh["Khatam"]
+        KhatamList --> KhatamDetail & KhatamCreate
+    end
+
+    subgraph Qaida["Qaida"]
+        QaidaHome --> QaidaReader & QaidaLetters
+    end
+
+    subgraph H["Hadith"]
+        HadithHome --> HadithBook --> HadithChapter --> HadithReader
+        HadithHome --> HadithSearch & HadithBookmarks & HadithSettings
+    end
+
+    subgraph D["Dua"]
+        DuaHome --> DuaCategory --> DuaReader
+        DuaHome --> DuaFavorites & DuaSearch & DuaSettings
+    end
+
+    subgraph P["Prayer"]
+        PrayerTimes --> PrayerTracker & PrayerStats & QadaPrayers & MonthlyPrayerTimes
+    end
+
+    subgraph F["Fasting"]
+        FastingHome --> FastingTracker & FastingStats
+    end
+
+    subgraph T["Tasbih screens"]
+        TasbihHub --> TasbihCounter & TasbihPresets & TasbihStats & TasbihHistory & TasbihAddPreset
+    end
+
+    subgraph Z["Zakat / Calendar"]
+        ZakatCalculator --> ZakatHistory
+        IslamicCalendar --> IslamicMonth
+    end
+
+    subgraph S["Settings"]
+        Settings --> SettingsPrayerCalculation & SettingsNotifications & SettingsAppearance & SettingsLanguage & SettingsLocation & SettingsQuran & SettingsWidgets & SettingsAbout
+        Settings --> SettingsHelp & SettingsSync
+        SettingsHelp --> HelpTopicDetail & HelpGuide
+        SettingsAbout --> Licenses --> LicenseDetail
+    end
+
+    More --> HadithHome & DuaHome & PrayerTimes & FastingHome & ZakatCalculator & IslamicCalendar
+    More --> AsmaUlHusnaList & AsmaUnNabiList & ProphetsList & KhatamList & QaidaHome
+    More --> AllBookmarks & GlobalSearch & Settings
+    Qibla --> Qibla
+```
+
+> The graph shows the primary reachability, not every edge (most screens can also be reached
+> via deep links and cross-feature actions). `Home`, `Quran`, `Tasbih`, `Qibla`, and `More` are
+> the five bottom-nav roots; `More` is the hub for everything else.
+
+## Route reference
+
+All routes live in `core/navigation/Routes.kt` and are wired in `core/navigation/NavGraph.kt`
+(75 `composable<Route.X>` destinations). `data object` = no args; `data class` = typed args.
+
+### Bottom navigation (`BottomNavDestination`)
+| Route | Screen |
+|-------|--------|
+| `Home` | HomeScreen |
+| `Quran` | QuranHomeScreen |
+| `Tasbih` | TasbihHomeScreen |
+| `QiblaNav` → `Qibla` | QiblaScreen |
+| `More` | MoreScreen (hub) |
+
+### Quran
+| Route | Args | Screen |
+|-------|------|--------|
+| `QuranReader` | `surahNumber: Int, ayahNumber: Int = 1` | QuranReaderScreen |
+| `QuranPage` | `pageNumber: Int` | QuranPageScreen (mushaf) |
+| `QuranJuz` | `juzNumber: Int` | QuranJuzScreen |
+| `QuranSearch` | — | QuranSearchScreen |
+| `QuranBookmarks` | — | QuranBookmarksScreen |
+| `SurahInfo` | `surahNumber: Int` | SurahInfoScreen |
+| `Tafseer` | `surahNumber: Int, ayahNumber: Int = 1` | TafseerScreen |
+| `SelectReciter` | — | SelectReciterScreen |
+
+### Hadith
+| Route | Args | Screen |
+|-------|------|--------|
+| `HadithHome` | — | HadithCollectionScreen |
+| `HadithBook` | `bookId: String` | HadithBookScreen |
+| `HadithChapter` | `bookId: String, chapterId: String` | HadithChapterScreen |
+| `HadithReader` | `hadithId: String` | HadithReaderScreen |
+| `HadithSearch` | — | HadithSearchScreen |
+| `HadithBookmarks` | — | HadithBookmarksScreen |
+| `HadithSettings` | — | HadithSettingsScreen |
+
+### Dua
+| Route | Args | Screen |
+|-------|------|--------|
+| `DuaHome` | — | DuasCollectionScreen |
+| `DuaCategory` | `categoryId: String` | DuaCategoryScreen |
+| `DuaReader` | `duaId: String` | DuaReaderScreen |
+| `DuaFavorites` | — | DuaFavoritesScreen |
+| `DuaSearch` | — | DuaSearchScreen |
+| `DuaSettings` | — | DuaSettingsScreen |
+
+### Prayer
+| Route | Args | Screen |
+|-------|------|--------|
+| `PrayerTimes` | — | PrayerTimesScreen |
+| `PrayerTracker` | `initialTab: Int = 0` | PrayerTrackerScreen |
+| `PrayerStats` | — | PrayerStatsScreen |
+| `QadaPrayers` | — | QadaPrayersScreen |
+| `MonthlyPrayerTimes` | — | MonthlyPrayerTimesScreen |
+
+### Fasting
+| Route | Args | Screen |
+|-------|------|--------|
+| `FastingHome` | — | FastTrackerScreen |
+| `FastingTracker` | — | FastTrackerScreen |
+| `FastingStats` | — | (fasting stats) |
+
+> **Makeup fasts is a tab inside `FastTrackerScreen`** (driven by `FastingEvent.LoadMakeupFasts`),
+> not a standalone route. There is intentionally **no** `Route.MakeupFasts`.
+
+### Tasbih
+| Route | Args | Screen |
+|-------|------|--------|
+| `TasbihHome` | — | TasbihHomeScreen |
+| `TasbihCounter` | `presetId: Long? = null` | TasbihCounterScreen |
+| `TasbihPresets` | — | TasbihPresetsScreen |
+| `TasbihStats` | — | TasbihStatsScreen |
+| `TasbihHistory` | — | TasbihHistoryScreen |
+| `TasbihAddPreset` | — | TasbihAddPresetScreen |
+
+### Zakat, Qibla, Calendar
+| Route | Args | Screen |
+|-------|------|--------|
+| `ZakatCalculator` | — | ZakatCalculatorScreen |
+| `ZakatHistory` | — | ZakatHistoryScreen |
+| `Qibla` | — | QiblaScreen |
+| `IslamicCalendar` | — | IslamicCalendarScreen |
+| `IslamicMonth` | `month: Int, year: Int` | IslamicMonthScreen |
+
+### Qaida (children's Arabic reader)
+| Route | Args | Screen |
+|-------|------|--------|
+| `QaidaHome` | — | QaidaHomeScreen |
+| `QaidaReader` | `lessonId: Int` | QaidaReaderScreen |
+| `QaidaLetters` | — | QaidaLettersScreen |
+
+### Names & Prophets
+| Route | Args | Screen |
+|-------|------|--------|
+| `AsmaUlHusnaList` | — | AsmaUlHusnaListScreen |
+| `AsmaUlHusnaDetail` | `nameId: Int` | AsmaUlHusnaDetailScreen |
+| `AsmaUnNabiList` | — | AsmaUnNabiListScreen |
+| `AsmaUnNabiDetail` | `nameId: Int` | AsmaUnNabiDetailScreen |
+| `ProphetsList` | — | ProphetsListScreen |
+| `ProphetDetail` | `prophetId: Int` | ProphetDetailScreen |
+
+### Khatam
+| Route | Args | Screen |
+|-------|------|--------|
+| `KhatamList` | — | KhatamListScreen |
+| `KhatamDetail` | `khatamId: Long` | KhatamDetailScreen |
+| `KhatamCreate` | — | KhatamCreateScreen |
+
+### Settings & misc
+| Route | Args | Screen |
+|-------|------|--------|
+| `Settings` | — | SettingsScreen |
+| `SettingsPrayerCalculation` | — | PrayerCalculationSettingsScreen |
+| `SettingsNotifications` | — | NotificationSettingsScreen |
+| `SettingsAppearance` | — | AppearanceSettingsScreen |
+| `SettingsLanguage` | — | LanguageSettingsScreen |
+| `SettingsLocation` | — | LocationSettingsScreen |
+| `SettingsQuran` | — | QuranSettingsScreen |
+| `SettingsWidgets` | — | WidgetsScreen |
+| `SettingsAbout` | — | AboutScreen |
+| `SettingsHelp` | — | HelpScreen |
+| `HelpTopicDetail` | `topicId: String` | HelpTopicDetailScreen |
+| `HelpGuide` | `guideId: String` | HelpGuideScreen |
+| `SettingsSync` | — | SyncScreen |
+| `Licenses` | — | LicensesScreen |
+| `LicenseDetail` | `libraryHashCode: Int` | LicenseDetailScreen |
+| `Onboarding` | — | OnboardingScreen |
+| `AllBookmarks` | — | BookmarksScreen |
+| `GlobalSearch` | — | SearchScreen |
+
+## Adding / changing a route — checklist
+
+1. Add a `@Serializable` entry to `Route` in `core/navigation/Routes.kt` (`data object` for
+   no-arg, `data class` for typed args; give args sensible defaults).
+2. Add a `composable<Route.X> { backStackEntry -> ... }` in `core/navigation/NavGraph.kt`; read
+   typed args with `backStackEntry.toRoute<Route.X>()`.
+3. Put the screen under `presentation/screens/<feature>/`.
+4. Navigate via the typed route object (`navController.navigate(Route.X(...))`).
+5. If it's a deep-link target, wire it in `core/navigation/HelpDeepLink.kt`.
+6. **Update this file** — add the route to the table and (if it changes the high-level map) the
+   diagram. Validate the diagram (Mermaid).
+7. Remember: **not every `Route` is a full screen** — some features are tabs/sections inside a
+   parent screen (e.g. makeup fasts inside `FastTrackerScreen`). Don't add a `composable` for
+   those, and don't leave an orphaned `Route` declaration either.
+
+*Keep this file honest — a route that isn't in this table is a documentation bug.*
+</content>

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -269,6 +269,17 @@ no deps). All third-party usage is isolated here.
 - `CrashReporter.kt` → Firebase **Crashlytics**. `recordException`, `log` (breadcrumb), `setCustomKey`. Pairs with `AppAnalytics.logError` (frequency) for the stack trace.
 - `PerfMonitor.kt` → Firebase **Performance**. Custom traces via `newTrace`/`stop` + inline `trace { }` / `traceSuspend { }`; catalog `Traces` (`app_initialize`, `notification_schedule`).
 
+**Instrumentation conventions (apply these as you write code):**
+- **Error-swallowing `catch`/`runCatching`** that hides a real failure (data load, IO, parse,
+  audio, network, background work) should call `CrashReporter.recordException(e)` — rename
+  `catch (_: …)` to `catch (e: …)`. In ViewModels, also call `AppAnalytics.logError(feature, type, e.message)`
+  for frequency. Skip *expected* control-flow catches (permission probes, optional system
+  services, "no data yet"). All monitoring calls are safe no-ops when Firebase is absent.
+- **Significant user actions** (open a reader/detail, toggle favorite/bookmark, create/complete/delete,
+  play audio, run a search) get one `AppAnalytics.logFeatureUsed("<feature>", "<action>")` in the
+  relevant `onEvent` branch — never log trivial state churn (text edits, scroll). Coverage is broad:
+  every ViewModel logs usage, and error paths across data/widget/worker/util/VM layers report to Crashlytics.
+
 ---
 
 ## 10. Device-to-device sync

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -1,0 +1,309 @@
+# Nimaz — Subsystems Guide
+
+> **Audience:** developers and AI agents working on this codebase.
+> **Purpose:** documents the app's **cross-cutting subsystems** — the runtime machinery
+> (audio, widgets, background work, notifications, database, preferences, content
+> seeding, prayer-time calc, init/monitoring, sync) that the feature screens depend on.
+> For *how features are layered* (`presentation → domain → data`, MVVM/UDF, DI, navigation,
+> theming) read **[`ARCHITECTURE.md`](ARCHITECTURE.md)** first — this doc assumes it.
+
+App package root: `com.arshadshah.nimaz`
+Source root: `app/src/main/java/com/arshadshah/nimaz/`
+
+---
+
+## Table of contents
+
+1. [Audio playback](#1-audio-playback)
+2. [Glance widgets](#2-glance-widgets)
+3. [Background work (WorkManager)](#3-background-work-workmanager)
+4. [Prayer-time / adhan notifications](#4-prayer-time--adhan-notifications)
+5. [Database & migrations](#5-database--migrations)
+6. [Preferences (DataStore)](#6-preferences-datastore)
+7. [Content seeding & versioning](#7-content-seeding--versioning)
+8. [Prayer-time calculation](#8-prayer-time-calculation)
+9. [App initialization & monitoring](#9-app-initialization--monitoring)
+10. [Device-to-device sync](#10-device-to-device-sync)
+11. [Keeping this doc updated](#keeping-this-doc-updated)
+
+---
+
+## 1. Audio playback
+
+All in `data/audio/`. There are **three independent playback engines** (Quran recitation,
+Adhan, Qaida tap-to-hear) plus an Adhan **download** pipeline. They share no player instance.
+
+**Manager / service split.** The *manager* owns the player + playback logic and exposes a
+`StateFlow`; the *service* is a foreground `Service` that only owns the notification /
+`MediaSession` lifecycle and routes control intents back into the manager.
+
+| Class | Role |
+|---|---|
+| `data/audio/QuranAudioManager.kt` | `@Singleton`; one `ExoPlayer`, gapless ayah playlist, exposes `val audioState: StateFlow<AudioState>` |
+| `data/audio/QuranAudioService.kt` | `@AndroidEntryPoint` foreground `mediaPlayback` service; `MediaStyle` notification (channel `quran_audio_channel`, id 1001) over the manager's `ForwardingPlayer` |
+| `data/audio/AdhanAudioManager.kt` | `@Singleton`; legacy `MediaPlayer` for in-app `preview()`, plus adhan **download** logic; exposes `isPlaying`, `currentlyPlaying`, `downloadState` flows |
+| `data/audio/AdhanPlaybackService.kt` | foreground `mediaPlayback` service; plays the adhan when a prayer fires (works app-closed) using `ExoPlayer` with `USAGE_ALARM` + wake lock + audio focus |
+| `data/audio/AdhanDownloadService.kt` | foreground `dataSync` service that downloads both adhan variants with a progress notification (channel `adhan_download_channel`, id 7777) |
+| `data/audio/AdhanDownloadWorker.kt` | `@HiltWorker` background fallback for the download (see §3) |
+| `data/audio/QaidaAudioManager.kt` | `@Singleton`; stripped-down `ExoPlayer` for single Qaida tokens — **no service/notification/MediaSession/CDN**; exposes `val state: StateFlow<QaidaAudioState>` |
+| `data/audio/AdhanSound.kt` | enum of adhans (MISHARY, ABDUL_BASIT, MAKKAH, SIMPLE_BEEP) with per-variant file names + download URLs |
+
+**Wiring.** None of these have a DI module — the managers are `@Singleton @Inject constructor(@ApplicationContext …)` (Hilt provides them automatically) and the services are `@AndroidEntryPoint` field-injecting their manager. Services are declared in `AndroidManifest.xml` with `foregroundServiceType` `mediaPlayback`/`dataSync`; permissions `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `FOREGROUND_SERVICE_DATA_SYNC`.
+
+**Media3/ExoPlayer specifics (Quran).** Ayahs are downloaded first then added as a `List<MediaItem>` for gapless sequential playback. ExoPlayer reports `0` duration for unloaded items, so durations are pre-extracted with `MediaMetadataRetriever`; a `ForwardingPlayer` (`getPlayer()`) translates per-item ExoPlayer position/duration into **whole-surah** ("total playlist") coordinates so the lock-screen scrubber reflects the surah, not one ayah. Recitations stream from `cdn.islamic.network` (reciter→CDN in `RECITER_CDN_MAP`), cached under `filesDir/quran_audio/`. Adhan files cache under `filesDir/adhan/`, Qaida clips fall back to the bundled asset `file:///android_asset/qaida/audio/{key}.mp3`.
+
+**How ViewModels consume it.** ViewModels inject the manager **directly** and re-expose its flow (e.g. `QuranViewModel.audioState = audioManager.audioState`; `QaidaReaderViewModel.audioState = audioManager.state`; `SettingsViewModel` injects `adhanAudioManager` for preview/download). They drive playback via `onEvent`. *Deviation:* this bypasses the "ViewModels inject `XxxUseCases`" rule (§ARCHITECTURE), and `QuranViewModel` even exposes the manager as a public field — a known clean-architecture deviation, not a pattern to copy.
+
+**Gotchas.**
+- Two player APIs: ExoPlayer everywhere **except** `AdhanAudioManager.preview()` (legacy `MediaPlayer`).
+- `QuranAudioManager.stop()` deliberately does **not** send a stop intent to the service — it sets `isActive=false` and lets the service's state-observer self-stop after a 500 ms debounce, avoiding a start/stop race.
+- Adhan downloads are heavily validated (MP3/WAV magic bytes, content-type, min size, URL-version invalidation via `ADHAN_URL_VERSION`) because the external CDNs sometimes serve HTML error pages; on corrupt/missing files playback falls back to the generated beep, **never** to the wrong adhan variant.
+- `SIMPLE_BEEP` is **synthesized locally** (`generateBeepSound` → WAV), not downloaded.
+
+---
+
+## 2. Glance widgets
+
+All in `widget/`. Five Jetpack **Glance** AppWidgets, each in its own subpackage, plus a
+shared `widget/core/` package and two top-level helpers.
+
+| Widget | Package | Refresh | State type |
+|---|---|---|---|
+| Next Prayer | `widget/nextprayer/` | Worker 15 min + AlarmManager 1 min tick | `NextPrayerWidgetState` |
+| Prayer Times | `widget/prayertimes/` | Worker 15 min + 1 min tick | `PrayerTimesWidgetState` |
+| Prayer Tracker | `widget/prayertracker/` | Worker 30 min + immediate on toggle | `PrayerTrackerWidgetState` |
+| Hijri Date | `widget/hijridate/` | Worker 6 hr | `HijriDateWidgetState` |
+| Hijri Calendar | `widget/hijricalendar/` | Worker 6 hr | `HijriCalendarWidgetState` |
+
+Each widget = a `GlanceAppWidget` subclass (`provideGlance` → `provideContent { GlanceTheme { … } }`, reads `currentState<T>()`) + a `GlanceAppWidgetReceiver` (the manifest-registered `BroadcastReceiver`; `onEnabled` starts refresh, `onDisabled` cancels). State is a `@Serializable sealed interface` with `Loading`/`Success(data)`/`Error(message)`. Colors come from `res/color` via `ColorProvider(R.color.widget_*)` — no hardcoded colors.
+
+**Data access — two patterns.**
+1. **`@HiltWorker` injection (main path).** Workers inject real deps directly (e.g. `NextPrayerWorker` injects `PrayerTimeCalculator` + `PreferencesDataStore`; `PrayerTrackerWorker` injects `PrayerDao`). Each `doWork()` returns `Result.success()` early if no widgets are placed, computes fresh data, persists via `setWidgetState(...) → Success`, and on failure persists `Error` + `Result.retry()` for the first 3 attempts. This only works because `NimazApp` provides the `HiltWorkerFactory` (§3).
+2. **Hilt `@EntryPoint`** — `widget/WidgetEntryPoint.kt` exposes `prayerDao()` via `EntryPointAccessors.fromApplication(...)`. Used by the **only interactive widget** (Prayer Tracker): its checkbox click handler (`togglePrayerStatus` in `PrayerTrackerWidget.kt`) writes to Room from inside the composable click callback (not a Worker), then re-renders via `PrayerTrackerWorker.enqueueImmediateWork(context)`.
+
+**Update mechanism — three layers.**
+- **Periodic WorkManager** via `widget/core/WidgetWork.kt` (`enqueuePeriodic`/`enqueueImmediate`/`cancel`), enqueued in each receiver's `onEnabled`.
+- **Per-minute AlarmManager tick** via `widget/WidgetUpdateScheduler.kt` (WorkManager's 15-min floor is too coarse for a live countdown). `setInexactRepeating(ELAPSED_REALTIME, …, 60_000)` fires `WidgetTickReceiver`, which just calls `updateAll(context)` on the two countdown widgets — it does **not** recompute prayer times; the composable recomputes the countdown string from the stored `nextPrayerEpochMillis`.
+- **Immediate refresh** on prayer-status change, from the tracker toggle and from `HomeViewModel` (keeps the widget in sync with in-app tracking).
+
+**Shared `widget/core/`.** `JsonGlanceStateDefinition.kt` (generic JSON-over-DataStore `GlanceStateDefinition`, one DataStore per file via a process-wide map), `WidgetStateUpdater.kt` (`updateWidgetState(...)`), `WidgetFormatters.kt` (time/countdown), `WidgetUi.kt` (`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`), `WidgetWork.kt`.
+
+**Manifest/res.** Five `<receiver>`s + the non-exported `WidgetTickReceiver` in `AndroidManifest.xml`; provider-info XMLs in `res/xml/*_widget_info.xml`.
+
+**Gotchas.**
+- Default state is `Success(emptyData)`, not `Loading` → widgets show em-dash skeletons, not a spinner, before the first worker run.
+- The 1-min tick only recomposes; prayer time/name only refresh on the 15-min worker.
+- NextPrayer and PrayerTimes share one AlarmManager request code (`9876`); removing one countdown widget can silently cancel the tick for the other (documented in `NextPrayerWidget.onDisabled`).
+- `togglePrayerStatus` writes a Room `PrayerRecordEntity` directly from the widget layer via the EntryPoint — a layering deviation, noted but intentional for interactivity.
+
+---
+
+## 3. Background work (WorkManager)
+
+`NimazApp` (`NimazApp.kt`) is `@HiltAndroidApp` **and** `Configuration.Provider`: it injects
+`HiltWorkerFactory` and supplies it via `workManagerConfiguration`, which is what lets every
+`@HiltWorker` be constructed with injected dependencies. Without this, worker injection fails
+at runtime.
+
+**Workers in the app:**
+- `widget/*/{NextPrayer,PrayerTimes,PrayerTracker,HijriDate,HijriCalendar}Worker.kt` — widget refresh (§2), all `@HiltWorker CoroutineWorker`, enqueued through `widget/core/WidgetWork.kt`.
+- `data/audio/AdhanDownloadWorker.kt` — `@HiltWorker CoroutineWorker`; the background fallback for adhan downloads when a foreground service can't be started (see below). `enqueue(...)` builds a `OneTimeWorkRequest` with a `CONNECTED` constraint, `ExistingWorkPolicy.KEEP`, unique name `adhan_download_work`, retrying up to 3 times.
+
+**Foreground-service-from-background gotcha.** On Android 12+ starting a foreground service from the background throws `ForegroundServiceStartNotAllowedException`. `AdhanDownloadService.startServiceWithFallback` gates on `ActivityManager` process importance: start the foreground service only if the app is foregrounded, otherwise **degrade to `AdhanDownloadWorker`**. The two share the same `AdhanAudioManager` download logic.
+
+**Note: prayer notifications do NOT use WorkManager** — they use `AlarmManager` exact alarms (§4). WorkManager here is widgets + the adhan-download fallback.
+
+**Boot.** `core/util/BootReceiver.kt` re-runs scheduling on `BOOT_COMPLETED` (§4); widget periodic work survives reboots via WorkManager's own persistence.
+
+---
+
+## 4. Prayer-time / adhan notifications
+
+Built on **`AlarmManager` exact alarms** (no WorkManager). Per-prayer notifications, optional
+adhan playback, pre-prayer reminders, a nightly daily summary, and re-scheduling on midnight
+rollover and boot.
+
+**Key files.**
+- `core/util/PrayerNotificationScheduler.kt` — `@Singleton`; schedules/cancels alarms, owns the channels.
+- `core/util/BootReceiver.kt` — `@AndroidEntryPoint BroadcastReceiver`; fires for **all** alarms and actually posts notifications / triggers adhan.
+- `core/util/NotificationContentHelper.kt` — pure title/message/summary text generator.
+- `data/audio/AdhanPlaybackService.kt` — plays the adhan and posts the merged prayer+adhan notification (§1).
+
+**Channels** (created in `PrayerNotificationScheduler.init`, API 26+): `CHANNEL_ID_PRAYER` = `prayer_notifications` (HIGH), `CHANNEL_ID_ADHAN` = `adhan_notifications` (HIGH), `CHANNEL_ID_DAILY_SUMMARY` = `daily_summary_notifications` (DEFAULT). `AdhanPlaybackService` also creates `adhan_playback_channel` but **posts on `CHANNEL_ID_ADHAN`** — so the playback channel is effectively unused for the visible notification.
+
+**Scheduling.** `scheduleTodaysPrayerNotifications(...)` cancels everything then re-arms enabled prayers, using `setExactAndAllowWhileIdle(RTC_WAKEUP, …)` with `PendingIntent.getBroadcast` targeting `BootReceiver` (explicit intent). Request codes: prayer `1000 + ordinal`, pre-reminder `2000 + ordinal`, midnight reschedule `9999` (00:01), daily summary `8889` (23:00). Pre-reminders fire at `prayerTime − preReminderMinutes` (skipped for Sunrise).
+
+**Firing.** `BootReceiver.onReceive` dispatches on action: boot → reschedule; `ACTION_MIDNIGHT_RESCHEDULE` → mark missed prayers + reschedule (self-perpetuating daily chain); `ACTION_PRAYER_NOTIFICATION` → post notification &/or play adhan; `ACTION_DAILY_SUMMARY` → summary. If adhan should play and the file exists, it calls `AdhanPlaybackService.playAdhan(...)` and the service's foreground notification **doubles as** the prayer notification (shared id `prayerName.hashCode()`); if the file is missing it triggers a download for next time and falls back to beep.
+
+**Wiring.** `PrayerNotificationScheduler` is constructor-injected (`@Singleton @Inject`, deps: `PrayerTimeCalculator`). Called by `AppInitializer` on startup and by `SettingsViewModel.rescheduleNotifications()` when prayer/notification settings change. Permissions in `AndroidManifest.xml`: `POST_NOTIFICATIONS`, `SCHEDULE_EXACT_ALARM`, `USE_EXACT_ALARM`, `RECEIVE_BOOT_COMPLETED`, `WAKE_LOCK`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`.
+
+**Gotchas.**
+- Uses `USE_EXACT_ALARM` (auto-granted, alarm-clock class app) and does **not** check `canScheduleExactAlarms()` or catch `SecurityException`.
+- **Doze / battery optimization** is the main "fired late" failure mode; the code measures `deliveryLatencySeconds` for telemetry but doesn't request the battery exemption itself.
+- `POST_NOTIFICATIONS` (API 33+) isn't checked before `notify()` — denied → silent no-op.
+- Channels exist only once the scheduler singleton is first instantiated by DI.
+- `BootReceiver` handles `LOCKED_BOOT_COMPLETED`/QUICKBOOT in code but only `BOOT_COMPLETED` has a manifest intent-filter.
+
+---
+
+## 5. Database & migrations
+
+`data/local/database/NimazDatabase.kt` — a single Room `@Database` (`version = 17`), provided
+in `core/di/DatabaseModule.kt`.
+
+**Prepopulated DB.** The app ships a prebuilt DB in `app/src/main/assets/database/nimaz_prepopulated.db`, wired via `.createFromAsset("database/nimaz_prepopulated.db", NimazDatabase.PREPACKAGED_CALLBACK)`. **Room copies this asset only on a fresh install** — it is *not* re-copied on app update. That single fact drives both the migration discipline here and the entire content-seeding subsystem (§7).
+
+**`PREPACKAGED_CALLBACK`** repairs the shipped asset right after copy and before Room validates its schema (the bundled asset was stamped at `user_version 12` while still missing the `updatedAt` columns and shipping tafseer indices under the wrong names). The same idempotent repair is also exposed as `MIGRATION_12_13`, because devices already sitting at v12 never re-run the copy callback.
+
+**Migration chain** (registered in `DatabaseModule.provideNimazDatabase`): `MIGRATION_7_8` (khatam) → `8_9` (asma/prophets) → `9_10` (a *missing* migration restored after the original release bumped the version without registering it) → `10_11` (`updatedAt` columns) → `11_12` (surah start_page fix) → `12_13` (legacy asset repair) → `13_14` (Help tables) → `14_15` (Qaida tables) → `15_16` (tasbih `category`) → `16_17` (hadith `narrator_chain`).
+
+**Rules / patterns.**
+- **A schema change requires a migration.** Bump `@Database(version = …)` and add a `MIGRATION_x_y`. Room runs migrations **even after `createFromAsset`**, so every migration must work for both fresh installs (asset already has newer tables → `CREATE TABLE IF NOT EXISTS` is a no-op) and upgraders (tables created empty / columns added).
+- **Migrations must be idempotent.** SQLite has no `ADD COLUMN IF NOT EXISTS`, so column adds go through the `SupportSQLiteDatabase.addColumnIfMissing(...)` helper at the bottom of the file; table creates use `CREATE TABLE IF NOT EXISTS`.
+- **Content tables vs user-data tables.** Content tables (help/qaida/dua) are seeded; user-progress tables (`*_progress`, bookmarks) are always created empty.
+
+**Keep `SCHEMA_VERSION` in sync.** `NimazDatabase.SCHEMA_VERSION` (used only to tag crash reports via `NimazApp`'s `db_schema_version` key) must match `@Database(version = …)`. Both are currently **17** — **bump `SCHEMA_VERSION` alongside every new migration** so crash tags stay accurate.
+
+---
+
+## 6. Preferences (DataStore)
+
+`data/local/datastore/PreferencesDataStore.kt` — the app's **single central settings store**,
+backed by a Jetpack Preferences DataStore (`preferencesDataStore(name = "nimaz_preferences")`).
+
+**It implements the `domain/repository/SettingsRepository` interface.** Presentation code
+(ViewModels, `MainActivity`) injects **`SettingsRepository`**, not the concrete class (bound via
+`@Binds` in `RepositoryModule`); the combined snapshot model `UserPreferences` lives in
+`domain/model`. Data-layer consumers (both sync classes, all content seeders, `AppInitializer`,
+`BootReceiver`, widget workers) inject the concrete `PreferencesDataStore` directly — that's fine,
+they're in the data layer. When you add a new setting, add it to **both** the class and the
+`SettingsRepository` interface.
+
+**API shape — Flow getter + `suspend` setter per setting:**
+```kotlin
+val calculationMethod: Flow<String> = preference(PreferencesKeys.CALCULATION_METHOD, "MUSLIM_WORLD_LEAGUE")
+suspend fun setCalculationMethod(method: String) = put(PreferencesKeys.CALCULATION_METHOD, method)
+```
+Getters expose `Flow<…>` only (never `MutableStateFlow`/`LiveData`); writes are `suspend`. Internal helpers `preference(key, default)` / `preference(key)` / `put(key, value)` keep the surface uniform. `private object PreferencesKeys` holds all typed keys and is private to the class — consumers never touch raw keys.
+
+**Aggregate.** `val userPreferences: Flow<UserPreferences>` maps a curated subset of keys into a top-level `data class UserPreferences(...)` for one-shot reads of the common cross-cutting settings (used by `SettingsViewModel`, `LocationViewModel`, `AppInitializer`, `BootReceiver`, `WidgetsScreen`).
+
+**Bulk ops.** `clearAllData()`, `exportAllPreferences(): Map<String,String>`, `importPreferences(map)` (type-infers values back to keys, skips `onboarding_completed`) — used by the sync subsystem (§10).
+
+**Wiring.** Provided in `core/di/DataStoreModule.kt` via `@Provides @Singleton`. (Minor: it already has an `@Inject constructor(context)`, so the explicit provider is redundant with constructor injection.)
+
+It also stores the **content-version flags** that drive seeding — see §7.
+
+---
+
+## 7. Content seeding & versioning
+
+**Why this exists.** The prepopulated DB (§5) is **not re-copied on app update**, and schema
+migrations only create empty tables. So new *bundled content* shipped in an update would never
+reach existing users. **Seeders** read a versioned JSON asset at runtime and upsert content
+idempotently, so fresh installs and upgraders converge on the same content.
+
+**Four content types use seeders:**
+
+| Content | Seeder | JSON asset | Pattern |
+|---|---|---|---|
+| Dua | `data/local/dua/DuaContentSeeder.kt` | `duas/duas.json` | full content replace |
+| Help | `data/local/help/HelpContentSeeder.kt` | `help/help.json` | full content replace |
+| Qaida | `data/local/qaida/QaidaContentSeeder.kt` | `qaida/qaida_content.json` | full content replace |
+| Hadith | `data/local/hadith/HadithBackfillSeeder.kt` | `hadith/hadith_fills.json` | keyed UPDATE backfill |
+
+**Content-version pattern.** The version is stored in **DataStore** (not a file, not a table):
+`PreferencesKeys.{DUA,HELP,QAIDA}_CONTENT_VERSION` and `HADITH_BACKFILL_VERSION` (default `0` = never seeded). Each JSON root carries a `contentVersion: Int` field. `seedIfNeeded()`:
+1. parse the JSON asset;
+2. if the table is already populated **and** stored version ≥ JSON `contentVersion` → skip;
+3. otherwise seed and write the new stored version.
+
+Content seeders do an **atomic full-content replace** (`dao.replaceAllContent(...)` / clear-then-insert), touching only content tables — user data (bookmarks/progress) lives in separate tables with no FK into content, so it survives a re-seed. The Hadith backfill is different: the JSON `id` is the stable PK of the `hadiths` row, so each fix is a keyed UPDATE (`backfillHadith`/`updateNarratorChain`); it also has a fast-path gap detector (`emptyArabicCount()`). All seeders serialize concurrent calls with a `Mutex`.
+
+**Where seeding is triggered — lazy "seed-then-read," NOT `AppInitializer`.** Three are triggered inside repositories at first content access (`DuaRepositoryImpl`/`HelpRepositoryImpl` use a `seededFlow { seeder.seedIfNeeded(); emitAll(...) }` wrapper; `HadithRepositoryImpl` calls `backfillSeeder.seedIfNeeded()` at the top of each suspend read). **Qaida is the exception** — seeded in `QaidaReaderViewModel.init`.
+
+**Wiring.** The `XxxAssetReader` and `XxxVersionStore` interfaces (which exist to make seeders testable without Android/DataStore) are bound in `core/di/RepositoryModule.kt` via `@Binds` (→ `AndroidXxxAssetReader` / `DataStoreXxxVersionStore`); the seeder classes are `@Singleton @Inject`.
+
+**Gotchas.**
+- **To ship new content to existing users you must bump `contentVersion` in the JSON asset.** Editing the prepopulated DB alone does nothing for upgraders; editing JSON without bumping the version does nothing once the table is populated.
+- Content seeders **fully replace** content tables — anything not in the JSON is wiped. Adding an FK from a user table into a content table would make re-seeding destructive.
+- Qaida seeds only when `QaidaReaderViewModel` is created, not on first repository access.
+- Qaida `conceptTags` are stored JSON-encoded-as-string to match the prepopulated-DB convention.
+
+---
+
+## 8. Prayer-time calculation
+
+`core/util/PrayerTimeCalculator.kt` — `@Singleton @Inject constructor()` (pure compute,
+no deps). All third-party usage is isolated here.
+
+**Library.** **Adhan2** by Batoul Apps (`com.batoulapps.adhan:adhan2:0.0.6`, `libs.adhan`). Adhan2 types are import-aliased (e.g. `CalculationMethod as AdhanMethod`) to avoid colliding with the app's own domain enums.
+
+**Integration.** The calculator maps domain enums → Adhan2 `CalculationParameters`:
+- **Method** — `adhanMethodFor(method)` maps 11 domain `CalculationMethod`s to `AdhanMethod` (MWL, Egyptian, Karachi, Umm al-Qura, Dubai, MoonSighting, North America, Kuwait, Qatar, Singapore, Turkey).
+- **Madhab / Asr** — `AsrCalculation.STANDARD → SHAFI`, `HANAFI → HANAFI`.
+- **High-latitude rule** — optional; maps MIDDLE_OF_THE_NIGHT / SEVENTH_OF_THE_NIGHT / TWILIGHT_ANGLE, else library default.
+
+**Inputs/outputs.** `getPrayerTimes(lat, lon, date, method, asr, highLat, adjustments)` → `List<PrayerTime>` (raw `Instant`s; supports per-prayer minute `adjustments`). `calculatePrayerTimes(date, location)` / `…ForRange(...)` take a domain `Location` and return `PrayerTimes`/`List<PrayerTimes>` (Adhan `Instant`s converted to `LocalDateTime` in the location's zone). Returns **domain models** (`domain/model/PrayerModels.kt`), never Adhan types. Settings come from `PreferencesDataStore` (string prefs parsed to enums by the caller).
+
+**Hijri conversion** — `core/util/HijriDateCalculator.kt`, a stateless Kotlin `object` (no Hilt). It does **not** use `ummalqura`; it delegates to the platform `java.time.chrono.HijrahChronology.INSTANCE` (OS-updated Umm al-Qura). Provides `toHijri`/`toGregorian`, Ramadan helpers, validity checks, and a hardcoded Islamic-events calendar (`getIslamicEvents`/`getUpcomingEvents`).
+
+**Wiring.** No module — both are constructor-injected / static. `PrayerTimeCalculator` is injected into `PrayerRepositoryImpl` and (a deviation from the use-case rule) directly into several ViewModels, widget workers, and `PrayerNotificationScheduler`.
+
+---
+
+## 9. App initialization & monitoring
+
+**`NimazApp.kt`** (`@HiltAndroidApp`, `Configuration.Provider`). `onCreate` calls
+`AppAnalytics.init(this)`, logs a crash breadcrumb, tags the crash DB-schema key, and runs
+`appInitializer.initialize()`. It also supplies the `HiltWorkerFactory` (§3).
+
+**`core/init/AppInitializer.kt`** — `@Singleton`. `initialize()` launches an IO coroutine that runs three tasks **in parallel under a 5 s `withTimeout`** (then proceeds to UI regardless): apply saved locale, schedule today's prayer notifications (§4), download the default adhan/beep if missing (§1). It exposes `val isReady: StateFlow<Boolean>` (the splash gate). Failures are reported to monitoring but never block startup.
+
+**`core/monitoring/`** — three thin Kotlin `object` wrappers over Firebase, each guarded so **every call is wrapped in `runCatching` and no-ops if Firebase isn't initialized** (debug/PR-check builds without `google-services.json` run unchanged). They are static singletons, never Hilt-injected.
+- `AppAnalytics.kt` → Firebase **Analytics**. The only one with `init(context)` (called from `NimazApp`) — it caches `applicationContext` so any caller can log without a `Context`. Provides semantic helpers + name catalogs (`Event`/`Param`/`UserProperty`), notably the notification pipeline (`notification_scheduled`/`_displayed`/`_suppressed`/`_opened`) and `logDiagnostics()` (records OS-level notification/exact-alarm/battery state as durable user properties).
+- `CrashReporter.kt` → Firebase **Crashlytics**. `recordException`, `log` (breadcrumb), `setCustomKey`. Pairs with `AppAnalytics.logError` (frequency) for the stack trace.
+- `PerfMonitor.kt` → Firebase **Performance**. Custom traces via `newTrace`/`stop` + inline `trace { }` / `traceSuspend { }`; catalog `Traces` (`app_initialize`, `notification_schedule`).
+
+---
+
+## 10. Device-to-device sync
+
+`data/sync/` — offline peer-to-peer transfer of a user's app data directly between two phones
+over Google's **Nearby Connections** API. No server, no account: one device sends, the other
+receives.
+
+| File | Role |
+|---|---|
+| `data/sync/NearbyConnectionsManager.kt` | `@Singleton`; transport (advertise/discover/connect/payload) |
+| `data/sync/SyncDataExporter.kt` | `@Singleton`; DB + DataStore → `SyncPayload` |
+| `data/sync/SyncDataImporter.kt` | `@Singleton`; `SyncPayload` → DB + DataStore (last-write-wins merge) |
+| `data/sync/SyncData.kt` | `SyncPayload` + per-table DTOs + `categories()` |
+| `data/sync/SyncSignal.kt` | control-message protocol |
+| `presentation/viewmodel/SyncViewModel.kt` | orchestrator (`@HiltViewModel`, proper UDF) |
+
+**What syncs.** `SyncDataExporter.export()` pulls 14 DAOs + the full DataStore dump (`exportAllPreferences()`) into one `SyncPayload`: Quran bookmarks/favorites/progress, prayer/fast/makeup records, tasbih, khatam, tafseer highlights/notes, zakat, name/prophet favorites, hadith/dua bookmarks + dua progress, qaida progress, and **favorite locations only** (the active-location flag is deliberately never carried, so a sync never changes the receiver's prayer times). `SyncData.categories()` is the single source of truth for the UI summary; a reflection-based test fails the build if a `SyncPayload` field is added without a matching category.
+
+**Transport.** `kotlinx.serialization` JSON, GZIP-compressed, over `Strategy.P2P_POINT_TO_POINT` (`SERVICE_ID = "com.arshadshah.nimaz.sync"`). Handshake: sender advertises, receiver discovers → auto `requestConnection` → user confirms via `authenticationDigits`. State is `StateFlow<ConnectionState>` (sealed). Payloads multiplex over one channel: a `0x1F` prefix (GZIP magic byte) distinguishes compressed **data** from `SyncSignal` JSON; **BYTES** is used when ≤ 31 KB, else a **FILE** payload (`cacheDir/sync_export.gz`). `SyncSignal` (sealed) carries control messages (`Ready`/`Cancel`/`ImportStarted`/`ImportProgress`/`ImportComplete`/`Ack`) so the sender mirrors the receiver's import progress.
+
+**Conflict handling.** `SyncDataImporter` does a per-table, keyed **last-write-wins** merge (compare `updatedAt`, preserve local row IDs); name/prophet favorites are insert-if-absent. Never a blind overwrite. `Json { ignoreUnknownKeys = true }` tolerates app-version skew.
+
+**Wiring.** No DI module — all three classes are `@Singleton @Inject constructor`; the Nearby client is `by lazy { Nearby.getConnectionsClient(context) }`. Reached from `SyncScreen.kt`.
+
+**Gotchas.**
+- Runtime permissions required (`AndroidManifest.xml`): `ACCESS_FINE_LOCATION`, the `BLUETOOTH_*` set, `ACCESS_WIFI_STATE`, `NEARBY_WIFI_DEVICES` — without them advertising/discovery fails as `ConnectionState.Error`.
+- `P2P_POINT_TO_POINT` is strictly one-to-one; the manager's single-slot callbacks assume one sync at a time.
+- The 31 KB BYTES threshold and the `0x1F` data/signal prefix are load-bearing — changing compression breaks disambiguation.
+- `appVersion = 11` is hardcoded in the exporter and not validated on import (skew tolerated via `ignoreUnknownKeys` + field-level merge).
+
+---
+
+## Keeping this doc updated
+
+This file is a **living map of the subsystems**, not a one-time snapshot. When you change a
+subsystem — add/rename a Worker or service, change a notification channel or alarm scheme, add
+a migration (and bump `SCHEMA_VERSION`), add a content seeder or content-version key, change a
+DataStore key surface, alter the sync payload/protocol, or swap a monitoring backend — **update
+the corresponding section here in the same change**, and add a row to the relevant table. Keep
+claims grounded in the code (read the file, cite the path in backticks). If a subsystem grows
+large enough to warrant its own doc, link it from here rather than letting this overview drift.

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -162,7 +162,11 @@ in `core/di/DatabaseModule.kt`.
 - **Migrations must be idempotent.** SQLite has no `ADD COLUMN IF NOT EXISTS`, so column adds go through the `SupportSQLiteDatabase.addColumnIfMissing(...)` helper at the bottom of the file; table creates use `CREATE TABLE IF NOT EXISTS`.
 - **Content tables vs user-data tables.** Content tables (help/qaida/dua) are seeded; user-progress tables (`*_progress`, bookmarks) are always created empty.
 
-**Keep `SCHEMA_VERSION` in sync.** `NimazDatabase.SCHEMA_VERSION` (used only to tag crash reports via `NimazApp`'s `db_schema_version` key) must match `@Database(version = …)`. Both are currently **17** — **bump `SCHEMA_VERSION` alongside every new migration** so crash tags stay accurate.
+**One version constant.** The schema version lives in a single top-level `const val
+NIMAZ_DATABASE_VERSION` (in `NimazDatabase.kt`). It drives **both** the Room
+`@Database(version = …)` annotation and `NimazDatabase.SCHEMA_VERSION` (the latter only tags crash
+reports via `NimazApp`'s `db_schema_version` key). **Bump `NIMAZ_DATABASE_VERSION` in that one
+place** whenever you add a migration — the two can no longer drift.
 
 ---
 
@@ -302,7 +306,7 @@ receives.
 
 This file is a **living map of the subsystems**, not a one-time snapshot. When you change a
 subsystem — add/rename a Worker or service, change a notification channel or alarm scheme, add
-a migration (and bump `SCHEMA_VERSION`), add a content seeder or content-version key, change a
+a migration (and bump `NIMAZ_DATABASE_VERSION`), add a content seeder or content-version key, change a
 DataStore key surface, alter the sync payload/protocol, or swap a monitoring backend — **update
 the corresponding section here in the same change**, and add a row to the relevant table. Keep
 claims grounded in the code (read the file, cite the path in backticks). If a subsystem grows

--- a/docs/nimaz-pro-claude-code-tasks.md
+++ b/docs/nimaz-pro-claude-code-tasks.md
@@ -1,4 +1,10 @@
-# Nimaz Pro - Claude Code Task Instructions
+# Nimaz - Claude Code Task Instructions
+
+> **Historical reference.** This is an original design/planning document from the initial build;
+> it does **not** necessarily reflect the current code. For how the app is built today see
+> [`ARCHITECTURE.md`](ARCHITECTURE.md), [`NAVIGATION.md`](NAVIGATION.md) and
+> [`SUBSYSTEMS.md`](SUBSYSTEMS.md). App name: **Nimaz**; package: **`com.arshadshah.nimaz`**.
+
 
 > **Important**: Execute these tasks in order. Each task builds on the previous. Do not skip tasks.
 
@@ -22,7 +28,7 @@ Before starting, ensure you have:
 ```
 1. Create new Android Studio project:
    - Template: Empty Compose Activity
-   - Package name: com.nimazpro.app
+   - Package name: com.arshadshah.nimaz
    - Minimum SDK: 26 (Android 8.0)
    - Build configuration: Kotlin DSL
 
@@ -78,7 +84,7 @@ plugins {
 **Objective**: Set up the Clean Architecture folder structure.
 
 ```
-Create the following package structure under app/src/main/java/com/nimazpro/app/:
+Create the following package structure under app/src/main/java/com/arshadshah/nimaz/:
 
 ├── NimazProApp.kt
 ├── MainActivity.kt
@@ -123,7 +129,7 @@ Create the following package structure under app/src/main/java/com/nimazpro/app/
 
 **Create NimazProApp.kt**:
 ```kotlin
-package com.nimazpro.app
+package com.arshadshah.nimaz
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
@@ -134,7 +140,7 @@ class NimazProApp : Application()
 
 **Create MainActivity.kt**:
 ```kotlin
-package com.nimazpro.app
+package com.arshadshah.nimaz
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -143,7 +149,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.nimazpro.app.presentation.theme.NimazProTheme
+import com.arshadshah.nimaz.presentation.theme.NimazProTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -179,7 +185,7 @@ class MainActivity : ComponentActivity() {
 
 **Create presentation/theme/Color.kt**:
 ```kotlin
-package com.nimazpro.app.presentation.theme
+package com.arshadshah.nimaz.presentation.theme
 
 import androidx.compose.ui.graphics.Color
 
@@ -232,7 +238,7 @@ object NimazColors {
 
 **Create presentation/theme/Type.kt**:
 ```kotlin
-package com.nimazpro.app.presentation.theme
+package com.arshadshah.nimaz.presentation.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
@@ -240,7 +246,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.R
+import com.arshadshah.nimaz.R
 
 val OutfitFontFamily = FontFamily(
     Font(R.font.outfit_regular, FontWeight.Normal),
@@ -358,7 +364,7 @@ val NimazTypography = Typography(
 
 **Create presentation/theme/Shape.kt**:
 ```kotlin
-package com.nimazpro.app.presentation.theme
+package com.arshadshah.nimaz.presentation.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
@@ -375,7 +381,7 @@ val NimazShapes = Shapes(
 
 **Create presentation/theme/Theme.kt**:
 ```kotlin
-package com.nimazpro.app.presentation.theme
+package com.arshadshah.nimaz.presentation.theme
 
 import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -473,7 +479,7 @@ fun NimazProTheme(
 
 **Create data/local/database/entity/SurahEntity.kt**:
 ```kotlin
-package com.nimazpro.app.data.local.database.entity
+package com.arshadshah.nimaz.data.local.database.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
@@ -516,12 +522,12 @@ data class SurahEntity(
 
 **Create data/local/database/NimazDatabase.kt**:
 ```kotlin
-package com.nimazpro.app.data.local.database
+package com.arshadshah.nimaz.data.local.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import com.nimazpro.app.data.local.database.dao.*
-import com.nimazpro.app.data.local.database.entity.*
+import com.arshadshah.nimaz.data.local.database.dao.*
+import com.arshadshah.nimaz.data.local.database.entity.*
 
 @Database(
     entities = [
@@ -564,11 +570,11 @@ abstract class NimazDatabase : RoomDatabase() {
 
 **Create core/di/DatabaseModule.kt**:
 ```kotlin
-package com.nimazpro.app.core.di
+package com.arshadshah.nimaz.core.di
 
 import android.content.Context
 import androidx.room.Room
-import com.nimazpro.app.data.local.database.NimazDatabase
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -632,7 +638,7 @@ object DatabaseModule {
 
 **Create core/navigation/Routes.kt**:
 ```kotlin
-package com.nimazpro.app.core.navigation
+package com.arshadshah.nimaz.core.navigation
 
 import kotlinx.serialization.Serializable
 
@@ -671,14 +677,14 @@ sealed interface Routes {
 
 **Create core/navigation/NavGraph.kt**:
 ```kotlin
-package com.nimazpro.app.core.navigation
+package com.arshadshah.nimaz.core.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.nimazpro.app.presentation.screens.home.HomeScreen
+import com.arshadshah.nimaz.presentation.screens.home.HomeScreen
 // Import all other screens...
 
 @Composable
@@ -752,10 +758,10 @@ class MainActivity : ComponentActivity() {
 
 **Create data/local/database/dao/QuranDao.kt**:
 ```kotlin
-package com.nimazpro.app.data.local.database.dao
+package com.arshadshah.nimaz.data.local.database.dao
 
 import androidx.room.*
-import com.nimazpro.app.data.local.database.entity.*
+import com.arshadshah.nimaz.data.local.database.entity.*
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -837,7 +843,7 @@ data class AyahWithSurah(
 
 **Create domain/model/Surah.kt**:
 ```kotlin
-package com.nimazpro.app.domain.model
+package com.arshadshah.nimaz.domain.model
 
 data class Surah(
     val id: Int,
@@ -883,9 +889,9 @@ data class ReadingProgress(
 
 **Create domain/repository/QuranRepository.kt**:
 ```kotlin
-package com.nimazpro.app.domain.repository
+package com.arshadshah.nimaz.domain.repository
 
-import com.nimazpro.app.domain.model.*
+import com.arshadshah.nimaz.domain.model.*
 import kotlinx.coroutines.flow.Flow
 
 interface QuranRepository {
@@ -926,13 +932,13 @@ enum class SearchResultType {
 
 **Create data/repository/QuranRepositoryImpl.kt**:
 ```kotlin
-package com.nimazpro.app.data.repository
+package com.arshadshah.nimaz.data.repository
 
-import com.nimazpro.app.data.local.database.dao.QuranDao
-import com.nimazpro.app.data.local.database.entity.QuranBookmarkEntity
-import com.nimazpro.app.data.local.database.entity.ReadingProgressEntity
-import com.nimazpro.app.domain.model.*
-import com.nimazpro.app.domain.repository.QuranRepository
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
+import com.arshadshah.nimaz.domain.model.*
+import com.arshadshah.nimaz.domain.repository.QuranRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -1078,12 +1084,12 @@ class QuranRepositoryImpl @Inject constructor(
 
 **Create presentation/screens/quran/QuranViewModel.kt**:
 ```kotlin
-package com.nimazpro.app.presentation.screens.quran
+package com.arshadshah.nimaz.presentation.screens.quran
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nimazpro.app.domain.model.*
-import com.nimazpro.app.domain.repository.QuranRepository
+import com.arshadshah.nimaz.domain.model.*
+import com.arshadshah.nimaz.domain.repository.QuranRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch

--- a/docs/nimaz-pro-data-guide.md
+++ b/docs/nimaz-pro-data-guide.md
@@ -1,4 +1,11 @@
-# Nimaz Pro - Data Sourcing & Integration Guide
+# Nimaz - Data Sourcing & Integration Guide
+
+> **Status:** the data *formats* below are still a useful reference, but the app now ships a
+> prebuilt database (`app/src/main/assets/database/nimaz_prepopulated.db`) and backfills newer
+> content at runtime via idempotent seeders. See the "Database & migrations" and "Content seeding
+> & versioning" sections of [`SUBSYSTEMS.md`](SUBSYSTEMS.md), and `nimaz-pro-data/` for the
+> generation scripts. App name: **Nimaz**; package: **`com.arshadshah.nimaz`**.
+
 
 ## For Parallel Claude Code Instance
 
@@ -295,7 +302,7 @@ Create `scripts/generate_database.py`:
 ```python
 #!/usr/bin/env python3
 """
-Nimaz Pro - SQLite Database Generator
+Nimaz - SQLite Database Generator
 Converts JSON files to pre-populated Room database
 """
 
@@ -561,7 +568,7 @@ def populate_database(conn):
 
 def main():
     print("=" * 60)
-    print("Nimaz Pro - Database Generator")
+    print("Nimaz - Database Generator")
     print("=" * 60)
     
     # Remove existing database
@@ -633,7 +640,7 @@ After app launch, query counts should match:
 Use this prompt to run data generation in parallel:
 
 ```
-I need you to generate all Islamic content data for the Nimaz Pro Android app.
+I need you to generate all Islamic content data for the Nimaz Android app.
 
 ## Task
 Create JSON files matching the exact formats specified in this document, then generate a pre-populated SQLite database.

--- a/docs/nimaz-pro-technical-foundation.md
+++ b/docs/nimaz-pro-technical-foundation.md
@@ -1,4 +1,10 @@
-# NIMAZ PRO
+# NIMAZ
+
+> **Historical reference.** This is an original design/planning document from the initial build;
+> it does **not** necessarily reflect the current code. For how the app is built today see
+> [`ARCHITECTURE.md`](ARCHITECTURE.md), [`NAVIGATION.md`](NAVIGATION.md) and
+> [`SUBSYSTEMS.md`](SUBSYSTEMS.md). App name: **Nimaz**; package: **`com.arshadshah.nimaz`**.
+
 ## Android Technical Foundation Document
 ### Complete Offline-First Islamic Companion App
 
@@ -23,7 +29,7 @@
 
 # 1. Executive Summary
 
-Nimaz Pro is a **100% offline-capable** Islamic companion app built with the latest Android technologies. This document provides the complete technical foundation for building the app, including database schemas, architecture patterns, and a comprehensive task list for Claude Code to execute.
+Nimaz is a **100% offline-capable** Islamic companion app built with the latest Android technologies. This document provides the complete technical foundation for building the app, including database schemas, architecture patterns, and a comprehensive task list for Claude Code to execute.
 
 ## 1.1 Core Principles
 
@@ -116,11 +122,11 @@ plugins {
 }
 
 android {
-    namespace = "com.nimazpro.app"
+    namespace = "com.arshadshah.nimaz"
     compileSdk = 35
     
     defaultConfig {
-        applicationId = "com.nimazpro.app"
+        applicationId = "com.arshadshah.nimaz"
         minSdk = 26
         targetSdk = 35
         versionCode = 1
@@ -200,7 +206,7 @@ The app follows Clean Architecture with three main layers:
 ## 3.2 Package Structure
 
 ```
-com.nimazpro.app/
+com.arshadshah.nimaz/
 ├── NimazProApp.kt                    # @HiltAndroidApp
 ├── MainActivity.kt                   # @AndroidEntryPoint, single activity
 │
@@ -976,7 +982,7 @@ The following tasks should be executed in order. Each task creates a complete, t
 
 ### Task 1: Create Android Project
 
-Create new Android Studio project with Empty Compose Activity. Package: `com.nimazpro.app`. Min SDK 26, Target SDK 35.
+Create new Android Studio project with Empty Compose Activity. Package: `com.arshadshah.nimaz`. Min SDK 26, Target SDK 35.
 
 - Create project structure as defined in Section 3.2
 - Add all dependencies from Section 2.7 to build.gradle.kts
@@ -1425,7 +1431,7 @@ List any tasks this depends on.
 
 # Summary
 
-This document provides the complete technical foundation for building Nimaz Pro. Following the 35 tasks in order will result in a **100% functional offline-first app** with all data layers complete. The UI can then be built on top of this foundation, replacing the minimal placeholder screens with the designs from the HTML prototypes.
+This document provides the complete technical foundation for building Nimaz. Following the 35 tasks in order will result in a **100% functional offline-first app** with all data layers complete. The UI can then be built on top of this foundation, replacing the minimal placeholder screens with the designs from the HTML prototypes.
 
 ## Key Deliverables
 

--- a/docs/nimaz-pro-ui-tasks.md
+++ b/docs/nimaz-pro-ui-tasks.md
@@ -1,4 +1,10 @@
-# Nimaz Pro - UI Component & Screen Building Tasks
+# Nimaz - UI Component & Screen Building Tasks
+
+> **Historical reference.** This is an original design/planning document from the initial build;
+> it does **not** necessarily reflect the current code. For how the app is built today see
+> [`ARCHITECTURE.md`](ARCHITECTURE.md), [`NAVIGATION.md`](NAVIGATION.md) and
+> [`SUBSYSTEMS.md`](SUBSYSTEMS.md). App name: **Nimaz**; package: **`com.arshadshah.nimaz`**.
+
 
 > **Prerequisites**: Complete all 35 foundation tasks first. This document assumes you have working ViewModels and data layer.
 
@@ -32,7 +38,7 @@ Atoms are the smallest, indivisible UI components. They are pure composables wit
 Create buttons with 4 variants matching the design system.
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -41,7 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 enum class NimazButtonVariant {
     PRIMARY,      // Teal filled
@@ -179,7 +185,7 @@ enum class IconPosition { START, END }
 **File**: `presentation/components/atoms/NimazIconButton.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -194,7 +200,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 enum class NimazIconButtonStyle {
     FILLED,       // Solid background
@@ -253,7 +259,7 @@ fun NimazIconButton(
 **File**: `presentation/components/atoms/NimazCard.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -267,7 +273,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 enum class NimazCardStyle {
     FILLED,       // Solid neutral-900 background
@@ -342,7 +348,7 @@ fun NimazGradientCard(
 **File**: `presentation/components/atoms/ArabicText.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.LocalTextStyle
@@ -355,8 +361,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.presentation.theme.AmiriFontFamily
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun ArabicText(
@@ -420,7 +426,7 @@ fun Int.toArabicNumerals(): String {
 **File**: `presentation/components/atoms/NimazTextField.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -439,7 +445,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun NimazTextField(
@@ -567,7 +573,7 @@ fun NimazTextField(
 **File**: `presentation/components/atoms/NimazSwitch.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
@@ -583,7 +589,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun NimazSwitch(
@@ -631,7 +637,7 @@ fun NimazSwitch(
 **File**: `presentation/components/atoms/NimazChip.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -646,7 +652,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 enum class NimazChipStyle {
     FILLED,
@@ -753,7 +759,7 @@ fun NimazFilterChipGroup(
 **File**: `presentation/components/atoms/NimazBadge.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -768,7 +774,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 enum class NimazBadgeType {
     DEFAULT,      // Neutral gray
@@ -863,7 +869,7 @@ fun NimazCountBadge(
 **File**: `presentation/components/atoms/NimazDivider.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -872,7 +878,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun NimazDivider(
@@ -910,7 +916,7 @@ fun NimazVerticalDivider(
 **File**: `presentation/components/atoms/NimazProgressIndicators.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
@@ -929,7 +935,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 // Linear progress bar
 @Composable
@@ -1014,7 +1020,7 @@ fun NimazLoadingSpinner(
 **File**: `presentation/components/atoms/PrayerColorIndicator.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -1025,8 +1031,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.domain.model.PrayerType
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun PrayerColorIndicator(
@@ -1088,7 +1094,7 @@ fun PrayerColorBar(
 **File**: `presentation/components/atoms/NimazIcon.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -1104,7 +1110,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 // Icon with colored background container
 @Composable
@@ -1165,7 +1171,7 @@ fun NimazEmojiIcon(
 **File**: `presentation/components/atoms/NimazSlider.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.*
@@ -1173,7 +1179,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun NimazSlider(
@@ -1212,7 +1218,7 @@ fun NimazSlider(
 **File**: `presentation/components/atoms/NimazSelectionControls.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
@@ -1231,7 +1237,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun NimazCheckbox(
@@ -1311,7 +1317,7 @@ fun NimazRadioButton(
 **File**: `presentation/components/atoms/NimazContainers.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.atoms
+package com.arshadshah.nimaz.presentation.components.atoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -1324,7 +1330,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 // Bottom sheet handle
 @Composable
@@ -1428,7 +1434,7 @@ Molecules are combinations of atoms that form functional UI components.
 **File**: `presentation/components/molecules/PrayerTimeCard.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.molecules
+package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -1444,9 +1450,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.nimazpro.app.domain.model.PrayerType
-import com.nimazpro.app.presentation.components.atoms.*
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.presentation.components.atoms.*
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 data class PrayerTimeData(
     val type: PrayerType,
@@ -1572,7 +1578,7 @@ val PrayerType.icon: ImageVector
 **File**: `presentation/components/molecules/CountdownTimer.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.molecules
+package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -1586,8 +1592,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.presentation.theme.NimazColors
-import com.nimazpro.app.presentation.theme.OutfitFontFamily
+import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.OutfitFontFamily
 
 data class CountdownTime(
     val hours: Int,
@@ -1680,7 +1686,7 @@ fun CompactCountdown(
 **File**: `presentation/components/molecules/SurahListItem.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.molecules
+package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -1695,13 +1701,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.domain.model.RevelationType
-import com.nimazpro.app.domain.model.Surah
-import com.nimazpro.app.presentation.components.atoms.ArabicText
-import com.nimazpro.app.presentation.components.atoms.NimazBadge
-import com.nimazpro.app.presentation.components.atoms.NimazBadgeType
-import com.nimazpro.app.presentation.theme.NimazColors
-import com.nimazpro.app.presentation.theme.OutfitFontFamily
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeType
+import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.OutfitFontFamily
 
 @Composable
 fun SurahListItem(
@@ -1796,7 +1802,7 @@ fun SurahListItem(
 **File**: `presentation/components/molecules/AyahCard.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.components.molecules
+package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -1811,9 +1817,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nimazpro.app.domain.model.Ayah
-import com.nimazpro.app.presentation.components.atoms.*
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.presentation.components.atoms.*
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun AyahCard(
@@ -2016,7 +2022,7 @@ Build complete screens using organisms and molecules.
 **File**: `presentation/screens/home/HomeScreen.kt`
 
 ```kotlin
-package com.nimazpro.app.presentation.screens.home
+package com.arshadshah.nimaz.presentation.screens.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -2031,10 +2037,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.nimazpro.app.presentation.components.atoms.*
-import com.nimazpro.app.presentation.components.molecules.*
-import com.nimazpro.app.presentation.components.organisms.*
-import com.nimazpro.app.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.components.atoms.*
+import com.arshadshah.nimaz.presentation.components.molecules.*
+import com.arshadshah.nimaz.presentation.components.organisms.*
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 @Composable
 fun HomeScreen(


### PR DESCRIPTION
Document the app's Clean Architecture + MVVM/UDF patterns as the source of
truth to prevent drift. Adds docs/ARCHITECTURE.md (layer patterns, DI,
navigation, theming, UDF/DI/feature mermaid diagrams, a new-feature recipe,
and a validated tech-debt registry of known deviations), a root CLAUDE.md
that points agents to it with the non-negotiable rules, and a README link.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cyi96UPA5xD4o7DdgJTvM9