### PR TITLE
feat(glass): icon + backdrop-blur glass system, larger reader controls, sky tweaks

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/GlassPill.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/GlassPill.kt
@@ -1,2 +1,500 @@
 package com.arshadshah.nimaz.presentation.components.atoms
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import android.os.Build
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+
+/**
+ * Visual weight of a [GlassPill]. All three are derived from a single `tint`
+ * (white by default) so the pill stays legible over any sky gradient.
+ *
+ * - [Frosted] — the everyday legibility pill: a soft fill plus the lit glass edge.
+ * - [Solid]   — heavier fill for titles / primary emphasis.
+ * - [Ghost]   — no fill, only the lit edge; lets the sky show through the most.
+ */
+enum class GlassPillTone { Frosted, Solid, Ghost }
+
+/** Compact label vs. the default. Controls padding, icon size and the icon gap. */
+enum class GlassPillSize { Small, Medium }
+
+/** A sensible default blur strength for the frosted-glass effect. */
+val DefaultGlassBlur: Dp = 24.dp
+
+/**
+ * A shared handle that lets a glass surface blur whatever is drawn behind it —
+ * the real "frosted pane" property, not just a translucent fill.
+ *
+ * Wiring is two-sided and dependency-free:
+ * 1. mark the content to be blurred with [Modifier.glassBackdropSource] — it
+ *    records that content into a [GraphicsLayer];
+ * 2. pass the same backdrop to a [GlassPill] / [GlassIconButton], which samples
+ *    the region under itself and draws it blurred beneath its fill.
+ *
+ * Real blur needs Android 12+ (API 31); on older devices the surface falls back
+ * to its (slightly stronger) translucent fill, which stays legible.
+ *
+ * Create one with [rememberGlassBackdrop].
+ */
+@Stable
+class GlassBackdrop internal constructor(internal val layer: GraphicsLayer) {
+    /** Where the source content sits in the window, so the glass can align to it. */
+    internal var sourcePositionInRoot by mutableStateOf(Offset.Zero)
+}
+
+/** Remembers a [GlassBackdrop] backed by a recording [GraphicsLayer]. */
+@Composable
+fun rememberGlassBackdrop(): GlassBackdrop {
+    val layer = rememberGraphicsLayer()
+    return remember(layer) { GlassBackdrop(layer) }
+}
+
+/**
+ * Marks this content as the thing a glass surface blurs. Records the node's
+ * drawing into [backdrop]'s layer (then draws it normally) and tracks its
+ * position so overlaid glass can sample the right region.
+ */
+fun Modifier.glassBackdropSource(backdrop: GlassBackdrop): Modifier = this
+    .onGloballyPositioned { backdrop.sourcePositionInRoot = it.positionInRoot() }
+    .drawWithContent {
+        backdrop.layer.record { this@drawWithContent.drawContent() }
+        drawLayer(backdrop.layer)
+    }
+
+/**
+ * A translucent "frosted glass" pill used to keep overlay text legible over the
+ * living sky regardless of the time-of-day gradient behind it.
+ *
+ * The refinement over a plain translucent box is the **glass edge**: a hairline
+ * border that fades from a bright top rim to a dim base, the way real frosted
+ * glass catches light. Combined with a richer fill it reads as a lit pane rather
+ * than a flat rectangle.
+ *
+ * Everything is derived from [tint] (white by default), so passing an accent
+ * colour — gold for "soon", green for "done" — re-skins the whole pill coherently.
+ *
+ * @param leadingIcon  optional icon shown before the text, tinted to match it.
+ * @param trailingIcon optional icon shown after the text (e.g. a chevron).
+ * @param tone         visual weight — see [GlassPillTone].
+ * @param size         compact vs. default metrics — see [GlassPillSize].
+ * @param tint         base colour the fill, edge and content are derived from.
+ * @param backdrop     when set (see [rememberGlassBackdrop]), the pill blurs the
+ *                     content behind it for a true frosted-glass surface.
+ * @param blurRadius   how strongly the backdrop is blurred; ignored without a
+ *                     [backdrop]. Set to 0.dp for a flat translucent fill.
+ * @param onClick      makes the whole pill tappable when provided.
+ */
+@Composable
+fun GlassPill(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.labelLarge,
+    leadingIcon: ImageVector? = null,
+    trailingIcon: ImageVector? = null,
+    tone: GlassPillTone = GlassPillTone.Frosted,
+    size: GlassPillSize = GlassPillSize.Medium,
+    tint: Color = Color.White,
+    backdrop: GlassBackdrop? = null,
+    blurRadius: Dp = DefaultGlassBlur,
+    onClick: (() -> Unit)? = null,
+) {
+    val shape = RoundedCornerShape(percent = 100)
+
+    val (hPad, vPad, iconSize, gap) = when (size) {
+        GlassPillSize.Small -> PillMetrics(10.dp, 4.dp, 14.dp, 4.dp)
+        GlassPillSize.Medium -> PillMetrics(14.dp, 7.dp, 18.dp, 6.dp)
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(gap),
+        modifier = modifier
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .glassSurface(tone = tone, tint = tint, shape = shape, backdrop = backdrop, blurRadius = blurRadius)
+            .padding(horizontal = hPad, vertical = vPad),
+    ) {
+        if (leadingIcon != null) {
+            Icon(
+                imageVector = leadingIcon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(iconSize),
+            )
+        }
+        Text(text = text, style = style, color = tint)
+        if (trailingIcon != null) {
+            Icon(
+                imageVector = trailingIcon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(iconSize),
+            )
+        }
+    }
+}
+
+private data class PillMetrics(
+    val hPad: Dp,
+    val vPad: Dp,
+    val iconSize: Dp,
+    val gap: Dp,
+)
+
+/**
+ * The shared glass treatment: an optional backdrop blur, a [tone]-weighted fill,
+ * and the lit edge — a hairline border that fades from a bright top rim to a dim
+ * base. Both [GlassPill] and [GlassIconButton] derive their look from here so the
+ * family stays visually identical across shapes.
+ *
+ * The fill alphas are deliberately substantial: a glass pill must stay legible
+ * even with no [backdrop] (e.g. on Android < 12, where the blur is skipped).
+ */
+@Composable
+private fun Modifier.glassSurface(
+    tone: GlassPillTone,
+    tint: Color,
+    shape: Shape,
+    backdrop: GlassBackdrop?,
+    blurRadius: Dp,
+): Modifier {
+    val fillAlpha = when (tone) {
+        GlassPillTone.Frosted -> 0.26f
+        GlassPillTone.Solid -> 0.42f
+        GlassPillTone.Ghost -> 0.10f
+    }
+    val edgeTopAlpha = when (tone) {
+        GlassPillTone.Frosted -> 0.55f
+        GlassPillTone.Solid -> 0.65f
+        GlassPillTone.Ghost -> 0.45f
+    }
+    val edgeBottomAlpha = 0.12f
+    return this
+        .then(
+            if (backdrop != null && blurRadius > 0.dp) {
+                Modifier.glassBlur(backdrop = backdrop, blurRadius = blurRadius, shape = shape)
+            } else {
+                Modifier
+            }
+        )
+        .background(color = tint.copy(alpha = fillAlpha), shape = shape)
+        .border(
+            width = 1.dp,
+            brush = Brush.verticalGradient(
+                listOf(
+                    tint.copy(alpha = edgeTopAlpha),
+                    tint.copy(alpha = edgeBottomAlpha),
+                )
+            ),
+            shape = shape,
+        )
+}
+
+/**
+ * Draws the slice of [backdrop] sitting directly behind this node, blurred and
+ * clipped to [shape], beneath the node's own content. Needs API 31+; below that
+ * it is a no-op and the translucent fill carries the legibility on its own.
+ */
+@Composable
+private fun Modifier.glassBlur(
+    backdrop: GlassBackdrop,
+    blurRadius: Dp,
+    shape: Shape,
+): Modifier {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+    val blurPx = with(LocalDensity.current) { blurRadius.toPx() }
+    val glassLayer = rememberGraphicsLayer()
+    var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+    return this
+        .onGloballyPositioned { positionInRoot = it.positionInRoot() }
+        .drawWithContent {
+            val offset = positionInRoot - backdrop.sourcePositionInRoot
+            glassLayer.renderEffect = BlurEffect(blurPx, blurPx, TileMode.Clamp)
+            glassLayer.record {
+                translate(left = -offset.x, top = -offset.y) {
+                    drawLayer(backdrop.layer)
+                }
+            }
+            val outline = shape.createOutline(size, layoutDirection, this)
+            clipPath(Path().apply { addOutline(outline) }) {
+                drawLayer(glassLayer)
+            }
+            drawContent()
+        }
+}
+
+/**
+ * The circular, icon-only sibling of [GlassPill] — same frosted fill and lit
+ * edge, sized as a tap target. Use it for overlay actions that sit on the
+ * living sky, e.g. the settings button in the home top bar.
+ *
+ * Because everything derives from [tint], a caller can cross-fade the whole
+ * button from white (over sky) to a surface colour (over a solid bar) just by
+ * lerping the tint — no separate scrim needed.
+ *
+ * @param tone visual weight — see [GlassPillTone].
+ * @param size [GlassPillSize.Small] (36dp) or [GlassPillSize.Medium] (44dp) target.
+ * @param tint base colour the fill, edge and icon are derived from.
+ * @param backdrop   when set, blurs the content behind the button (see [rememberGlassBackdrop]).
+ * @param blurRadius backdrop blur strength; ignored without a [backdrop].
+ */
+@Composable
+fun GlassIconButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tone: GlassPillTone = GlassPillTone.Frosted,
+    size: GlassPillSize = GlassPillSize.Medium,
+    tint: Color = Color.White,
+    backdrop: GlassBackdrop? = null,
+    blurRadius: Dp = DefaultGlassBlur,
+) {
+    val (target, iconSize) = when (size) {
+        GlassPillSize.Small -> 36.dp to 18.dp
+        GlassPillSize.Medium -> 44.dp to 22.dp
+    }
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(target)
+            .glassSurface(tone = tone, tint = tint, shape = CircleShape, backdrop = backdrop, blurRadius = blurRadius),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Previews — rendered over representative sky gradients (a white pill on a
+// white canvas is invisible), so the frosted effect actually reads.
+// ---------------------------------------------------------------------------
+
+/** A stand-in for the real time-of-day sky so previews show true contrast. */
+@Composable
+private fun SkyPreview(
+    colors: List<Color>,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(width = 320.dp, height = 200.dp)
+            .background(Brush.verticalGradient(colors)),
+        contentAlignment = Alignment.Center,
+    ) { content() }
+}
+
+private val MiddaySky = listOf(
+    Color(0xFF0A2E7A), Color(0xFF1E62D6), Color(0xFF4F9BF5), Color(0xFFBFE0FB)
+)
+private val DuskSky = listOf(
+    Color(0xFF2B3A8C), Color(0xFF7C6AB0), Color(0xFFE59AB0), Color(0xFFFBB778)
+)
+private val NightSky = listOf(
+    Color(0xFF03060F), Color(0xFF0A0F26), Color(0xFF141A38), Color(0xFF33285E)
+)
+private val DawnSky = listOf(
+    Color(0xFF16204A), Color(0xFF3B3270), Color(0xFF8A4F6E), Color(0xFFD08A5E)
+)
+
+private val pillShadow = Shadow(Color.Black.copy(alpha = 0.35f), Offset(0f, 1f), 4f)
+
+@Preview(name = "Tones · midday", showBackground = true)
+@Composable
+private fun GlassPill_Tones() {
+    NimazTheme {
+        SkyPreview(MiddaySky) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                GlassPill("Frosted", tone = GlassPillTone.Frosted)
+                GlassPill("Solid", tone = GlassPillTone.Solid)
+                GlassPill("Ghost", tone = GlassPillTone.Ghost)
+            }
+        }
+    }
+}
+
+@Preview(name = "Leading icons · dusk", showBackground = true)
+@Composable
+private fun GlassPill_LeadingIcons() {
+    NimazTheme {
+        SkyPreview(DuskSky) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                GlassPill("Manchester, UK", leadingIcon = Icons.Filled.Place)
+                GlassPill("Maghrib", leadingIcon = Icons.Filled.WbSunny, tone = GlassPillTone.Solid)
+                GlassPill("3 reminders", leadingIcon = Icons.Filled.Notifications, tone = GlassPillTone.Ghost)
+            }
+        }
+    }
+}
+
+@Preview(name = "Accent tints · night", showBackground = true)
+@Composable
+private fun GlassPill_Tints() {
+    NimazTheme {
+        SkyPreview(NightSky) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                GlassPill(
+                    "Completed",
+                    leadingIcon = Icons.Filled.Check,
+                    tone = GlassPillTone.Solid,
+                    tint = Color(0xFF7FE3A4),
+                )
+                GlassPill(
+                    "Starts soon",
+                    leadingIcon = Icons.Filled.WbSunny,
+                    tint = Color(0xFFFFD27D),
+                )
+                GlassPill("Details", trailingIcon = Icons.Filled.KeyboardArrowDown)
+            }
+        }
+    }
+}
+
+@Preview(name = "Sizes · dawn", showBackground = true)
+@Composable
+private fun GlassPill_Sizes() {
+    NimazTheme {
+        SkyPreview(DawnSky) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                GlassPill("Medium", leadingIcon = Icons.Filled.Place, size = GlassPillSize.Medium)
+                GlassPill("Small", leadingIcon = Icons.Filled.Place, size = GlassPillSize.Small)
+            }
+        }
+    }
+}
+
+@Preview(name = "Icon buttons · midday", showBackground = true)
+@Composable
+private fun GlassIconButton_Tones() {
+    NimazTheme {
+        SkyPreview(MiddaySky) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                GlassIconButton(Icons.Filled.Settings, "Settings", onClick = {})
+                GlassIconButton(Icons.Filled.Search, "Search", onClick = {}, tone = GlassPillTone.Solid)
+                GlassIconButton(Icons.Filled.Notifications, "Alerts", onClick = {}, tone = GlassPillTone.Ghost)
+                GlassIconButton(Icons.Filled.Place, "Location", onClick = {}, size = GlassPillSize.Small)
+            }
+        }
+    }
+}
+
+@Preview(name = "Backdrop blur · frosted glass", showBackground = true)
+@Composable
+private fun GlassPill_BackdropBlur() {
+    NimazTheme {
+        val backdrop = rememberGlassBackdrop()
+        val dots = listOf(
+            Color(0xFFFFB000), Color(0xFFFF5C5C), Color(0xFF4ADE80),
+            Color(0xFF38BDF8), Color(0xFFC084FC), Color(0xFFFF8FA3),
+        )
+        Box(
+            modifier = Modifier.size(width = 320.dp, height = 200.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            // Sharp, high-frequency content so the blur is unmistakable.
+            Row(
+                modifier = Modifier
+                    .size(width = 320.dp, height = 200.dp)
+                    .glassBackdropSource(backdrop)
+                    .background(Brush.verticalGradient(MiddaySky)),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                dots.forEach { c ->
+                    Box(
+                        modifier = Modifier
+                            .size(44.dp)
+                            .background(c, CircleShape),
+                    )
+                }
+            }
+            GlassPill(
+                text = "Frosted glass",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                leadingIcon = Icons.Filled.WbSunny,
+                tone = GlassPillTone.Solid,
+                backdrop = backdrop,
+            )
+        }
+    }
+}
+
+@Preview(name = "In context · title + status", showBackground = true)
+@Composable
+private fun GlassPill_InContext() {
+    NimazTheme {
+        SkyPreview(DawnSky) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                GlassPill(
+                    text = "5:42 AM",
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        shadow = pillShadow,
+                        fontWeight = FontWeight.Bold,
+                    ),
+                    leadingIcon = Icons.Filled.WbSunny,
+                    tone = GlassPillTone.Solid,
+                )
+                GlassPill(
+                    text = "Fajr begins",
+                    style = MaterialTheme.typography.labelMedium.copy(shadow = pillShadow),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/GlassPill.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/GlassPill.kt
@@ -1,0 +1,2 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazActionPill.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazActionPill.kt
@@ -45,8 +45,8 @@ fun NimazActionPill(
         ),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier.padding(horizontal = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalAlignment = Alignment.CenterVertically,
             content = content
         )
@@ -75,13 +75,13 @@ fun NimazPillActionButton(
     )
     IconButton(
         onClick = onClick,
-        modifier = modifier.size(36.dp)
+        modifier = modifier.size(48.dp)
     ) {
         Icon(
             imageVector = icon,
             contentDescription = contentDescription,
             tint = tint,
-            modifier = Modifier.size(18.dp)
+            modifier = Modifier.size(22.dp)
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazReaderBottomBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazReaderBottomBar.kt
@@ -58,7 +58,7 @@ fun NimazReaderBottomBar(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             if (hasPager) {
@@ -83,15 +83,15 @@ fun NimazReaderBottomBar(
         if (hasPager) {
             if (pageCount <= 12) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     repeat(pageCount) { index ->
                         val selected = index == currentPage
                         Box(
                             modifier = Modifier
-                                .height(5.dp)
-                                .width(if (selected) 16.dp else 5.dp)
+                                .height(6.dp)
+                                .width(if (selected) 20.dp else 6.dp)
                                 .background(
                                     color = if (selected) MaterialTheme.colorScheme.primary
                                     else MaterialTheme.colorScheme.outlineVariant,
@@ -134,14 +134,14 @@ private fun NavChevron(
             if (enabled) MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
             else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
         ),
-        modifier = Modifier.size(32.dp)
+        modifier = Modifier.size(48.dp)
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = icon,
                 contentDescription = contentDescription,
                 tint = tint,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeDynamicTopBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeDynamicTopBar.kt
@@ -13,12 +13,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,13 +31,16 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.presentation.components.atoms.GlassIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPill
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPillTone
 import com.arshadshah.nimaz.presentation.components.atoms.getPrayerColor
+import com.arshadshah.nimaz.presentation.components.atoms.rememberGlassBackdrop
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 /**
@@ -74,6 +74,8 @@ fun HomeDynamicTopBar(
     val progress = transitionProgress.coerceIn(0f, 1f)
     val surfaceColor = MaterialTheme.colorScheme.surface
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
+
+    val backdrop = rememberGlassBackdrop()
 
     Box(
         modifier = modifier
@@ -118,7 +120,15 @@ fun HomeDynamicTopBar(
                         .alpha(1f - progress)
                         .graphicsLayer { translationY = -SLIDE_DISTANCE_DP.toPx() * progress }
                 ) {
-                    LocationPill(locationName = locationName)
+                    GlassPill(
+                        text = locationName,
+                        leadingIcon = Icons.Default.LocationOn,
+                        tone = GlassPillTone.Solid,
+                        backdrop = backdrop,
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontWeight = FontWeight.Bold,
+                        )
+                    )
                 }
                 Box(
                     modifier = Modifier
@@ -140,50 +150,18 @@ fun HomeDynamicTopBar(
 
 private val SLIDE_DISTANCE_DP = 12.dp
 
-@Composable
-private fun LocationPill(locationName: String) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .clip(RoundedCornerShape(50))
-            .background(Color.Black.copy(alpha = 0.28f))
-            .padding(horizontal = 12.dp, vertical = 6.dp),
-    ) {
-        Icon(
-            imageVector = Icons.Default.LocationOn,
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(16.dp),
-        )
-        Spacer(modifier = Modifier.width(6.dp))
-        Text(
-            text = locationName.ifEmpty { "Set location" },
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = Color.White,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
 
 @Composable
 private fun SettingsButton(progress: Float, onClick: () -> Unit) {
-    // Scrim circle backs the icon while over the sky, fading as the bar solidifies.
-    val scrim = Color.Black.copy(alpha = 0.28f * (1f - progress))
-    val iconTint = lerp(Color.White, MaterialTheme.colorScheme.onSurfaceVariant, progress)
-    IconButton(
+    // The glass cross-fades with the bar: bright white over the sky, settling to
+    // a surface tint as the bar solidifies — no separate scrim needed.
+    val tint = lerp(Color.White, MaterialTheme.colorScheme.onSurfaceVariant, progress)
+    GlassIconButton(
+        icon = Icons.Default.Settings,
+        contentDescription = stringResource(R.string.cd_settings),
         onClick = onClick,
-        modifier = Modifier
-            .clip(CircleShape)
-            .background(scrim),
-    ) {
-        Icon(
-            imageVector = Icons.Default.Settings,
-            contentDescription = stringResource(R.string.cd_settings),
-            tint = iconTint,
-        )
-    }
+        tint = tint,
+    )
 }
 
 @Composable
@@ -239,9 +217,8 @@ private fun TopBar_AtRest_Preview() {
     NimazTheme {
         Box(
             modifier = Modifier.background(
-                Brush.verticalGradient(
-                    colors = listOf(Color(0xFF3E86C9), Color(0xFFBFE0F2))
-                )
+                Color(0xFF3E86C9)
+
             )
         ) {
             HomeDynamicTopBar(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeHero.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeHero.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -37,6 +38,11 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPill
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPillTone
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
+import com.arshadshah.nimaz.presentation.components.atoms.StatusBadge
 import com.arshadshah.nimaz.presentation.components.atoms.getArabicPrayerName
 import com.arshadshah.nimaz.presentation.theme.LocalUseHijriPrimary
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
@@ -44,6 +50,7 @@ import kotlinx.coroutines.delay
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Home hero: a living-sky banner (current time + date) at the original hero
@@ -71,7 +78,7 @@ fun HomeHero(
             val now = LocalTime.now()
             timeOfDay = (now.hour * 60 + now.minute) / 1440f
             clock = formatClock12(now.hour, now.minute)
-            delay(30_000)
+            delay(30_000.milliseconds)
         }
     }
     val moonFraction = remember {
@@ -81,7 +88,7 @@ fun HomeHero(
     }
     val useHijriPrimary = LocalUseHijriPrimary.current
     val shadow =
-        Shadow(color = Color.Black.copy(alpha = 0.45f), offset = Offset(0f, 1f), blurRadius = 6f)
+        Shadow(color = Color.Black.copy(alpha = 0.6f), offset = Offset(0f, 1f), blurRadius = 7f)
 
     // The screen is edge-to-edge, so grow the sky by the status-bar inset to
     // leave a clean band of empty sky behind the status bar at the top.
@@ -110,26 +117,28 @@ fun HomeHero(
                     .align(Alignment.Center)
                     .padding(top = statusBarTop),
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Text(
+                GlassPill(
                     text = clock,
+                    tone = GlassPillTone.Solid,
                     style = MaterialTheme.typography.displaySmall.copy(
                         fontWeight = FontWeight.Bold,
                         shadow = shadow
                     ),
-                    color = Color.White,
                 )
-                Text(
+
+                GlassPill(
                     text = if (useHijriPrimary) hijriDate.ifEmpty { gregorianDate } else gregorianDate,
                     style = MaterialTheme.typography.bodyMedium.copy(shadow = shadow),
-                    color = Color.White.copy(alpha = 0.9f),
                 )
                 if (useHijriPrimary && gregorianDate.isNotEmpty()) {
-                    Text(
+                    GlassPill(
                         text = gregorianDate,
                         style = MaterialTheme.typography.bodySmall.copy(shadow = shadow),
-                        color = Color.White.copy(alpha = 0.8f),
                     )
+
+
                 }
             }
         }
@@ -139,7 +148,7 @@ fun HomeHero(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
-                .offset(y = (-28).dp),
+                .offset(y = (-10).dp),
             shape = RoundedCornerShape(20.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
@@ -158,7 +167,7 @@ fun HomeHero(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         letterSpacing = 2.sp,
                     )
-                    Row(verticalAlignment = Alignment.Bottom) {
+                    Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(
                             text = nextPrayer?.displayName ?: "—",
                             style = MaterialTheme.typography.headlineSmall,
@@ -169,7 +178,7 @@ fun HomeHero(
                             text = getArabicPrayerName(nextPrayer),
                             size = ArabicTextSize.SMALL,
                             color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(start = 8.dp, bottom = 2.dp),
+//                            modifier = Modifier.padding(start = 8.dp, bottom = 2.dp),
                         )
                     }
                     Text(
@@ -214,13 +223,16 @@ val HERO_BOTTOM_RADIUS = 32.dp
 @Preview(showBackground = true, widthDp = 412, heightDp = 380)
 @Composable
 private fun HomeHero_Preview() {
-    NimazTheme {
+    NimazTheme(
+        useHijriPrimary = true
+    ) {
         HomeHero(
             hijriDate = "7 Rajab 1446",
             gregorianDate = "Friday, January 31, 2026",
-            nextPrayer = PrayerType.ASR,
+            nextPrayer = PrayerType.MAGHRIB,
             nextPrayerTime = "4:30 PM",
-            timeUntilNextPrayer = "1h 12m"
+            timeUntilNextPrayer = "1h 12m",
+
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asAndroidPath
@@ -56,6 +57,10 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPill
+import com.arshadshah.nimaz.presentation.components.atoms.GlassPillTone
+import com.arshadshah.nimaz.presentation.components.atoms.glassBackdropSource
+import com.arshadshah.nimaz.presentation.components.atoms.rememberGlassBackdrop
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import kotlin.math.PI
 import kotlin.math.abs
@@ -152,11 +157,14 @@ fun PrayerSkyScene(
     shape: Shape = RoundedCornerShape(20.dp),
     cloudsEnabled: Boolean = true,
 ) {
+    val backdrop = rememberGlassBackdrop()
     Box(modifier = modifier) {
         SkyBackground(
             timeOfDay = timeOfDay,
             moonFraction = moonFraction,
-            modifier = Modifier.matchParentSize(),
+            modifier = Modifier
+                .matchParentSize()
+                .glassBackdropSource(backdrop),
             shape = shape,
             cloudsEnabled = cloudsEnabled,
         )
@@ -175,37 +183,16 @@ fun PrayerSkyScene(
                     shadow = shadow,
                     fontWeight = FontWeight.Bold,
                 ),
+                tone = GlassPillTone.Solid,
+                backdrop = backdrop,
             )
             GlassPill(
                 text = statusLabel,
                 style = MaterialTheme.typography.labelMedium.copy(shadow = shadow),
+                backdrop = backdrop,
             )
         }
     }
-}
-
-/**
- * A translucent "frosted glass" pill used to keep overlay text legible over the
- * living sky regardless of the time-of-day gradient behind it. The semi-opaque
- * white fill establishes a consistent contrast floor without hiding the sky.
- */
-@Composable
-private fun GlassPill(
-    text: String,
-    style: TextStyle,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = text,
-        style = style,
-        color = Color.White,
-        modifier = modifier
-            .background(
-                color = Color.White.copy(alpha = 0.20f),
-                shape = RoundedCornerShape(100),
-            )
-            .padding(horizontal = 14.dp, vertical = 6.dp),
-    )
 }
 
 private const val SPRITE_SCALE = 0.6f
@@ -244,7 +231,7 @@ private fun DrawScope.drawScene(t: Float, moonFraction: Float) {
     if (night > 0f) {
         drawNight(night)
         drawMoon(
-            Offset(size.width * 0.72f, size.height * 0.32f),
+            Offset(size.width * 0.72f, size.height * 0.44f),
             size.minDimension * 0.16f,
             moonFraction,
             alpha = night
@@ -275,8 +262,8 @@ private fun DrawScope.drawSunAt(td: Float, alt: Float, sunAlpha: Float) {
     val w = size.width
     val h = size.height
     val sunX = lerpF(0.16f, 0.84f, td.coerceIn(0f, 1f)) * w
-    val horizonY = h * 0.92f
-    val apexY = h * 0.16f
+    val horizonY = h * 0.86f
+    val apexY = h * 0.30f
     val sunY = horizonY - alt * (horizonY - apexY) // alt<0 sinks it below the frame
     val radius = size.minDimension * 0.085f
     val warm = (1f - alt).coerceIn(0f, 1f) // warmer near the horizon
@@ -349,9 +336,9 @@ private fun DrawScope.drawCloudLayer() {
     // White→grey luminance so a per-phase ColorFilter.tint shades them correctly.
     val w = size.width
     val h = size.height
-    drawCloud(w * 0.25f, h * 0.36f, scale(), Color.White, Color(0xFFAFAFAF), 0.95f)
-    drawCloud(w * 0.6f, h * 0.24f, scale() * 0.8f, Color.White, Color(0xFFAFAFAF), 0.9f)
-    drawCloud(w * 0.78f, h * 0.5f, scale() * 0.7f, Color.White, Color(0xFFAFAFAF), 0.85f)
+    drawCloud(w * 0.25f, h * 0.49f, scale(), Color.White, Color(0xFFAFAFAF), 0.95f, CloudShape.Classic)
+    drawCloud(w * 0.6f, h * 0.37f, scale() * 0.8f, Color.White, Color(0xFFAFAFAF), 0.9f, CloudShape.Puffy)
+    drawCloud(w * 0.78f, h * 0.63f, scale() * 0.7f, Color.White, Color(0xFFAFAFAF), 0.85f, CloudShape.Wide)
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -550,13 +537,21 @@ private fun DrawScope.drawSun(
 private fun fade(stops: List<Pair<Float, Color>>, alpha: Float): Array<Pair<Float, Color>> =
     stops.map { it.first to it.second.copy(alpha = it.second.alpha * alpha) }.toTypedArray()
 
+/**
+ * Silhouette variants for [drawCloud]. All follow the same recipe — a base oval,
+ * a row of puff circles for the bumpy crown, and a flat-bottomed slab — so they
+ * read as one family while no two clouds look identical.
+ */
+private enum class CloudShape { Classic, Puffy, Wide }
+
 private fun DrawScope.drawCloud(
     cx: Float,
     cy: Float,
     s: Float,
     top: Color,
     bottom: Color,
-    alpha: Float
+    alpha: Float,
+    shape: CloudShape = CloudShape.Classic
 ) {
     drawIntoCanvas { c ->
         val paint = Paint().apply {
@@ -575,12 +570,36 @@ private fun DrawScope.drawCloud(
         }
         val dir = android.graphics.Path.Direction.CW
         val p = android.graphics.Path().apply {
-            addOval(RectF(cx - 30f * s, cy - 12f * s, cx + 30f * s, cy + 12f * s), dir)
-            addCircle(cx - 22f * s, cy - 2f * s, 14f * s, dir)
-            addCircle(cx - 6f * s, cy - 12f * s, 16f * s, dir)
-            addCircle(cx + 12f * s, cy - 8f * s, 13f * s, dir)
-            addCircle(cx + 24f * s, cy - 1f * s, 15f * s, dir)
-            addRoundRect(RectF(cx - 44f * s, cy, cx + 44f * s, cy + 16f * s), 8f * s, 8f * s, dir)
+            when (shape) {
+                CloudShape.Classic -> {
+                    addOval(RectF(cx - 30f * s, cy - 12f * s, cx + 30f * s, cy + 12f * s), dir)
+                    addCircle(cx - 22f * s, cy - 2f * s, 14f * s, dir)
+                    addCircle(cx - 6f * s, cy - 12f * s, 16f * s, dir)
+                    addCircle(cx + 12f * s, cy - 8f * s, 13f * s, dir)
+                    addCircle(cx + 24f * s, cy - 1f * s, 15f * s, dir)
+                    addRoundRect(RectF(cx - 44f * s, cy, cx + 44f * s, cy + 16f * s), 8f * s, 8f * s, dir)
+                }
+                // Rounder and taller — a fifth puff lifts the crown into a dome.
+                CloudShape.Puffy -> {
+                    addOval(RectF(cx - 28f * s, cy - 10f * s, cx + 28f * s, cy + 12f * s), dir)
+                    addCircle(cx - 20f * s, cy - 4f * s, 13f * s, dir)
+                    addCircle(cx - 8f * s, cy - 14f * s, 17f * s, dir)
+                    addCircle(cx + 6f * s, cy - 16f * s, 16f * s, dir)
+                    addCircle(cx + 18f * s, cy - 9f * s, 14f * s, dir)
+                    addCircle(cx + 26f * s, cy - 2f * s, 12f * s, dir)
+                    addRoundRect(RectF(cx - 40f * s, cy + 2f * s, cx + 40f * s, cy + 16f * s), 9f * s, 9f * s, dir)
+                }
+                // Stretched and flat — a low, drifting wisp with smaller bumps.
+                CloudShape.Wide -> {
+                    addOval(RectF(cx - 38f * s, cy - 8f * s, cx + 38f * s, cy + 10f * s), dir)
+                    addCircle(cx - 28f * s, cy - 2f * s, 11f * s, dir)
+                    addCircle(cx - 12f * s, cy - 9f * s, 14f * s, dir)
+                    addCircle(cx + 4f * s, cy - 10f * s, 14f * s, dir)
+                    addCircle(cx + 20f * s, cy - 6f * s, 12f * s, dir)
+                    addCircle(cx + 30f * s, cy - 1f * s, 10f * s, dir)
+                    addRoundRect(RectF(cx - 50f * s, cy, cx + 50f * s, cy + 14f * s), 7f * s, 7f * s, dir)
+                }
+            }
         }
         c.nativeCanvas.drawPath(p, paint)
     }
@@ -757,7 +776,11 @@ private fun PrayerSkyScene_Isha_Preview() {
             "9:39 PM",
             "Isha · Fajr in 6h 04m",
             scenePreviewModifier(),
-            moonFraction = 0.62f
+            moonFraction = 0.62f,
+            shape = RoundedCornerShape(
+                bottomStart = 26.dp,
+                bottomEnd = 26.dp
+            )
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt
@@ -2,9 +2,13 @@ package com.arshadshah.nimaz.widget.core
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.glance.ColorFilter
 import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
@@ -17,6 +21,9 @@ import androidx.glance.layout.Column
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
@@ -78,4 +85,82 @@ fun WidgetLoadingBox(
             )
         }
     }
+}
+
+/**
+ * The standard solid, rounded, tappable widget surface. Pass a Column/Row that
+ * calls `fillMaxSize()` so `defaultWeight()` distributes inside it.
+ */
+@Composable
+fun WidgetCard(
+    background: ColorProvider,
+    onClick: Action,
+    modifier: GlanceModifier = GlanceModifier,
+    cornerRadius: Dp = 16.dp,
+    padding: Dp = 12.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(background)
+            .cornerRadius(cornerRadius)
+            .clickable(onClick)
+            .padding(padding)
+            .then(modifier),
+        content = content,
+    )
+}
+
+/** The single place widget icons are drawn — a tinted vector drawable. */
+@Composable
+fun WidgetIcon(
+    resId: Int,
+    tint: ColorProvider,
+    size: Dp = 16.dp,
+    contentDescription: String? = null,
+) {
+    Image(
+        provider = ImageProvider(resId),
+        contentDescription = contentDescription,
+        modifier = GlanceModifier.size(size),
+        colorFilter = ColorFilter.tint(tint),
+    )
+}
+
+/** Small medium-weight caption used for eyebrow labels. */
+@Composable
+fun WidgetLabel(text: String, color: ColorProvider, fontSize: TextUnit = 11.sp) {
+    Text(
+        text = text,
+        style = TextStyle(color = color, fontSize = fontSize, fontWeight = FontWeight.Medium),
+    )
+}
+
+/** Rounded badge container for countdowns and the "next prayer" highlight. */
+@Composable
+fun WidgetPill(
+    container: ColorProvider,
+    modifier: GlanceModifier = GlanceModifier,
+    cornerRadius: Dp = 8.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .background(container)
+            .cornerRadius(cornerRadius)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .then(modifier),
+        content = content,
+    )
+}
+
+/** Maps a prayer name to its celestial drawable. Defaults to the zenith sun. */
+fun prayerIconRes(prayerName: String): Int = when (prayerName.trim().lowercase()) {
+    "fajr" -> R.drawable.ic_widget_fajr
+    "dhuhr", "zuhr" -> R.drawable.ic_widget_dhuhr
+    "asr" -> R.drawable.ic_widget_asr
+    "maghrib" -> R.drawable.ic_widget_maghrib
+    "isha" -> R.drawable.ic_widget_isha
+    else -> R.drawable.ic_widget_dhuhr
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
@@ -41,6 +41,7 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetIcon
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
@@ -398,17 +399,16 @@ private fun EventRow(
     textSecondary: ColorProvider,
     primaryColor: ColorProvider,
 ) {
+    val iconRes = if (
+        event.type.contains("fast", ignoreCase = true) ||
+        event.type.contains("recommend", ignoreCase = true)
+    ) R.drawable.ic_widget_star else R.drawable.ic_widget_event
+
     Row(verticalAlignment = Alignment.Top) {
-        // Tiny accent dot — visual marker that this is a list item, not a
-        // paragraph. 4dp circle aligned with the text baseline-ish via a
-        // small top padding.
-        Box(
-            modifier = GlanceModifier
-                .padding(top = 5.dp)
-                .size(4.dp)
-                .cornerRadius(2.dp)
-                .background(primaryColor)
-        ) {}
+        // Small leading icon marks this as a typed list item, not a paragraph.
+        Box(modifier = GlanceModifier.padding(top = 1.dp)) {
+            WidgetIcon(resId = iconRes, tint = primaryColor, size = 12.dp)
+        }
         Spacer(modifier = GlanceModifier.width(6.dp))
         Column(modifier = GlanceModifier.defaultWeight()) {
             Text(

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
@@ -31,6 +31,11 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import androidx.glance.layout.Row
+import androidx.glance.layout.width
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+import com.arshadshah.nimaz.widget.core.WidgetLabel
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
@@ -94,51 +99,37 @@ private fun HijriDateSuccessContent(
     textSecondary: ColorProvider,
     primaryColor: ColorProvider
 ) {
-    Column(
-        modifier = GlanceModifier
-            .fillMaxSize()
-            .background(backgroundColor)
-            .cornerRadius(16.dp)
-            .clickable(actionStartActivity<MainActivity>())
-            .padding(12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalAlignment = Alignment.CenterVertically
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 14.dp,
     ) {
-        Text(
-            text = data.gregorianDayOfWeek.ifEmpty { "—" },
-            style = TextStyle(
-                color = textSecondary,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.Medium
+        Column(
+            modifier = GlanceModifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = GlanceModifier.defaultWeight())
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                WidgetIcon(resId = R.drawable.ic_widget_crescent, tint = primaryColor, size = 13.dp)
+                Spacer(modifier = GlanceModifier.width(5.dp))
+                WidgetLabel(text = data.gregorianDayOfWeek.ifEmpty { "—" }, color = textSecondary)
+            }
+            Spacer(modifier = GlanceModifier.height(6.dp))
+            Text(
+                text = data.hijriDay.toString(),
+                style = TextStyle(color = primaryColor, fontSize = 52.sp, fontWeight = FontWeight.Bold),
             )
-        )
-
-        Spacer(modifier = GlanceModifier.defaultWeight())
-
-        Text(
-            text = data.hijriDay.toString(),
-            style = TextStyle(
-                color = primaryColor,
-                fontSize = 42.sp,
-                fontWeight = FontWeight.Bold
+            Text(
+                text = "${data.hijriMonth.ifEmpty { "—" }} ${data.hijriYear}",
+                style = TextStyle(color = textColor, fontSize = 14.sp, fontWeight = FontWeight.Medium),
             )
-        )
-
-        Text(
-            text = "${data.hijriMonth.ifEmpty { "—" }} ${data.hijriYear}",
-            style = TextStyle(
-                color = textColor,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Medium
+            Spacer(modifier = GlanceModifier.height(4.dp))
+            Text(
+                text = data.gregorianDate.ifEmpty { "—" },
+                style = TextStyle(color = textSecondary, fontSize = 11.sp),
             )
-        )
-
-        Spacer(modifier = GlanceModifier.defaultWeight())
-
-        Text(
-            text = data.gregorianDate.ifEmpty { "—" },
-            style = TextStyle(color = textSecondary, fontSize = 11.sp)
-        )
+            Spacer(modifier = GlanceModifier.defaultWeight())
+        }
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
@@ -33,9 +33,15 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import androidx.glance.layout.width
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+import com.arshadshah.nimaz.widget.core.WidgetLabel
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
+import com.arshadshah.nimaz.widget.core.WidgetPill
+import com.arshadshah.nimaz.widget.core.prayerIconRes
 
 class NextPrayerWidget : GlanceAppWidget() {
 
@@ -98,75 +104,51 @@ private fun NextPrayerSuccessContent(
     primaryColor: ColorProvider
 ) {
     val context = LocalContext.current
-    Box(
-        modifier = GlanceModifier
-            .fillMaxSize()
-            .background(backgroundColor)
-            .cornerRadius(16.dp)
-            .clickable(actionStartActivity<MainActivity>())
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
+    val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
+        WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
+    } else {
+        data.countdown.ifEmpty { "—" }
+    }
+
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 16.dp,
     ) {
-        Column(
-            modifier = GlanceModifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = context.getString(R.string.widget_next_prayer),
-                style = TextStyle(
-                    color = textSecondary,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                WidgetIcon(
+                    resId = prayerIconRes(data.prayerName),
+                    tint = primaryColor,
+                    size = 16.dp,
+                    contentDescription = data.prayerName,
                 )
-            )
-
-            Spacer(modifier = GlanceModifier.height(4.dp))
-
+                Spacer(modifier = GlanceModifier.width(6.dp))
+                WidgetLabel(
+                    text = context.getString(R.string.widget_next_prayer),
+                    color = textSecondary,
+                )
+            }
+            Spacer(modifier = GlanceModifier.height(10.dp))
             Text(
                 text = data.prayerName.ifEmpty { "—" },
-                style = TextStyle(
-                    color = primaryColor,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold
-                )
+                style = TextStyle(color = primaryColor, fontSize = 20.sp, fontWeight = FontWeight.Bold),
             )
-
+            Spacer(modifier = GlanceModifier.defaultWeight())
             Text(
                 text = data.prayerTime.ifEmpty { "—" },
-                style = TextStyle(
-                    color = textColor,
-                    fontSize = 28.sp,
-                    fontWeight = FontWeight.Bold
-                )
+                style = TextStyle(color = textColor, fontSize = 32.sp, fontWeight = FontWeight.Bold),
             )
-
             Spacer(modifier = GlanceModifier.height(8.dp))
-
-            // Compute countdown live from stored epoch for freshness
-            val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
-                WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
-            } else {
-                data.countdown.ifEmpty { "—" }
-            }
-
-            Box(
-                modifier = GlanceModifier
-                    .background(ColorProvider(R.color.widget_primary_dim))
-                    .cornerRadius(8.dp)
-                    .padding(horizontal = 12.dp, vertical = 6.dp)
-            ) {
+            WidgetPill(container = ColorProvider(R.color.widget_primary_dim)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         text = if (data.isValid && liveCountdown != "—") "in " else "",
-                        style = TextStyle(color = primaryColor, fontSize = 12.sp)
+                        style = TextStyle(color = primaryColor, fontSize = 12.sp),
                     )
                     Text(
                         text = liveCountdown,
-                        style = TextStyle(
-                            color = primaryColor,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Bold
-                        )
+                        style = TextStyle(color = primaryColor, fontSize = 12.sp, fontWeight = FontWeight.Bold),
                     )
                 }
             }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
@@ -34,6 +34,7 @@ import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
+import com.arshadshah.nimaz.widget.core.WidgetCard
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
@@ -89,6 +90,8 @@ private fun PrayerTimesContent(state: PrayerTimesWidgetState) {
     }
 }
 
+private enum class PrayerCellState { PAST, NEXT, UPCOMING }
+
 @Composable
 private fun PrayerTimesSuccessContent(
     data: PrayerTimesData,
@@ -97,145 +100,105 @@ private fun PrayerTimesSuccessContent(
     textSecondary: ColorProvider,
     primaryColor: ColorProvider
 ) {
-    Box(
-        modifier = GlanceModifier
-            .fillMaxSize()
-            .background(backgroundColor)
-            .cornerRadius(16.dp)
-            .clickable(actionStartActivity<MainActivity>())
-            .padding(12.dp)
+    val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
+        WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
+    } else {
+        data.timeUntilNext
+    }
+    val rightLine = buildString {
+        if (data.hijriDate.isNotEmpty()) append(data.hijriDate)
+        if (data.nextPrayerName.isNotEmpty() && liveCountdown.isNotEmpty() && liveCountdown != "—") {
+            if (isNotEmpty()) append(" · ")
+            append("${data.nextPrayerName} in $liveCountdown")
+        }
+    }.ifEmpty { "—" }
+
+    // Five (name, time, passed) cells in order; the next prayer is the first not-passed.
+    val cells = listOf(
+        Triple("Fajr", data.fajrTime, data.fajrPassed),
+        Triple("Dhuhr", data.dhuhrTime, data.dhuhrPassed),
+        Triple("Asr", data.asrTime, data.asrPassed),
+        Triple("Maghrib", data.maghribTime, data.maghribPassed),
+        Triple("Isha", data.ishaTime, data.ishaPassed),
+    )
+    val nextIndex = cells.indexOfFirst { !it.third }
+
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 12.dp,
     ) {
         Column(modifier = GlanceModifier.fillMaxSize()) {
-            // Header
-            Row(
-                modifier = GlanceModifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = GlanceModifier.defaultWeight()) {
-                    Text(
-                        text = data.locationName.ifEmpty { "Location" },
-                        style = TextStyle(
-                            color = textColor,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    )
-                    Text(
-                        text = data.hijriDate.ifEmpty { "—" },
-                        style = TextStyle(color = textSecondary, fontSize = 11.sp)
-                    )
-                }
-
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        text = data.nextPrayerName.ifEmpty { "—" },
-                        style = TextStyle(
-                            color = primaryColor,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    )
-                    // Compute countdown live from stored epoch for freshness
-                    val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
-                        val cd = WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
-                        if (cd != "—") "in $cd" else "—"
-                    } else {
-                        if (data.timeUntilNext.isNotEmpty()) "in ${data.timeUntilNext}" else "—"
-                    }
-                    Text(
-                        text = liveCountdown,
-                        style = TextStyle(color = textSecondary, fontSize = 10.sp)
-                    )
-                }
+            Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = data.locationName.ifEmpty { "Location" },
+                    style = TextStyle(color = textColor, fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                    modifier = GlanceModifier.defaultWeight(),
+                )
+                Text(
+                    text = rightLine,
+                    style = TextStyle(color = textSecondary, fontSize = 10.sp),
+                    maxLines = 1,
+                )
             }
-
-            Spacer(modifier = GlanceModifier.height(10.dp))
-
-            // Prayer times row
-            Row(
-                modifier = GlanceModifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                PrayerTimeItem(
-                    "Fajr",
-                    data.fajrTime,
-                    data.fajrPassed,
-                    textColor,
-                    textSecondary,
-                    primaryColor,
-                    GlanceModifier.defaultWeight()
-                )
-                PrayerTimeItem(
-                    "Dhuhr",
-                    data.dhuhrTime,
-                    data.dhuhrPassed,
-                    textColor,
-                    textSecondary,
-                    primaryColor,
-                    GlanceModifier.defaultWeight()
-                )
-                PrayerTimeItem(
-                    "Asr",
-                    data.asrTime,
-                    data.asrPassed,
-                    textColor,
-                    textSecondary,
-                    primaryColor,
-                    GlanceModifier.defaultWeight()
-                )
-                PrayerTimeItem(
-                    "Mgrb",
-                    data.maghribTime,
-                    data.maghribPassed,
-                    textColor,
-                    textSecondary,
-                    primaryColor,
-                    GlanceModifier.defaultWeight()
-                )
-                PrayerTimeItem(
-                    "Isha",
-                    data.ishaTime,
-                    data.ishaPassed,
-                    textColor,
-                    textSecondary,
-                    primaryColor,
-                    GlanceModifier.defaultWeight()
-                )
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            Row(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+                cells.forEachIndexed { index, (name, time, passed) ->
+                    val state = when {
+                        passed -> PrayerCellState.PAST
+                        index == nextIndex -> PrayerCellState.NEXT
+                        else -> PrayerCellState.UPCOMING
+                    }
+                    PrayerPill(
+                        name = name,
+                        time = time.ifEmpty { "—" },
+                        state = state,
+                        textColor = textColor,
+                        textSecondary = textSecondary,
+                        primaryColor = primaryColor,
+                        modifier = GlanceModifier.defaultWeight(),
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-private fun PrayerTimeItem(
+private fun PrayerPill(
     name: String,
     time: String,
-    isPassed: Boolean,
+    state: PrayerCellState,
     textColor: ColorProvider,
     textSecondary: ColorProvider,
     primaryColor: ColorProvider,
-    modifier: GlanceModifier = GlanceModifier
+    modifier: GlanceModifier = GlanceModifier,
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = name,
-            style = TextStyle(
-                color = if (isPassed) textSecondary else textColor,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Medium
+    val onPrimary = ColorProvider(R.color.widget_on_primary)
+    val nameColor = if (state == PrayerCellState.NEXT) onPrimary else textSecondary
+    val timeColor = when (state) {
+        PrayerCellState.PAST -> textSecondary
+        PrayerCellState.NEXT -> onPrimary
+        PrayerCellState.UPCOMING -> textColor
+    }
+    val inner = GlanceModifier.let {
+        if (state == PrayerCellState.NEXT) {
+            it.background(primaryColor).cornerRadius(12.dp).padding(vertical = 6.dp, horizontal = 4.dp)
+        } else it
+    }
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Column(modifier = inner.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = name,
+                style = TextStyle(color = nameColor, fontSize = 10.sp, fontWeight = FontWeight.Medium),
+                maxLines = 1,
             )
-        )
-        Text(
-            text = time.ifEmpty { "—" },
-            style = TextStyle(
-                color = if (isPassed) textSecondary else primaryColor,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold
+            Text(
+                text = time,
+                style = TextStyle(color = timeColor, fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                maxLines = 1,
             )
-        )
+        }
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
@@ -35,6 +35,8 @@ import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.widget.WidgetEntryPoint
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 import dagger.hilt.android.EntryPointAccessors
@@ -120,70 +122,42 @@ private fun PrayerTrackerSuccessContent(
     textSecondary: ColorProvider,
     primaryColor: ColorProvider
 ) {
-    val checkedColor = ColorProvider(R.color.widget_checked)
-    val uncheckedColor = ColorProvider(R.color.widget_unchecked)
-
-    Box(
-        modifier = GlanceModifier
-            .fillMaxSize()
-            .background(backgroundColor)
-            .cornerRadius(16.dp)
-            .clickable(actionStartActivity<MainActivity>())
-            .padding(12.dp)
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 12.dp,
     ) {
-        Column(
-            modifier = GlanceModifier.fillMaxSize()
-        ) {
-            // Header row with title and count
-            Row(
-                modifier = GlanceModifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = data.dateLabel,
-                    style = TextStyle(
-                        color = textSecondary,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.Medium
-                    )
+                    style = TextStyle(color = textSecondary, fontSize = 11.sp, fontWeight = FontWeight.Medium),
                 )
                 Spacer(modifier = GlanceModifier.defaultWeight())
                 Text(
-                    text = "${data.prayedCount}/${data.totalCount}",
-                    style = TextStyle(
-                        color = primaryColor,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold
-                    )
+                    text = "${data.prayedCount} / ${data.totalCount}",
+                    style = TextStyle(color = primaryColor, fontSize = 12.sp, fontWeight = FontWeight.Bold),
                 )
             }
-
             Spacer(modifier = GlanceModifier.height(8.dp))
-
-            // Prayer checkboxes row
-            Row(
-                modifier = GlanceModifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
+            Row(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
                 val prayers = listOf(
-                    Triple("Fajr", "F", data.fajr),
-                    Triple("Dhuhr", "D", data.dhuhr),
-                    Triple("Asr", "A", data.asr),
-                    Triple("Maghrib", "M", data.maghrib),
-                    Triple("Isha", "I", data.isha)
+                    "Fajr" to data.fajr,
+                    "Dhuhr" to data.dhuhr,
+                    "Asr" to data.asr,
+                    "Maghrib" to data.maghrib,
+                    "Isha" to data.isha,
                 )
-
-                prayers.forEach { (name, shortName, isPrayed) ->
+                prayers.forEach { (name, isPrayed) ->
                     PrayerCheckbox(
                         prayerName = name,
-                        shortName = shortName,
                         isPrayed = isPrayed,
                         context = context,
-                        checkedColor = checkedColor,
-                        uncheckedColor = uncheckedColor,
+                        backgroundColor = backgroundColor,
+                        primaryColor = primaryColor,
                         textColor = textColor,
                         textSecondary = textSecondary,
-                        modifier = GlanceModifier.defaultWeight()
+                        modifier = GlanceModifier.defaultWeight(),
                     )
                 }
             }
@@ -194,50 +168,46 @@ private fun PrayerTrackerSuccessContent(
 @Composable
 private fun PrayerCheckbox(
     prayerName: String,
-    shortName: String,
     isPrayed: Boolean,
     context: Context,
-    checkedColor: ColorProvider,
-    uncheckedColor: ColorProvider,
+    backgroundColor: ColorProvider,
+    primaryColor: ColorProvider,
     textColor: ColorProvider,
     textSecondary: ColorProvider,
     modifier: GlanceModifier = GlanceModifier
 ) {
+    val uncheckedColor = ColorProvider(R.color.widget_unchecked)
+    val onPrimary = ColorProvider(R.color.widget_on_primary)
     Column(
-        modifier = modifier.clickable {
-            // Toggle prayer status
-            togglePrayerStatus(context, prayerName.lowercase())
-        },
+        modifier = modifier.clickable { togglePrayerStatus(context, prayerName.lowercase()) },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Checkbox circle
-        Box(
-            modifier = GlanceModifier
-                .size(28.dp)
-                .cornerRadius(14.dp)
-                .background(if (isPrayed) checkedColor else uncheckedColor),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = if (isPrayed) "\u2713" else "",
-                style = TextStyle(
-                    color = ColorProvider(R.color.widget_background),
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold
-                )
-            )
+        if (isPrayed) {
+            // Filled teal disc + tinted check vector.
+            Box(
+                modifier = GlanceModifier.size(28.dp).cornerRadius(14.dp).background(primaryColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                WidgetIcon(resId = R.drawable.ic_widget_check, tint = onPrimary, size = 16.dp)
+            }
+        } else {
+            // Outline ring built from two discs (Glance has no stroke modifier).
+            Box(
+                modifier = GlanceModifier.size(28.dp).cornerRadius(14.dp).background(uncheckedColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(modifier = GlanceModifier.size(24.dp).cornerRadius(12.dp).background(backgroundColor)) {}
+            }
         }
-
-        Spacer(modifier = GlanceModifier.height(4.dp))
-
-        // Prayer name
+        Spacer(modifier = GlanceModifier.height(5.dp))
         Text(
-            text = shortName,
+            text = prayerName,
             style = TextStyle(
                 color = if (isPrayed) textColor else textSecondary,
-                fontSize = 10.sp,
-                fontWeight = if (isPrayed) FontWeight.Bold else FontWeight.Normal
-            )
+                fontSize = 9.sp,
+                fontWeight = if (isPrayed) FontWeight.Bold else FontWeight.Normal,
+            ),
+            maxLines = 1,
         )
     }
 }

--- a/app/src/main/res/drawable/ic_widget_asr.xml
+++ b/app/src/main/res/drawable/ic_widget_asr.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,20 L21,20 M12,9 a4,4 0 1 1 -0.01,0 M12,3 L12,4.5 M4.5,12 L6,12 M18,12 L19.5,12 M6.2,6.2 L7.2,7.2 M17.8,6.2 L16.8,7.2" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_check.xml
+++ b/app/src/main/res/drawable/ic_widget_check.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="2.6" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M5,12.5 L10,17 L19,7" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_crescent.xml
+++ b/app/src/main/res/drawable/ic_widget_crescent.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M19,14.5 a7.5,7.5 0 0 1 -9.5,-9.5 a6,6 0 1 0 9.5,9.5 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_dhuhr.xml
+++ b/app/src/main/res/drawable/ic_widget_dhuhr.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M12,7.5 a4.5,4.5 0 1 1 -0.01,0 M12,2 L12,4 M12,20 L12,22 M2,12 L4,12 M20,12 L22,12 M4.9,4.9 L6.3,6.3 M17.7,17.7 L19.1,19.1 M19.1,4.9 L17.7,6.3 M4.9,19.1 L6.3,17.7" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_event.xml
+++ b/app/src/main/res/drawable/ic_widget_event.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M5,5 L19,5 a2,2 0 0 1 2,2 L21,19 a2,2 0 0 1 -2,2 L5,21 a2,2 0 0 1 -2,-2 L3,7 a2,2 0 0 1 2,-2 Z M3,10 L21,10 M8,3 L8,7 M16,3 L16,7" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_fajr.xml
+++ b/app/src/main/res/drawable/ic_widget_fajr.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,18 L21,18 M6.5,18 a5.5,5.5 0 0 1 11,0 M12,4 L12,7 M9,8 L12,5 L15,8" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_isha.xml
+++ b/app/src/main/res/drawable/ic_widget_isha.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M19,14.5 a7.5,7.5 0 0 1 -9.5,-9.5 a6,6 0 1 0 9.5,9.5 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_maghrib.xml
+++ b/app/src/main/res/drawable/ic_widget_maghrib.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,18 L21,18 M6.5,18 a5.5,5.5 0 0 1 11,0 M9,7 L12,10 L15,7" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_star.xml
+++ b/app/src/main/res/drawable/ic_widget_star.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M12,3 L14.5,8.6 L20.5,9.2 L16,13.2 L17.3,19 L12,15.9 L6.7,19 L8,13.2 L3.5,9.2 L9.5,8.6 Z" />
+</vector>

--- a/app/src/main/res/layout/widget_hijri_date_preview.xml
+++ b/app/src/main/res/layout/widget_hijri_date_preview.xml
@@ -3,26 +3,37 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:ignore="HardcodedText"
+    tools:ignore="HardcodedText,ContentDescription"
     android:orientation="vertical"
     android:background="@color/widget_background"
     android:gravity="center"
-    android:padding="16dp">
+    android:padding="14dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <ImageView
+            android:layout_width="13dp"
+            android:layout_height="13dp"
+            android:src="@drawable/ic_widget_crescent"
+            android:tint="@color/widget_primary" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:text="Friday"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Friday"
-        android:textColor="@color/widget_text_secondary"
-        android:textSize="11sp" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:text="15"
         android:textColor="@color/widget_primary"
-        android:textSize="42sp"
+        android:textSize="52sp"
         android:textStyle="bold" />
 
     <TextView

--- a/app/src/main/res/layout/widget_next_prayer_preview.xml
+++ b/app/src/main/res/layout/widget_next_prayer_preview.xml
@@ -3,23 +3,34 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:ignore="HardcodedText"
+    tools:ignore="HardcodedText,ContentDescription"
     android:orientation="vertical"
     android:background="@color/widget_background"
-    android:gravity="center"
     android:padding="16dp">
 
-    <TextView
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Next Prayer"
-        android:textColor="@color/widget_text_secondary"
-        android:textSize="11sp" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:src="@drawable/ic_widget_maghrib"
+            android:tint="@color/widget_primary" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:text="Next Prayer"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="10dp"
         android:text="Maghrib"
         android:textColor="@color/widget_primary"
         android:textSize="20sp"
@@ -28,15 +39,15 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
         android:text="6:15 PM"
         android:textColor="@color/widget_text"
-        android:textSize="28sp"
+        android:textSize="30sp"
         android:textStyle="bold" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:background="@color/widget_primary_dim"
         android:paddingHorizontal="12dp"
         android:paddingVertical="6dp"

--- a/app/src/main/res/layout/widget_prayer_times_preview.xml
+++ b/app/src/main/res/layout/widget_prayer_times_preview.xml
@@ -11,172 +11,55 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <LinearLayout
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Dublin"
-                android:textColor="@color/widget_text"
-                android:textSize="14sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="15 Rajab"
-                android:textColor="@color/widget_text_secondary"
-                android:textSize="11sp" />
-        </LinearLayout>
-
-        <LinearLayout
+            android:text="Dublin"
+            android:textColor="@color/widget_text"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="end">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Maghrib"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="in 2h 30m"
-                android:textColor="@color/widget_text_secondary"
-                android:textSize="10sp" />
-        </LinearLayout>
+            android:text="15 Rajab · Maghrib in 2h 30m"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="10sp" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:orientation="horizontal">
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        android:weightSum="5">
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Fajr"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="5:30"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Fajr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="5:30" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Dhuhr"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="12:45"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Dhuhr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="12:45" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Asr"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="3:30"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Asr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="3:30" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Mgrb"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="6:15"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center"
+            android:background="@color/widget_primary" android:paddingVertical="6dp">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Maghrib" android:textColor="@color/widget_on_primary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="6:15" android:textColor="@color/widget_on_primary" android:textSize="15sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Isha"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="7:45"
-                android:textColor="@color/widget_primary"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Isha" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="7:45" android:textColor="@color/widget_text" android:textSize="15sp" android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/widget_prayer_tracker_preview.xml
+++ b/app/src/main/res/layout/widget_prayer_tracker_preview.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:ignore="HardcodedText"
+    tools:ignore="HardcodedText,ContentDescription,UseCompoundDrawables"
     android:orientation="vertical"
     android:background="@color/widget_background"
     android:padding="12dp">
@@ -13,19 +13,17 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical">
-
         <TextView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Today"
+            android:text="Today · 15 Rajab"
             android:textColor="@color/widget_text_secondary"
             android:textSize="11sp" />
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="3/5"
+            android:text="3 / 5"
             android:textColor="@color/widget_primary"
             android:textSize="12sp"
             android:textStyle="bold" />
@@ -36,151 +34,31 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:orientation="horizontal"
-        android:gravity="center">
+        android:weightSum="5">
 
-        <!-- Fajr - checked -->
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:background="@color/widget_checked">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:text="✓"
-                    android:textColor="@color/widget_background"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="F"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="5dp" android:text="Fajr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <!-- Dhuhr - checked -->
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:background="@color/widget_checked">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:text="✓"
-                    android:textColor="@color/widget_background"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="D"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="5dp" android:text="Dhuhr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <!-- Asr - checked -->
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:background="@color/widget_checked">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:text="✓"
-                    android:textColor="@color/widget_background"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="A"
-                android:textColor="@color/widget_text"
-                android:textSize="10sp"
-                android:textStyle="bold" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="5dp" android:text="Asr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
         </LinearLayout>
 
-        <!-- Maghrib - unchecked -->
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:background="@color/widget_unchecked">
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="M"
-                android:textColor="@color/widget_text_secondary"
-                android:textSize="10sp" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <View android:layout_width="28dp" android:layout_height="28dp" android:background="@color/widget_unchecked" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="5dp" android:text="Maghrib" android:textColor="@color/widget_text_secondary" android:textSize="9sp" />
         </LinearLayout>
 
-        <!-- Isha - unchecked -->
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:background="@color/widget_unchecked">
-            </FrameLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="I"
-                android:textColor="@color/widget_text_secondary"
-                android:textSize="10sp" />
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <View android:layout_width="28dp" android:layout_height="28dp" android:background="@color/widget_unchecked" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="5dp" android:text="Isha" android:textColor="@color/widget_text_secondary" android:textSize="9sp" />
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values-night/widget_colors.xml
+++ b/app/src/main/res/values-night/widget_colors.xml
@@ -8,4 +8,5 @@
     <color name="widget_primary_dim">#2614B8A6</color>
     <color name="widget_checked">#22C55E</color>
     <color name="widget_unchecked">#3F3F46</color>
+    <color name="widget_on_primary">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/widget_colors.xml
+++ b/app/src/main/res/values/widget_colors.xml
@@ -8,4 +8,5 @@
     <color name="widget_primary_dim">#1A14B8A6</color>
     <color name="widget_checked">#22C55E</color>
     <color name="widget_unchecked">#E5E5E5</color>
+    <color name="widget_on_primary">#FFFFFF</color>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt
@@ -1,0 +1,37 @@
+package com.arshadshah.nimaz.widget
+
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard: widget UI must use real vector drawables, never emoji or
+ * unicode symbol glyphs. The em-dash (U+2014) is allowed as a text fallback.
+ * Runs from the module dir, so source paths are relative to `app/`.
+ */
+class WidgetGlyphGuardTest {
+
+    private val forbidden = setOf('✓', '✔', '✅', '☆', '★', '→', '←')
+
+    @Test
+    fun `widget sources contain no emoji or symbol glyphs`() {
+        val dir = File("src/main/java/com/arshadshah/nimaz/widget")
+        assert(dir.isDirectory) { "Widget source dir not found at ${dir.absolutePath}" }
+
+        val offenders = mutableListOf<String>()
+        dir.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            file.readLines().forEachIndexed { i, line ->
+                line.forEach { ch ->
+                    val code = ch.code
+                    val isSymbol = code in 0x2600..0x27BF // misc symbols + dingbats (incl. ✓)
+                    val isEmoji = code in 0x1F000..0x1FAFF || Character.isSurrogate(ch)
+                    if (ch in forbidden || isSymbol || isEmoji) {
+                        offenders += "%s:%d U+%04X '%s'".format(file.name, i + 1, code, ch)
+                    }
+                }
+            }
+        }
+        assert(offenders.isEmpty()) {
+            "Forbidden glyph(s) in widget sources:\n" + offenders.joinToString("\n")
+        }
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -86,7 +86,17 @@ Each widget = a `GlanceAppWidget` subclass (`provideGlance` → `provideContent 
 - **Per-minute AlarmManager tick** via `widget/WidgetUpdateScheduler.kt` (WorkManager's 15-min floor is too coarse for a live countdown). `setInexactRepeating(ELAPSED_REALTIME, …, 60_000)` fires `WidgetTickReceiver`, which just calls `updateAll(context)` on the two countdown widgets — it does **not** recompute prayer times; the composable recomputes the countdown string from the stored `nextPrayerEpochMillis`.
 - **Immediate refresh** on prayer-status change, from the tracker toggle and from `HomeViewModel` (keeps the widget in sync with in-app tracking).
 
-**Shared `widget/core/`.** `JsonGlanceStateDefinition.kt` (generic JSON-over-DataStore `GlanceStateDefinition`, one DataStore per file via a process-wide map), `WidgetStateUpdater.kt` (`updateWidgetState(...)`), `WidgetFormatters.kt` (time/countdown), `WidgetUi.kt` (`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`), `WidgetWork.kt`.
+**Shared `widget/core/`.** `JsonGlanceStateDefinition.kt` (generic JSON-over-DataStore `GlanceStateDefinition`, one DataStore per file via a process-wide map), `WidgetStateUpdater.kt` (`updateWidgetState(...)`), `WidgetFormatters.kt` (time/countdown), `WidgetUi.kt` (`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`, plus the redesign atoms `WidgetCard`, `WidgetIcon`, `WidgetLabel`, `WidgetPill`, `prayerIconRes`), `WidgetWork.kt`.
+
+**Widget UI design ("Refined Minimal").** Solid `widget_background` surface, `16dp`
+corners, teal `widget_primary` accent. **No emoji/ASCII/unicode glyphs** — all icons
+are monochrome vector drawables in `res/drawable/ic_widget_*.xml` drawn via `WidgetIcon`
+(`Image` + `ColorFilter.tint`), so they follow light/dark + accent. The Next Prayer
+widget picks a celestial icon per prayer via `prayerIconRes`; the Tracker uses a teal
+disc + `ic_widget_check` when prayed and a two-disc outline ring when not (Glance has no
+stroke modifier); Prayer Times is a clean 5-cell pill row with the next prayer filled
+teal and past prayers dimmed. A JVM regression test (`WidgetGlyphGuardTest`) fails the
+build if any widget source reintroduces a glyph.
 
 **Manifest/res.** Five `<receiver>`s + the non-exported `WidgetTickReceiver` in `AndroidManifest.xml`; provider-info XMLs in `res/xml/*_widget_info.xml`.
 

--- a/docs/superpowers/plans/2026-06-22-widget-ui-redesign.md
+++ b/docs/superpowers/plans/2026-06-22-widget-ui-redesign.md
@@ -1,0 +1,1229 @@
+# Widget UI Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign all five Glance home-screen widgets into one "Refined Minimal" visual language, replacing every emoji/ASCII/unicode glyph with real vector-drawable iconography.
+
+**Architecture:** UI-layer-only change. Each widget keeps its `GlanceAppWidget`, `provideGlance`, state definition, worker and receiver untouched — only the `Success` composable is rewritten. New monochrome vector drawables in `res/drawable/` are tinted at runtime via `ColorFilter.tint(ColorProvider)`. Repeated container/icon/label/pill UI is centralized as new atoms in `widget/core/WidgetUi.kt`.
+
+**Tech Stack:** Kotlin, Jetpack Glance `1.2.0-rc01` (glance-appwidget), Android vector drawables, JUnit (JVM unit test for the glyph guard). minSdk 29, compileSdk 37.
+
+## Global Constraints
+
+- **No emoji, no ASCII art, no unicode symbol glyphs** in widget UI. The em-dash `—` (U+2014) is permitted ONLY as a last-resort empty-value text fallback. The checkmark `✓` (U+2713) and single-letter prayer labels (`F/D/A/M/I`) must be gone.
+- Glance cannot use Compose `Icons.*` (`material-icons-extended`). All widget icons ship as **vector drawable XML** in `app/src/main/res/drawable/`.
+- No hardcoded `Color(0xFF…)`; colors come from `res/color`/`res/values*/widget_colors.xml` via `ColorProvider(R.color.widget_*)`.
+- No changes to data classes, state definitions, workers, receivers, `WidgetUpdateScheduler`, or the tracker's `togglePrayerStatus` behaviour.
+- Widget package: `com.arshadshah.nimaz.widget`. App package: `com.arshadshah.nimaz`.
+- Verify each task with `./gradlew :app:compileDebugKotlin` (runs KSP + resource processing, so it validates both Kotlin and the new drawable XML referenced by `R.drawable.*`). Develop on branch `feat/widget-ui-redesign`; do not push to `dev`.
+
+---
+
+## File Structure
+
+**Create (drawables, `app/src/main/res/drawable/`):**
+- `ic_widget_fajr.xml`, `ic_widget_dhuhr.xml`, `ic_widget_asr.xml`, `ic_widget_maghrib.xml`, `ic_widget_isha.xml` — celestial prayer icons (Next Prayer widget)
+- `ic_widget_check.xml` — checkmark (Tracker)
+- `ic_widget_crescent.xml` — crescent accent (Hijri Date)
+- `ic_widget_event.xml`, `ic_widget_star.xml` — calendar event markers
+
+**Create (color):** add `widget_on_primary` (#FFFFFF) to both `res/values/widget_colors.xml` and `res/values-night/widget_colors.xml`.
+
+**Create (test):** `app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt`
+
+**Modify:**
+- `app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt` — add `WidgetCard`, `WidgetIcon`, `WidgetLabel`, `WidgetPill`, `prayerIconRes`
+- `widget/nextprayer/NextPrayerWidget.kt`, `widget/hijridate/HijriDateWidget.kt`, `widget/prayertimes/PrayerTimesWidget.kt`, `widget/prayertracker/PrayerTrackerWidget.kt`, `widget/hijricalendar/HijriCalendarWidget.kt` — rewrite the `Success` composable
+- `app/src/main/res/layout/widget_*_preview.xml` (5 files) — match new look
+- `docs/SUBSYSTEMS.md` — widgets section
+
+---
+
+## Task 1: Vector drawables + on-primary color
+
+**Files:**
+- Create: `app/src/main/res/drawable/ic_widget_fajr.xml`, `ic_widget_dhuhr.xml`, `ic_widget_asr.xml`, `ic_widget_maghrib.xml`, `ic_widget_isha.xml`, `ic_widget_check.xml`, `ic_widget_crescent.xml`, `ic_widget_event.xml`, `ic_widget_star.xml`
+- Modify: `app/src/main/res/values/widget_colors.xml`, `app/src/main/res/values-night/widget_colors.xml`
+
+**Interfaces:**
+- Produces: `R.drawable.ic_widget_{fajr,dhuhr,asr,maghrib,isha,check,crescent,event,star}`, `R.color.widget_on_primary`. All icons are 24×24 monochrome (opaque strokes/fills) so `ColorFilter.tint` recolours them.
+
+- [ ] **Step 1: Create the line-style prayer + accent icons**
+
+`ic_widget_fajr.xml` (dawn — horizon, sun arc, up chevron):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,18 L21,18 M6.5,18 a5.5,5.5 0 0 1 11,0 M12,4 L12,7 M9,8 L12,5 L15,8" />
+</vector>
+```
+
+`ic_widget_dhuhr.xml` (zenith — full sun + rays):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M12,7.5 a4.5,4.5 0 1 1 -0.01,0 M12,2 L12,4 M12,20 L12,22 M2,12 L4,12 M20,12 L22,12 M4.9,4.9 L6.3,6.3 M17.7,17.7 L19.1,19.1 M19.1,4.9 L17.7,6.3 M4.9,19.1 L6.3,17.7" />
+</vector>
+```
+
+`ic_widget_asr.xml` (low sun above horizon):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,20 L21,20 M12,9 a4,4 0 1 1 -0.01,0 M12,3 L12,4.5 M4.5,12 L6,12 M18,12 L19.5,12 M6.2,6.2 L7.2,7.2 M17.8,6.2 L16.8,7.2" />
+</vector>
+```
+
+`ic_widget_maghrib.xml` (sunset — horizon, sun arc, down chevron):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M3,18 L21,18 M6.5,18 a5.5,5.5 0 0 1 11,0 M9,7 L12,10 L15,7" />
+</vector>
+```
+
+`ic_widget_isha.xml` (night — crescent, filled):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M19,14.5 a7.5,7.5 0 0 1 -9.5,-9.5 a6,6 0 1 0 9.5,9.5 Z" />
+</vector>
+```
+
+`ic_widget_crescent.xml` (same crescent shape, used by Hijri Date):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M19,14.5 a7.5,7.5 0 0 1 -9.5,-9.5 a6,6 0 1 0 9.5,9.5 Z" />
+</vector>
+```
+
+- [ ] **Step 2: Create the check, event and star icons**
+
+`ic_widget_check.xml`:
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="2.6" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M5,12.5 L10,17 L19,7" />
+</vector>
+```
+
+`ic_widget_event.xml` (calendar):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:strokeColor="#FF000000" android:strokeWidth="1.9" android:fillColor="#00000000"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M5,5 L19,5 a2,2 0 0 1 2,2 L21,19 a2,2 0 0 1 -2,2 L5,21 a2,2 0 0 1 -2,-2 L3,7 a2,2 0 0 1 2,-2 Z M3,10 L21,10 M8,3 L8,7 M16,3 L16,7" />
+</vector>
+```
+
+`ic_widget_star.xml` (filled star — recommended fast / special day):
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M12,3 L14.5,8.6 L20.5,9.2 L16,13.2 L17.3,19 L12,15.9 L6.7,19 L8,13.2 L3.5,9.2 L9.5,8.6 Z" />
+</vector>
+```
+
+- [ ] **Step 3: Add the on-primary color (white check on teal disc, identical in both modes)**
+
+In `app/src/main/res/values/widget_colors.xml`, add inside `<resources>`:
+```xml
+    <color name="widget_on_primary">#FFFFFF</color>
+```
+In `app/src/main/res/values-night/widget_colors.xml`, add inside `<resources>`:
+```xml
+    <color name="widget_on_primary">#FFFFFF</color>
+```
+
+- [ ] **Step 4: Verify resources compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL (resource processing parses every new vector XML and generates `R.drawable.*` / `R.color.widget_on_primary`). If a `pathData` is malformed, the build fails here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/res/drawable/ic_widget_*.xml app/src/main/res/values/widget_colors.xml app/src/main/res/values-night/widget_colors.xml
+git commit -m "feat(widget): add vector icon set + on-primary color for redesign"
+```
+
+---
+
+## Task 2: Shared core atoms in WidgetUi.kt
+
+**Files:**
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt`
+
+**Interfaces:**
+- Consumes: `R.drawable.ic_widget_*` (Task 1), existing `WidgetPalette`.
+- Produces (all in package `com.arshadshah.nimaz.widget.core`):
+  - `WidgetCard(background: ColorProvider, onClick: Action, modifier: GlanceModifier = GlanceModifier, cornerRadius: Dp = 16.dp, padding: Dp = 12.dp, content: @Composable () -> Unit)`
+  - `WidgetIcon(resId: Int, tint: ColorProvider, size: Dp = 16.dp, contentDescription: String? = null)`
+  - `WidgetLabel(text: String, color: ColorProvider, fontSize: TextUnit = 11.sp)`
+  - `WidgetPill(container: ColorProvider, modifier: GlanceModifier = GlanceModifier, cornerRadius: Dp = 8.dp, content: @Composable () -> Unit)`
+  - `prayerIconRes(prayerName: String): Int`
+
+- [ ] **Step 1: Add imports to WidgetUi.kt**
+
+Add these imports (the file already imports `Dp`, `dp`, `sp`, `GlanceModifier`, `LocalContext`, `Action`, `clickable`, `cornerRadius`, `background`, `Alignment`, `Box`, `Column`, `Spacer`, `fillMaxSize`, `height`, `Text`, `TextStyle`, `ColorProvider`, `R`):
+```kotlin
+import androidx.compose.ui.unit.TextUnit
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.ColorFilter
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.text.FontWeight
+```
+
+- [ ] **Step 2: Append the new atoms to WidgetUi.kt**
+
+Add at the end of the file:
+```kotlin
+/**
+ * The standard solid, rounded, tappable widget surface. Pass a Column/Row that
+ * calls `fillMaxSize()` so `defaultWeight()` distributes inside it.
+ */
+@Composable
+fun WidgetCard(
+    background: ColorProvider,
+    onClick: Action,
+    modifier: GlanceModifier = GlanceModifier,
+    cornerRadius: Dp = 16.dp,
+    padding: Dp = 12.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(background)
+            .cornerRadius(cornerRadius)
+            .clickable(onClick)
+            .padding(padding)
+            .then(modifier),
+        content = content,
+    )
+}
+
+/** The single place widget icons are drawn — a tinted vector drawable. */
+@Composable
+fun WidgetIcon(
+    resId: Int,
+    tint: ColorProvider,
+    size: Dp = 16.dp,
+    contentDescription: String? = null,
+) {
+    Image(
+        provider = ImageProvider(resId),
+        contentDescription = contentDescription,
+        modifier = GlanceModifier.size(size),
+        colorFilter = ColorFilter.tint(tint),
+    )
+}
+
+/** Small medium-weight caption used for eyebrow labels. */
+@Composable
+fun WidgetLabel(text: String, color: ColorProvider, fontSize: TextUnit = 11.sp) {
+    Text(
+        text = text,
+        style = TextStyle(color = color, fontSize = fontSize, fontWeight = FontWeight.Medium),
+    )
+}
+
+/** Rounded badge container for countdowns and the "next prayer" highlight. */
+@Composable
+fun WidgetPill(
+    container: ColorProvider,
+    modifier: GlanceModifier = GlanceModifier,
+    cornerRadius: Dp = 8.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .background(container)
+            .cornerRadius(cornerRadius)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .then(modifier),
+        content = content,
+    )
+}
+
+/** Maps a prayer name to its celestial drawable. Defaults to the zenith sun. */
+fun prayerIconRes(prayerName: String): Int = when (prayerName.trim().lowercase()) {
+    "fajr" -> R.drawable.ic_widget_fajr
+    "dhuhr", "zuhr" -> R.drawable.ic_widget_dhuhr
+    "asr" -> R.drawable.ic_widget_asr
+    "maghrib" -> R.drawable.ic_widget_maghrib
+    "isha" -> R.drawable.ic_widget_isha
+    else -> R.drawable.ic_widget_dhuhr
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetUi.kt
+git commit -m "feat(widget): add WidgetCard/Icon/Label/Pill atoms + prayerIconRes"
+```
+
+---
+
+## Task 3: Next Prayer widget rewrite
+
+**Files:**
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt` (replace `NextPrayerSuccessContent`, lines 92-175)
+
+**Interfaces:**
+- Consumes: `WidgetCard`, `WidgetIcon`, `WidgetLabel`, `WidgetPill`, `prayerIconRes` (Task 2); `NextPrayerData(prayerName, prayerTime, countdown, isValid, nextPrayerEpochMillis)`; `WidgetUpdateScheduler.computeCountdown`.
+
+- [ ] **Step 1: Update imports**
+
+In `NextPrayerWidget.kt`, add:
+```kotlin
+import androidx.glance.layout.width
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+import com.arshadshah.nimaz.widget.core.WidgetLabel
+import com.arshadshah.nimaz.widget.core.WidgetPill
+import com.arshadshah.nimaz.widget.core.prayerIconRes
+```
+
+- [ ] **Step 2: Replace `NextPrayerSuccessContent`**
+
+Replace the entire `NextPrayerSuccessContent` function (lines 92-175) with:
+```kotlin
+@Composable
+private fun NextPrayerSuccessContent(
+    data: NextPrayerData,
+    backgroundColor: ColorProvider,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider
+) {
+    val context = LocalContext.current
+    val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
+        WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
+    } else {
+        data.countdown.ifEmpty { "—" }
+    }
+
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 16.dp,
+    ) {
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                WidgetIcon(
+                    resId = prayerIconRes(data.prayerName),
+                    tint = primaryColor,
+                    size = 16.dp,
+                    contentDescription = data.prayerName,
+                )
+                Spacer(modifier = GlanceModifier.width(6.dp))
+                WidgetLabel(
+                    text = context.getString(R.string.widget_next_prayer),
+                    color = textSecondary,
+                )
+            }
+            Spacer(modifier = GlanceModifier.height(10.dp))
+            Text(
+                text = data.prayerName.ifEmpty { "—" },
+                style = TextStyle(color = primaryColor, fontSize = 20.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(modifier = GlanceModifier.defaultWeight())
+            Text(
+                text = data.prayerTime.ifEmpty { "—" },
+                style = TextStyle(color = textColor, fontSize = 32.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            WidgetPill(container = ColorProvider(R.color.widget_primary_dim)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = if (data.isValid && liveCountdown != "—") "in " else "",
+                        style = TextStyle(color = primaryColor, fontSize = 12.sp),
+                    )
+                    Text(
+                        text = liveCountdown,
+                        style = TextStyle(color = primaryColor, fontSize = 12.sp, fontWeight = FontWeight.Bold),
+                    )
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. (`Box`, `cornerRadius`, `clickable`, `background`, `fillMaxWidth` imports may now be unused — remove any the compiler flags as unused if it warns; unused imports don't fail the build.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
+git commit -m "feat(widget): redesign Next Prayer widget (icon + refined layout)"
+```
+
+---
+
+## Task 4: Hijri Date widget rewrite
+
+**Files:**
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt` (replace `HijriDateSuccessContent`, lines 89-143)
+
+**Interfaces:**
+- Consumes: `WidgetCard`, `WidgetIcon`, `WidgetLabel` (Task 2); `R.drawable.ic_widget_crescent`; `HijriDateData(hijriDay: Int, hijriMonth, hijriYear: Int, gregorianDayOfWeek, gregorianDate)`.
+
+- [ ] **Step 1: Update imports**
+
+In `HijriDateWidget.kt`, add:
+```kotlin
+import androidx.glance.layout.Row
+import androidx.glance.layout.width
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+import com.arshadshah.nimaz.widget.core.WidgetLabel
+```
+
+- [ ] **Step 2: Replace `HijriDateSuccessContent`**
+
+Replace the entire `HijriDateSuccessContent` function (lines 89-143) with:
+```kotlin
+@Composable
+private fun HijriDateSuccessContent(
+    data: HijriDateData,
+    backgroundColor: ColorProvider,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider
+) {
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 14.dp,
+    ) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = GlanceModifier.defaultWeight())
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                WidgetIcon(resId = R.drawable.ic_widget_crescent, tint = primaryColor, size = 13.dp)
+                Spacer(modifier = GlanceModifier.width(5.dp))
+                WidgetLabel(text = data.gregorianDayOfWeek.ifEmpty { "—" }, color = textSecondary)
+            }
+            Spacer(modifier = GlanceModifier.height(6.dp))
+            Text(
+                text = data.hijriDay.toString(),
+                style = TextStyle(color = primaryColor, fontSize = 52.sp, fontWeight = FontWeight.Bold),
+            )
+            Text(
+                text = "${data.hijriMonth.ifEmpty { "—" }} ${data.hijriYear}",
+                style = TextStyle(color = textColor, fontSize = 14.sp, fontWeight = FontWeight.Medium),
+            )
+            Spacer(modifier = GlanceModifier.height(4.dp))
+            Text(
+                text = data.gregorianDate.ifEmpty { "—" },
+                style = TextStyle(color = textSecondary, fontSize = 11.sp),
+            )
+            Spacer(modifier = GlanceModifier.defaultWeight())
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
+git commit -m "feat(widget): redesign Hijri Date widget (crescent accent + scale)"
+```
+
+---
+
+## Task 5: Prayer Times widget rewrite — Clean Pills
+
+**Files:**
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt` (replace `PrayerTimesSuccessContent` + `PrayerTimeItem`, lines 92-240)
+
+**Interfaces:**
+- Consumes: `WidgetCard` (Task 2); `PrayerTimesData(locationName, hijriDate, nextPrayerName, timeUntilNext, fajrTime..ishaTime, fajrPassed..ishaPassed, nextPrayerEpochMillis)`; `WidgetUpdateScheduler.computeCountdown`.
+- Produces (file-private): `enum class PrayerCellState { PAST, NEXT, UPCOMING }`, `PrayerPill(...)`.
+
+- [ ] **Step 1: Update imports**
+
+In `PrayerTimesWidget.kt`, add:
+```kotlin
+import com.arshadshah.nimaz.widget.core.WidgetCard
+```
+
+- [ ] **Step 2: Replace `PrayerTimesSuccessContent` and `PrayerTimeItem`**
+
+Replace both functions (lines 92-240) with:
+```kotlin
+private enum class PrayerCellState { PAST, NEXT, UPCOMING }
+
+@Composable
+private fun PrayerTimesSuccessContent(
+    data: PrayerTimesData,
+    backgroundColor: ColorProvider,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider
+) {
+    val liveCountdown = if (data.nextPrayerEpochMillis > 0L) {
+        WidgetUpdateScheduler.computeCountdown(data.nextPrayerEpochMillis)
+    } else {
+        data.timeUntilNext
+    }
+    val rightLine = buildString {
+        if (data.hijriDate.isNotEmpty()) append(data.hijriDate)
+        if (data.nextPrayerName.isNotEmpty() && liveCountdown.isNotEmpty() && liveCountdown != "—") {
+            if (isNotEmpty()) append(" · ")
+            append("${data.nextPrayerName} in $liveCountdown")
+        }
+    }.ifEmpty { "—" }
+
+    // Five (name, time, passed) cells in order; the next prayer is the first not-passed.
+    val cells = listOf(
+        Triple("Fajr", data.fajrTime, data.fajrPassed),
+        Triple("Dhuhr", data.dhuhrTime, data.dhuhrPassed),
+        Triple("Asr", data.asrTime, data.asrPassed),
+        Triple("Maghrib", data.maghribTime, data.maghribPassed),
+        Triple("Isha", data.ishaTime, data.ishaPassed),
+    )
+    val nextIndex = cells.indexOfFirst { !it.third }
+
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 12.dp,
+    ) {
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = data.locationName.ifEmpty { "Location" },
+                    style = TextStyle(color = textColor, fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                    modifier = GlanceModifier.defaultWeight(),
+                )
+                Text(
+                    text = rightLine,
+                    style = TextStyle(color = textSecondary, fontSize = 10.sp),
+                    maxLines = 1,
+                )
+            }
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            Row(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+                cells.forEachIndexed { index, (name, time, passed) ->
+                    val state = when {
+                        passed -> PrayerCellState.PAST
+                        index == nextIndex -> PrayerCellState.NEXT
+                        else -> PrayerCellState.UPCOMING
+                    }
+                    PrayerPill(
+                        name = name,
+                        time = time.ifEmpty { "—" },
+                        state = state,
+                        textColor = textColor,
+                        textSecondary = textSecondary,
+                        primaryColor = primaryColor,
+                        modifier = GlanceModifier.defaultWeight(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrayerPill(
+    name: String,
+    time: String,
+    state: PrayerCellState,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider,
+    modifier: GlanceModifier = GlanceModifier,
+) {
+    val onPrimary = ColorProvider(R.color.widget_on_primary)
+    val nameColor = if (state == PrayerCellState.NEXT) onPrimary else textSecondary
+    val timeColor = when (state) {
+        PrayerCellState.PAST -> textSecondary
+        PrayerCellState.NEXT -> onPrimary
+        PrayerCellState.UPCOMING -> textColor
+    }
+    val inner = GlanceModifier.let {
+        if (state == PrayerCellState.NEXT) {
+            it.background(primaryColor).cornerRadius(12.dp).padding(vertical = 6.dp, horizontal = 4.dp)
+        } else it
+    }
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Column(modifier = inner.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = name,
+                style = TextStyle(color = nameColor, fontSize = 10.sp, fontWeight = FontWeight.Medium),
+                maxLines = 1,
+            )
+            Text(
+                text = time,
+                style = TextStyle(color = timeColor, fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                maxLines = 1,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
+git commit -m "feat(widget): redesign Prayer Times widget (clean pills, next highlighted)"
+```
+
+---
+
+## Task 6: Prayer Tracker widget rewrite — checkbox + glyph guard test
+
+**Files:**
+- Create: `app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt`
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt` (replace `PrayerTrackerSuccessContent` + `PrayerCheckbox`, lines 114-243). Leave `togglePrayerStatus`, the receiver and `provideGlance` untouched.
+
+**Interfaces:**
+- Consumes: `WidgetCard`, `WidgetIcon` (Task 2); `R.drawable.ic_widget_check`; `R.color.widget_on_primary`; `PrayerTrackerData(dateLabel, fajr, dhuhr, asr, maghrib, isha, prayedCount, totalCount)`; existing `togglePrayerStatus(context, prayerName)`.
+
+- [ ] **Step 1: Write the failing glyph-guard test**
+
+Create `app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt`:
+```kotlin
+package com.arshadshah.nimaz.widget
+
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard: widget UI must use real vector drawables, never emoji or
+ * unicode symbol glyphs. The em-dash (U+2014) is allowed as a text fallback.
+ * Runs from the module dir, so source paths are relative to `app/`.
+ */
+class WidgetGlyphGuardTest {
+
+    private val forbidden = setOf('✓', '✔', '✅', '☆', '★', '→', '←')
+
+    @Test
+    fun `widget sources contain no emoji or symbol glyphs`() {
+        val dir = File("src/main/java/com/arshadshah/nimaz/widget")
+        assert(dir.isDirectory) { "Widget source dir not found at ${dir.absolutePath}" }
+
+        val offenders = mutableListOf<String>()
+        dir.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            file.readLines().forEachIndexed { i, line ->
+                line.forEach { ch ->
+                    val code = ch.code
+                    val isSymbol = code in 0x2600..0x27BF // misc symbols + dingbats (incl. ✓)
+                    val isEmoji = code in 0x1F000..0x1FAFF || Character.isSurrogate(ch)
+                    if (ch in forbidden || isSymbol || isEmoji) {
+                        offenders += "%s:%d U+%04X '%s'".format(file.name, i + 1, code, ch)
+                    }
+                }
+            }
+        }
+        assert(offenders.isEmpty()) {
+            "Forbidden glyph(s) in widget sources:\n" + offenders.joinToString("\n")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.arshadshah.nimaz.widget.WidgetGlyphGuardTest"`
+Expected: FAIL — reports `PrayerTrackerWidget.kt:222 U+2713 '✓'` (the current checkmark glyph).
+
+- [ ] **Step 3: Update imports in PrayerTrackerWidget.kt**
+
+Add:
+```kotlin
+import com.arshadshah.nimaz.widget.core.WidgetCard
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+```
+
+- [ ] **Step 4: Replace `PrayerTrackerSuccessContent` and `PrayerCheckbox`**
+
+Replace both functions (lines 114-243) with:
+```kotlin
+@Composable
+private fun PrayerTrackerSuccessContent(
+    context: Context,
+    data: PrayerTrackerData,
+    backgroundColor: ColorProvider,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider
+) {
+    WidgetCard(
+        background = backgroundColor,
+        onClick = actionStartActivity<MainActivity>(),
+        padding = 12.dp,
+    ) {
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = data.dateLabel,
+                    style = TextStyle(color = textSecondary, fontSize = 11.sp, fontWeight = FontWeight.Medium),
+                )
+                Spacer(modifier = GlanceModifier.defaultWeight())
+                Text(
+                    text = "${data.prayedCount} / ${data.totalCount}",
+                    style = TextStyle(color = primaryColor, fontSize = 12.sp, fontWeight = FontWeight.Bold),
+                )
+            }
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            Row(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+                val prayers = listOf(
+                    "Fajr" to data.fajr,
+                    "Dhuhr" to data.dhuhr,
+                    "Asr" to data.asr,
+                    "Maghrib" to data.maghrib,
+                    "Isha" to data.isha,
+                )
+                prayers.forEach { (name, isPrayed) ->
+                    PrayerCheckbox(
+                        prayerName = name,
+                        isPrayed = isPrayed,
+                        context = context,
+                        backgroundColor = backgroundColor,
+                        primaryColor = primaryColor,
+                        textColor = textColor,
+                        textSecondary = textSecondary,
+                        modifier = GlanceModifier.defaultWeight(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrayerCheckbox(
+    prayerName: String,
+    isPrayed: Boolean,
+    context: Context,
+    backgroundColor: ColorProvider,
+    primaryColor: ColorProvider,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    modifier: GlanceModifier = GlanceModifier
+) {
+    val uncheckedColor = ColorProvider(R.color.widget_unchecked)
+    val onPrimary = ColorProvider(R.color.widget_on_primary)
+    Column(
+        modifier = modifier.clickable { togglePrayerStatus(context, prayerName.lowercase()) },
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (isPrayed) {
+            // Filled teal disc + tinted check vector.
+            Box(
+                modifier = GlanceModifier.size(28.dp).cornerRadius(14.dp).background(primaryColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                WidgetIcon(resId = R.drawable.ic_widget_check, tint = onPrimary, size = 16.dp)
+            }
+        } else {
+            // Outline ring built from two discs (Glance has no stroke modifier).
+            Box(
+                modifier = GlanceModifier.size(28.dp).cornerRadius(14.dp).background(uncheckedColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(modifier = GlanceModifier.size(24.dp).cornerRadius(12.dp).background(backgroundColor)) {}
+            }
+        }
+        Spacer(modifier = GlanceModifier.height(5.dp))
+        Text(
+            text = prayerName,
+            style = TextStyle(
+                color = if (isPrayed) textColor else textSecondary,
+                fontSize = 9.sp,
+                fontWeight = if (isPrayed) FontWeight.Bold else FontWeight.Normal,
+            ),
+            maxLines = 1,
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Run the glyph guard + compile**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.arshadshah.nimaz.widget.WidgetGlyphGuardTest"`
+Expected: PASS (the `✓` is gone; em-dash fallbacks in other widget files are allowed).
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/test/java/com/arshadshah/nimaz/widget/WidgetGlyphGuardTest.kt app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+git commit -m "feat(widget): redesign Prayer Tracker checkbox + add glyph-guard test"
+```
+
+---
+
+## Task 7: Hijri Calendar event icons
+
+**Files:**
+- Modify: `app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt` (replace `EventRow`, lines 394-431)
+
+**Interfaces:**
+- Consumes: `WidgetIcon` (Task 2); `R.drawable.ic_widget_event`, `R.drawable.ic_widget_star`; `HijriCalendarEventData(name, nameArabic, type)`.
+
+- [ ] **Step 1: Update imports**
+
+In `HijriCalendarWidget.kt`, add:
+```kotlin
+import com.arshadshah.nimaz.widget.core.WidgetIcon
+```
+
+- [ ] **Step 2: Replace `EventRow`**
+
+Replace the entire `EventRow` function (lines 394-431) with:
+```kotlin
+@Composable
+private fun EventRow(
+    event: HijriCalendarEventData,
+    textColor: ColorProvider,
+    textSecondary: ColorProvider,
+    primaryColor: ColorProvider,
+) {
+    val iconRes = if (
+        event.type.contains("fast", ignoreCase = true) ||
+        event.type.contains("recommend", ignoreCase = true)
+    ) R.drawable.ic_widget_star else R.drawable.ic_widget_event
+
+    Row(verticalAlignment = Alignment.Top) {
+        Box(modifier = GlanceModifier.padding(top = 1.dp)) {
+            WidgetIcon(resId = iconRes, tint = primaryColor, size = 12.dp)
+        }
+        Spacer(modifier = GlanceModifier.width(6.dp))
+        Column(modifier = GlanceModifier.defaultWeight()) {
+            Text(
+                text = event.name,
+                style = TextStyle(color = textColor, fontSize = 10.sp, fontWeight = FontWeight.Medium),
+                maxLines = 2,
+            )
+            Text(
+                text = event.type.replace("_", " ").lowercase()
+                    .replaceFirstChar { it.uppercase() },
+                style = TextStyle(color = textSecondary, fontSize = 9.sp),
+                maxLines = 1,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
+git commit -m "feat(widget): Hijri Calendar events use vector icons instead of dots"
+```
+
+---
+
+## Task 8: Update widget preview layouts
+
+**Files:**
+- Modify: `app/src/main/res/layout/widget_next_prayer_preview.xml`, `widget_hijri_date_preview.xml`, `widget_prayer_times_preview.xml`, `widget_prayer_tracker_preview.xml`, `widget_hijri_calendar_preview.xml`
+
+These static RemoteViews previews appear in the launcher's widget picker. Update them to echo the new look. They support `ImageView` with `android:tint` for icons.
+
+- [ ] **Step 1: Update the Next Prayer preview**
+
+Replace `app/src/main/res/layout/widget_next_prayer_preview.xml` with:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="HardcodedText,ContentDescription"
+    android:orientation="vertical"
+    android:background="@color/widget_background"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:src="@drawable/ic_widget_maghrib"
+            android:tint="@color/widget_primary" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:text="Next Prayer"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Maghrib"
+        android:textColor="@color/widget_primary"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="6:15 PM"
+        android:textColor="@color/widget_text"
+        android:textSize="30sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/widget_primary_dim"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="6dp"
+        android:text="in 2h 30m"
+        android:textColor="@color/widget_primary"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+</LinearLayout>
+```
+
+- [ ] **Step 2: Update the Hijri Date preview**
+
+Replace `app/src/main/res/layout/widget_hijri_date_preview.xml` with:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="HardcodedText,ContentDescription"
+    android:orientation="vertical"
+    android:background="@color/widget_background"
+    android:gravity="center"
+    android:padding="14dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <ImageView
+            android:layout_width="13dp"
+            android:layout_height="13dp"
+            android:src="@drawable/ic_widget_crescent"
+            android:tint="@color/widget_primary" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:text="Monday"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="15"
+        android:textColor="@color/widget_primary"
+        android:textSize="52sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Muharram 1446"
+        android:textColor="@color/widget_text"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="June 22, 2024"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="11sp" />
+</LinearLayout>
+```
+
+- [ ] **Step 3: Update the Prayer Times preview**
+
+Replace `app/src/main/res/layout/widget_prayer_times_preview.xml` with:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="HardcodedText"
+    android:orientation="vertical"
+    android:background="@color/widget_background"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Dublin"
+            android:textColor="@color/widget_text"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="15 Muharram · Maghrib in 2h 30m"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="10sp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        android:weightSum="5">
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Fajr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="5:02" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Dhuhr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="1:18" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Asr" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="4:45" android:textColor="@color/widget_text_secondary" android:textSize="15sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center"
+            android:background="@color/widget_primary" android:paddingVertical="6dp">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Maghrib" android:textColor="@color/widget_on_primary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="6:15" android:textColor="@color/widget_on_primary" android:textSize="15sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Isha" android:textColor="@color/widget_text_secondary" android:textSize="10sp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="7:58" android:textColor="@color/widget_text" android:textSize="15sp" android:textStyle="bold" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>
+```
+
+- [ ] **Step 4: Update the Prayer Tracker preview**
+
+Replace `app/src/main/res/layout/widget_prayer_tracker_preview.xml` with:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="HardcodedText,ContentDescription,UseCompoundDrawables"
+    android:orientation="vertical"
+    android:background="@color/widget_background"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Today · 15 Muharram"
+            android:textColor="@color/widget_text_secondary"
+            android:textSize="11sp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="3 / 5"
+            android:textColor="@color/widget_primary"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        android:weightSum="5">
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Fajr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Dhuhr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <ImageView android:layout_width="28dp" android:layout_height="28dp" android:src="@drawable/ic_widget_check" android:background="@color/widget_primary" android:tint="@color/widget_on_primary" android:padding="6dp" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Asr" android:textColor="@color/widget_text" android:textSize="9sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <View android:layout_width="28dp" android:layout_height="28dp" android:background="@color/widget_unchecked" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Maghrib" android:textColor="@color/widget_text_secondary" android:textSize="9sp" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+            <View android:layout_width="28dp" android:layout_height="28dp" android:background="@color/widget_unchecked" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Isha" android:textColor="@color/widget_text_secondary" android:textSize="9sp" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>
+```
+
+- [ ] **Step 5: Leave the Hijri Calendar preview as-is or lightly refresh**
+
+The `widget_hijri_calendar_preview.xml` layout structure is fine; if it references no removed resources it needs no change. Open it and confirm it still references only existing `@color/widget_*` and (optionally) the new event icons. If it shows event "dots", optionally swap one `View` dot for `<ImageView android:src="@drawable/ic_widget_event" android:tint="@color/widget_primary" .../>` to match — otherwise no edit needed.
+
+- [ ] **Step 6: Verify previews compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL (resource processing validates all five preview layouts and their `@drawable`/`@color` references).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/res/layout/widget_*_preview.xml
+git commit -m "feat(widget): refresh picker preview layouts to match redesign"
+```
+
+---
+
+## Task 9: Update documentation
+
+**Files:**
+- Modify: `docs/SUBSYSTEMS.md` (Glance widgets section, around lines 65-94)
+
+- [ ] **Step 1: Read the current widgets section**
+
+Read `docs/SUBSYSTEMS.md` lines 65-95 to confirm current wording before editing.
+
+- [ ] **Step 2: Update the shared-core sentence (line ~89)**
+
+Find the sentence beginning ``**Shared `widget/core/`.**`` and update the `WidgetUi.kt` parenthetical from:
+```
+`WidgetUi.kt` (`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`)
+```
+to:
+```
+`WidgetUi.kt` (`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`, plus the redesign atoms `WidgetCard`, `WidgetIcon`, `WidgetLabel`, `WidgetPill`, `prayerIconRes`)
+```
+
+- [ ] **Step 3: Add a UI-design note**
+
+Immediately after the "Shared `widget/core/`" paragraph, add:
+```markdown
+
+**Widget UI design ("Refined Minimal").** Solid `widget_background` surface, `16dp`
+corners, teal `widget_primary` accent. **No emoji/ASCII/unicode glyphs** — all icons
+are monochrome vector drawables in `res/drawable/ic_widget_*.xml` drawn via
+`WidgetIcon` (`Image` + `ColorFilter.tint`), so they follow light/dark + accent. Per
+prayer the Next Prayer widget picks a celestial icon via `prayerIconRes`; the Tracker
+uses a teal disc + `ic_widget_check` when prayed and a two-disc outline ring when not
+(Glance has no stroke modifier); Prayer Times is a clean 5-cell pill row with the next
+prayer filled teal and past prayers dimmed. A JVM regression test
+(`WidgetGlyphGuardTest`) fails the build if any widget source reintroduces a glyph.
+```
+
+- [ ] **Step 4: Verify docs reference reality**
+
+Confirm the names in the new prose (`WidgetCard`, `WidgetIcon`, `prayerIconRes`, `ic_widget_check`, `WidgetGlyphGuardTest`) all exist from earlier tasks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/SUBSYSTEMS.md
+git commit -m "docs: document Refined Minimal widget UI + new core atoms"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full gates**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL; `WidgetGlyphGuardTest` passes.
+
+- [ ] **Manual smoke test (device/emulator, JDK 21 + Android SDK)**
+
+Add each of the five widgets to the launcher in **light** and **dark** mode and confirm:
+1. No glyphs render anywhere; icons are crisp and tinted teal/white correctly.
+2. Next Prayer shows the correct celestial icon for the upcoming prayer.
+3. Prayer Times highlights the next prayer (teal pill) and dims past prayers.
+4. Tapping a Tracker checkbox toggles it, persists, and the widget refreshes.
+5. Tapping the Hijri Calendar opens the Islamic Calendar screen (deep link intact).
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Design language §2 → Task 2 (atoms) + all widget tasks. Iconography §3 → Task 1 (drawables) + Task 2 (`prayerIconRes`). Color §4 → Task 1 (`widget_on_primary`), reuse elsewhere. Core §5 → Task 2. Per-widget §6.1–6.5 → Tasks 3,4,5,6,7. Previews §7 → Task 8. Verification §9 → Final verification. Docs §10 → Task 9. Glyph elimination (global constraint) → Task 6 guard test. All sections covered.
+- **Placeholder scan:** No TBD/TODO; every code/XML step is complete and concrete.
+- **Type consistency:** `WidgetCard`/`WidgetIcon`/`WidgetLabel`/`WidgetPill`/`prayerIconRes` signatures defined in Task 2 are used with matching arguments in Tasks 3–7. `widget_on_primary` created in Task 1, used in Tasks 5, 6, 8. `PrayerCellState` defined and used within Task 5 only.
+```

--- a/docs/superpowers/specs/2026-06-22-widget-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-22-widget-ui-redesign-design.md
@@ -1,0 +1,172 @@
+# Widget UI Redesign — "Refined Minimal"
+
+**Date:** 2026-06-22
+**Status:** Design approved, pending spec review
+**Scope:** UI layer only for all five Glance home-screen widgets. No changes to data
+loading, workers, state definitions, or the `provideGlance` plumbing.
+
+## 1. Goal
+
+Give the five widgets one coherent, modern visual language and **eliminate every
+emoji / ASCII / unicode-glyph crutch** in favour of real vector iconography. Today
+the widgets are text-only and lean on glyphs:
+
+- Prayer Tracker: single-letter labels `F/D/A/M/I` and a unicode checkmark `✓` (U+2713).
+- Em-dash `—` (U+2014) used as empty-state fallbacks across widgets.
+
+These are replaced with proper vector drawables and full words.
+
+## 2. Design language — "Refined Minimal"
+
+The agreed direction (chosen over a tonal-card and a bold-hero alternative):
+
+- **Solid surface.** Opaque card — `widget_background` (white in light, `#1C1917` in
+  dark), `16dp` corner radius. No translucency/glass (legibility first).
+- **One accent.** Teal `widget_primary` `#14B8A6` for highlights, the next prayer, the
+  checkbox "done" state, the calendar "today", and icon tints.
+- **Real vector icons**, tinted via `ColorFilter.tint(ColorProvider)` so they follow
+  light/dark + accent automatically. No glyphs anywhere.
+- **Crisp type scale, airy spacing.** Content-first, system-native feel.
+- Every widget keeps a matching **dark variant** via the existing `values-night`
+  color resources — no per-widget dark logic needed.
+
+## 3. Iconography & assets
+
+Glance renders to RemoteViews and **cannot** consume the app's Compose
+`Icons.*` (`material-icons-extended`). All widget icons must ship as **vector
+drawable XML** in `res/drawable/`. minSdk 29 + Glance 1.2.0 render vector drawables
+in widgets correctly.
+
+New drawables (all `24dp` viewport, stroke-based line icons matching the line weight
+shown in mockups; rendered monochrome and tinted at runtime):
+
+| Drawable | Used by | Meaning |
+|---|---|---|
+| `ic_widget_fajr.xml` | Next Prayer | dawn — horizon + rising sun + up chevron |
+| `ic_widget_dhuhr.xml` | Next Prayer | zenith — full sun, all rays |
+| `ic_widget_asr.xml` | Next Prayer | low sun above horizon |
+| `ic_widget_maghrib.xml` | Next Prayer | sunset — sun on horizon + down chevron |
+| `ic_widget_isha.xml` | Next Prayer | night — crescent moon |
+| `ic_widget_check.xml` | Prayer Tracker | checkmark stroke (replaces `✓`) |
+| `ic_widget_crescent.xml` | Hijri Date | crescent accent next to weekday |
+| `ic_widget_event.xml` | Hijri Calendar | calendar/event marker |
+| `ic_widget_star.xml` | Hijri Calendar | special-day / fast marker |
+
+A single mapping helper resolves a prayer name → its celestial drawable res id
+(see §6). The existing unused `ic_dua.xml` is left untouched.
+
+> Note: the **Prayer Times** widget intentionally uses **no per-cell icons** (that was
+> the clutter we removed). The celestial icons are only needed by Next Prayer.
+
+## 4. Color tokens
+
+Reuse the current palette in `res/values/widget_colors.xml` +
+`res/values-night/widget_colors.xml`. No new colors are strictly required; the
+"empty checkbox ring" uses `widget_unchecked`, "past prayer" uses
+`widget_text_secondary`, the "next prayer pill" uses `widget_primary` with white text,
+and the soft pill/badge backgrounds use `widget_primary_dim`.
+
+If a dedicated faint divider/ring reads better than `widget_unchecked` we may add one
+token (`widget_outline`), but the default is to reuse existing tokens.
+
+## 5. Shared core (`widget/core/`)
+
+Centralize the repeated UI atoms in `WidgetUi.kt` (consistent with the existing
+`WidgetPalette`, `WidgetMessageBox`, `WidgetLoadingBox`). Add small, single-purpose,
+reusable composables so each widget file shrinks to layout + data mapping:
+
+- `WidgetCard(palette, onClick, padding, content)` — the standard solid, rounded,
+  tappable surface (replaces the hand-rolled `Box(...).background().cornerRadius()`
+  repeated in every widget).
+- `WidgetIcon(resId, tint, size)` — `Image(ImageProvider(resId), colorFilter =
+  ColorFilter.tint(tint))`, the one place icons are drawn.
+- `WidgetLabel(text, palette)` — the uppercase 10sp tracking-wide caption.
+- `WidgetPill(text, container, content)` — the rounded badge used for countdowns and
+  the "next" highlight.
+- `prayerIconRes(prayerName): Int` — name → celestial drawable mapping.
+
+Error/empty states keep using `WidgetMessageBox`; the em-dash fallbacks stay **only**
+as last-resort empty-data placeholders inside text (they are typographic, not
+decorative glyphs) — acceptable, but where a value is structurally absent we prefer a
+short word ("—" stays only for "no time available").
+
+## 6. Per-widget specs
+
+All five keep their current `provideGlance`/state handling; only the `Success`
+composable changes. Sizes unchanged (see `res/xml/*_widget_info.xml`).
+
+### 6.1 Next Prayer (2×2)
+- `WidgetCard`, vertical layout, space-between.
+- Top: `WidgetIcon(prayerIconRes(name), tint=primary, 16dp)` + `WidgetLabel("Next Prayer")`.
+- Prayer name — 20sp Bold, primary.
+- Time — 32–33sp ExtraBold, `widget_text`.
+- Countdown — `WidgetPill`, primary text on `widget_primary_dim`, bottom-left.
+
+### 6.2 Hijri Date (2×2)
+- `WidgetCard`, centered column.
+- Weekday row: `WidgetIcon(ic_widget_crescent, primary, 13dp)` + weekday (11sp, secondary).
+- Hijri day — large, ~54sp ExtraBold, primary.
+- Month + year — 14sp Bold, `widget_text`.
+- Gregorian date — 11sp, secondary.
+
+### 6.3 Prayer Times (4×1, resizable taller) — **Clean Pills**
+- `WidgetCard`, column.
+- Header row: location (12sp Bold) on the left; on the right a compact
+  "`<hijri> · <NextPrayer> in <countdown>`" (10sp, secondary).
+- Grid row: five equal-weight cells, **no icons**. Each cell = name (10sp) over time
+  (15sp Bold).
+  - Past prayers: name + time in `widget_text_secondary`/dimmed.
+  - **Next prayer cell**: solid `widget_primary` rounded pill, white name + time.
+  - Upcoming (not-yet, not-next): normal `widget_text`.
+- Drives off existing `PrayerTimesData` (`*Passed` flags + `nextPrayerName`); no data
+  change.
+
+### 6.4 Prayer Tracker (4×1) — **custom checkbox**
+- `WidgetCard`, column.
+- Header: date label (11sp, secondary) + count badge `N / 5` (12sp Bold, primary).
+- Five equal-weight cells, each a tappable column:
+  - **Prayed**: filled `widget_primary` disc (`28dp`) containing
+    `WidgetIcon(ic_widget_check, white, 16dp)`.
+  - **Not prayed**: empty `2dp` outline ring (`widget_unchecked`), no inner content.
+  - Full prayer name below (Fajr/Dhuhr/Asr/Maghrib/Isha) — 9–10sp; bold + `widget_text`
+    when prayed, secondary when not.
+- Tap behaviour (`togglePrayerStatus` + `enqueueImmediateWork`) is **unchanged**.
+
+### 6.5 Hijri Calendar (4×2) — minor refresh
+- Keep the two-panel layout (month grid left, today panel right) — it was approved.
+- Left: header (month/year + gregorian), weekday strip (Friday tinted primary), month
+  grid with **today as a filled primary circle**.
+- Right: "TODAY" label + large day number + divider, then events.
+  - **Events use real icons** instead of the tiny drawn accent dots:
+    `WidgetIcon(ic_widget_event, primary, 13dp)` (or `ic_widget_star` for
+    recommended-fast/special days) + event name (max 2 lines).
+- Existing deep-link action (`ACTION_OPEN_ISLAMIC_CALENDAR`) unchanged.
+
+## 7. Preview layouts (RemoteViews)
+
+Each widget ships a static `res/layout/widget_*_preview.xml` used by the picker. These
+must be updated to visually match the new design (they are plain `LinearLayout`/
+`TextView` RemoteViews, not Glance). Where the preview should show an icon, reference
+the new drawables. `glance_default_loading.xml` stays as-is.
+
+## 8. Out of scope (YAGNI)
+
+- No new widgets, no resize-aware (`SizeMode.Responsive`) layout variants beyond what
+  exists.
+- No data/worker/state-definition changes.
+- No theming system beyond the existing `widget_colors.xml` light/dark resources.
+- No animation (Glance can't).
+
+## 9. Verification
+
+- `./gradlew :app:compileDebugKotlin` (KSP/Hilt/Room wiring intact).
+- `./gradlew :app:testDebugUnitTest`.
+- Manual: add each widget to the launcher in light **and** dark mode; confirm no
+  glyphs render, icons tint correctly, Tracker toggle still writes + refreshes, and
+  the calendar deep-link still opens.
+
+## 10. Docs to update (part of the work)
+
+- `docs/SUBSYSTEMS.md` — widgets section: new shared `widget/core` atoms, the
+  drawable-based icon approach, per-widget visual description.
+- No route/DB/schema changes, so `NAVIGATION.md` / data guide are untouched.


### PR DESCRIPTION
## Summary

Refines the glass overlay system, applies it across the home hero, and improves reader accessibility.

### Glass system (`GlassPill.kt`)
- **`GlassPill`** — leading/trailing icons, `Frosted`/`Solid`/`Ghost` tones, `Small`/`Medium` sizes, tint-derived accents, optional `onClick`, and a lit "glass edge" (top-rim → base gradient border).
- **`GlassIconButton`** — circular, icon-only sibling sharing the same glass treatment via a shared `Modifier.glassSurface`. Replaces the home top-bar settings scrim button.
- **Backdrop blur** — dependency-free frosted glass (`GraphicsLayer` + `RenderEffect`) via `rememberGlassBackdrop()` + `Modifier.glassBackdropSource()`; real blur on Android 12+ (API 31) with a graceful translucent fallback on 29–30. Fill opacities raised for legibility everywhere.

### Wiring
- `PrayerSkyScene` and `HomeDynamicTopBar` / `HomeHero` now use the glass system (sky pills blur the clouds/celestials behind them).

### Accessibility
- Reader bottom controls bumped to **48dp** touch targets — `NavChevron` (`NimazReaderBottomBar`) and `NimazPillActionButton` (`NimazActionPill`). Benefits **Hadith, Dua and Quran** readers (shared components). Page dots/spacing nudged for balance.

### Living sky
- Nudged sun/moon/clouds down to fill bottom empty space.
- Added `Classic`/`Puffy`/`Wide` cloud silhouette variety (same design recipe).
- Raised the Maghrib/horizon sun off the bottom (`horizonY` 0.92 → 0.86).

## Test plan
- `./gradlew :app:compileDebugKotlin` passes (KSP/Hilt/Room wiring validated).
- New `@Preview`s cover all `GlassPill`/`GlassIconButton` variants and the backdrop blur over sharp content.
- Visual on-device verification of the frosted blur still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)