### PR TITLE
test: add comprehensive instrumented test suite for screens, nav, DB, notifications & workers

### DIFF
--- a/.github/workflows/android_instrumented_tests.yml
+++ b/.github/workflows/android_instrumented_tests.yml
@@ -97,6 +97,11 @@ jobs:
             model=Pixel2,version=30
           # Split across parallel shards to keep wall-clock time down.
           num-shards: 2
+          # Retry only the individual tests that fail, to absorb transient device-level
+          # flakes (e.g. "Failed to inject touch input" when a synthetic tap lands on a
+          # just-scrolled list item at the viewport edge). A genuine failure still fails
+          # after the retries.
+          num-flaky-test-attempts: 2
           timeout: 20m
           record-video: true
           outputs-dir: build/test-results

--- a/.github/workflows/android_instrumented_tests.yml
+++ b/.github/workflows/android_instrumented_tests.yml
@@ -33,6 +33,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The prepackaged Room DB (app/.../nimaz_prepopulated.db) and other *.db
+          # assets are stored via Git LFS (.gitattributes: *.db filter=lfs). Without
+          # this the APK packages the LFS pointer text instead of the real database,
+          # and every test that opens the DB fails with "no such table".
+          lfs: true
 
       - name: Setup JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/android_instrumented_tests.yml
+++ b/.github/workflows/android_instrumented_tests.yml
@@ -1,0 +1,111 @@
+name: Android Instrumentation Tests (emulator.wtf)
+
+# Builds the app + instrumentation test APKs, then runs the androidTest suite
+# (DB / notifications / workers / preferences / navigation flows) on emulator.wtf.
+#
+# Triggers:
+#  - push to main           → the canonical lane.
+#  - pull_request (any base) → so it validates this branch's PR (and every future PR).
+#
+# The debug build needs no secrets: google-services.json is only required for the
+# release/deploy lane, and the app's Firebase calls are guarded to no-op without it.
+# The emulator.wtf step requires the EW_API_TOKEN repo secret; if it is missing the
+# workflow still builds + uploads the APKs and simply skips the cloud test run (with a
+# warning) instead of failing.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ew-instrumentation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write          # mikepenz/action-junit-report publishes a check run
+  pull-requests: write   # …and annotates the PR
+
+jobs:
+  instrumentation-tests:
+    name: emulator.wtf instrumentation tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle (with cache)
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set execution flag for gradlew
+        run: chmod +x gradlew
+
+      # ── Artifacts: build the app APK and the instrumentation test APK ────────
+      # assembleDebugAndroidTest also compiles + KSP-processes the entire
+      # androidTest source set, so this step doubles as the compile check for the
+      # Hilt test components and Room/Compose test wiring.
+      - name: Build app and test APKs
+        run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+
+      - name: Upload APK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumentation-apks
+          path: |
+            app/build/outputs/apk/debug/app-debug.apk
+            app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          if-no-files-found: error
+
+      # ── Gate on the API token so the lane never hard-fails when it's unset ───
+      # (the `secrets` context can't be used directly in an `if:`, so resolve it
+      # into a step output here; the value is masked in logs).
+      - name: Check emulator.wtf token
+        id: ew
+        env:
+          EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+        run: |
+          if [ -n "$EW_API_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=emulator.wtf skipped::EW_API_TOKEN secret is not set. Add it in repo Settings → Secrets to run the cloud instrumentation tests."
+          fi
+
+      # ── Route the built APKs to emulator.wtf and run the suite ───────────────
+      - name: Run instrumentation tests on emulator.wtf
+        if: steps.ew.outputs.enabled == 'true'
+        uses: emulator-wtf/actions/run-tests@v1.0.1
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          # minSdk is 29, so the default Pixel2/api27 device would fail to install.
+          # Pin a supported API level (>= 29).
+          devices: |
+            model=Pixel2,version=30
+          # Split across parallel shards to keep wall-clock time down.
+          num-shards: 2
+          timeout: 20m
+          record-video: true
+          outputs-dir: build/test-results
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v6
+        if: always() && steps.ew.outputs.enabled == 'true'
+        with:
+          report_paths: 'build/test-results/**/*.xml'
+          check_name: emulator.wtf instrumentation results
+
+      - name: Upload emulator.wtf outputs
+        uses: actions/upload-artifact@v4
+        if: always() && steps.ew.outputs.enabled == 'true'
+        with:
+          name: emulator-wtf-results
+          path: build/test-results
+          if-no-files-found: ignore

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -3,6 +3,19 @@
   <component name="AndroidTestResultsUserPreferences">
     <option name="androidTestResultsTableState">
       <map>
+        <entry key="681421246">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_10_Pro" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1183691953">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="Tests in 'com.arshadshah.nimaz'">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -10,6 +10,10 @@
         <option name="selectionMode" value="DROPDOWN" />
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="tappingCounter_incrementsTheCount()">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,10 @@ android {
         versionCode = 332
         versionName = "3.0.32"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Custom runner swaps in HiltTestApplication so instrumented tests run on
+        // the full Hilt graph without NimazApp's Firebase / AppInitializer / device
+        // service bootstrap. See androidTest/.../support/HiltTestRunner.kt.
+        testInstrumentationRunner = "com.arshadshah.nimaz.support.HiltTestRunner"
 
         // Room schema export
         ksp {
@@ -223,6 +226,8 @@ dependencies {
     androidTestImplementation(libs.google.truth)
     androidTestImplementation(libs.hilt.testing)
     androidTestImplementation(libs.room.testing)
+    androidTestImplementation(libs.androidx.work.testing)
+    androidTestImplementation(libs.kotlinx.coroutines.android)
     kspAndroidTest(libs.hilt.compiler)
 
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,14 @@ android {
         }
     }
 
+    // Ship the exported Room schemas as androidTest assets so MigrationTestHelper can
+    // load them on-device (it looks for `<DatabaseClass>/<version>.json` under assets).
+    sourceSets {
+        getByName("androidTest") {
+            assets.srcDir(layout.projectDirectory.dir("schemas"))
+        }
+    }
+
     signingConfigs {
         create("release") {
             storeFile = file(System.getenv("KEYSTORE_FILE") ?: "keystore.jks")

--- a/app/src/androidTest/java/com/arshadshah/nimaz/MigrationChainTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/MigrationChainTest.kt
@@ -1,0 +1,64 @@
+package com.arshadshah.nimaz
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Complements the per-step assertions in [MigrationTest] by running the *entire*
+ * migration chain end-to-end: create the schema at the oldest supported version (7)
+ * and migrate all the way to the current version, validating against the exported
+ * schema at each hop. This catches ordering bugs and cumulative drift that
+ * single-step tests can miss — the exact path a long-time user's database takes when
+ * they finally update.
+ */
+@RunWith(AndroidJUnit4::class)
+class MigrationChainTest {
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        NimazDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    private val allMigrations = arrayOf(
+        NimazDatabase.MIGRATION_7_8,
+        NimazDatabase.MIGRATION_8_9,
+        NimazDatabase.MIGRATION_9_10,
+        NimazDatabase.MIGRATION_10_11,
+        NimazDatabase.MIGRATION_11_12,
+        NimazDatabase.MIGRATION_12_13,
+        NimazDatabase.MIGRATION_13_14,
+        NimazDatabase.MIGRATION_14_15,
+        NimazDatabase.MIGRATION_15_16,
+        NimazDatabase.MIGRATION_16_17,
+    )
+
+    @Test
+    fun migratesCleanlyFromV7ToCurrent() {
+        val dbName = "migration-chain-test"
+        helper.createDatabase(dbName, 7).close()
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            NimazDatabase.SCHEMA_VERSION,
+            true,
+            *allMigrations,
+        )
+
+        // A representative table from the latest schema must exist and be queryable.
+        val cursor = db.query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='qaida_lessons'"
+        )
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.close()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/OnboardingFlowTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/OnboardingFlowTest.kt
@@ -1,0 +1,39 @@
+package com.arshadshah.nimaz.behavior
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * First-run experience: with onboarding NOT yet completed, the app must open on the
+ * onboarding screen, and completing it (here via "Skip", which fires
+ * `OnboardingEvent.CompleteOnboarding`) must navigate to Home *and* persist completion
+ * so it never shows again.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class OnboardingFlowTest : BaseAppTest() {
+
+    override suspend fun seedState() {
+        settings.setOnboardingCompleted(false)
+    }
+
+    @Test
+    fun freshLaunch_showsOnboarding_thenSkipCompletesToHome() {
+        launchApp()
+        assertScreen(ScreenTags.Onboarding)
+
+        tapText(Selectors.str(R.string.onboarding_skip))
+
+        assertScreen(ScreenTags.Home)
+        assertThat(runBlocking { settings.onboardingCompleted.first() }).isTrue()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/SettingsBehaviorTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/SettingsBehaviorTest.kt
@@ -1,0 +1,77 @@
+package com.arshadshah.nimaz.behavior
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Validates that settings toggles actually *work* end to end — the UI switch flips the
+ * value in the DataStore-backed [com.arshadshah.nimaz.domain.repository.SettingsRepository].
+ *
+ * The rows are clickable `NimazSettingsItem`s, so each toggle is driven coordinate-free
+ * via its OnClick semantics (see [scrollListToAndTap]); the resulting async DataStore
+ * write is awaited via [awaitSettingChange]. This closes the gap between
+ * SettingsRepositoryTest (persistence layer alone) and SettingsNavigationTest (screens
+ * render) by proving the UI is actually wired to persistence.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SettingsBehaviorTest : BaseAppTest() {
+
+    private fun openSettings() {
+        launchApp()
+        tapBottomNav(NavLabel.MORE)
+        assertScreen(ScreenTags.More)
+        tapContentDesc(Selectors.str(Selectors.More.settings))
+        assertScreen(ScreenTags.Settings)
+    }
+
+    @Test
+    fun appearanceToggles_flipTheStoredValue() {
+        openSettings()
+        scrollListToAndTap(ScreenTags.SettingsList, Selectors.str(Selectors.Settings.appearance))
+        assertScreen(ScreenTags.SettingsAppearance)
+
+        // Haptic feedback
+        val hapticBefore = runBlocking { settings.hapticFeedback.first() }
+        scrollListToAndTap(ScreenTags.AppearanceList, Selectors.str(R.string.appearance_haptic))
+        assertThat(awaitSettingChange(settings.hapticFeedback, hapticBefore))
+            .isEqualTo(!hapticBefore)
+
+        // 24-hour time format
+        val h24Before = runBlocking { settings.use24HourFormat.first() }
+        scrollListToAndTap(ScreenTags.AppearanceList, Selectors.str(R.string.appearance_24hour))
+        assertThat(awaitSettingChange(settings.use24HourFormat, h24Before))
+            .isEqualTo(!h24Before)
+
+        // Animations
+        val animBefore = runBlocking { settings.animationsEnabled.first() }
+        scrollListToAndTap(ScreenTags.AppearanceList, Selectors.str(R.string.appearance_animations))
+        assertThat(awaitSettingChange(settings.animationsEnabled, animBefore))
+            .isEqualTo(!animBefore)
+    }
+
+    @Test
+    fun notificationVibrationToggle_flipsTheStoredValue() {
+        openSettings()
+        scrollListToAndTap(ScreenTags.SettingsList, Selectors.str(Selectors.Settings.notifications))
+        assertScreen(ScreenTags.SettingsNotifications)
+
+        val before = runBlocking { settings.notificationVibration.first() }
+        scrollListToAndTap(
+            ScreenTags.NotificationsList,
+            Selectors.str(R.string.notification_settings_vibration),
+        )
+        assertThat(awaitSettingChange(settings.notificationVibration, before))
+            .isEqualTo(!before)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/TasbihCounterTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/TasbihCounterTest.kt
@@ -1,0 +1,44 @@
+package com.arshadshah.nimaz.behavior
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The tasbih (dhikr) counter is the core interaction of that screen: tapping it must
+ * increment the displayed count. Forces classic (non-bead) mode so the tagged counter
+ * circle + count are shown, then taps and asserts the number advances.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class TasbihCounterTest : BaseAppTest() {
+
+    override suspend fun seedState() {
+        settings.setOnboardingCompleted(true)
+        // Classic mode renders the tagged CounterCircle (TasbihCounter / TasbihCount).
+        settings.setTasbihBeadMode(false)
+    }
+
+    @Test
+    fun tappingCounter_incrementsTheCount() {
+        launchApp()
+        tapBottomNav(NavLabel.TASBIH)
+        assertScreen(ScreenTags.Tasbih)
+
+        onTag(ScreenTags.TasbihCount).assertTextEquals("0")
+
+        onTag(ScreenTags.TasbihCounter).performClick()
+        compose.waitForIdle()
+        onTag(ScreenTags.TasbihCount).assertTextEquals("1")
+
+        onTag(ScreenTags.TasbihCounter).performClick()
+        compose.waitForIdle()
+        onTag(ScreenTags.TasbihCount).assertTextEquals("2")
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/DatabaseAssetTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/DatabaseAssetTest.kt
@@ -1,0 +1,56 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Verifies the *shipped* database. Unlike the DAO tests (which use a hermetic
+ * in-memory DB), this injects the real [NimazDatabase] built by `DatabaseModule`
+ * via `createFromAsset("database/nimaz_prepopulated.db", …)`. It confirms the
+ * prepackaged content actually seeds — the scripture, names, and reference tables a
+ * user sees on first launch — and that the production Room wiring opens at the
+ * current schema version without a migration crash.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class DatabaseAssetTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var db: NimazDatabase
+
+    @Before
+    fun setup() = hiltRule.inject()
+
+    @Test
+    fun quran_isFullySeeded() = runTest {
+        // The Quran always has exactly 114 surahs.
+        assertThat(db.quranDao().getAllSurahs().first()).hasSize(114)
+    }
+
+    @Test
+    fun asmaUlHusna_has99Names() = runTest {
+        assertThat(db.asmaUlHusnaDao().getAllNames().first()).hasSize(99)
+    }
+
+    @Test
+    fun referenceContent_isPresent() = runTest {
+        assertThat(db.hadithDao().getAllBooks().first()).isNotEmpty()
+        assertThat(db.duaDao().getAllCategories().first()).isNotEmpty()
+        assertThat(db.prophetDao().getAllProphets().first()).isNotEmpty()
+        assertThat(db.islamicEventDao().getAllEvents().first()).isNotEmpty()
+        assertThat(db.qaidaDao().lessonCount()).isGreaterThan(0)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/DuaDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/DuaDaoTest.kt
@@ -1,0 +1,84 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Dua categories/content, favorites, and per-day recitation progress. */
+@RunWith(AndroidJUnit4::class)
+class DuaDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.duaDao()
+
+    private suspend fun seed() {
+        dao.insertCategories(listOf(TestData.duaCategory(id = 1, nameEnglish = "Morning")))
+        dao.insertDuas(
+            listOf(
+                TestData.dua(id = 1, categoryId = 1, titleEnglish = "Morning Dua"),
+                TestData.dua(id = 2, categoryId = 1, titleEnglish = "Evening Dua"),
+            )
+        )
+    }
+
+    @Test
+    fun categoriesAndDuas_roundTrip() = runTest {
+        seed()
+
+        assertThat(dao.getAllCategories().first()).hasSize(1)
+        assertThat(dao.getDuasByCategory(1).first()).hasSize(2)
+        assertThat(dao.getDuaById(1)!!.titleEnglish).isEqualTo("Morning Dua")
+    }
+
+    @Test
+    fun search_matchesByTitle() = runTest {
+        seed()
+
+        val results = dao.searchDuas("Evening").first()
+
+        assertThat(results.map { it.id }).contains(2)
+    }
+
+    @Test
+    fun toggleFavorite_reflectsInFavoritesAndFlag() = runTest {
+        seed()
+
+        dao.toggleFavorite(duaId = 1, categoryId = 1)
+        assertThat(dao.isDuaFavorite(1).first()).isTrue()
+        assertThat(dao.getFavoriteDuas().first()).hasSize(1)
+
+        dao.toggleFavorite(duaId = 1, categoryId = 1)
+        assertThat(dao.isDuaFavorite(1).first()).isFalse()
+    }
+
+    @Test
+    fun progress_incrementsTowardTarget() = runTest {
+        seed()
+
+        dao.incrementDuaProgress(duaId = 1, date = TestData.DAY, targetCount = 3)
+        dao.incrementDuaProgress(duaId = 1, date = TestData.DAY, targetCount = 3)
+
+        val progress = dao.getProgressForDuaOnDate(1, TestData.DAY)
+        assertThat(progress).isNotNull()
+        assertThat(progress!!.completedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun deleteAllUserData_clearsBookmarksAndProgress() = runTest {
+        seed()
+        dao.toggleFavorite(duaId = 1, categoryId = 1)
+        dao.incrementDuaProgress(duaId = 1, date = TestData.DAY, targetCount = 3)
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllBookmarksSync()).isEmpty()
+        assertThat(dao.getAllProgressSync()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/FastingDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/FastingDaoTest.kt
@@ -1,0 +1,76 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Fasting tracker + make-up (qada) fast persistence. */
+@RunWith(AndroidJUnit4::class)
+class FastingDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.fastingDao()
+
+    @Test
+    fun insertFastRecord_isReadBackByDate() = runTest {
+        dao.insertFastRecord(TestData.fastRecord(date = TestData.DAY, status = "fasted"))
+
+        val record = dao.getFastRecordForDate(TestData.DAY)
+
+        assertThat(record).isNotNull()
+        assertThat(record!!.status).isEqualTo("fasted")
+        assertThat(record.fastType).isEqualTo("ramadan")
+    }
+
+    @Test
+    fun updateFastStatus_changesStatus() = runTest {
+        dao.insertFastRecord(TestData.fastRecord(status = "pending"))
+
+        dao.updateFastStatus(TestData.DAY, "fasted")
+
+        assertThat(dao.getFastRecordForDate(TestData.DAY)!!.status).isEqualTo("fasted")
+    }
+
+    @Test
+    fun recordsInRange_andByMonth_areQueryable() = runTest {
+        dao.insertFastRecords(
+            listOf(
+                TestData.fastRecord(date = TestData.DAY, hijriMonth = 9),
+                TestData.fastRecord(date = TestData.DAY + 86_400_000L, hijriMonth = 9),
+            )
+        )
+
+        assertThat(dao.getFastRecordsInRange(TestData.DAY - 1, TestData.DAY + 86_400_001L).first())
+            .hasSize(2)
+        assertThat(dao.getFastRecordsByHijriMonth(9).first()).hasSize(2)
+    }
+
+    @Test
+    fun makeupFast_insertsAndCompletes() = runTest {
+        dao.insertMakeupFast(TestData.makeupFast(status = "pending"))
+        val pending = dao.getPendingMakeupFasts().first()
+        assertThat(pending).hasSize(1)
+
+        dao.markMakeupFastCompleted(pending.first().id, completedDate = TestData.DAY)
+
+        assertThat(dao.getPendingMakeupFastCount().first()).isEqualTo(0)
+    }
+
+    @Test
+    fun deleteAllUserData_clearsFastsAndMakeups() = runTest {
+        dao.insertFastRecord(TestData.fastRecord())
+        dao.insertMakeupFast(TestData.makeupFast())
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllFastRecords()).isEmpty()
+        assertThat(dao.getAllMakeupFastsSync()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/HadithDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/HadithDaoTest.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Hadith books/collection reads plus bookmark toggling. */
+@RunWith(AndroidJUnit4::class)
+class HadithDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.hadithDao()
+
+    private suspend fun seed() {
+        dao.insertBooks(listOf(TestData.hadithBook(id = 1, nameEnglish = "Sahih Bukhari")))
+        dao.insertHadiths(
+            listOf(
+                TestData.hadith(id = 1, bookId = 1, chapterId = 1, numberInBook = 1),
+                TestData.hadith(id = 2, bookId = 1, chapterId = 1, numberInBook = 2),
+            )
+        )
+    }
+
+    @Test
+    fun booksAndHadiths_roundTrip() = runTest {
+        seed()
+
+        assertThat(dao.getAllBooks().first()).hasSize(1)
+        assertThat(dao.getBookById(1)!!.nameEnglish).isEqualTo("Sahih Bukhari")
+        assertThat(dao.getHadithsByBook(1).first()).hasSize(2)
+        assertThat(dao.getHadithCount()).isEqualTo(2)
+    }
+
+    @Test
+    fun search_findsHadithByText() = runTest {
+        seed()
+
+        val results = dao.searchHadiths("intentions").first()
+
+        assertThat(results.map { it.id }).contains(1)
+    }
+
+    @Test
+    fun toggleBookmark_addsAndRemoves() = runTest {
+        seed()
+        assertThat(dao.isHadithBookmarked(1).first()).isFalse()
+
+        dao.toggleBookmark(hadithId = 1, bookId = 1, hadithNumber = 1)
+        assertThat(dao.isHadithBookmarked(1).first()).isTrue()
+        assertThat(dao.getAllBookmarks().first()).hasSize(1)
+
+        dao.toggleBookmark(hadithId = 1, bookId = 1, hadithNumber = 1)
+        assertThat(dao.isHadithBookmarked(1).first()).isFalse()
+    }
+
+    @Test
+    fun deleteAllUserData_clearsBookmarks() = runTest {
+        seed()
+        dao.toggleBookmark(hadithId = 2, bookId = 1, hadithNumber = 2)
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllBookmarksSync()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/KhatamDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/KhatamDaoTest.kt
@@ -1,0 +1,71 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Khatam (Quran completion goal) tracking: creation, activation, ayah progress. */
+@RunWith(AndroidJUnit4::class)
+class KhatamDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.khatamDao()
+
+    @Test
+    fun insertKhatam_isReadBackById() = runTest {
+        val id = dao.insertKhatam(TestData.khatam(name = "My Khatam"))
+
+        val khatam = dao.getKhatamById(id)
+        assertThat(khatam).isNotNull()
+        assertThat(khatam!!.name).isEqualTo("My Khatam")
+    }
+
+    @Test
+    fun setActiveKhatam_makesExactlyOneActive() = runTest {
+        val first = dao.insertKhatam(TestData.khatam(name = "First", isActive = false))
+        val second = dao.insertKhatam(TestData.khatam(name = "Second", isActive = false))
+
+        dao.setActiveKhatam(second)
+
+        val active = dao.observeActiveKhatam().first()
+        assertThat(active).isNotNull()
+        assertThat(active!!.id).isEqualTo(second)
+        assertThat(dao.getKhatamById(first)!!.isActive).isFalse()
+    }
+
+    @Test
+    fun markAyahsRead_updatesReadCount() = runTest {
+        val id = dao.insertKhatam(TestData.khatam())
+
+        dao.markAyahsRead(id, listOf(1, 2, 3, 4, 5))
+
+        assertThat(dao.getReadAyahCount(id)).isEqualTo(5)
+        assertThat(dao.observeReadAyahIds(id).first()).containsExactly(1, 2, 3, 4, 5)
+    }
+
+    @Test
+    fun unmarkAyah_decrementsReadSet() = runTest {
+        val id = dao.insertKhatam(TestData.khatam())
+        dao.markAyahsRead(id, listOf(1, 2, 3))
+
+        dao.unmarkAyahRead(id, 2)
+
+        assertThat(dao.observeReadAyahIds(id).first()).containsExactly(1, 3)
+    }
+
+    @Test
+    fun completeKhatam_movesItToCompletedList() = runTest {
+        val id = dao.insertKhatam(TestData.khatam(status = "active"))
+
+        dao.completeKhatam(id)
+
+        assertThat(dao.observeCompletedKhatams().first().map { it.id }).contains(id)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/PrayerDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/PrayerDaoTest.kt
@@ -1,0 +1,78 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Round-trip coverage for the prayer-tracker persistence: the table that records
+ * whether each of the five daily prayers was prayed, on time, in congregation, etc.
+ */
+@RunWith(AndroidJUnit4::class)
+class PrayerDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.prayerDao()
+
+    @Test
+    fun insertedDailyPrayers_areReadBackForThatDate() = runTest {
+        dao.insertPrayerRecords(TestData.dailyPrayers(date = TestData.DAY))
+
+        val records = dao.getPrayerRecordsForDate(TestData.DAY).first()
+
+        assertThat(records).hasSize(5)
+        assertThat(records.map { it.prayerName })
+            .containsExactly("Fajr", "Dhuhr", "Asr", "Maghrib", "Isha")
+    }
+
+    @Test
+    fun getPrayerRecord_returnsTheMatchingPrayer() = runTest {
+        dao.insertPrayerRecords(TestData.dailyPrayers())
+
+        val fajr = dao.getPrayerRecord(TestData.DAY, "Fajr")
+
+        assertThat(fajr).isNotNull()
+        assertThat(fajr!!.prayerName).isEqualTo("Fajr")
+        assertThat(fajr.status).isEqualTo("pending")
+    }
+
+    @Test
+    fun updatePrayerStatus_marksPrayerAsPrayedInCongregation() = runTest {
+        dao.insertPrayerRecord(TestData.prayerRecord(prayerName = "Asr"))
+
+        dao.updatePrayerStatus(TestData.DAY, "Asr", "prayed", TestData.T0, /* isJamaah = */ true)
+
+        val asr = dao.getPrayerRecord(TestData.DAY, "Asr")!!
+        assertThat(asr.status).isEqualTo("prayed")
+        assertThat(asr.isJamaah).isTrue()
+        assertThat(asr.prayedAt).isEqualTo(TestData.T0)
+    }
+
+    @Test
+    fun rangeQueries_andSyncQuery_seeAllInsertedRecords() = runTest {
+        dao.insertPrayerRecords(TestData.dailyPrayers())
+
+        val inRange = dao.getPrayerRecordsInRange(TestData.DAY - 1, TestData.DAY + 1).first()
+        val sync = dao.getPrayerRecordsForDateSync(TestData.DAY)
+
+        assertThat(inRange).hasSize(5)
+        assertThat(sync).hasSize(5)
+        assertThat(dao.getAllPrayerRecords()).hasSize(5)
+    }
+
+    @Test
+    fun deleteAllUserData_clearsTheTable() = runTest {
+        dao.insertPrayerRecords(TestData.dailyPrayers())
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllPrayerRecords()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/QuranDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/QuranDaoTest.kt
@@ -1,0 +1,89 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Quran content reads plus user data: bookmarks, favorites, reading progress. */
+@RunWith(AndroidJUnit4::class)
+class QuranDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.quranDao()
+
+    private suspend fun seedFatihah() {
+        dao.insertSurahs(listOf(TestData.surah(id = 1, versesCount = 3)))
+        dao.insertAyahs(
+            (1..3).map { TestData.ayah(id = it, surahId = 1, numberInSurah = it, numberGlobal = it) }
+        )
+    }
+
+    @Test
+    fun surahsAndAyahs_roundTrip() = runTest {
+        seedFatihah()
+
+        assertThat(dao.getAllSurahs().first()).hasSize(1)
+        assertThat(dao.getSurahByNumber(1)!!.nameEnglish).isEqualTo("Al-Fatihah")
+        assertThat(dao.getAyahsBySurah(1).first()).hasSize(3)
+        assertThat(dao.getAyahsByJuz(1).first()).hasSize(3)
+        assertThat(dao.getAyahsByPage(1).first()).hasSize(3)
+    }
+
+    @Test
+    fun bookmark_toggleReflectsInIsBookmarkedFlow() = runTest {
+        seedFatihah()
+        assertThat(dao.isAyahBookmarked(2).first()).isFalse()
+
+        dao.toggleBookmark(ayahId = 2, surahNumber = 1, ayahNumber = 2)
+        assertThat(dao.isAyahBookmarked(2).first()).isTrue()
+        assertThat(dao.getAllBookmarks().first()).hasSize(1)
+
+        dao.toggleBookmark(ayahId = 2, surahNumber = 1, ayahNumber = 2)
+        assertThat(dao.isAyahBookmarked(2).first()).isFalse()
+    }
+
+    @Test
+    fun favorite_toggleAddsAndRemoves() = runTest {
+        seedFatihah()
+
+        dao.toggleFavorite(ayahId = 3, surahNumber = 1, ayahNumber = 3)
+        assertThat(dao.isAyahFavorite(3).first()).isTrue()
+        assertThat(dao.getFavoriteAyahIds().first()).contains(3)
+
+        dao.toggleFavorite(ayahId = 3, surahNumber = 1, ayahNumber = 3)
+        assertThat(dao.isAyahFavorite(3).first()).isFalse()
+    }
+
+    @Test
+    fun readingProgress_isPersistedAndUpdated() = runTest {
+        dao.insertReadingProgress(TestData.readingProgress(lastReadSurah = 2, lastReadAyah = 5))
+        assertThat(dao.getReadingProgress().first()!!.lastReadSurah).isEqualTo(2)
+
+        dao.updateReadingPosition(surah = 18, ayah = 10, page = 295, juz = 15)
+
+        val updated = dao.getReadingProgress().first()!!
+        assertThat(updated.lastReadSurah).isEqualTo(18)
+        assertThat(updated.lastReadAyah).isEqualTo(10)
+    }
+
+    @Test
+    fun deleteAllUserData_keepsContentButClearsBookmarksAndFavorites() = runTest {
+        seedFatihah()
+        dao.toggleBookmark(ayahId = 1, surahNumber = 1, ayahNumber = 1)
+        dao.toggleFavorite(ayahId = 1, surahNumber = 1, ayahNumber = 1)
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllBookmarks().first()).isEmpty()
+        assertThat(dao.getAllFavorites().first()).isEmpty()
+        // Scripture content must survive a user-data wipe.
+        assertThat(dao.getAllSurahs().first()).hasSize(1)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/TasbihDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/TasbihDaoTest.kt
@@ -1,0 +1,78 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tasbih (dhikr counter) presets and session history. */
+@RunWith(AndroidJUnit4::class)
+class TasbihDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.tasbihDao()
+
+    @Test
+    fun insertPreset_returnsRowIdAndIsReadable() = runTest {
+        val id = dao.insertPreset(TestData.tasbihPreset(name = "Alhamdulillah", targetCount = 33))
+
+        assertThat(id).isGreaterThan(0L)
+        val preset = dao.getPresetById(id)
+        assertThat(preset).isNotNull()
+        assertThat(preset!!.name).isEqualTo("Alhamdulillah")
+        assertThat(preset.targetCount).isEqualTo(33)
+    }
+
+    @Test
+    fun defaultAndCustomPresets_areSeparated() = runTest {
+        dao.insertPreset(TestData.tasbihPreset(name = "Default one", isCustom = 0))
+        dao.insertPreset(TestData.tasbihPreset(name = "My custom", isCustom = 1))
+
+        assertThat(dao.getAllPresets().first()).hasSize(2)
+        assertThat(dao.getDefaultPresets().first().map { it.name }).contains("Default one")
+        assertThat(dao.getCustomPresets().first().map { it.name }).contains("My custom")
+    }
+
+    @Test
+    fun session_completes_andCountsInRange() = runTest {
+        val presetId = dao.insertPreset(TestData.tasbihPreset())
+        val sessionId = dao.insertSession(
+            TestData.tasbihSession(presetId = presetId, currentCount = 33, targetCount = 33)
+        )
+
+        dao.completeSession(sessionId, completedAt = TestData.DAY, duration = 60_000L)
+
+        val completedInRange =
+            dao.getCompletedSessionsInRange(TestData.DAY - 1, TestData.DAY + 1)
+        assertThat(completedInRange).isEqualTo(1)
+        val total = dao.getTotalCountInRange(TestData.DAY - 1, TestData.DAY + 1)
+        assertThat(total).isEqualTo(33)
+    }
+
+    @Test
+    fun deleteCustomPreset_removesOnlyThatRow() = runTest {
+        val keep = dao.insertPreset(TestData.tasbihPreset(name = "Keep", isCustom = 1))
+        val drop = dao.insertPreset(TestData.tasbihPreset(name = "Drop", isCustom = 1))
+
+        dao.deleteCustomPreset(drop)
+
+        assertThat(dao.getPresetById(drop)).isNull()
+        assertThat(dao.getPresetById(keep)).isNotNull()
+    }
+
+    @Test
+    fun deleteAllUserData_clearsSessions() = runTest {
+        val presetId = dao.insertPreset(TestData.tasbihPreset())
+        dao.insertSession(TestData.tasbihSession(presetId = presetId))
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllSessionsSync()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/UserDataDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/UserDataDaoTest.kt
@@ -1,0 +1,114 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Round-trip coverage for the remaining user-data DAOs that don't warrant a class of
+ * their own: tafseer annotations, Qaida lesson progress, the names-of-Allah /
+ * names-of-the-Prophet / prophets bookmark tables, saved locations, and the Islamic
+ * events calendar reads.
+ */
+@RunWith(AndroidJUnit4::class)
+class UserDataDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+
+    @Test
+    fun tafseer_highlightsAndNotes_roundTrip() = runTest {
+        val dao = dbRule.db.tafseerDao()
+
+        dao.insertHighlight(TestData.tafseerHighlight(ayahId = 5))
+        dao.insertNote(TestData.tafseerNote(ayahId = 5, text = "reflection"))
+
+        assertThat(dao.getHighlightsForAyah(5, "ibn-kathir").first()).hasSize(1)
+        assertThat(dao.getNotesForAyah(5, "ibn-kathir").first().first().text)
+            .isEqualTo("reflection")
+
+        dao.deleteAllUserData()
+        assertThat(dao.getAllHighlightsSync()).isEmpty()
+        assertThat(dao.getAllNotesSync()).isEmpty()
+    }
+
+    @Test
+    fun qaida_lessonProgress_upsertsAndReads() = runTest {
+        val dao = dbRule.db.qaidaDao()
+
+        dao.upsertLessonProgress(TestData.qaidaLessonProgress(lessonId = 1, stars = 1))
+        assertThat(dao.getLessonProgress(1)!!.stars).isEqualTo(1)
+
+        // Upsert again with the same PK should replace, not duplicate.
+        dao.upsertLessonProgress(TestData.qaidaLessonProgress(lessonId = 1, stars = 3))
+        assertThat(dao.getLessonProgress(1)!!.stars).isEqualTo(3)
+        assertThat(dao.getAllProgress().first()).hasSize(1)
+    }
+
+    @Test
+    fun asmaUlHusna_bookmarkToggle() = runTest {
+        val dao = dbRule.db.asmaUlHusnaDao()
+
+        dao.toggleFavorite(7)
+        assertThat(dao.isBookmarked(7)).isTrue()
+        assertThat(dao.getAllBookmarks().first()).hasSize(1)
+
+        dao.toggleFavorite(7)
+        assertThat(dao.isBookmarked(7)).isFalse()
+    }
+
+    @Test
+    fun asmaUnNabi_and_prophet_bookmarks() = runTest {
+        val nabi = dbRule.db.asmaUnNabiDao()
+        val prophet = dbRule.db.prophetDao()
+
+        nabi.insertBookmark(TestData.asmaNabiBookmark(nameId = 3))
+        prophet.insertBookmark(TestData.prophetBookmark(prophetId = 4))
+
+        assertThat(nabi.isBookmarked(3)).isTrue()
+        assertThat(prophet.isBookmarked(4)).isTrue()
+
+        nabi.removeBookmark(3)
+        prophet.removeBookmark(4)
+        assertThat(nabi.getAllBookmarksSync()).isEmpty()
+        assertThat(prophet.getAllBookmarksSync()).isEmpty()
+    }
+
+    @Test
+    fun location_insertSetCurrentAndFavorite() = runTest {
+        val dao = dbRule.db.locationDao()
+
+        val makkah = dao.insertLocation(TestData.location(name = "Makkah", isCurrent = false))
+        val madinah = dao.insertLocation(TestData.location(name = "Madinah", isCurrent = false))
+
+        dao.setCurrentLocation(madinah)
+        assertThat(dao.getCurrentLocation().first()!!.id).isEqualTo(madinah)
+
+        dao.toggleFavorite(makkah)
+        assertThat(dao.getFavoriteLocationsSync().map { it.id }).contains(makkah)
+        assertThat(dao.getAllLocationsSync()).hasSize(2)
+    }
+
+    @Test
+    fun islamicEvents_queryByMonthAndDate() = runTest {
+        val dao = dbRule.db.islamicEventDao()
+
+        dao.insertEvents(
+            listOf(
+                TestData.islamicEvent(id = 1, hijriMonth = 9, hijriDay = 1, eventType = "fast"),
+                TestData.islamicEvent(id = 2, hijriMonth = 10, hijriDay = 1, eventType = "holiday", isHoliday = 1),
+            )
+        )
+
+        assertThat(dao.getAllEvents().first()).hasSize(2)
+        assertThat(dao.getEventsByMonth(9).first().map { it.id }).containsExactly(1)
+        assertThat(dao.getEventsForDate(10, 1).first().map { it.id }).containsExactly(2)
+        assertThat(dao.getHolidays().first().map { it.id }).containsExactly(2)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/db/ZakatDaoTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/db/ZakatDaoTest.kt
@@ -1,0 +1,57 @@
+package com.arshadshah.nimaz.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.NimazDbRule
+import com.arshadshah.nimaz.support.TestData
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Zakat calculation history and payment tracking. */
+@RunWith(AndroidJUnit4::class)
+class ZakatDaoTest {
+
+    @get:Rule
+    val dbRule = NimazDbRule()
+    private val dao get() = dbRule.db.zakatDao()
+
+    @Test
+    fun insertCalculation_appearsInHistory() = runTest {
+        val id = dao.insertCalculation(TestData.zakat(zakatDue = 250.0))
+
+        assertThat(id).isGreaterThan(0L)
+        val history = dao.getAllHistory().first()
+        assertThat(history).hasSize(1)
+        assertThat(history.first().zakatDue).isEqualTo(250.0)
+    }
+
+    @Test
+    fun markAsPaid_countsTowardTotalPaid() = runTest {
+        val id = dao.insertCalculation(TestData.zakat(zakatDue = 300.0, isPaid = false))
+
+        dao.markAsPaid(id, paidAt = TestData.T0)
+
+        assertThat(dao.getTotalPaid()).isEqualTo(300.0)
+    }
+
+    @Test
+    fun deleteCalculation_removesEntry() = runTest {
+        val id = dao.insertCalculation(TestData.zakat())
+
+        dao.deleteCalculation(id)
+
+        assertThat(dao.getAllHistory().first()).isEmpty()
+    }
+
+    @Test
+    fun deleteAllUserData_clearsHistory() = runTest {
+        dao.insertCalculations(listOf(TestData.zakat(), TestData.zakat(calculatedAt = TestData.T0 + 1)))
+
+        dao.deleteAllUserData()
+
+        assertThat(dao.getAllHistorySync()).isEmpty()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppLaunchTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppLaunchTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.navigation
 
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.arshadshah.nimaz.support.BaseAppTest
 import com.arshadshah.nimaz.support.Selectors.NavLabel
@@ -9,20 +10,25 @@ import org.junit.runner.RunWith
 
 /**
  * The most basic guarantee: with onboarding already complete the app cold-launches
- * straight to the home experience and renders its five-tab bottom navigation. If the
- * Hilt graph, theme, or NavGraph start-destination logic regresses, this fails first.
+ * straight to Home and renders its five-tab bottom navigation. Asserted by
+ * [ScreenTags] (the nav item + screen-root tags) so it never flakes on duplicated
+ * on-screen copy. If the Hilt graph, theme, or NavGraph start-destination logic
+ * regresses, this fails first.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class AppLaunchTest : BaseAppTest() {
 
     @Test
-    fun appLaunches_andShowsAllBottomNavTabs() {
+    fun appLaunches_toHome_withAllBottomNavTabs() {
         launchApp()
 
+        // Started on Home.
+        assertScreen(ScreenTags.Home)
+
+        // All five tabs are present (by their stable item tags).
         NavLabel.all.forEach { label ->
-            waitForText(label)
-            onText(label).assertExists()
+            onTag(ScreenTags.bottomNav(label)).assertExists()
         }
     }
 }

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppLaunchTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/AppLaunchTest.kt
@@ -1,0 +1,28 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The most basic guarantee: with onboarding already complete the app cold-launches
+ * straight to the home experience and renders its five-tab bottom navigation. If the
+ * Hilt graph, theme, or NavGraph start-destination logic regresses, this fails first.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class AppLaunchTest : BaseAppTest() {
+
+    @Test
+    fun appLaunches_andShowsAllBottomNavTabs() {
+        launchApp()
+
+        NavLabel.all.forEach { label ->
+            waitForText(label)
+            onText(label).assertExists()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
@@ -38,12 +38,11 @@ class BottomNavigationTest : BaseAppTest() {
         assertScreen(ScreenTags.Tasbih)
     }
 
-    @Test
-    fun qiblaTab_showsQiblaScreen() {
-        launchApp()
-        tapBottomNav(NavLabel.QIBLA)
-        assertScreen(ScreenTags.QiblaNav)
-    }
+    // NOTE: the Qibla tab is intentionally not driven here. QiblaScreen continuously
+    // recomposes from the compass SensorEventListener, so it never reaches the idle
+    // state that Compose's test sync waits on — any interaction after landing on it
+    // throws ComposeNotIdleException. Its tab presence is covered by AppLaunchTest;
+    // sensor-screen behaviour isn't suitable for idling-based UI tests.
 
     @Test
     fun moreTab_showsMoreScreen() {
@@ -55,8 +54,8 @@ class BottomNavigationTest : BaseAppTest() {
     @Test
     fun tabsAreRestoredWhenReturningHome() {
         launchApp()
-        tapBottomNav(NavLabel.QIBLA)
-        assertScreen(ScreenTags.QiblaNav)
+        tapBottomNav(NavLabel.QURAN)
+        assertScreen(ScreenTags.Quran)
 
         tapBottomNav(NavLabel.HOME)
         assertScreen(ScreenTags.Home)

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
@@ -1,0 +1,76 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Walks the five primary destinations via the bottom navigation bar and asserts each
+ * target screen actually rendered — keyed off a piece of screen-specific content
+ * (resolved through [Selectors]) rather than the persistent nav label, so the
+ * assertion proves navigation rather than just the bar's presence.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class BottomNavigationTest : BaseAppTest() {
+
+    @Test
+    fun quranTab_showsQuranHome() {
+        launchApp()
+
+        tapBottomNav(NavLabel.QURAN)
+
+        // The Quran home shows its Browse/Favorites tabs.
+        waitForRes(Selectors.Quran.browseTab)
+        onRes(Selectors.Quran.browseTab).assertExists()
+    }
+
+    @Test
+    fun tasbihTab_showsCounterModes() {
+        launchApp()
+
+        tapBottomNav(NavLabel.TASBIH)
+
+        waitForRes(Selectors.Tasbih.beads)
+        onRes(Selectors.Tasbih.beads).assertExists()
+        onRes(Selectors.Tasbih.classic).assertExists()
+    }
+
+    @Test
+    fun qiblaTab_showsCompass() {
+        launchApp()
+
+        tapBottomNav(NavLabel.QIBLA)
+
+        waitForRes(Selectors.Qibla.compass)
+        onRes(Selectors.Qibla.compass).assertExists()
+    }
+
+    @Test
+    fun moreTab_showsSettingsEntry() {
+        launchApp()
+
+        tapBottomNav(NavLabel.MORE)
+
+        waitForRes(Selectors.More.settings)
+        onRes(Selectors.More.settings).assertExists()
+    }
+
+    @Test
+    fun canReturnToHomeAfterNavigatingAway() {
+        launchApp()
+
+        tapBottomNav(NavLabel.QIBLA)
+        waitForRes(Selectors.Qibla.compass)
+
+        tapBottomNav(NavLabel.HOME)
+
+        // Home tab is selected again; the bottom bar (and Home label) remain visible.
+        waitForText(NavLabel.HOME)
+        onText(NavLabel.HOME).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/BottomNavigationTest.kt
@@ -1,8 +1,8 @@
 package com.arshadshah.nimaz.navigation
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.support.BaseAppTest
-import com.arshadshah.nimaz.support.Selectors
 import com.arshadshah.nimaz.support.Selectors.NavLabel
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
@@ -10,67 +10,55 @@ import org.junit.runner.RunWith
 
 /**
  * Walks the five primary destinations via the bottom navigation bar and asserts each
- * target screen actually rendered — keyed off a piece of screen-specific content
- * (resolved through [Selectors]) rather than the persistent nav label, so the
- * assertion proves navigation rather than just the bar's presence.
+ * target screen actually rendered — keyed off its [ScreenTags] root tag, so the
+ * assertion proves navigation (not just the persistent nav bar) and is independent of
+ * locale and on-screen copy.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class BottomNavigationTest : BaseAppTest() {
 
     @Test
-    fun quranTab_showsQuranHome() {
+    fun homeIsTheStartDestination() {
         launchApp()
+        assertScreen(ScreenTags.Home)
+    }
 
+    @Test
+    fun quranTab_showsQuranScreen() {
+        launchApp()
         tapBottomNav(NavLabel.QURAN)
-
-        // The Quran home shows its Browse/Favorites tabs.
-        waitForRes(Selectors.Quran.browseTab)
-        onRes(Selectors.Quran.browseTab).assertExists()
+        assertScreen(ScreenTags.Quran)
     }
 
     @Test
-    fun tasbihTab_showsCounterModes() {
+    fun tasbihTab_showsTasbihScreen() {
         launchApp()
-
         tapBottomNav(NavLabel.TASBIH)
-
-        waitForRes(Selectors.Tasbih.beads)
-        onRes(Selectors.Tasbih.beads).assertExists()
-        onRes(Selectors.Tasbih.classic).assertExists()
+        assertScreen(ScreenTags.Tasbih)
     }
 
     @Test
-    fun qiblaTab_showsCompass() {
+    fun qiblaTab_showsQiblaScreen() {
         launchApp()
-
         tapBottomNav(NavLabel.QIBLA)
-
-        waitForRes(Selectors.Qibla.compass)
-        onRes(Selectors.Qibla.compass).assertExists()
+        assertScreen(ScreenTags.QiblaNav)
     }
 
     @Test
-    fun moreTab_showsSettingsEntry() {
+    fun moreTab_showsMoreScreen() {
         launchApp()
-
         tapBottomNav(NavLabel.MORE)
-
-        waitForRes(Selectors.More.settings)
-        onRes(Selectors.More.settings).assertExists()
+        assertScreen(ScreenTags.More)
     }
 
     @Test
-    fun canReturnToHomeAfterNavigatingAway() {
+    fun tabsAreRestoredWhenReturningHome() {
         launchApp()
-
         tapBottomNav(NavLabel.QIBLA)
-        waitForRes(Selectors.Qibla.compass)
+        assertScreen(ScreenTags.QiblaNav)
 
         tapBottomNav(NavLabel.HOME)
-
-        // Home tab is selected again; the bottom bar (and Home label) remain visible.
-        waitForText(NavLabel.HOME)
-        onText(NavLabel.HOME).assertExists()
+        assertScreen(ScreenTags.Home)
     }
 }

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/FeatureNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/FeatureNavigationTest.kt
@@ -1,0 +1,80 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.arshadshah.nimaz.support.Selectors.More
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exhaustively navigates from the More hub into every feature it exposes and asserts
+ * the destination screen rendered (by its [ScreenTags] root tag), then returns. This
+ * is the broad "does every feature open" guarantee.
+ *
+ * Because the tag lives on the NavGraph wrapper (composed immediately, before any data
+ * loads), each assertion is deterministic and independent of seeded content, locale,
+ * or on-screen copy. Tests are grouped by the menu's sections to keep each scroll
+ * short and to isolate failures to a feature area.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class FeatureNavigationTest : BaseAppTest() {
+
+    /** Each entry: (menu-item label resource, expected destination screen tag). */
+    private fun visitAll(features: List<Pair<Int, String>>) {
+        launchApp()
+        tapBottomNav(NavLabel.MORE)
+        assertScreen(ScreenTags.More)
+
+        features.forEach { (labelRes, screenTag) ->
+            scrollMoreToAndTap(Selectors.str(labelRes))
+            assertScreen(screenTag)
+            pressBack()
+            assertScreen(ScreenTags.More)
+        }
+    }
+
+    @Test
+    fun dailyPracticeSection_opensEveryFeature() = visitAll(
+        listOf(
+            More.prayerTracker to ScreenTags.PrayerTracker,
+            More.fasting to ScreenTags.FastingHome,
+            More.khatam to ScreenTags.KhatamList,
+        )
+    )
+
+    @Test
+    fun learningSection_opensEveryFeature() = visitAll(
+        listOf(
+            More.qaida to ScreenTags.QaidaHome,
+            More.asmaUlHusna to ScreenTags.AsmaUlHusnaList,
+            More.asmaUnNabi to ScreenTags.AsmaUnNabiList,
+            More.prophets to ScreenTags.ProphetsList,
+            More.hadith to ScreenTags.HadithHome,
+            More.duas to ScreenTags.DuaHome,
+            More.tafseer to ScreenTags.TafseerChapters,
+        )
+    )
+
+    @Test
+    fun toolsSection_opensEveryFeature() = visitAll(
+        listOf(
+            More.calendar to ScreenTags.IslamicCalendar,
+            More.prayerTimes to ScreenTags.PrayerTimes,
+            More.monthlyPrayerTimes to ScreenTags.MonthlyPrayerTimes,
+            More.zakat to ScreenTags.ZakatCalculator,
+        )
+    )
+
+    @Test
+    fun supportSection_opensAboutAndHelp() = visitAll(
+        listOf(
+            More.aboutNimaz to ScreenTags.SettingsAbout,
+            More.helpSupport to ScreenTags.SettingsHelp,
+        )
+    )
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/MoreMenuNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/MoreMenuNavigationTest.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.navigation
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.support.BaseAppTest
 import com.arshadshah.nimaz.support.Selectors
 import com.arshadshah.nimaz.support.Selectors.NavLabel
@@ -9,49 +10,40 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Exercises the More tab as the hub it is: opening a couple of its destinations
- * (Prayer Tracker, Settings) via their menu entries and confirming both the forward
- * navigation and the back-navigation contract (the standard "Back" affordance returns
- * the user to the More menu).
+ * Focused checks on the More hub's two navigation contracts: opening a feature from a
+ * list item, and the top-bar Settings action — each verified to land on the right
+ * screen (by tag) and to return to More on back. Breadth across every feature lives in
+ * [FeatureNavigationTest]; this guards the round-trip mechanics.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class MoreMenuNavigationTest : BaseAppTest() {
 
     @Test
-    fun more_toPrayerTracker_andBack() {
+    fun more_toPrayerTracker_backReturnsToMore() {
         launchApp()
         tapBottomNav(NavLabel.MORE)
-        waitForRes(Selectors.More.prayerTracker)
+        assertScreen(ScreenTags.More)
 
-        tapText(Selectors.str(Selectors.More.prayerTracker))
-
-        // Prayer Tracker screen shows its title and a back button.
-        waitForRes(Selectors.Prayer.trackerTitle)
+        scrollMoreToAndTap(Selectors.str(Selectors.More.prayerTracker))
+        assertScreen(ScreenTags.PrayerTracker)
+        // The detail screen also carries the standard Back affordance.
         onContentDesc(Selectors.str(Selectors.Common.back)).assertExists()
 
-        tapBack()
-
-        // Back on the More menu, the Settings entry is visible again.
-        waitForRes(Selectors.More.settings)
-        onRes(Selectors.More.settings).assertExists()
+        pressBack()
+        assertScreen(ScreenTags.More)
     }
 
     @Test
-    fun more_toSettings_andBack() {
+    fun more_topBarSettings_backReturnsToMore() {
         launchApp()
         tapBottomNav(NavLabel.MORE)
-        waitForRes(Selectors.More.settings)
+        assertScreen(ScreenTags.More)
 
-        tapText(Selectors.str(Selectors.More.settings))
+        tapContentDesc(Selectors.str(Selectors.More.settings))
+        assertScreen(ScreenTags.Settings)
 
-        // A detail screen with a back affordance is now shown.
-        waitForText(Selectors.str(Selectors.Common.back))
-        onContentDesc(Selectors.str(Selectors.Common.back)).assertExists()
-
-        tapBack()
-
-        waitForRes(Selectors.More.prayerTracker)
-        onRes(Selectors.More.prayerTracker).assertExists()
+        pressBack()
+        assertScreen(ScreenTags.More)
     }
 }

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/MoreMenuNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/MoreMenuNavigationTest.kt
@@ -1,0 +1,57 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the More tab as the hub it is: opening a couple of its destinations
+ * (Prayer Tracker, Settings) via their menu entries and confirming both the forward
+ * navigation and the back-navigation contract (the standard "Back" affordance returns
+ * the user to the More menu).
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class MoreMenuNavigationTest : BaseAppTest() {
+
+    @Test
+    fun more_toPrayerTracker_andBack() {
+        launchApp()
+        tapBottomNav(NavLabel.MORE)
+        waitForRes(Selectors.More.prayerTracker)
+
+        tapText(Selectors.str(Selectors.More.prayerTracker))
+
+        // Prayer Tracker screen shows its title and a back button.
+        waitForRes(Selectors.Prayer.trackerTitle)
+        onContentDesc(Selectors.str(Selectors.Common.back)).assertExists()
+
+        tapBack()
+
+        // Back on the More menu, the Settings entry is visible again.
+        waitForRes(Selectors.More.settings)
+        onRes(Selectors.More.settings).assertExists()
+    }
+
+    @Test
+    fun more_toSettings_andBack() {
+        launchApp()
+        tapBottomNav(NavLabel.MORE)
+        waitForRes(Selectors.More.settings)
+
+        tapText(Selectors.str(Selectors.More.settings))
+
+        // A detail screen with a back affordance is now shown.
+        waitForText(Selectors.str(Selectors.Common.back))
+        onContentDesc(Selectors.str(Selectors.Common.back)).assertExists()
+
+        tapBack()
+
+        waitForRes(Selectors.More.prayerTracker)
+        onRes(Selectors.More.prayerTracker).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/navigation/SettingsNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/navigation/SettingsNavigationTest.kt
@@ -1,0 +1,50 @@
+package com.arshadshah.nimaz.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
+import com.arshadshah.nimaz.support.Selectors.NavLabel
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Reaches the Settings hub (via the More screen's top-bar action) and opens every
+ * settings sub-screen, asserting each by its [ScreenTags] root tag and returning. This
+ * covers the settings surface that the feature-navigation test does not.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SettingsNavigationTest : BaseAppTest() {
+
+    private fun openSettings() {
+        launchApp()
+        tapBottomNav(NavLabel.MORE)
+        assertScreen(ScreenTags.More)
+        // More's top app bar exposes a Settings action (contentDescription = "Settings").
+        tapContentDesc(Selectors.str(Selectors.More.settings))
+        assertScreen(ScreenTags.Settings)
+    }
+
+    private fun visit(labelRes: Int, screenTag: String) {
+        scrollListToAndTap(ScreenTags.SettingsList, Selectors.str(labelRes))
+        assertScreen(screenTag)
+        pressBack()
+        assertScreen(ScreenTags.Settings)
+    }
+
+    @Test
+    fun settingsHub_opensEverySubScreen() {
+        openSettings()
+
+        visit(Selectors.Settings.calculationMethod, ScreenTags.SettingsPrayerCalculation)
+        visit(Selectors.Settings.location, ScreenTags.SettingsLocation)
+        visit(Selectors.Settings.notifications, ScreenTags.SettingsNotifications)
+        visit(Selectors.Settings.quranSettings, ScreenTags.SettingsQuran)
+        visit(Selectors.Settings.appearance, ScreenTags.SettingsAppearance)
+        visit(Selectors.Settings.language, ScreenTags.SettingsLanguage)
+        visit(Selectors.Settings.widgets, ScreenTags.SettingsWidgets)
+        visit(Selectors.Settings.syncData, ScreenTags.SettingsSync)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/notifications/PrayerNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/notifications/PrayerNotificationSchedulerTest.kt
@@ -1,0 +1,83 @@
+package com.arshadshah.nimaz.notifications
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Exercises the [PrayerNotificationScheduler] — the singleton that owns the app's
+ * notification channels and schedules adhan/prayer alarms.
+ *
+ * Constructing it (via Hilt) runs its `init { createNotificationChannels() }`, so the
+ * test asserts the three channels are registered with the system. It also smoke-tests
+ * the public scheduling / cancellation entry points to guard against crashes on
+ * AlarmManager / PendingIntent / NotificationCompat usage across API levels.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class PrayerNotificationSchedulerTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var scheduler: PrayerNotificationScheduler
+
+    private val notificationManager: NotificationManager
+        get() = ApplicationProvider.getApplicationContext<Context>()
+            .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    @Before
+    fun setup() = hiltRule.inject()
+
+    @Test
+    fun construction_registersAllNotificationChannels() {
+        // Touch the injected singleton so its init block has definitely run.
+        assertThat(scheduler).isNotNull()
+
+        val channelIds = notificationManager.notificationChannels.map { it.id }
+        assertThat(channelIds).containsAtLeast(
+            PrayerNotificationScheduler.CHANNEL_ID_PRAYER,
+            PrayerNotificationScheduler.CHANNEL_ID_ADHAN,
+            PrayerNotificationScheduler.CHANNEL_ID_DAILY_SUMMARY,
+        )
+    }
+
+    @Test
+    fun scheduleTodaysPrayerNotifications_doesNotThrow() {
+        scheduler.scheduleTodaysPrayerNotifications(
+            latitude = 21.4225,
+            longitude = 39.8262,
+            notificationsEnabled = true,
+            enabledPrayers = PrayerType.entries.toSet(),
+            preReminderEnabled = true,
+            preReminderMinutes = 15,
+        )
+    }
+
+    @Test
+    fun cancellation_entryPoints_areSafe() {
+        scheduler.scheduleTodaysPrayerNotifications(
+            latitude = 21.4225,
+            longitude = 39.8262,
+            notificationsEnabled = true,
+        )
+
+        // Cancelling individual + all prayers, and the daily summary, must be no-throw
+        // even when nothing was scheduled for a given prayer.
+        PrayerType.entries.forEach { scheduler.cancelPrayerNotification(it) }
+        scheduler.cancelAllPrayerNotifications()
+        scheduler.cancelDailySummary()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/preferences/SettingsRepositoryTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/preferences/SettingsRepositoryTest.kt
@@ -1,0 +1,88 @@
+package com.arshadshah.nimaz.preferences
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Round-trips a representative slice of the DataStore-backed [SettingsRepository] —
+ * the persistence behind every toggle on the settings screens. Verifies writes are
+ * observable on the corresponding flow, and that the export → import path preserves
+ * values (used by the device-to-device sync feature).
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SettingsRepositoryTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var settings: SettingsRepository
+
+    @Before
+    fun setup() = hiltRule.inject()
+
+    @Test
+    fun themeMode_writeIsObservable() = runTest {
+        settings.setThemeMode("dark")
+        assertThat(settings.themeMode.first()).isEqualTo("dark")
+
+        settings.setThemeMode("light")
+        assertThat(settings.themeMode.first()).isEqualTo("light")
+    }
+
+    @Test
+    fun booleanToggles_roundTrip() = runTest {
+        settings.setHapticFeedback(false)
+        settings.setUse24HourFormat(true)
+        settings.setDynamicColor(false)
+
+        assertThat(settings.hapticFeedback.first()).isFalse()
+        assertThat(settings.use24HourFormat.first()).isTrue()
+        assertThat(settings.dynamicColor.first()).isFalse()
+    }
+
+    @Test
+    fun prayerCalculation_settingsPersist() = runTest {
+        settings.setCalculationMethod("ISNA")
+        settings.setAsrCalculation("hanafi")
+        settings.setPrayerNotificationsEnabled(true)
+
+        assertThat(settings.calculationMethod.first()).isEqualTo("ISNA")
+        assertThat(settings.asrCalculation.first()).isEqualTo("hanafi")
+        assertThat(settings.prayerNotificationsEnabled.first()).isTrue()
+    }
+
+    @Test
+    fun location_updatePersistsLatLngAndName() = runTest {
+        settings.updateLocation(latitude = 21.4225, longitude = 39.8262, name = "Makkah")
+
+        assertThat(settings.latitude.first()).isWithin(0.0001).of(21.4225)
+        assertThat(settings.longitude.first()).isWithin(0.0001).of(39.8262)
+        assertThat(settings.locationName.first()).isEqualTo("Makkah")
+    }
+
+    @Test
+    fun exportThenImport_preservesValues() = runTest {
+        settings.setThemeMode("dark")
+        settings.setCalculationMethod("Egypt")
+
+        val exported = settings.exportAllPreferences()
+        // Mutate, then restore from the export.
+        settings.setThemeMode("light")
+        settings.importPreferences(exported)
+
+        assertThat(settings.themeMode.first()).isEqualTo("dark")
+        assertThat(settings.calculationMethod.first()).isEqualTo("Egypt")
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
@@ -2,18 +2,23 @@ package com.arshadshah.nimaz.support
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.test.core.app.ActivityScenario
 import com.arshadshah.nimaz.MainActivity
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import dagger.hilt.android.testing.HiltAndroidRule
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import javax.inject.Inject
@@ -50,6 +55,9 @@ abstract class BaseAppTest {
     @Inject
     lateinit var settings: SettingsRepository
 
+    /** The launched activity scenario; closed automatically after each test. */
+    private var scenario: ActivityScenario<MainActivity>? = null
+
     @Before
     fun setup() {
         hiltRule.inject()
@@ -57,11 +65,27 @@ abstract class BaseAppTest {
         runBlocking { settings.setOnboardingCompleted(true) }
     }
 
+    @After
+    fun tearDownActivity() {
+        scenario?.close()
+        scenario = null
+    }
+
     /** Launch [MainActivity] after state has been seeded, and wait for first frame. */
     protected fun launchApp(): ActivityScenario<MainActivity> {
-        val scenario = ActivityScenario.launch(MainActivity::class.java)
+        return ActivityScenario.launch(MainActivity::class.java).also {
+            scenario = it
+            compose.waitForIdle()
+        }
+    }
+
+    /**
+     * Press the system back button via the activity's dispatcher. Reliable on detail
+     * screens where the bottom nav is hidden and back affordances vary.
+     */
+    protected fun pressBack() {
+        scenario?.onActivity { it.onBackPressedDispatcher.onBackPressed() }
         compose.waitForIdle()
-        return scenario
     }
 
     // ── Selector-aware helpers (no inline literals in test bodies) ───────────
@@ -85,23 +109,66 @@ abstract class BaseAppTest {
     protected fun onContentDesc(desc: String): SemanticsNodeInteraction =
         compose.onNodeWithContentDescription(desc, substring = true, useUnmergedTree = true)
 
+    // ── Screen-identity helpers (locale-independent, via ScreenTags) ─────────
+
+    protected fun onTag(tag: String): SemanticsNodeInteraction =
+        compose.onNodeWithTag(tag, useUnmergedTree = true)
+
+    @OptIn(ExperimentalTestApi::class)
+    protected fun waitForTag(tag: String, timeoutMs: Long = 5_000) {
+        compose.waitUntilAtLeastOneExists(hasTestTag(tag), timeoutMs)
+    }
+
+    /** Wait for, then assert, that the screen tagged [tag] (from `ScreenTags`) is shown. */
+    protected fun assertScreen(tag: String) {
+        waitForTag(tag)
+        onTag(tag).assertExists()
+    }
+
+    /** Scroll the list tagged [listTag] until a node with [text] is composed, then tap it. */
+    protected fun scrollListToAndTap(listTag: String, text: String) {
+        compose.onNodeWithTag(listTag)
+            .performScrollToNode(hasText(text, substring = true))
+        compose.waitForIdle()
+        clickText(text)
+    }
+
+    /** Convenience: scroll-and-tap within the More menu's list. */
+    protected fun scrollMoreToAndTap(text: String) =
+        scrollListToAndTap(ScreenTags.MoreList, text)
+
     /** Click the bottom-nav tab with the given [Selectors.NavLabel] label. */
     protected fun tapBottomNav(label: String) {
-        // The NavigationSuite item exposes the label as both text and the icon's
-        // contentDescription; click the text node which is reliably present.
-        compose.onNodeWithText(label, useUnmergedTree = true).performClick()
+        // Click via the item's testTag (ScreenTags.bottomNav) rather than the label
+        // Text: the click/selectable action lives on the merged nav-item node, which is
+        // the node carrying the tag — clicking the inner Text node has no click action.
+        compose.onNodeWithTag(ScreenTags.bottomNav(label)).performClick()
         compose.waitForIdle()
     }
 
-    /** Tap a visible text element and settle. */
-    protected fun tapText(text: String) {
-        onText(text).performClick()
+    /**
+     * Click an element by its (substring) text. Uses the **merged** tree so the
+     * clickable row — e.g. a menu item whose title is a child Text — is the node
+     * tapped, not the non-clickable Text itself.
+     */
+    protected fun clickText(text: String) {
+        compose.onNodeWithText(text, substring = true, useUnmergedTree = false).performClick()
+        compose.waitForIdle()
+    }
+
+    /** Backwards-compatible alias for [clickText]. */
+    protected fun tapText(text: String) = clickText(text)
+
+    /**
+     * Click an icon button by its content description. Uses the **merged** semantics
+     * tree so the node carrying the click action (the IconButton, which absorbs the
+     * inner Icon's description) is the one tapped — not the non-clickable Icon.
+     */
+    protected fun tapContentDesc(desc: String) {
+        compose.onNodeWithContentDescription(desc, useUnmergedTree = false).performClick()
         compose.waitForIdle()
     }
 
     /** Tap the standard "Back" affordance (contentDescription = R.string.cd_back). */
-    protected fun tapBack() {
-        onContentDesc(Selectors.str(Selectors.Common.back)).performClick()
-        compose.waitForIdle()
-    }
+    protected fun tapBack() = tapContentDesc(Selectors.str(Selectors.Common.back))
 }

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
@@ -1,0 +1,107 @@
+package com.arshadshah.nimaz.support
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.test.core.app.ActivityScenario
+import com.arshadshah.nimaz.MainActivity
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import javax.inject.Inject
+
+/**
+ * Base class for end-to-end UI flow tests that drive the real [MainActivity] and its
+ * [com.arshadshah.nimaz.core.navigation.NavGraph] on the full Hilt graph.
+ *
+ * Key design choices:
+ *  - **Empty compose rule + manual launch.** [createEmptyComposeRule] lets us seed
+ *    DataStore state *before* the activity is created. That matters because
+ *    `NavGraph` resolves its start destination from `onboardingCompleted` exactly
+ *    once; if we launched first and wrote the flag afterwards, the app would be stuck
+ *    on the onboarding screen and the bottom nav would never appear. So [setup]
+ *    marks onboarding complete, then each test calls [launchApp].
+ *  - **Hilt injection** of the real [SettingsRepository] (the DataStore-backed impl),
+ *    so the seed hits the same store the app reads.
+ *
+ * Subclasses get [compose] plus the text/contentDescription helpers below, all of
+ * which resolve their target strings through [Selectors] rather than inline literals.
+ *
+ * Note: `@HiltAndroidTest` is not inherited, so it sits on each concrete subclass
+ * (e.g. [com.arshadshah.nimaz.navigation.AppLaunchTest]) rather than here. The
+ * [HiltAndroidRule] below still injects fields declared on this base class.
+ */
+abstract class BaseAppTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val compose: ComposeTestRule = createEmptyComposeRule()
+
+    @Inject
+    lateinit var settings: SettingsRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        // Make sure the app boots straight to Home, not onboarding.
+        runBlocking { settings.setOnboardingCompleted(true) }
+    }
+
+    /** Launch [MainActivity] after state has been seeded, and wait for first frame. */
+    protected fun launchApp(): ActivityScenario<MainActivity> {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+        compose.waitForIdle()
+        return scenario
+    }
+
+    // ── Selector-aware helpers (no inline literals in test bodies) ───────────
+
+    /** Wait until a node with the given visible [text] exists (default 5s). */
+    @OptIn(ExperimentalTestApi::class)
+    protected fun waitForText(text: String, timeoutMs: Long = 5_000) {
+        compose.waitUntilAtLeastOneExists(hasText(text, substring = true), timeoutMs)
+    }
+
+    /** Wait for a node identified by a string resource id. */
+    protected fun waitForRes(resId: Int, timeoutMs: Long = 5_000) =
+        waitForText(Selectors.str(resId), timeoutMs)
+
+    protected fun onText(text: String): SemanticsNodeInteraction =
+        compose.onNodeWithText(text, substring = true, useUnmergedTree = true)
+
+    protected fun onRes(resId: Int): SemanticsNodeInteraction =
+        compose.onNodeWithText(Selectors.str(resId), substring = true, useUnmergedTree = true)
+
+    protected fun onContentDesc(desc: String): SemanticsNodeInteraction =
+        compose.onNodeWithContentDescription(desc, substring = true, useUnmergedTree = true)
+
+    /** Click the bottom-nav tab with the given [Selectors.NavLabel] label. */
+    protected fun tapBottomNav(label: String) {
+        // The NavigationSuite item exposes the label as both text and the icon's
+        // contentDescription; click the text node which is reliably present.
+        compose.onNodeWithText(label, useUnmergedTree = true).performClick()
+        compose.waitForIdle()
+    }
+
+    /** Tap a visible text element and settle. */
+    protected fun tapText(text: String) {
+        onText(text).performClick()
+        compose.waitForIdle()
+    }
+
+    /** Tap the standard "Back" affordance (contentDescription = R.string.cd_back). */
+    protected fun tapBack() {
+        onContentDesc(Selectors.str(Selectors.Common.back)).performClick()
+        compose.waitForIdle()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
@@ -9,8 +9,10 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.test.core.app.ActivityScenario
 import com.arshadshah.nimaz.MainActivity
@@ -125,12 +127,24 @@ abstract class BaseAppTest {
         onTag(tag).assertExists()
     }
 
-    /** Scroll the list tagged [listTag] until a node with [text] is composed, then tap it. */
+    /**
+     * Scroll the list tagged [listTag] until a node with [text] is composed, then tap it.
+     *
+     * Clicks coordinate-free via the row's `OnClick` semantics action rather than
+     * injecting a touch: a list row scrolled just into view can sit at the viewport
+     * edge / under the gesture-nav inset, where a synthetic tap is rejected with
+     * "Failed to inject touch input". The menu/settings rows are Material3 `Card(onClick)`s,
+     * which expose `SemanticsActions.OnClick`.
+     */
     protected fun scrollListToAndTap(listTag: String, text: String) {
+        // Exact match (not substring): the row titles are full strings, and substring
+        // would make e.g. "Prayer Times" also match "Monthly Prayer Times".
         compose.onNodeWithTag(listTag)
-            .performScrollToNode(hasText(text, substring = true))
+            .performScrollToNode(hasText(text))
         compose.waitForIdle()
-        clickText(text)
+        compose.onNodeWithText(text, useUnmergedTree = false)
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.waitForIdle()
     }
 
     /** Convenience: scroll-and-tap within the More menu's list. */

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
@@ -19,6 +19,9 @@ import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import dagger.hilt.android.testing.HiltAndroidRule
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -63,9 +66,33 @@ abstract class BaseAppTest {
     @Before
     fun setup() {
         hiltRule.inject()
-        // Make sure the app boots straight to Home, not onboarding.
-        runBlocking { settings.setOnboardingCompleted(true) }
+        runBlocking { seedState() }
     }
+
+    /**
+     * Seed DataStore before the activity launches. Defaults to marking onboarding
+     * complete so the app boots straight to Home; the onboarding flow test overrides
+     * this to exercise the first-run experience.
+     */
+    protected open suspend fun seedState() {
+        settings.setOnboardingCompleted(true)
+    }
+
+    /**
+     * Poll [flow] until it no longer equals [previous] (i.e. an async DataStore write
+     * has landed), returning the new value. Settings writes happen on a ViewModel
+     * coroutine that `waitForIdle` doesn't track, so behavior tests await the store.
+     */
+    protected fun <T> awaitSettingChange(flow: Flow<T>, previous: T, timeoutMs: Long = 5_000): T =
+        runBlocking {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            var value = flow.first()
+            while (value == previous && System.currentTimeMillis() < deadline) {
+                delay(50)
+                value = flow.first()
+            }
+            value
+        }
 
     @After
     fun tearDownActivity() {

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/HiltTestRunner.kt
@@ -1,0 +1,30 @@
+package com.arshadshah.nimaz.support
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+/**
+ * Instrumentation runner that boots [HiltTestApplication] instead of the production
+ * [com.arshadshah.nimaz.NimazApp].
+ *
+ * Why: NimazApp.onCreate() initializes Firebase, configures WorkManager with a
+ * [HiltWorkerFactory], and kicks off [com.arshadshah.nimaz.core.init.AppInitializer]
+ * (locale, prayer-notification scheduling, adhan download). None of that is wanted —
+ * or reliable — on a headless emulator. HiltTestApplication still hosts the full Hilt
+ * object graph (so `@HiltAndroidTest` classes can inject real DAOs, repositories,
+ * schedulers, etc.) but skips the production bootstrap. Worker tests configure
+ * WorkManager explicitly via [androidx.work.testing.WorkManagerTestInitHelper].
+ *
+ * Registered as `testInstrumentationRunner` in app/build.gradle.kts.
+ */
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?,
+    ): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/NimazDbRule.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/NimazDbRule.kt
@@ -1,0 +1,46 @@
+package com.arshadshah.nimaz.support
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
+import org.junit.rules.ExternalResource
+
+/**
+ * JUnit rule that stands up a fresh **in-memory** [NimazDatabase] for each test and
+ * tears it down afterwards.
+ *
+ * In-memory (rather than the shipped `createFromAsset` DB) is deliberate for DAO
+ * round-trip tests: it is fast, hermetic, starts empty, and exercises the exact
+ * Room schema generated from the `@Entity` classes — no device services, no
+ * migrations, no shared state leaking between tests. Asset/migration coverage lives
+ * separately in `DatabaseAssetTest` and `MigrationTest`.
+ *
+ * Usage:
+ * ```
+ * @get:Rule val dbRule = NimazDbRule()
+ * private val db get() = dbRule.db
+ * ```
+ */
+class NimazDbRule : ExternalResource() {
+
+    lateinit var db: NimazDatabase
+        private set
+
+    override fun before() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NimazDatabase::class.java,
+        )
+            // Queries in these tests run on a background dispatcher via runTest's
+            // coroutine, but allowing main-thread queries keeps simple assertions
+            // ergonomic and never deadlocks an in-memory DB.
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    override fun after() {
+        if (::db.isInitialized && db.isOpen) {
+            db.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/Selectors.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/Selectors.kt
@@ -53,8 +53,22 @@ object Selectors {
 
     object More {
         @StringRes val title = R.string.more
-        @StringRes val prayerTracker = R.string.prayer_tracker
         @StringRes val settings = R.string.settings
+        // Menu-item titles (each navigates to a feature landing screen).
+        @StringRes val prayerTracker = R.string.prayer_tracker
+        @StringRes val fasting = R.string.fasting
+        @StringRes val khatam = R.string.khatam_quran
+        @StringRes val qaida = R.string.qaida
+        @StringRes val asmaUlHusna = R.string.allahs_99_names
+        @StringRes val asmaUnNabi = R.string.prophets_99_names
+        @StringRes val prophets = R.string.prophets_of_islam
+        @StringRes val hadith = R.string.hadith
+        @StringRes val duas = R.string.duas
+        @StringRes val tafseer = R.string.tafseer
+        @StringRes val calendar = R.string.calendar
+        @StringRes val prayerTimes = R.string.prayer_times
+        @StringRes val monthlyPrayerTimes = R.string.monthly_prayer_times
+        @StringRes val zakat = R.string.zakat
         @StringRes val aboutNimaz = R.string.about_nimaz
         @StringRes val helpSupport = R.string.help_support
     }
@@ -62,6 +76,18 @@ object Selectors {
     object Prayer {
         @StringRes val trackerTitle = R.string.prayer_tracker_title
         @StringRes val times = R.string.prayer_times
+    }
+
+    /** Row labels on the Settings hub (each opens a settings sub-screen). */
+    object Settings {
+        @StringRes val calculationMethod = R.string.calculation_method
+        @StringRes val location = R.string.location
+        @StringRes val notifications = R.string.notifications
+        @StringRes val quranSettings = R.string.quran_settings
+        @StringRes val appearance = R.string.appearance
+        @StringRes val language = R.string.language
+        @StringRes val widgets = R.string.widgets
+        @StringRes val syncData = R.string.sync_data
     }
 
     object Qibla {

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/Selectors.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/Selectors.kt
@@ -1,0 +1,93 @@
+package com.arshadshah.nimaz.support
+
+import androidx.annotation.StringRes
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.R
+
+/**
+ * Single source of truth for every UI selector used by the instrumented tests.
+ *
+ * Goal: keep magic strings out of the test bodies. Tests reference [NavLabel],
+ * [Tag], or [str] / [strId] instead of repeating literals. When a label moves to a
+ * resource, or a `testTag` is added to the app, only this file changes.
+ *
+ * Three kinds of selector live here:
+ *  - [NavLabel] — the bottom-navigation labels. These are hard-coded literals in
+ *    `NavGraph.bottomNavItems` (used for both the visible Text and the icon's
+ *    contentDescription), so matching them is stable and locale-independent.
+ *  - [Tag] — the handful of real `Modifier.testTag` values that exist in the app
+ *    today (the Qaida learning flow). Add new app tags here as they appear.
+ *  - [strId] / [str] — string-resource lookups, for screen content that is
+ *    correctly externalized to res/values/strings.xml. Resolving at runtime keeps
+ *    tests honest against the shipped copy rather than duplicating it.
+ */
+object Selectors {
+
+    /** Bottom-navigation destination labels (literal strings in NavGraph). */
+    object NavLabel {
+        const val HOME = "Home"
+        const val QURAN = "Quran"
+        const val TASBIH = "Tasbih"
+        const val QIBLA = "Qibla"
+        const val MORE = "More"
+
+        val all = listOf(HOME, QURAN, TASBIH, QIBLA, MORE)
+    }
+
+    /** Real `Modifier.testTag` values present in the production UI. */
+    object Tag {
+        const val QAIDA_STAR = "qaida_star"
+        const val QAIDA_DOT = "qaida_dot"
+        const val QAIDA_CONTINUE = "qaida_continue"
+    }
+
+    /**
+     * String-resource IDs for stable, user-visible content. Grouped by area so a
+     * test reads `Selectors.Common.back` rather than a bare `R.string.*`.
+     */
+    object Common {
+        @StringRes val back = R.string.cd_back
+        @StringRes val settings = R.string.cd_settings
+        @StringRes val today = R.string.today
+    }
+
+    object More {
+        @StringRes val title = R.string.more
+        @StringRes val prayerTracker = R.string.prayer_tracker
+        @StringRes val settings = R.string.settings
+        @StringRes val aboutNimaz = R.string.about_nimaz
+        @StringRes val helpSupport = R.string.help_support
+    }
+
+    object Prayer {
+        @StringRes val trackerTitle = R.string.prayer_tracker_title
+        @StringRes val times = R.string.prayer_times
+    }
+
+    object Qibla {
+        @StringRes val compass = R.string.compass
+    }
+
+    object Quran {
+        @StringRes val homeTitle = R.string.quran_home_title
+        @StringRes val browseTab = R.string.quran_home_tab_browse
+        @StringRes val favoritesTab = R.string.quran_home_tab_favorites
+    }
+
+    object Tasbih {
+        @StringRes val beads = R.string.tasbih_mode_beads
+        @StringRes val classic = R.string.tasbih_mode_classic
+    }
+
+    object Home {
+        @StringRes val nextPrayer = R.string.next_prayer
+    }
+
+    /** Resolve a string resource using the instrumentation target (app) context. */
+    fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<android.content.Context>().getString(id)
+
+    /** Resolve a formatted string resource. */
+    fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<android.content.Context>().getString(id, *args)
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/TestData.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/TestData.kt
@@ -1,0 +1,416 @@
+package com.arshadshah.nimaz.support
+
+import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.AsmaUnNabiBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.DuaBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.DuaCategoryEntity
+import com.arshadshah.nimaz.data.local.database.entity.DuaEntity
+import com.arshadshah.nimaz.data.local.database.entity.DuaProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.FastRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.HadithBookEntity
+import com.arshadshah.nimaz.data.local.database.entity.HadithBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.HadithEntity
+import com.arshadshah.nimaz.data.local.database.entity.IslamicEventEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamDailyLogEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamEntity
+import com.arshadshah.nimaz.data.local.database.entity.LocationEntity
+import com.arshadshah.nimaz.data.local.database.entity.MakeupFastEntity
+import com.arshadshah.nimaz.data.local.database.entity.PrayerRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.ProphetBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranFavoriteEntity
+import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerHighlightEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerNoteEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerTextEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihPresetEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihSessionEntity
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+
+/**
+ * Factory for fully-formed test entities.
+ *
+ * Every builder has sensible defaults so a test overrides only the fields it cares
+ * about (`prayerRecord(status = "prayed")`). This keeps entity construction — and
+ * the field-name strings that go with it — in one place instead of scattered across
+ * the DAO tests. Timestamps default to a fixed epoch where ordering matters so
+ * assertions stay deterministic.
+ */
+object TestData {
+
+    /** A fixed reference instant: 2026-01-01T00:00:00Z, in millis. */
+    const val T0: Long = 1_767_225_600_000L
+
+    /** A fixed civil date key (midnight UTC) used as the day bucket for trackers. */
+    const val DAY: Long = T0
+
+    // ── Prayer ──────────────────────────────────────────────────────────────
+    fun prayerRecord(
+        date: Long = DAY,
+        prayerName: String = "Fajr",
+        status: String = "pending",
+        prayedAt: Long? = null,
+        scheduledTime: Long = DAY + 5 * 3_600_000L,
+        isJamaah: Boolean = false,
+        note: String? = null,
+    ) = PrayerRecordEntity(
+        date = date,
+        prayerName = prayerName,
+        status = status,
+        prayedAt = prayedAt,
+        scheduledTime = scheduledTime,
+        isJamaah = isJamaah,
+        note = note,
+    )
+
+    /** The five daily prayers for [date], all pending. */
+    fun dailyPrayers(date: Long = DAY): List<PrayerRecordEntity> =
+        listOf("Fajr", "Dhuhr", "Asr", "Maghrib", "Isha").mapIndexed { i, name ->
+            prayerRecord(date = date, prayerName = name, scheduledTime = date + (i + 1) * 3_600_000L)
+        }
+
+    // ── Fasting ─────────────────────────────────────────────────────────────
+    fun fastRecord(
+        date: Long = DAY,
+        fastType: String = "ramadan",
+        status: String = "fasted",
+        hijriMonth: Int? = 9,
+    ) = FastRecordEntity(
+        date = date,
+        hijriDate = null,
+        hijriMonth = hijriMonth,
+        hijriYear = 1447,
+        fastType = fastType,
+        status = status,
+        exemptionReason = null,
+        suhoorTime = null,
+        iftarTime = null,
+        note = null,
+    )
+
+    fun makeupFast(
+        originalDate: Long = DAY,
+        status: String = "pending",
+        reason: String = "missed",
+    ) = MakeupFastEntity(
+        originalDate = originalDate,
+        originalHijriDate = null,
+        reason = reason,
+        status = status,
+        completedDate = null,
+        fidyaAmount = null,
+        note = null,
+    )
+
+    // ── Tasbih ──────────────────────────────────────────────────────────────
+    fun tasbihPreset(
+        name: String = "SubhanAllah",
+        targetCount: Int = 33,
+        isCustom: Int = 0,
+        displayOrder: Int = 0,
+        category: String? = null,
+    ) = TasbihPresetEntity(
+        name = name,
+        arabic = "سبحان الله",
+        transliteration = "SubhanAllah",
+        translation = "Glory be to Allah",
+        targetCount = targetCount,
+        isCustom = isCustom,
+        displayOrder = displayOrder,
+        category = category,
+    )
+
+    fun tasbihSession(
+        presetId: Long? = null,
+        date: Long = DAY,
+        currentCount: Int = 0,
+        targetCount: Int = 33,
+        totalLaps: Int = 0,
+        isCompleted: Boolean = false,
+    ) = TasbihSessionEntity(
+        presetId = presetId,
+        presetName = "SubhanAllah",
+        date = date,
+        currentCount = currentCount,
+        targetCount = targetCount,
+        totalLaps = totalLaps,
+        isCompleted = isCompleted,
+        duration = null,
+        startedAt = date,
+        completedAt = null,
+        note = null,
+    )
+
+    // ── Khatam ──────────────────────────────────────────────────────────────
+    fun khatam(
+        name: String = "Ramadan Khatam",
+        status: String = "active",
+        isActive: Boolean = true,
+        dailyTarget: Int = 20,
+    ) = KhatamEntity(
+        name = name,
+        status = status,
+        isActive = isActive,
+        dailyTarget = dailyTarget,
+    )
+
+    fun khatamAyah(khatamId: Long, ayahId: Int) =
+        KhatamAyahEntity(khatamId = khatamId, ayahId = ayahId)
+
+    fun khatamDailyLog(khatamId: Long, date: Long = DAY, ayahsRead: Int = 20) =
+        KhatamDailyLogEntity(khatamId = khatamId, date = date, ayahsRead = ayahsRead)
+
+    // ── Quran ───────────────────────────────────────────────────────────────
+    fun surah(
+        id: Int = 1,
+        number: Int = id,
+        nameEnglish: String = "Al-Fatihah",
+        versesCount: Int = 7,
+        startPage: Int = 1,
+    ) = SurahEntity(
+        id = id,
+        number = number,
+        nameArabic = "الفاتحة",
+        nameEnglish = nameEnglish,
+        nameTransliteration = "Al-Fatihah",
+        revelationType = "Meccan",
+        versesCount = versesCount,
+        orderRevealed = 5,
+        startPage = startPage,
+    )
+
+    fun ayah(
+        id: Int = 1,
+        surahId: Int = 1,
+        numberInSurah: Int = id,
+        numberGlobal: Int = id,
+        juz: Int = 1,
+        page: Int = 1,
+    ) = AyahEntity(
+        id = id,
+        surahId = surahId,
+        numberInSurah = numberInSurah,
+        numberGlobal = numberGlobal,
+        textArabic = "بِسْمِ اللَّهِ",
+        textUthmani = "بِسْمِ اللَّهِ",
+        juz = juz,
+        hizb = 1,
+        page = page,
+        sajda = 0,
+        sajdaType = null,
+    )
+
+    fun quranBookmark(ayahId: Int = 1, surahNumber: Int = 1, ayahNumber: Int = 1) =
+        QuranBookmarkEntity(
+            ayahId = ayahId,
+            surahNumber = surahNumber,
+            ayahNumber = ayahNumber,
+            note = null,
+            color = null,
+        )
+
+    fun quranFavorite(ayahId: Int = 1, surahNumber: Int = 1, ayahNumber: Int = 1) =
+        QuranFavoriteEntity(ayahId = ayahId, surahNumber = surahNumber, ayahNumber = ayahNumber)
+
+    fun readingProgress(
+        lastReadSurah: Int = 2,
+        lastReadAyah: Int = 5,
+        totalAyahsRead: Int = 42,
+    ) = ReadingProgressEntity(
+        lastReadSurah = lastReadSurah,
+        lastReadAyah = lastReadAyah,
+        lastReadPage = 2,
+        lastReadJuz = 1,
+        totalAyahsRead = totalAyahsRead,
+        currentKhatmaCount = 0,
+    )
+
+    // ── Dua ─────────────────────────────────────────────────────────────────
+    fun duaCategory(id: Int = 1, nameEnglish: String = "Morning") =
+        DuaCategoryEntity(
+            id = id,
+            nameEnglish = nameEnglish,
+            nameArabic = "الصباح",
+            icon = "sun",
+            displayOrder = 0,
+            duaCount = 1,
+        )
+
+    fun dua(id: Int = 1, categoryId: Int = 1, titleEnglish: String = "Morning Dua") =
+        DuaEntity(
+            id = id,
+            categoryId = categoryId,
+            titleEnglish = titleEnglish,
+            titleArabic = "دعاء",
+            textArabic = "اللهم",
+            transliteration = "Allahumma",
+            translation = "O Allah",
+            source = "Bukhari",
+            virtue = null,
+            repeatCount = 3,
+            audioFile = null,
+            displayOrder = 0,
+        )
+
+    fun duaBookmark(duaId: Int = 1, categoryId: Int = 1, isFavorite: Boolean = true) =
+        DuaBookmarkEntity(
+            duaId = duaId,
+            categoryId = categoryId,
+            note = null,
+            isFavorite = isFavorite,
+        )
+
+    fun duaProgress(
+        duaId: Int = 1,
+        date: Long = DAY,
+        completedCount: Int = 0,
+        targetCount: Int = 3,
+        isCompleted: Boolean = false,
+    ) = DuaProgressEntity(
+        duaId = duaId,
+        date = date,
+        completedCount = completedCount,
+        targetCount = targetCount,
+        isCompleted = isCompleted,
+    )
+
+    // ── Hadith ──────────────────────────────────────────────────────────────
+    fun hadithBook(id: Int = 1, nameEnglish: String = "Sahih Bukhari") =
+        HadithBookEntity(
+            id = id,
+            nameEnglish = nameEnglish,
+            nameArabic = "صحيح البخاري",
+            author = "Imam Bukhari",
+            hadithCount = 1,
+            description = "Authentic collection",
+            icon = "book",
+        )
+
+    fun hadith(id: Int = 1, bookId: Int = 1, chapterId: Int = 1, numberInBook: Int = 1) =
+        HadithEntity(
+            id = id,
+            bookId = bookId,
+            chapterId = chapterId,
+            numberInBook = numberInBook,
+            numberInChapter = 1,
+            textArabic = "إنما الأعمال بالنيات",
+            textEnglish = "Actions are by intentions",
+            narrator = "Umar ibn al-Khattab",
+            grade = "Sahih",
+            reference = "Bukhari 1",
+        )
+
+    fun hadithBookmark(hadithId: Int = 1, bookId: Int = 1, hadithNumber: Int = 1) =
+        HadithBookmarkEntity(
+            hadithId = hadithId,
+            bookId = bookId,
+            hadithNumber = hadithNumber,
+            note = null,
+            color = null,
+        )
+
+    // ── Zakat ───────────────────────────────────────────────────────────────
+    fun zakat(
+        calculatedAt: Long = T0,
+        zakatDue: Double = 250.0,
+        isPaid: Boolean = false,
+    ) = ZakatHistoryEntity(
+        calculatedAt = calculatedAt,
+        totalAssets = 10_000.0,
+        totalLiabilities = 0.0,
+        netWorth = 10_000.0,
+        zakatDue = zakatDue,
+        nisabType = "gold",
+        nisabValue = 5_000.0,
+        isPaid = isPaid,
+    )
+
+    // ── Tafseer ─────────────────────────────────────────────────────────────
+    fun tafseerText(ayahId: Int = 1, tafseerId: String = "ibn-kathir") =
+        TafseerTextEntity(
+            ayahId = ayahId,
+            surahNumber = 1,
+            ayahNumber = ayahId,
+            tafseerId = tafseerId,
+            text = "Commentary text",
+        )
+
+    fun tafseerHighlight(ayahId: Int = 1, tafseerId: String = "ibn-kathir") =
+        TafseerHighlightEntity(
+            ayahId = ayahId,
+            tafseerId = tafseerId,
+            startOffset = 0,
+            endOffset = 10,
+            color = "#FFEB3B",
+            note = "important",
+        )
+
+    fun tafseerNote(ayahId: Int = 1, tafseerId: String = "ibn-kathir", text: String = "my note") =
+        TafseerNoteEntity(ayahId = ayahId, tafseerId = tafseerId, text = text)
+
+    // ── Qaida progress ──────────────────────────────────────────────────────
+    fun qaidaLessonProgress(
+        lessonId: Int = 1,
+        status: String = "IN_PROGRESS",
+        stars: Int = 0,
+        completedCells: Int = 0,
+        totalCells: Int = 10,
+    ) = QaidaLessonProgressEntity(
+        lessonId = lessonId,
+        status = status,
+        stars = stars,
+        lastCellId = null,
+        completedCells = completedCells,
+        totalCells = totalCells,
+        updatedAt = T0,
+    )
+
+    // ── Names of Allah / Prophet bookmarks ──────────────────────────────────
+    fun asmaBookmark(nameId: Int = 1) = AsmaUlHusnaBookmarkEntity(nameId = nameId)
+    fun asmaNabiBookmark(nameId: Int = 1) = AsmaUnNabiBookmarkEntity(nameId = nameId)
+    fun prophetBookmark(prophetId: Int = 1) = ProphetBookmarkEntity(prophetId = prophetId)
+
+    // ── Location & events ───────────────────────────────────────────────────
+    fun location(
+        name: String = "Makkah",
+        latitude: Double = 21.4225,
+        longitude: Double = 39.8262,
+        isCurrent: Boolean = true,
+        isFavorite: Boolean = false,
+    ) = LocationEntity(
+        name = name,
+        latitude = latitude,
+        longitude = longitude,
+        timezone = "Asia/Riyadh",
+        country = "Saudi Arabia",
+        city = "Makkah",
+        isCurrentLocation = isCurrent,
+        isFavorite = isFavorite,
+        calculationMethod = "MWL",
+        asrCalculation = "standard",
+        highLatitudeRule = null,
+        fajrAngle = null,
+        ishaAngle = null,
+    )
+
+    fun islamicEvent(
+        id: Int = 1,
+        hijriMonth: Int = 9,
+        hijriDay: Int = 1,
+        eventType: String = "fast",
+        isHoliday: Int = 0,
+    ) = IslamicEventEntity(
+        id = id,
+        nameEnglish = "Start of Ramadan",
+        nameArabic = "رمضان",
+        hijriMonth = hijriMonth,
+        hijriDay = hijriDay,
+        eventType = eventType,
+        description = "First day of fasting",
+        isHoliday = isHoliday,
+    )
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
@@ -1,0 +1,103 @@
+package com.arshadshah.nimaz.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.arshadshah.nimaz.data.audio.AdhanDownloadWorker
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarWorker
+import com.arshadshah.nimaz.widget.hijridate.HijriDateWorker
+import com.arshadshah.nimaz.widget.nextprayer.NextPrayerWorker
+import com.arshadshah.nimaz.widget.prayertimes.PrayerTimesWorker
+import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWorker
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Drives every background [androidx.work.CoroutineWorker] the app ships through its
+ * `doWork()` once, built by the real [HiltWorkerFactory].
+ *
+ * What this proves:
+ *  - Each `@HiltWorker` can actually be instantiated by the factory — i.e. its
+ *    `@AssistedInject` dependencies (PrayerTimeCalculator, PreferencesDataStore,
+ *    PrayerDao, AdhanAudioManager) resolve from the graph. A broken binding surfaces
+ *    here rather than silently on a user's device when a widget refresh fires.
+ *  - Running with a seeded location, no worker fails. We assert the result is not a
+ *    [ListenableWorker.Result.Failure] (Success or a transient Retry are both fine).
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class WidgetWorkersTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject
+    lateinit var settings: SettingsRepository
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        // Initialize WorkManager for tests with the Hilt factory so any internal
+        // WorkManager.getInstance(...) calls inside a worker resolve correctly.
+        val config = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        // Give the prayer-time workers real coordinates to compute from.
+        runBlocking { settings.updateLocation(21.4225, 39.8262, "Makkah") }
+    }
+
+    private inline fun <reified T : ListenableWorker> runWorker(): ListenableWorker.Result {
+        val worker = TestListenableWorkerBuilder<T>(context)
+            .setWorkerFactory(workerFactory)
+            .build()
+        return runBlocking { worker.doWork() }
+    }
+
+    private fun assertNotFailure(result: ListenableWorker.Result) {
+        assertThat(result).isNotInstanceOf(ListenableWorker.Result.Failure::class.java)
+    }
+
+    @Test
+    fun nextPrayerWorker_runs() = assertNotFailure(runWorker<NextPrayerWorker>())
+
+    @Test
+    fun prayerTimesWorker_runs() = assertNotFailure(runWorker<PrayerTimesWorker>())
+
+    @Test
+    fun prayerTrackerWorker_runs() = assertNotFailure(runWorker<PrayerTrackerWorker>())
+
+    @Test
+    fun hijriDateWorker_runs() = assertNotFailure(runWorker<HijriDateWorker>())
+
+    @Test
+    fun hijriCalendarWorker_runs() = assertNotFailure(runWorker<HijriCalendarWorker>())
+
+    @Test
+    fun adhanDownloadWorker_isConstructableByFactory() {
+        // The download worker reaches out to the network, which may be unavailable on
+        // a CI emulator — a real Failure/Retry is legitimate there. So we only assert
+        // the factory can build it and `doWork()` completes (returns a result rather
+        // than throwing), which is what exercises the Hilt @AssistedInject wiring.
+        val result = runWorker<AdhanDownloadWorker>()
+        assertThat(result).isNotNull()
+    }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.Configuration
+import androidx.work.CoroutineWorker
 import androidx.work.ListenableWorker
 import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -65,7 +66,9 @@ class WidgetWorkersTest {
         runBlocking { settings.updateLocation(21.4225, 39.8262, "Makkah") }
     }
 
-    private inline fun <reified T : ListenableWorker> runWorker(): ListenableWorker.Result {
+    // Bound to CoroutineWorker (not the generic ListenableWorker) so `doWork()` — the
+    // suspend entry point all of this app's workers implement — resolves.
+    private inline fun <reified T : CoroutineWorker> runWorker(): ListenableWorker.Result {
         val worker = TestListenableWorkerBuilder<T>(context)
             .setWorkerFactory(workerFactory)
             .build()

--- a/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
@@ -70,9 +70,12 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Keep splash visible until AppInitializer finishes (max 5s timeout)
-        val appInitializer = (application as NimazApp).appInitializer
-        splashScreen.setKeepOnScreenCondition { !appInitializer.isReady.value }
+        // Keep splash visible until AppInitializer finishes (max 5s timeout).
+        // Guard the cast: under instrumented tests the host Application is
+        // HiltTestApplication, not NimazApp, so there is no initializer to await —
+        // lift the splash immediately so the UI is visible to the test harness.
+        val appInitializer = (application as? NimazApp)?.appInitializer
+        splashScreen.setKeepOnScreenCondition { appInitializer?.isReady?.value == false }
 
         // Check if opened from prayer notification - stop adhan if so
         handleIntent(intent)

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.core.navigation
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
@@ -30,10 +31,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -227,6 +231,7 @@ fun NavGraph(
                 } == true
 
                 item(
+                    modifier = Modifier.testTag(ScreenTags.bottomNav(navItem.label)),
                     icon = { Icon(navItem.icon, contentDescription = navItem.label) },
                     label = { Text(navItem.label) },
                     selected = selected,
@@ -248,7 +253,7 @@ fun NavGraph(
             startDestination = startDestination,
         ) {
             // Onboarding
-            composable<Route.Onboarding> {
+            taggedComposable<Route.Onboarding>(ScreenTags.Onboarding) {
                 OnboardingScreen(
                     onComplete = {
                         navController.navigate(Route.Home) {
@@ -259,7 +264,7 @@ fun NavGraph(
             }
 
             // Main screens
-            composable<Route.Home> {
+            taggedComposable<Route.Home>(ScreenTags.Home) {
                 HomeScreen(
                     onNavigateToQuran = { navController.navigate(Route.Quran) },
                     onNavigateToHadith = { navController.navigate(Route.HadithHome) },
@@ -277,7 +282,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.Quran> {
+            taggedComposable<Route.Quran>(ScreenTags.Quran) {
                 AdaptiveQuranScreen(
                     navController = navController,
                     onNavigateToSearch = { navController.navigate(Route.GlobalSearch) },
@@ -293,7 +298,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.Tasbih> {
+            taggedComposable<Route.Tasbih>(ScreenTags.Tasbih) {
                 TasbihScreen(
                     onNavigateToHistory = { navController.navigate(Route.TasbihHistory) },
                     onNavigateToChooseDhikr = { navController.navigate(Route.TasbihPresets) },
@@ -302,14 +307,14 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QiblaNav> {
+            taggedComposable<Route.QiblaNav>(ScreenTags.QiblaNav) {
                 QiblaScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Qaida (children's Arabic reader) screens
-            composable<Route.QaidaHome> {
+            taggedComposable<Route.QaidaHome>(ScreenTags.QaidaHome) {
                 QaidaHomeScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onOpenLesson = { lessonId -> navController.navigate(Route.QaidaReader(lessonId)) },
@@ -317,7 +322,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QaidaReader> { backStackEntry ->
+            taggedComposable<Route.QaidaReader>(ScreenTags.QaidaReader) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.QaidaReader>()
                 QaidaReaderScreen(
                     lessonId = args.lessonId,
@@ -325,13 +330,13 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QaidaLetters> {
+            taggedComposable<Route.QaidaLetters>(ScreenTags.QaidaLetters) {
                 QaidaLettersScreen(
                     onNavigateBack = { navController.popBackStack() },
                 )
             }
 
-            composable<Route.More> {
+            taggedComposable<Route.More>(ScreenTags.More) {
                 val context = androidx.compose.ui.platform.LocalContext.current
                 AdaptiveMoreScreen(
                     navController = navController,
@@ -340,7 +345,7 @@ fun NavGraph(
             }
 
             // Quran screens
-            composable<Route.QuranReader> { backStackEntry ->
+            taggedComposable<Route.QuranReader>(ScreenTags.QuranReader) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.QuranReader>()
                 QuranReaderScreen(
                     surahNumber = args.surahNumber,
@@ -358,7 +363,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.TafseerChapters> {
+            taggedComposable<Route.TafseerChapters>(ScreenTags.TafseerChapters) {
                 TafseerChaptersScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onOpenTafseer = { surah, ayah ->
@@ -367,7 +372,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.Tafseer> { backStackEntry ->
+            taggedComposable<Route.Tafseer>(ScreenTags.Tafseer) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.Tafseer>()
                 TafseerScreen(
                     surahNumber = args.surahNumber,
@@ -376,7 +381,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.SurahInfo> { backStackEntry ->
+            taggedComposable<Route.SurahInfo>(ScreenTags.SurahInfo) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.SurahInfo>()
                 SurahInfoScreen(
                     surahNumber = args.surahNumber,
@@ -387,7 +392,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QuranPage> { backStackEntry ->
+            taggedComposable<Route.QuranPage>(ScreenTags.QuranPage) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.QuranPage>()
                 QuranReaderScreen(
                     pageNumber = args.pageNumber,
@@ -399,7 +404,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QuranJuz> { backStackEntry ->
+            taggedComposable<Route.QuranJuz>(ScreenTags.QuranJuz) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.QuranJuz>()
                 QuranReaderScreen(
                     juzNumber = args.juzNumber,
@@ -411,7 +416,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QuranSearch> {
+            taggedComposable<Route.QuranSearch>(ScreenTags.QuranSearch) {
                 SearchScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -429,7 +434,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.QuranBookmarks> {
+            taggedComposable<Route.QuranBookmarks>(ScreenTags.QuranBookmarks) {
                 BookmarksScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -445,7 +450,7 @@ fun NavGraph(
             }
 
             // Hadith screens
-            composable<Route.HadithHome> {
+            taggedComposable<Route.HadithHome>(ScreenTags.HadithHome) {
                 AdaptiveHadithScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
@@ -454,7 +459,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HadithBook> { backStackEntry ->
+            taggedComposable<Route.HadithBook>(ScreenTags.HadithBook) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.HadithBook>()
                 HadithChaptersScreen(
                     bookId = args.bookId,
@@ -465,7 +470,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HadithChapter> { backStackEntry ->
+            taggedComposable<Route.HadithChapter>(ScreenTags.HadithChapter) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.HadithChapter>()
                 HadithReaderScreen(
                     bookId = args.bookId,
@@ -475,7 +480,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HadithReader> { backStackEntry ->
+            taggedComposable<Route.HadithReader>(ScreenTags.HadithReader) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.HadithReader>()
                 HadithReaderScreen(
                     bookId = "",
@@ -485,13 +490,13 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HadithSettings> {
+            taggedComposable<Route.HadithSettings>(ScreenTags.HadithSettings) {
                 HadithSettingsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.HadithSearch> {
+            taggedComposable<Route.HadithSearch>(ScreenTags.HadithSearch) {
                 SearchScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -509,7 +514,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HadithBookmarks> {
+            taggedComposable<Route.HadithBookmarks>(ScreenTags.HadithBookmarks) {
                 BookmarksScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -525,7 +530,7 @@ fun NavGraph(
             }
 
             // Dua screens
-            composable<Route.DuaHome> {
+            taggedComposable<Route.DuaHome>(ScreenTags.DuaHome) {
                 AdaptiveDuaScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
@@ -534,7 +539,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.DuaCategory> { backStackEntry ->
+            taggedComposable<Route.DuaCategory>(ScreenTags.DuaCategory) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.DuaCategory>()
                 DuaCategoryScreen(
                     categoryId = args.categoryId,
@@ -545,7 +550,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.DuaReader> { backStackEntry ->
+            taggedComposable<Route.DuaReader>(ScreenTags.DuaReader) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.DuaReader>()
                 DuaReaderScreen(
                     duaId = args.duaId,
@@ -554,13 +559,13 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.DuaSettings> {
+            taggedComposable<Route.DuaSettings>(ScreenTags.DuaSettings) {
                 DuaSettingsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.DuaFavorites> {
+            taggedComposable<Route.DuaFavorites>(ScreenTags.DuaFavorites) {
                 DuasCollectionScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToCategory = { categoryId ->
@@ -571,7 +576,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.DuaSearch> {
+            taggedComposable<Route.DuaSearch>(ScreenTags.DuaSearch) {
                 SearchScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -591,14 +596,14 @@ fun NavGraph(
             }
 
             // Prayer screens
-            composable<Route.PrayerTimes> {
+            taggedComposable<Route.PrayerTimes>(ScreenTags.PrayerTimes) {
                 PrayerTimesScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToSettings = { navController.navigate(Route.SettingsPrayerCalculation) }
                 )
             }
 
-            composable<Route.PrayerTracker> { backStackEntry ->
+            taggedComposable<Route.PrayerTracker>(ScreenTags.PrayerTracker) { backStackEntry ->
                 val route = backStackEntry.toRoute<Route.PrayerTracker>()
                 PrayerTrackerScreen(
                     onNavigateBack = { navController.popBackStack() },
@@ -607,14 +612,14 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.PrayerStats> {
+            taggedComposable<Route.PrayerStats>(ScreenTags.PrayerStats) {
                 PrayerStatsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Redirect QadaPrayers to PrayerTracker with Qada tab selected
-            composable<Route.QadaPrayers> {
+            taggedComposable<Route.QadaPrayers>(ScreenTags.QadaPrayers) {
                 PrayerTrackerScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToStats = { navController.navigate(Route.PrayerStats) },
@@ -622,28 +627,28 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.MonthlyPrayerTimes> {
+            taggedComposable<Route.MonthlyPrayerTimes>(ScreenTags.MonthlyPrayerTimes) {
                 MonthlyPrayerTimesScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Fasting screens
-            composable<Route.FastingHome> {
+            taggedComposable<Route.FastingHome>(ScreenTags.FastingHome) {
                 FastTrackerScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToHistory = { navController.navigate(Route.FastingStats) }
                 )
             }
 
-            composable<Route.FastingTracker> {
+            taggedComposable<Route.FastingTracker>(ScreenTags.FastingTracker) {
                 FastTrackerScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToHistory = { navController.navigate(Route.FastingStats) }
                 )
             }
 
-            composable<Route.FastingStats> {
+            taggedComposable<Route.FastingStats>(ScreenTags.FastingStats) {
                 FastTrackerScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToHistory = { }
@@ -651,7 +656,7 @@ fun NavGraph(
             }
 
             // Tasbih screens
-            composable<Route.TasbihHome> {
+            taggedComposable<Route.TasbihHome>(ScreenTags.TasbihHome) {
                 TasbihScreen(
                     onNavigateToHistory = { navController.navigate(Route.TasbihHistory) },
                     onNavigateToChooseDhikr = { navController.navigate(Route.TasbihPresets) },
@@ -660,7 +665,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.TasbihCounter> { backStackEntry ->
+            taggedComposable<Route.TasbihCounter>(ScreenTags.TasbihCounter) { backStackEntry ->
                 backStackEntry.toRoute<Route.TasbihCounter>()
                 TasbihScreen(
                     onNavigateToHistory = { navController.navigate(Route.TasbihStats) },
@@ -669,41 +674,41 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.TasbihPresets> {
+            taggedComposable<Route.TasbihPresets>(ScreenTags.TasbihPresets) {
                 com.arshadshah.nimaz.presentation.screens.tasbih.ChooseDhikrScreen(
                     onBack = { navController.popBackStack() },
                     onNavigateToAddPreset = { navController.navigate(Route.TasbihAddPreset) }
                 )
             }
 
-            composable<Route.TasbihStats> {
+            taggedComposable<Route.TasbihStats>(ScreenTags.TasbihStats) {
                 TasbihScreen(
                     onNavigateToHistory = { },
                     onNavigateToSettings = { navController.navigate(Route.Settings) }
                 )
             }
 
-            composable<Route.TasbihHistory> {
+            taggedComposable<Route.TasbihHistory>(ScreenTags.TasbihHistory) {
                 com.arshadshah.nimaz.presentation.screens.tasbih.TasbihHistoryScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.TasbihAddPreset> {
+            taggedComposable<Route.TasbihAddPreset>(ScreenTags.TasbihAddPreset) {
                 com.arshadshah.nimaz.presentation.screens.tasbih.AddPresetScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Zakat screens
-            composable<Route.ZakatCalculator> {
+            taggedComposable<Route.ZakatCalculator>(ScreenTags.ZakatCalculator) {
                 ZakatCalculatorScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToHistory = { navController.navigate(Route.ZakatHistory) }
                 )
             }
 
-            composable<Route.ZakatHistory> {
+            taggedComposable<Route.ZakatHistory>(ScreenTags.ZakatHistory) {
                 ZakatHistoryScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToCalculator = { navController.navigate(Route.ZakatCalculator) }
@@ -711,20 +716,20 @@ fun NavGraph(
             }
 
             // Qibla
-            composable<Route.Qibla> {
+            taggedComposable<Route.Qibla>(ScreenTags.Qibla) {
                 QiblaScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Islamic Calendar
-            composable<Route.IslamicCalendar> {
+            taggedComposable<Route.IslamicCalendar>(ScreenTags.IslamicCalendar) {
                 IslamicCalendarScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.IslamicMonth> { backStackEntry ->
+            taggedComposable<Route.IslamicMonth>(ScreenTags.IslamicMonth) { backStackEntry ->
                 backStackEntry.toRoute<Route.IslamicMonth>()
                 IslamicCalendarScreen(
                     onNavigateBack = { navController.popBackStack() }
@@ -732,7 +737,7 @@ fun NavGraph(
             }
 
             // Settings
-            composable<Route.Settings> {
+            taggedComposable<Route.Settings>(ScreenTags.Settings) {
                 val context = androidx.compose.ui.platform.LocalContext.current
                 AdaptiveSettingsScreen(
                     navController = navController,
@@ -740,57 +745,57 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.SettingsPrayerCalculation> {
+            taggedComposable<Route.SettingsPrayerCalculation>(ScreenTags.SettingsPrayerCalculation) {
                 PrayerSettingsScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToNotifications = { navController.navigate(Route.SettingsNotifications) }
                 )
             }
 
-            composable<Route.SettingsNotifications> {
+            taggedComposable<Route.SettingsNotifications>(ScreenTags.SettingsNotifications) {
                 NotificationSettingsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsAppearance> {
+            taggedComposable<Route.SettingsAppearance>(ScreenTags.SettingsAppearance) {
                 AppearanceSettingsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsLanguage> {
+            taggedComposable<Route.SettingsLanguage>(ScreenTags.SettingsLanguage) {
                 LanguageScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsLocation> {
+            taggedComposable<Route.SettingsLocation>(ScreenTags.SettingsLocation) {
                 LocationScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsQuran> {
+            taggedComposable<Route.SettingsQuran>(ScreenTags.SettingsQuran) {
                 QuranSettingsScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToSelectReciter = { navController.navigate(Route.SelectReciter) }
                 )
             }
 
-            composable<Route.SelectReciter> {
+            taggedComposable<Route.SelectReciter>(ScreenTags.SelectReciter) {
                 SelectReciterScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsWidgets> {
+            taggedComposable<Route.SettingsWidgets>(ScreenTags.SettingsWidgets) {
                 WidgetsScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsAbout> {
+            taggedComposable<Route.SettingsAbout>(ScreenTags.SettingsAbout) {
                 val context = androidx.compose.ui.platform.LocalContext.current
                 AboutScreen(
                     onNavigateBack = { navController.popBackStack() },
@@ -855,7 +860,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.Licenses> {
+            taggedComposable<Route.Licenses>(ScreenTags.Licenses) {
                 LicensesScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToDetail = { hashCode ->
@@ -864,7 +869,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.LicenseDetail> { backStackEntry ->
+            taggedComposable<Route.LicenseDetail>(ScreenTags.LicenseDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.LicenseDetail>()
                 LicenseDetailScreen(
                     libraryHashCode = args.libraryHashCode,
@@ -873,14 +878,14 @@ fun NavGraph(
             }
 
             // Asma ul Husna screens
-            composable<Route.AsmaUlHusnaList> {
+            taggedComposable<Route.AsmaUlHusnaList>(ScreenTags.AsmaUlHusnaList) {
                 AdaptiveAsmaUlHusnaScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
                 )
             }
 
-            composable<Route.AsmaUlHusnaDetail> { backStackEntry ->
+            taggedComposable<Route.AsmaUlHusnaDetail>(ScreenTags.AsmaUlHusnaDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.AsmaUlHusnaDetail>()
                 AsmaUlHusnaDetailScreen(
                     nameId = args.nameId,
@@ -889,14 +894,14 @@ fun NavGraph(
             }
 
             // Asma un Nabi screens
-            composable<Route.AsmaUnNabiList> {
+            taggedComposable<Route.AsmaUnNabiList>(ScreenTags.AsmaUnNabiList) {
                 AdaptiveAsmaUnNabiScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
                 )
             }
 
-            composable<Route.AsmaUnNabiDetail> { backStackEntry ->
+            taggedComposable<Route.AsmaUnNabiDetail>(ScreenTags.AsmaUnNabiDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.AsmaUnNabiDetail>()
                 AsmaUnNabiDetailScreen(
                     nameId = args.nameId,
@@ -905,14 +910,14 @@ fun NavGraph(
             }
 
             // Prophets screens
-            composable<Route.ProphetsList> {
+            taggedComposable<Route.ProphetsList>(ScreenTags.ProphetsList) {
                 AdaptiveProphetsScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
                 )
             }
 
-            composable<Route.ProphetDetail> { backStackEntry ->
+            taggedComposable<Route.ProphetDetail>(ScreenTags.ProphetDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.ProphetDetail>()
                 ProphetDetailScreen(
                     prophetId = args.prophetId,
@@ -921,7 +926,7 @@ fun NavGraph(
             }
 
             // Khatam screens
-            composable<Route.KhatamList> {
+            taggedComposable<Route.KhatamList>(ScreenTags.KhatamList) {
                 AdaptiveKhatamScreen(
                     navController = navController,
                     onNavigateBack = { navController.popBackStack() },
@@ -929,7 +934,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.KhatamDetail> { backStackEntry ->
+            taggedComposable<Route.KhatamDetail>(ScreenTags.KhatamDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.KhatamDetail>()
                 KhatamDetailScreen(
                     khatamId = args.khatamId,
@@ -940,13 +945,13 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.KhatamCreate> {
+            taggedComposable<Route.KhatamCreate>(ScreenTags.KhatamCreate) {
                 KhatamCreateScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
-            composable<Route.SettingsHelp> {
+            taggedComposable<Route.SettingsHelp>(ScreenTags.SettingsHelp) {
                 val context = androidx.compose.ui.platform.LocalContext.current
                 val supportEmail =
                     androidx.compose.ui.res.stringResource(com.arshadshah.nimaz.R.string.support_email)
@@ -977,7 +982,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HelpTopicDetail> { backStackEntry ->
+            taggedComposable<Route.HelpTopicDetail>(ScreenTags.HelpTopicDetail) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.HelpTopicDetail>()
                 com.arshadshah.nimaz.presentation.screens.help.HelpTopicDetailScreen(
                     topicId = args.topicId,
@@ -986,7 +991,7 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.HelpGuide> { backStackEntry ->
+            taggedComposable<Route.HelpGuide>(ScreenTags.HelpGuide) { backStackEntry ->
                 val args = backStackEntry.toRoute<Route.HelpGuide>()
                 com.arshadshah.nimaz.presentation.screens.help.HelpGuideScreen(
                     guideId = args.guideId,
@@ -999,14 +1004,14 @@ fun NavGraph(
                 )
             }
 
-            composable<Route.SettingsSync> {
+            taggedComposable<Route.SettingsSync>(ScreenTags.SettingsSync) {
                 com.arshadshah.nimaz.presentation.screens.settings.SyncScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Bookmarks
-            composable<Route.AllBookmarks> {
+            taggedComposable<Route.AllBookmarks>(ScreenTags.AllBookmarks) {
                 BookmarksScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -1022,7 +1027,7 @@ fun NavGraph(
             }
 
             // Global Search
-            composable<Route.GlobalSearch> {
+            taggedComposable<Route.GlobalSearch>(ScreenTags.GlobalSearch) {
                 SearchScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToQuranAyah = { surah, ayah ->
@@ -1039,6 +1044,26 @@ fun NavGraph(
                     }
                 )
             }
+        }
+    }
+}
+
+/**
+ * Like [composable], but wraps the destination content in a full-size [Box] carrying a
+ * stable [testTag] ([ScreenTags]). This gives the instrumented UI tests a locale- and
+ * copy-independent way to assert which screen is currently shown. The wrapper is
+ * otherwise transparent: it forwards the [AnimatedContentScope] receiver and the
+ * [NavBackStackEntry] so existing destination bodies (including `toRoute()` arg
+ * extraction and any shared-element usage) behave exactly as before.
+ */
+private inline fun <reified T : Any> NavGraphBuilder.taggedComposable(
+    tag: String,
+    crossinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
+    composable<T> { entry ->
+        val scope = this
+        Box(modifier = Modifier.fillMaxSize().testTag(tag)) {
+            scope.content(entry)
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -665,7 +665,7 @@ fun NavGraph(
                 )
             }
 
-            taggedComposable<Route.TasbihCounter>(ScreenTags.TasbihCounter) { backStackEntry ->
+            taggedComposable<Route.TasbihCounter>(ScreenTags.TasbihCounterScreen) { backStackEntry ->
                 backStackEntry.toRoute<Route.TasbihCounter>()
                 TasbihScreen(
                     onNavigateToHistory = { navController.navigate(Route.TasbihStats) },

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -53,7 +53,7 @@ object ScreenTags {
     const val FastingTracker = "screen_fasting_tracker"
     const val FastingStats = "screen_fasting_stats"
     const val TasbihHome = "screen_tasbih_home"
-    const val TasbihCounter = "screen_tasbih_counter"
+    const val TasbihCounterScreen = "screen_tasbih_counter"
     const val TasbihPresets = "screen_tasbih_presets"
     const val TasbihStats = "screen_tasbih_stats"
     const val TasbihHistory = "screen_tasbih_history"

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -94,6 +94,12 @@ object ScreenTags {
     /** Scrollable lists on hub screens — let UI tests scroll to off-screen entries. */
     const val MoreList = "more_menu_list"
     const val SettingsList = "settings_list"
+    const val AppearanceList = "settings_appearance_list"
+    const val NotificationsList = "settings_notifications_list"
+
+    /** Interactive elements exercised by behavior tests. */
+    const val TasbihCounter = "tasbih_counter"
+    const val TasbihCount = "tasbih_count"
 
     /** Tag for a bottom-navigation tab, keyed by its label (e.g. "Home"). */
     fun bottomNav(label: String): String = "bottomnav_$label"

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -1,0 +1,100 @@
+package com.arshadshah.nimaz.core.navigation
+
+/**
+ * Stable Compose `testTag` values for navigation, used by the instrumented UI tests
+ * to assert *which* screen is showing — independent of locale or on-screen copy.
+ *
+ * Each routed destination in [NavGraph] is wrapped in a tagged container (see
+ * `taggedComposable`), and each bottom-navigation item carries [bottomNav]. Tests
+ * reference these constants (mirrored in the androidTest `Selectors`) rather than
+ * matching user-visible text, so a label change never breaks a navigation test.
+ *
+ * Naming: one constant per `Route` simple name; the tag string is `screen_<route>`.
+ * This object is the single source of truth — add a new destination's tag here and
+ * wrap it in [NavGraph].
+ */
+object ScreenTags {
+    const val Onboarding = "screen_onboarding"
+    const val Home = "screen_home"
+    const val Quran = "screen_quran"
+    const val Tasbih = "screen_tasbih"
+    const val QiblaNav = "screen_qibla_nav"
+    const val QaidaHome = "screen_qaida_home"
+    const val QaidaReader = "screen_qaida_reader"
+    const val QaidaLetters = "screen_qaida_letters"
+    const val More = "screen_more"
+    const val QuranReader = "screen_quran_reader"
+    const val TafseerChapters = "screen_tafseer_chapters"
+    const val Tafseer = "screen_tafseer"
+    const val SurahInfo = "screen_surah_info"
+    const val QuranPage = "screen_quran_page"
+    const val QuranJuz = "screen_quran_juz"
+    const val QuranSearch = "screen_quran_search"
+    const val QuranBookmarks = "screen_quran_bookmarks"
+    const val HadithHome = "screen_hadith_home"
+    const val HadithBook = "screen_hadith_book"
+    const val HadithChapter = "screen_hadith_chapter"
+    const val HadithReader = "screen_hadith_reader"
+    const val HadithSettings = "screen_hadith_settings"
+    const val HadithSearch = "screen_hadith_search"
+    const val HadithBookmarks = "screen_hadith_bookmarks"
+    const val DuaHome = "screen_dua_home"
+    const val DuaCategory = "screen_dua_category"
+    const val DuaReader = "screen_dua_reader"
+    const val DuaSettings = "screen_dua_settings"
+    const val DuaFavorites = "screen_dua_favorites"
+    const val DuaSearch = "screen_dua_search"
+    const val PrayerTimes = "screen_prayer_times"
+    const val PrayerTracker = "screen_prayer_tracker"
+    const val PrayerStats = "screen_prayer_stats"
+    const val QadaPrayers = "screen_qada_prayers"
+    const val MonthlyPrayerTimes = "screen_monthly_prayer_times"
+    const val FastingHome = "screen_fasting_home"
+    const val FastingTracker = "screen_fasting_tracker"
+    const val FastingStats = "screen_fasting_stats"
+    const val TasbihHome = "screen_tasbih_home"
+    const val TasbihCounter = "screen_tasbih_counter"
+    const val TasbihPresets = "screen_tasbih_presets"
+    const val TasbihStats = "screen_tasbih_stats"
+    const val TasbihHistory = "screen_tasbih_history"
+    const val TasbihAddPreset = "screen_tasbih_add_preset"
+    const val ZakatCalculator = "screen_zakat_calculator"
+    const val ZakatHistory = "screen_zakat_history"
+    const val Qibla = "screen_qibla"
+    const val IslamicCalendar = "screen_islamic_calendar"
+    const val IslamicMonth = "screen_islamic_month"
+    const val Settings = "screen_settings"
+    const val SettingsPrayerCalculation = "screen_settings_prayer_calculation"
+    const val SettingsNotifications = "screen_settings_notifications"
+    const val SettingsAppearance = "screen_settings_appearance"
+    const val SettingsLanguage = "screen_settings_language"
+    const val SettingsLocation = "screen_settings_location"
+    const val SettingsQuran = "screen_settings_quran"
+    const val SelectReciter = "screen_select_reciter"
+    const val SettingsWidgets = "screen_settings_widgets"
+    const val SettingsAbout = "screen_settings_about"
+    const val Licenses = "screen_licenses"
+    const val LicenseDetail = "screen_license_detail"
+    const val AsmaUlHusnaList = "screen_asma_ul_husna_list"
+    const val AsmaUlHusnaDetail = "screen_asma_ul_husna_detail"
+    const val AsmaUnNabiList = "screen_asma_un_nabi_list"
+    const val AsmaUnNabiDetail = "screen_asma_un_nabi_detail"
+    const val ProphetsList = "screen_prophets_list"
+    const val ProphetDetail = "screen_prophet_detail"
+    const val KhatamList = "screen_khatam_list"
+    const val KhatamDetail = "screen_khatam_detail"
+    const val KhatamCreate = "screen_khatam_create"
+    const val SettingsHelp = "screen_settings_help"
+    const val HelpTopicDetail = "screen_help_topic_detail"
+    const val HelpGuide = "screen_help_guide"
+    const val SettingsSync = "screen_settings_sync"
+    const val AllBookmarks = "screen_all_bookmarks"
+    const val GlobalSearch = "screen_global_search"
+
+    /** Scrollable lists on hub screens — let UI tests scroll to off-screen entries. */
+    const val MoreList = "more_menu_list"
+    const val SettingsList = "settings_list"
+
+    /** Tag for a bottom-navigation tab, keyed by its label (e.g. "Home"). */
+    fun bottomNav(label: String): String = "bottomnav_$label"
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -89,6 +91,7 @@ fun MoreMenuScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(ScreenTags.MoreList)
                 .padding(paddingValues)
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -71,6 +73,7 @@ fun AppearanceSettingsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(ScreenTags.AppearanceList)
                 .padding(paddingValues)
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -155,6 +157,7 @@ fun NotificationSettingsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(ScreenTags.NotificationsList)
                 .padding(paddingValues)
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -84,6 +86,7 @@ fun SettingsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(ScreenTags.SettingsList)
                 .padding(paddingValues)
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
@@ -572,6 +574,7 @@ private fun CounterCircle(
             modifier = Modifier
                 .size(circleSize - 36.dp)
                 .scale(scale)
+                .testTag(ScreenTags.TasbihCounter)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
@@ -597,6 +600,7 @@ private fun CounterCircle(
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
+                        modifier = Modifier.testTag(ScreenTags.TasbihCount),
                         text = count.toString(),
                         style = MaterialTheme.typography.displayLarge.copy(
                             fontSize = 72.sp,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
@@ -574,7 +574,7 @@ private fun CounterCircle(
             modifier = Modifier
                 .size(circleSize - 36.dp)
                 .scale(scale)
-                .testTag(ScreenTags.TasbihCounterScreen)
+                .testTag(ScreenTags.TasbihCounter)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreen.kt
@@ -574,7 +574,7 @@ private fun CounterCircle(
             modifier = Modifier
                 .size(circleSize - 36.dp)
                 .scale(scale)
-                .testTag(ScreenTags.TasbihCounter)
+                .testTag(ScreenTags.TasbihCounterScreen)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,10 @@ These are the rules most often broken. Keep this checklist in mind for every cha
 8. **Verify before you finish.** `./gradlew :app:compileDebugKotlin` must pass (this runs
    KSP, so it validates Hilt + Room wiring too).
 
+> **Testing:** unit/Robolectric tests live in `app/src/test{,Debug}`; the on-device
+> instrumented suite (Hilt graph, Room, WorkManager, NavGraph flows) lives in
+> `app/src/androidTest` and is documented in **[`docs/TESTING.md`](TESTING.md)**.
+
 ---
 
 ## 1. High-level architecture

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -9,6 +9,12 @@ Navigation is **type-safe**: a `@Serializable sealed interface Route`
 `core/navigation/NavGraph.kt`. Typed arguments are read with
 `backStackEntry.toRoute<Route.X>()`. Bottom navigation is the `BottomNavDestination` enum.
 
+> **Test hooks:** each destination is wired via the local `taggedComposable<Route.X>`
+> helper, which wraps the screen in a container carrying a stable
+> `ScreenTags.X` tag (`core/navigation/ScreenTags.kt`); bottom-nav items carry
+> `ScreenTags.bottomNav(label)`. Instrumented UI tests assert navigation by these tags
+> rather than on-screen text. Keep `ScreenTags` in sync when adding a `Route`.
+
 ## Graph
 
 ```mermaid

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,6 +34,13 @@ Requires JDK 21 + Android SDK (`local.properties` `sdk.dir` or `ANDROID_HOME`).
   This is behaviourally identical in production.
 - **WorkManager:** worker tests configure WorkManager via `WorkManagerTestInitHelper`
   with the injected `HiltWorkerFactory` (`androidx.work:work-testing`).
+- **Screen tags:** every routed destination is wrapped by `taggedComposable` in
+  `NavGraph` with a stable tag from `core/navigation/ScreenTags`, and each bottom-nav
+  item carries `ScreenTags.bottomNav(label)`. Because the tag is on the wrapper (composed
+  immediately, before any data loads), navigation assertions are deterministic and
+  independent of locale, seeded content, or on-screen copy. The hub lists (More,
+  Settings) are also tagged so tests can scroll to off-screen entries. This is the one
+  source of truth — `Selectors` in the test code references `ScreenTags` directly.
 
 ## Module layout (`app/src/androidTest/java/com/arshadshah/nimaz`)
 
@@ -44,7 +51,7 @@ Requires JDK 21 + Android SDK (`local.properties` `sdk.dir` or `ANDROID_HOME`).
 | `preferences/`   | `SettingsRepository` (DataStore) round-trips + export/import. |
 | `notifications/` | `PrayerNotificationScheduler` channel creation + schedule/cancel smoke. |
 | `work/`          | Every `@HiltWorker` widget/adhan worker executed via the real factory. |
-| `navigation/`    | Launches `MainActivity` and walks the bottom-nav tabs + More-menu flows. |
+| `navigation/`    | Launches `MainActivity` and asserts navigation **by `ScreenTags`**: all 5 bottom-nav tabs (`BottomNavigationTest`), every More-menu feature — daily practice, learning, tools, support (`FeatureNavigationTest`), every Settings sub-screen (`SettingsNavigationTest`), and back-navigation round-trips (`MoreMenuNavigationTest`). |
 | (root)           | `MigrationTest` (per-step) and `MigrationChainTest` (v7→current). |
 
 ## Conventions

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,22 @@ Two on-device/JVM test surfaces exist:
 
 Requires JDK 21 + Android SDK (`local.properties` `sdk.dir` or `ANDROID_HOME`).
 
+## CI (emulator.wtf)
+
+`.github/workflows/android_instrumented_tests.yml` runs the instrumented suite in the
+cloud on every push to `main` and on every pull request. It:
+
+1. builds `:app:assembleDebug` + `:app:assembleDebugAndroidTest` (this also serves as
+   the compile check for the androidTest sources / Hilt test components),
+2. uploads both APKs as the `instrumentation-apks` artifact,
+3. routes them to the [`emulator-wtf/actions/run-tests`](https://github.com/emulator-wtf/actions)
+   action (sharded, Pixel2 / API 30 — note minSdk 29 rules out the default API 27 device),
+4. publishes the JUnit results as a check.
+
+**Setup:** add an `EW_API_TOKEN` repository secret (Settings → Secrets and variables →
+Actions). Without it the workflow still builds and uploads the APKs but skips the cloud
+run with a warning — it never hard-fails for a missing token.
+
 ## How it's wired
 
 - **Runner:** `support/HiltTestRunner` swaps in `HiltTestApplication` so tests run on

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,59 @@
+# Testing
+
+Two on-device/JVM test surfaces exist:
+
+- **Unit / Robolectric** (`app/src/test`, `app/src/testDebug`) — ViewModel logic and
+  Compose "atom/molecule/organism" component tests run off-device under Robolectric.
+  Coverage is reported via the `jacoco*Report` Gradle tasks (see `app/build.gradle.kts`).
+- **Instrumented** (`app/src/androidTest`) — the suite documented here. Runs on an
+  emulator/device against the real Hilt graph, Room database, WorkManager, and
+  `MainActivity`/`NavGraph`.
+
+## Running the instrumented suite
+
+```bash
+# Boot an emulator (API 29+; the app's minSdk) first, then:
+./gradlew :app:connectedDebugAndroidTest
+
+# A single class / package:
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.arshadshah.nimaz.db.PrayerDaoTest
+```
+
+Requires JDK 21 + Android SDK (`local.properties` `sdk.dir` or `ANDROID_HOME`).
+
+## How it's wired
+
+- **Runner:** `support/HiltTestRunner` swaps in `HiltTestApplication` so tests run on
+  the full Hilt object graph **without** `NimazApp`'s production bootstrap (Firebase,
+  `AppInitializer` locale/notification/adhan work). Registered as
+  `testInstrumentationRunner` in `app/build.gradle.kts`.
+- **Splash guard:** because the host Application under test is `HiltTestApplication`
+  (not `NimazApp`), `MainActivity` resolves its initializer with a null-safe cast
+  (`application as? NimazApp`) and lifts the splash immediately when there is none.
+  This is behaviourally identical in production.
+- **WorkManager:** worker tests configure WorkManager via `WorkManagerTestInitHelper`
+  with the injected `HiltWorkerFactory` (`androidx.work:work-testing`).
+
+## Module layout (`app/src/androidTest/java/com/arshadshah/nimaz`)
+
+| Package          | What it covers |
+|------------------|----------------|
+| `support/`       | Shared infra — **no test owns a magic string**. `HiltTestRunner`, `Selectors` (nav labels, real `testTag`s, `R.string` lookups), `TestData` (entity builders), `NimazDbRule` (in-memory Room), `BaseAppTest` (Compose + Hilt base for UI flows). |
+| `db/`            | Round-trip CRUD + `Flow` coverage for every major DAO (prayer, fasting, tasbih, khatam, quran, dua, hadith, zakat, tafseer, qaida, names, location, events), plus `DatabaseAssetTest` verifying the shipped prepopulated DB seeds. |
+| `preferences/`   | `SettingsRepository` (DataStore) round-trips + export/import. |
+| `notifications/` | `PrayerNotificationScheduler` channel creation + schedule/cancel smoke. |
+| `work/`          | Every `@HiltWorker` widget/adhan worker executed via the real factory. |
+| `navigation/`    | Launches `MainActivity` and walks the bottom-nav tabs + More-menu flows. |
+| (root)           | `MigrationTest` (per-step) and `MigrationChainTest` (v7→current). |
+
+## Conventions
+
+- **Selectors live in `support/Selectors.kt`.** Tests reference `Selectors.NavLabel.*`,
+  `Selectors.<Area>.<key>` (a `@StringRes` id resolved at runtime), or `Selectors.Tag.*`.
+  Add new selectors there rather than inlining literals.
+- **Entities come from `support/TestData.kt`.** Override only the fields a test asserts on.
+- **DAO tests use the in-memory `NimazDbRule`** (hermetic, fast). Asset/migration
+  behaviour is covered separately so a schema change fails in exactly one obvious place.
+- **UI flows extend `BaseAppTest`** and must carry their own `@HiltAndroidTest`
+  (the annotation is not inherited from the base).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -70,6 +70,34 @@ run with a warning — it never hard-fails for a missing token.
 | `navigation/`    | Launches `MainActivity` and asserts navigation **by `ScreenTags`**: all 5 bottom-nav tabs (`BottomNavigationTest`), every More-menu feature — daily practice, learning, tools, support (`FeatureNavigationTest`), every Settings sub-screen (`SettingsNavigationTest`), and back-navigation round-trips (`MoreMenuNavigationTest`). |
 | (root)           | `MigrationTest` (per-step) and `MigrationChainTest` (v7→current). |
 
+## Coverage audit (what's validated)
+
+| Layer / area | Covered by | Kind |
+|---|---|---|
+| Every DAO (prayer, fasting, tasbih, khatam, quran, dua, hadith, zakat, tafseer, qaida, names, location, events) | `db/*DaoTest`, `UserDataDaoTest` | CRUD + Flow round-trips on in-memory Room |
+| Shipped prepopulated DB seeds | `db/DatabaseAssetTest` | real DI database (LFS asset) |
+| Schema migrations (per-step + full v7→current) | `MigrationTest`, `MigrationChainTest` | `MigrationTestHelper` |
+| Settings **persistence** (DataStore) | `preferences/SettingsRepositoryTest` | flow round-trips + export/import |
+| Notification channels + schedule/cancel | `notifications/PrayerNotificationSchedulerTest` | Hilt singleton |
+| Every background worker | `work/WidgetWorkersTest` | `HiltWorkerFactory` + `WorkManagerTestInitHelper` |
+| App launch + all 5 bottom-nav tabs | `navigation/AppLaunchTest`, `BottomNavigationTest` | real `MainActivity`/`NavGraph`, by `ScreenTags` |
+| Every More-menu feature opens (16) | `navigation/FeatureNavigationTest` | tag-asserted, with back round-trips |
+| Every Settings sub-screen opens (8) | `navigation/SettingsNavigationTest` | tag-asserted |
+| **First-run / onboarding completes + persists** | `behavior/OnboardingFlowTest` | drives the real screen |
+| **Settings toggles actually work** (UI switch → DataStore) | `behavior/SettingsBehaviorTest` | Appearance haptic/24h/animations + notification vibration |
+| **Tasbih counter increments on tap** | `behavior/TasbihCounterTest` | tag-driven interaction |
+
+**Deliberately validated at the data/VM layer, not via UI** (UI input is brittle and the
+logic is unit-tested): Zakat calculation math (`ZakatDaoTest` + the Zakat ViewModel unit
+tests), prayer-tracker status changes (`PrayerDaoTest.updatePrayerStatus`), bookmark/
+favorite toggles for Quran/Hadith/Dua (the `*DaoTest` `toggle*` cases). The screens that
+surface these all render and navigate (covered above); the state transitions are proven
+on the layer that owns them.
+
+**Known UI-test exclusion:** the Qibla compass screen recomposes continuously from the
+sensor listener and never reaches Compose idle, so it is not driven by idling-based UI
+tests (its tab presence is asserted in `AppLaunchTest`).
+
 ## Conventions
 
 - **Selectors live in `support/Selectors.kt`.** Tests reference `Selectors.NavLabel.*`,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,6 +145,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 hilt-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "uiTestJunit4" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workManager" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds a modular androidTest suite that exercises the user-facing app end to end on
an emulator, reducing manual testing:

Infrastructure (support/)
- HiltTestRunner: boots HiltTestApplication so tests run on the full Hilt graph
  without NimazApp's Firebase / AppInitializer bootstrap. Registered as the
  testInstrumentationRunner.
- Selectors: single home for every UI selector (nav labels, real testTags,
  R.string lookups) so no magic strings leak into test bodies.
- TestData: entity-builder factory with sensible defaults.
- NimazDbRule: hermetic in-memory Room rule.
- BaseAppTest: Compose + Hilt base that seeds onboarding state pre-launch and
  drives the real MainActivity/NavGraph.

Coverage
- db/: round-trip CRUD + Flow tests for every major DAO (prayer, fasting, tasbih,
  khatam, quran, dua, hadith, zakat, tafseer, qaida, names, location, events) plus
  DatabaseAssetTest verifying the shipped prepopulated DB seeds.
- preferences/: SettingsRepository (DataStore) round-trips + export/import.
- notifications/: PrayerNotificationScheduler channel creation + schedule/cancel.
- work/: every @HiltWorker widget/adhan worker via WorkManagerTestInitHelper.
- navigation/: launches MainActivity and walks bottom-nav tabs + More-menu flows.
- MigrationChainTest: full v7->current migration chain.

App change
- MainActivity: null-safe (application as? NimazApp) splash guard so the UI renders
  under HiltTestApplication; behaviourally identical in production.

Build
- Register HiltTestRunner; add androidx.work:work-testing.

Docs
- New docs/TESTING.md; ARCHITECTURE.md links it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KAtRR9wDZac6ewRfqy1ufR