### PR TITLE
feat(ui): consolidate all switches into a NimazSwitch atom (#202)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazButton.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazButton.kt
@@ -202,9 +202,9 @@ private fun outlinedBorder(enabled: Boolean): BorderStroke {
 
 @Composable
 private fun textStyleFor(size: NimazButtonSize): TextStyle = when (size) {
-    NimazButtonSize.SMALL -> MaterialTheme.typography.labelMedium
-    NimazButtonSize.MEDIUM -> MaterialTheme.typography.labelLarge
-    NimazButtonSize.LARGE -> MaterialTheme.typography.titleSmall
+    NimazButtonSize.SMALL -> MaterialTheme.typography.titleSmall
+    NimazButtonSize.MEDIUM -> MaterialTheme.typography.titleMedium
+    NimazButtonSize.LARGE -> MaterialTheme.typography.titleLarge
 }
 
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSwitch.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSwitch.kt
@@ -1,0 +1,208 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import com.arshadshah.nimaz.presentation.theme.ThemeMode
+
+/**
+ * Semantic colour role for a [NimazSwitch]: it tints the **checked** track. The thumb,
+ * borders, check glyph and the whole unchecked pill use fixed scheme colours so the OFF
+ * state always stays legible; disabled states fall back to the Material 3 defaults. Roles
+ * map onto the app's Material 3 scheme so they track theming automatically — pass an
+ * explicit `trackTint` to [NimazSwitch] to escape them.
+ */
+enum class NimazSwitchVariant {
+    /** The faithful default toggle tint. `primary`. */
+    DEFAULT,
+
+    /** Brand emphasis. `primary`. */
+    PRIMARY,
+
+    /** Positive / "active" semantics. `NimazColors.Success`. */
+    SUCCESS,
+
+    /** Destructive / alert. `error`. */
+    ERROR
+}
+
+/**
+ * The app's single on/off toggle primitive.
+ *
+ * Replaces the mix of bare Material 3 `Switch`es and the one hand-styled, fully
+ * custom-coloured switch (with its broken all-`surface` disabled state) that the partial
+ * migration left in [com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem],
+ * `NotificationSettingsScreen`, the tasbih sheets and the calendar preview — with one
+ * variant-driven entry point so every toggle in the app reads identically.
+ *
+ * It wraps Material 3 `Switch` (so it keeps the platform drag gesture, the `Role.Switch`
+ * accessibility semantics and the tuned thumb animation) and layers on the canonical
+ * Nimaz look: a brand-tinted track and a light thumb with a check glyph when checked, and
+ * a clearly contrasted outlined pill (raised thumb on a surface track) when off. Only the
+ * disabled colours are left to `SwitchDefaults` — which dims them correctly — fixing the
+ * old custom switch that hard-coded every disabled colour to `surface` and turned invisible.
+ *
+ * Genuine multi-choice pickers keep their `RadioButton`; the bordered check box is
+ * [NimazCheckbox].
+ *
+ * Pass `onCheckedChange = null` when an enclosing clickable row owns the toggle (e.g. a
+ * whole settings row is tappable): the switch then renders its state and reports it for
+ * accessibility but does not handle its own clicks.
+ *
+ * @param checked whether the switch is currently on.
+ * @param onCheckedChange invoked with the toggled value on tap; `null` defers the click
+ *   to an enclosing clickable (the row-driven settings drop-in).
+ * @param variant semantic colour role for the checked track / glyph; [trackTint] overrides it.
+ * @param enabled when false, dims the switch (via Material defaults) and blocks interaction.
+ * @param thumbIcon glyph shown on the thumb while checked; `null` hides it for a plain thumb.
+ * @param trackTint escape hatch overriding [variant]'s checked-track colour (brand
+ *   `NimazColors.*` or a runtime colour).
+ * @param contentDescription accessibility label for the toggle.
+ */
+@Composable
+fun NimazSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    variant: NimazSwitchVariant = NimazSwitchVariant.PRIMARY,
+    enabled: Boolean = true,
+    thumbIcon: ImageVector? = Icons.Default.Check,
+    trackTint: Color? = null,
+    contentDescription: String? = null,
+) {
+    val trackColor = trackTint ?: variant.resolveTrack()
+
+    val descriptionModifier = if (contentDescription != null) {
+        Modifier.semantics { this.contentDescription = contentDescription }
+    } else {
+        Modifier
+    }
+
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier.then(descriptionModifier),
+        enabled = enabled,
+        thumbContent = if (checked && thumbIcon != null) {
+            {
+                NimazIcon(
+                    imageVector = thumbIcon,
+                    contentDescription = null,
+                    iconSize = 16.dp,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            null
+        },
+        // The full enabled palette from the original enhanced switch (so the OFF thumb stays
+        // visible against the track); only the variant drives the checked track colour. The
+        // disabled colours are left to SwitchDefaults — the old switch hard-coded every
+        // disabled colour to `surface`, which made a disabled switch invisible.
+        colors = SwitchDefaults.colors(
+            checkedThumbColor = MaterialTheme.colorScheme.surface,
+            checkedTrackColor = trackColor,
+            checkedBorderColor = MaterialTheme.colorScheme.outline,
+            checkedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            uncheckedThumbColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+            uncheckedBorderColor = MaterialTheme.colorScheme.outline,
+            uncheckedIconColor = MaterialTheme.colorScheme.onSurface,
+        )
+    )
+}
+
+/** Checked-track / glyph colour for the variant. */
+@Composable
+private fun NimazSwitchVariant.resolveTrack(): Color = when (this) {
+    NimazSwitchVariant.DEFAULT -> MaterialTheme.colorScheme.primary
+    NimazSwitchVariant.PRIMARY -> MaterialTheme.colorScheme.primary
+    NimazSwitchVariant.SUCCESS -> NimazColors.Success
+    NimazSwitchVariant.ERROR -> MaterialTheme.colorScheme.error
+}
+
+
+// ==================== PREVIEWS ====================
+
+@Composable
+private fun NimazSwitchVariantsShowcase() {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        NimazSwitchVariant.entries.forEach { variant ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                NimazSwitch(checked = false, onCheckedChange = {}, variant = variant)
+                NimazSwitch(checked = true, onCheckedChange = {}, variant = variant)
+                Text(variant.name, style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NimazSwitchStatesShowcase() {
+    Row(
+        modifier = Modifier.padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Disabled on / off.
+        NimazSwitch(checked = true, onCheckedChange = {}, enabled = false)
+        NimazSwitch(checked = false, onCheckedChange = {}, enabled = false)
+        // Plain thumb (no glyph).
+        NimazSwitch(checked = true, onCheckedChange = {}, thumbIcon = null)
+        // Row-driven (no own handler).
+        NimazSwitch(checked = true, onCheckedChange = null)
+    }
+}
+
+@Composable
+private fun NimazSwitchShowcase() {
+    Column(
+        modifier = Modifier.padding(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text("Variants (off · on)", style = MaterialTheme.typography.labelMedium)
+        NimazSwitchVariantsShowcase()
+        Text("Disabled · plain thumb · row-driven", style = MaterialTheme.typography.labelMedium)
+        NimazSwitchStatesShowcase()
+    }
+}
+
+@Preview(showBackground = true, name = "NimazSwitch — Light")
+@Composable
+private fun NimazSwitchLightPreview() {
+    NimazTheme(themeMode = ThemeMode.LIGHT) { NimazSwitchShowcase() }
+}
+
+@Preview(
+    showBackground = true, name = "NimazSwitch — Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun NimazSwitchDarkPreview() {
+    NimazTheme(themeMode = ThemeMode.DARK) { NimazSwitchShowcase() }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
@@ -13,11 +13,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchColors
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,6 +29,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @Composable
@@ -106,35 +104,11 @@ fun NimazSettingsItem(
         when {
             trailingContent != null -> trailingContent()
             checked != null && onCheckedChange != null -> {
-                Switch(
+                // The enclosing Row already toggles via clickModifier, so the switch
+                // itself defers its click (onCheckedChange = null) to avoid a double-fire.
+                NimazSwitch(
                     checked = checked,
-                    onCheckedChange = onCheckedChange,
-                    thumbContent = {
-                        if(checked){
-                            NimazIcon(
-                               imageVector =  Icons.Default.Check,
-                                size = NimazIconSize.SMALL,
-                            )
-                        }
-                    },
-                    colors = SwitchColors(
-                        checkedThumbColor = MaterialTheme.colorScheme.surface,
-                        checkedTrackColor = MaterialTheme.colorScheme.primary,
-                        checkedBorderColor = MaterialTheme.colorScheme.outline,
-                        checkedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        uncheckedThumbColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                        uncheckedBorderColor = MaterialTheme.colorScheme.outline,
-                        uncheckedIconColor = MaterialTheme.colorScheme.onSurface,
-                        disabledCheckedThumbColor = MaterialTheme.colorScheme.surface,
-                        disabledCheckedTrackColor = MaterialTheme.colorScheme.surface,
-                        disabledCheckedBorderColor = MaterialTheme.colorScheme.surface,
-                        disabledCheckedIconColor = MaterialTheme.colorScheme.surface,
-                        disabledUncheckedThumbColor = MaterialTheme.colorScheme.surface,
-                        disabledUncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                        disabledUncheckedBorderColor = MaterialTheme.colorScheme.surface,
-                        disabledUncheckedIconColor = MaterialTheme.colorScheme.surface
-                    )
+                    onCheckedChange = null
                 )
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/calendar/NimazCalendarShowcasePreviews.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/calendar/NimazCalendarShowcasePreviews.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Switch
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -217,7 +217,7 @@ private fun CalendarShowcase() {
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f)
             )
-            Switch(checked = showDual, onCheckedChange = { showDual = it })
+            NimazSwitch(checked = showDual, onCheckedChange = { showDual = it })
         }
 
         Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/tasbih/TasbihSheets.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/tasbih/TasbihSheets.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -40,6 +39,7 @@ import com.arshadshah.nimaz.domain.model.TasbihPreset
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperSize
@@ -128,7 +128,7 @@ fun BeadDesignPickerSheet(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                Switch(checked = leftHanded, onCheckedChange = onToggleHanded)
+                NimazSwitch(checked = leftHanded, onCheckedChange = onToggleHanded)
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -189,7 +189,7 @@ fun NotificationSettingsScreen(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
-                        Switch(
+                        NimazSwitch(
                             checked = notificationState.notificationsEnabled,
                             onCheckedChange = {
                                 viewModel.onEvent(SettingsEvent.SetNotificationsEnabled(!notificationState.notificationsEnabled))
@@ -271,7 +271,7 @@ fun NotificationSettingsScreen(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
-                            Switch(
+                            NimazSwitch(
                                 checked = notificationState.adhanEnabled,
                                 onCheckedChange = {
                                     viewModel.onEvent(SettingsEvent.SetAdhanEnabled(!notificationState.adhanEnabled))
@@ -596,7 +596,7 @@ private fun PrayerNotificationRow(
         Spacer(modifier = Modifier.width(15.dp))
 
         // Toggle
-        Switch(
+        NimazSwitch(
             checked = prayer.isEnabled,
             onCheckedChange = { onToggle() }
         )

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSwitchTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSwitchTest.kt
@@ -1,0 +1,145 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NimazSwitchTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    @Test
+    fun `switch variants are complete`() {
+        assertThat(NimazSwitchVariant.entries).hasSize(4)
+    }
+
+    @Test
+    fun `checked switch reports the on toggle state`() {
+        composeRule.setThemedContent {
+            NimazSwitch(checked = true, onCheckedChange = {}, contentDescription = "on")
+        }
+        composeRule.onNodeWithContentDescription("on").assertIsOn()
+    }
+
+    @Test
+    fun `unchecked switch reports the off toggle state`() {
+        composeRule.setThemedContent {
+            NimazSwitch(checked = false, onCheckedChange = {}, contentDescription = "off")
+        }
+        composeRule.onNodeWithContentDescription("off").assertIsOff()
+    }
+
+    @Test
+    fun `clicking an unchecked switch emits true`() {
+        var observed: Boolean? = null
+        composeRule.setThemedContent {
+            NimazSwitch(
+                checked = false,
+                onCheckedChange = { observed = it },
+                contentDescription = "toggle"
+            )
+        }
+        composeRule.onNodeWithContentDescription("toggle").performClick()
+        assertThat(observed).isTrue()
+    }
+
+    @Test
+    fun `clicking a checked switch emits false`() {
+        var observed: Boolean? = null
+        composeRule.setThemedContent {
+            NimazSwitch(
+                checked = true,
+                onCheckedChange = { observed = it },
+                contentDescription = "toggle"
+            )
+        }
+        composeRule.onNodeWithContentDescription("toggle").performClick()
+        assertThat(observed).isFalse()
+    }
+
+    @Test
+    fun `null handler renders a non-interactive switch deferring to the parent`() {
+        composeRule.setThemedContent {
+            NimazSwitch(checked = true, onCheckedChange = null, contentDescription = "deferred")
+        }
+        // With no own handler the switch carries no toggle role/click target — it simply
+        // renders its state for the enclosing clickable row to drive.
+        composeRule.onNodeWithContentDescription("deferred").assertExists()
+    }
+
+    @Test
+    fun `disabled switch does not emit on click`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazSwitch(
+                checked = false,
+                onCheckedChange = { clicked = true },
+                enabled = false,
+                contentDescription = "disabled"
+            )
+        }
+        composeRule.onNodeWithContentDescription("disabled").performClick()
+        assertThat(clicked).isFalse()
+    }
+
+    @Test
+    fun `every variant renders checked and emits on click`() {
+        val clicked = mutableSetOf<NimazSwitchVariant>()
+        composeRule.setThemedContent {
+            Column {
+                NimazSwitchVariant.entries.forEach { variant ->
+                    NimazSwitch(
+                        checked = true,
+                        onCheckedChange = { clicked += variant },
+                        variant = variant,
+                        contentDescription = variant.name
+                    )
+                }
+            }
+        }
+        NimazSwitchVariant.entries.forEach { variant ->
+            composeRule.onNodeWithContentDescription(variant.name).performClick()
+        }
+        assertThat(clicked).containsExactlyElementsIn(NimazSwitchVariant.entries)
+    }
+
+    @Test
+    fun `plain thumb without a glyph still toggles`() {
+        var observed: Boolean? = null
+        composeRule.setThemedContent {
+            NimazSwitch(
+                checked = false,
+                onCheckedChange = { observed = it },
+                thumbIcon = null,
+                contentDescription = "plain"
+            )
+        }
+        composeRule.onNodeWithContentDescription("plain").assertIsOff().performClick()
+        assertThat(observed).isTrue()
+    }
+
+    @Test
+    fun `track tint escape hatch still renders an interactive switch`() {
+        var clicked = false
+        composeRule.setThemedContent {
+            NimazSwitch(
+                checked = true,
+                onCheckedChange = { clicked = true },
+                trackTint = NimazColors.Success,
+                contentDescription = "tinted"
+            )
+        }
+        composeRule.onNodeWithContentDescription("tinted").assertIsOn().performClick()
+        assertThat(clicked).isTrue()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,9 +474,21 @@ typed route object.
       preset; `type` is `SQUARE` (rounded Material-style) or `CIRCLE` (the prayer/fast-completion
       look). Pass `onCheckedChange = null` for a **display-only indicator** (no click semantics) —
       the drop-in for selected-card/list rows where the parent owns the click; `tint =` escapes the
-      variant. **Not** for `Switch` (on/off settings) or genuine single-choice `RadioButton` pickers
-      — those stay as-is. It centralised the prayer/fast trackers, the settings/Quran pickers and
-      the dropdown/list selection check indicators.
+      variant. **Not** for on/off toggles (use `NimazSwitch`) or genuine single-choice `RadioButton`
+      pickers (those stay as-is). It centralised the prayer/fast trackers, the settings/Quran pickers
+      and the dropdown/list selection check indicators.
+    - an on/off toggle is `NimazSwitch(checked, onCheckedChange, variant = …)`
+      (`components/atoms/NimazSwitch.kt`), **not** a raw Material 3 `Switch`. It wraps Material's
+      `Switch` (keeping the drag gesture, `Role.Switch` semantics and thumb animation) and bakes in
+      the house look from the original enhanced switch: a brand-tinted checked track with a light
+      thumb + check glyph, and a clearly contrasted outlined pill (raised thumb on a `surface` track)
+      when off. Only the **disabled** colours are left to `SwitchDefaults` (the old hand-styled
+      switch hard-coded every disabled colour to `surface`, so it vanished when disabled —
+      `NimazSwitch` fixes that). `variant` is the checked-track colour role (`DEFAULT`/`PRIMARY` =
+      `primary`, `SUCCESS`, `ERROR`); `trackTint =` escapes it, `thumbIcon = null` drops the glyph.
+      Pass `onCheckedChange = null` when an enclosing clickable row owns the toggle (the
+      `NimazSettingsItem` pattern — the row toggles, the switch just renders state). It centralised
+      the settings/notification toggles, the tasbih left-handed switch and the calendar preview.
   Screen-local private composables are fine for **feature-specific** layout that isn't reused
   elsewhere; promote anything reused across screens into `components/`.
 


### PR DESCRIPTION
Closes #202.

## What & why

Switch styling was inconsistent: **one** fully hand-styled `Switch` (in `NimazSettingsItem` — a custom 16-property `SwitchColors` + check-glyph thumb) plus **five** bare Material 3 `Switch`es scattered across the app. The same control rendered differently depending on the screen.

This PR isolates the enhanced styling into a single `NimazSwitch` atom and migrates every switch site to it, matching the existing `Nimaz*` atom family (`NimazButton`, `NimazCheckbox`, `NimazIcon`, `NimazCard`, …).

## The component

`presentation/components/atoms/NimazSwitch.kt` **wraps** Material 3 `Switch` (keeps the drag gesture, `Role.Switch` semantics and thumb animation) and bakes in the house look:

- brand-tinted **checked** track, light thumb + check glyph
- a clearly contrasted **outlined pill** when off (raised thumb on a `surface` track)
- ```kotlin
  NimazSwitch(checked, onCheckedChange, variant = PRIMARY, enabled, thumbIcon = Check, trackTint, contentDescription)
  ```
- `variant` ∈ `DEFAULT · PRIMARY · SUCCESS · ERROR` drives the checked track; `trackTint` / `thumbIcon` / `enabled` are escape hatches.
- `onCheckedChange = null` defers the click to an enclosing clickable row (the `NimazSettingsItem` pattern).

### Bug fixed

The old hand-styled switch hard-coded **every disabled colour to `surface`**, so a disabled switch was invisible. `NimazSwitch` keeps the explicit enabled palette (needed for OFF-state contrast) and lets `SwitchDefaults` supply the correctly-dimmed disabled colours.

## Migrated sites

| File | Was |
|---|---|
| `NimazSettingsItem.kt` | the hand-styled switch (36 lines of `SwitchColors`) — now `NimazSwitch` deferring the toggle to the clickable row (no double-fire) |
| `NotificationSettingsScreen.kt` | 3 bare switches (notifications, adhan, per-prayer) |
| `TasbihSheets.kt` | left-handed beads toggle |
| `NimazCalendarShowcasePreviews.kt` | dual-calendar preview toggle |

Repo-wide sweep confirms no `material3.Switch` / `SwitchColors` / `SwitchDefaults` usage remains outside `NimazSwitch` itself. (No Glance widget switches exist.)

## Also included

- `NimazButton` size typography bumped (`label*` → `title*` per size) for consistent button text weight.

## Tests & docs

- New `NimazSwitchTest` — 10 Robolectric cases (on/off state, click both directions, disabled, null-handler, every variant, plain thumb, `trackTint` escape hatch).
- `docs/ARCHITECTURE.md` atom catalogue documents `NimazSwitch` and updates the `NimazCheckbox` note that previously said switches "stay as-is".

## Verification

- ✅ `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- ✅ `./gradlew :app:testDebugUnitTest --tests "*NimazSwitchTest"` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)