### PR TITLE
fix(search): search-as-you-type + redesign the search bar (#211, #204)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBar.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.organisms
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -152,19 +151,15 @@ fun NimazSearchBar(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
 
-    // Animate the border to communicate focus state. M3 OutlinedTextField does
-    // the same thing; we replicate it here so this primitive matches.
+    // Outlined-field language (matches NimazDropdownField): a neutral hairline at rest that
+    // animates to the primary tint on focus. Always outlined — no fill swap.
     val borderColor by animateColorAsState(
         targetValue = if (isFocused) {
             MaterialTheme.colorScheme.primary
         } else {
-            Color.Transparent
+            MaterialTheme.colorScheme.outlineVariant
         },
         label = "search_focus_border"
-    )
-    val borderWidth: Dp by animateDpAsState(
-        targetValue = if (isFocused) 1.5.dp else 0.dp,
-        label = "search_focus_border_width"
     )
 
     LaunchedEffect(autoFocus) {
@@ -179,12 +174,10 @@ fun NimazSearchBar(
                 else Modifier
             )
             .fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        tonalElevation = 1.dp,
-        border = if (borderWidth > 0.dp) {
-            androidx.compose.foundation.BorderStroke(borderWidth, borderColor)
-        } else null,
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp,
+        border = androidx.compose.foundation.BorderStroke(1.5.dp, borderColor),
     ) {
         Row(
             modifier = Modifier
@@ -270,12 +263,20 @@ fun NimazSearchBar(
                     },
                     modifier = Modifier.size(40.dp)
                 ) {
-                    NimazIcon(
-                        imageVector = Icons.Default.Clear,
-                        contentDescription = stringResource(R.string.cd_clear_search),
-                        variant = NimazIconVariant.MUTED,
-                        iconSize = 18.dp
-                    )
+                    Box(
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        NimazIcon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = stringResource(R.string.cd_clear_search),
+                            tint = MaterialTheme.colorScheme.primary,
+                            iconSize = 16.dp
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
@@ -11,6 +11,9 @@ import com.arshadshah.nimaz.domain.usecase.DuaUseCases
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -63,6 +66,9 @@ sealed interface SearchEvent {
     data object ClearRecentSearches : SearchEvent
 }
 
+/** Idle time after the last keystroke before a search-as-you-type lookup fires. */
+private const val SEARCH_DEBOUNCE_MS = 300L
+
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
@@ -78,6 +84,10 @@ class SearchViewModel @Inject constructor(
 
     private val recentSearchesList = mutableListOf<String>()
     private val pendingSearchCount = AtomicInteger(0)
+
+    // The in-flight search (debounce + the per-source lookups it launches as children).
+    // Cancelled and replaced on each new query so stale results never clobber newer ones.
+    private var searchJob: Job? = null
 
     fun onEvent(event: SearchEvent) {
         // Record the search action with its filter and query length only — never
@@ -102,10 +112,15 @@ class SearchViewModel @Inject constructor(
     private fun updateQuery(query: String) {
         _searchState.update { it.copy(query = query) }
 
-        // Only clear results when query is emptied, don't auto-search
-        if (query.isEmpty()) {
+        val trimmed = query.trim()
+        if (trimmed.isBlank()) {
+            searchJob?.cancel()
             clearResults()
+            return
         }
+        // Search-as-you-type, debounced. The recent-searches list is only touched on an
+        // explicit submit (enter / recent tap), not on every keystroke.
+        launchSearch(trimmed, addToRecent = false, debounceMillis = SEARCH_DEBOUNCE_MS)
     }
 
     private fun setFilter(filter: SearchFilter) {
@@ -131,25 +146,36 @@ class SearchViewModel @Inject constructor(
     private fun executeSearch() {
         val query = _searchState.value.query.trim()
         if (query.isBlank()) {
+            searchJob?.cancel()
             clearResults()
             return
         }
+        // Explicit submit (enter / recent search): search immediately and remember it.
+        launchSearch(query, addToRecent = true, debounceMillis = 0L)
+    }
 
+    /**
+     * Cancel any in-flight search and start a new one. [isSearching] flips on synchronously
+     * (before the debounce delay) so the screen's "no results" state can never show while a
+     * lookup is still pending. The per-source lookups are launched as children of [searchJob],
+     * so cancelling it cancels them too.
+     */
+    private fun launchSearch(query: String, addToRecent: Boolean, debounceMillis: Long) {
+        searchJob?.cancel()
         _searchState.update { it.copy(isSearching = true, error = null) }
-
-        // Add to recent searches
-        addToRecentSearches(query)
-
-        // Search based on filter
-        when (_searchState.value.selectedFilter) {
-            SearchFilter.ALL -> searchAll(query)
-            SearchFilter.QURAN -> searchQuranOnly(query)
-            SearchFilter.HADITH -> searchHadithOnly(query)
-            SearchFilter.DUA -> searchDuaOnly(query)
+        if (addToRecent) addToRecentSearches(query)
+        searchJob = viewModelScope.launch {
+            if (debounceMillis > 0) delay(debounceMillis)
+            when (_searchState.value.selectedFilter) {
+                SearchFilter.ALL -> searchAll(query, this)
+                SearchFilter.QURAN -> searchQuranOnly(query, this)
+                SearchFilter.HADITH -> searchHadithOnly(query, this)
+                SearchFilter.DUA -> searchDuaOnly(query, this)
+            }
         }
     }
 
-    private fun searchAll(query: String) {
+    private fun searchAll(query: String, scope: CoroutineScope) {
         val totalSearches = 4
         pendingSearchCount.set(totalSearches)
 
@@ -160,7 +186,7 @@ class SearchViewModel @Inject constructor(
         }
 
         // Search Quran (include translations for English search terms)
-        viewModelScope.launch {
+        scope.launch {
             quranUseCases.searchQuran(query, "sahih_international").collect { results ->
                 _searchState.update { state ->
                     val unified =
@@ -178,7 +204,7 @@ class SearchViewModel @Inject constructor(
         }
 
         // Search Surahs by name
-        viewModelScope.launch {
+        scope.launch {
             quranUseCases.getSurahList.search(query).collect { surahs ->
                 _searchState.update { state ->
                     val unified =
@@ -196,7 +222,7 @@ class SearchViewModel @Inject constructor(
         }
 
         // Search Hadith
-        viewModelScope.launch {
+        scope.launch {
             hadithUseCases.searchHadiths(query).collect { results ->
                 _searchState.update { state ->
                     val unified =
@@ -214,7 +240,7 @@ class SearchViewModel @Inject constructor(
         }
 
         // Search Duas
-        viewModelScope.launch {
+        scope.launch {
             duaUseCases.searchDuas(query).collect { results ->
                 _searchState.update { state ->
                     val unified =
@@ -232,7 +258,7 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun searchQuranOnly(query: String) {
+    private fun searchQuranOnly(query: String, scope: CoroutineScope) {
         val totalSearches = 2
         pendingSearchCount.set(totalSearches)
 
@@ -242,7 +268,7 @@ class SearchViewModel @Inject constructor(
             }
         }
 
-        viewModelScope.launch {
+        scope.launch {
             quranUseCases.searchQuran(query, "sahih_international").collect { results ->
                 val unified = results.map { UnifiedSearchResult.QuranResult(it) }
                 _searchState.update {
@@ -257,7 +283,7 @@ class SearchViewModel @Inject constructor(
             }
         }
 
-        viewModelScope.launch {
+        scope.launch {
             quranUseCases.getSurahList.search(query).collect { surahs ->
                 _searchState.update { state ->
                     val surahResults = surahs.map { UnifiedSearchResult.SurahResult(it) }
@@ -274,8 +300,8 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun searchHadithOnly(query: String) {
-        viewModelScope.launch {
+    private fun searchHadithOnly(query: String, scope: CoroutineScope) {
+        scope.launch {
             hadithUseCases.searchHadiths(query).collect { results ->
                 val unified = results.map { UnifiedSearchResult.HadithResult(it) }
                 _searchState.update {
@@ -291,8 +317,8 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun searchDuaOnly(query: String) {
-        viewModelScope.launch {
+    private fun searchDuaOnly(query: String, scope: CoroutineScope) {
+        scope.launch {
             duaUseCases.searchDuas(query).collect { results ->
                 val unified = results.map { UnifiedSearchResult.DuaResult(it) }
                 _searchState.update {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModelTest.kt
@@ -1,0 +1,105 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.GetSurahListUseCase
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.SearchDuasUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchHadithsUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchQuranUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var quranUseCases: QuranUseCases
+    private lateinit var hadithUseCases: HadithUseCases
+    private lateinit var duaUseCases: DuaUseCases
+    private lateinit var searchDuas: SearchDuasUseCase
+    private lateinit var searchHadiths: SearchHadithsUseCase
+    private lateinit var searchQuran: SearchQuranUseCase
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        searchQuran = mockk()
+        every { searchQuran.invoke(any(), any()) } returns flowOf(emptyList())
+        val getSurahList = mockk<GetSurahListUseCase>()
+        every { getSurahList.search(any()) } returns flowOf(emptyList())
+        quranUseCases = mockk(relaxed = true)
+        every { quranUseCases.searchQuran } returns searchQuran
+        every { quranUseCases.getSurahList } returns getSurahList
+
+        searchHadiths = mockk()
+        every { searchHadiths.invoke(any()) } returns flowOf(emptyList())
+        hadithUseCases = mockk(relaxed = true)
+        every { hadithUseCases.searchHadiths } returns searchHadiths
+
+        searchDuas = mockk()
+        every { searchDuas.invoke(any()) } returns flowOf(emptyList())
+        duaUseCases = mockk(relaxed = true)
+        every { duaUseCases.searchDuas } returns searchDuas
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = SearchViewModel(quranUseCases, hadithUseCases, duaUseCases)
+
+    @Test
+    fun `typing a query runs the search without pressing enter`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+        // The search must have executed off the query change alone — no ExecuteSearch event.
+        verify { searchDuas.invoke("noor") }
+    }
+
+    @Test
+    fun `a non-blank query marks the state as searching before results arrive`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        // Synchronously (before the debounce/search runs) the state must read as searching,
+        // so the screen's empty state can't flash "no results" prematurely.
+        assertThat(vm.searchState.value.isSearching).isTrue()
+    }
+
+    @Test
+    fun `rapid typing debounces to a single search for the final query`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("n"))
+        vm.onEvent(SearchEvent.UpdateQuery("no"))
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+        verify(exactly = 1) { searchDuas.invoke("noor") }
+        verify(exactly = 0) { searchDuas.invoke("n") }
+        verify(exactly = 0) { searchDuas.invoke("no") }
+    }
+
+    @Test
+    fun `clearing the query stops searching and empties results`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+        vm.onEvent(SearchEvent.UpdateQuery(""))
+        advanceUntilIdle()
+        assertThat(vm.searchState.value.isSearching).isFalse()
+        assertThat(vm.searchState.value.filteredResults).isEmpty()
+    }
+}


### PR DESCRIPTION
Closes #211. Closes #204.

This PR bundles the search **bug fix** (#211) with the search-bar **redesign** (#204), since they touch the same surface.

---

## #211 — search-as-you-type, no premature "No results"

**Symptoms:** typing showed "No results" before any search ran; search only executed on Enter.

**Root cause:** `SearchViewModel.updateQuery` stored the query but deliberately didn't search; the real lookup only ran on `ExecuteSearch` (wired to the keyboard Search/Enter action). So typing left a non-empty query with `isSearching == false` and empty results, and `SearchScreen`'s empty-state guard flashed "No results".

**Fix (ViewModel only):**
- `updateQuery` now runs a **debounced (300 ms) search-as-you-type** and flips `isSearching = true` synchronously, so the empty state can't show until a lookup completes.
- A single `searchJob` owns the debounce + per-source lookups (as children), cancelled/replaced per keystroke — no stale-result clobber, rapid typing debounces to one search.
- Enter / recent-search still submit immediately and remain the only paths that record search history.
- `SearchScreen` unchanged — its guard already keys off `isSearching`.

New `SearchViewModelTest` (4 cases) — fail on the old code, pass on the fix.

---

## #204 — search bar redesign (outlined field)

Brought the shared `NimazSearchBar` onto the app's **outlined-field language** (the `NimazDropdownField` look), via the one organism so all **8 call sites** update at once (global search, location, asma, asma-un-nabi, prophets, reciter picker, help, the list-picker dialog):

- surface bg with an always-present outline — neutral hairline at rest, animating to the primary tint on focus (was a heavy `surfaceContainerHighest` fill).
- 14dp corners (was `shapes.large`), tonal elevation → 0.
- clear button now sits in a soft teal circle with a primary glyph.
- loading spinner + optional trailing slot unchanged.

Direction picked via the visual companion (option **B**).

---

## Verification
- ✅ `:app:compileDebugKotlin`
- ✅ `SearchViewModelTest` 4/4; `NimazSearchBarTest` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)