### PR TITLE
fix(quran): remove duplicated content from surah banner (#213)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBanner.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBanner.kt
@@ -4,15 +4,12 @@ import androidx.compose.ui.res.stringResource
 import com.arshadshah.nimaz.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -36,10 +33,8 @@ import com.arshadshah.nimaz.presentation.theme.NimazTheme
 @Composable
 internal fun SurahBanner(
     surahNameArabic: String,
-    surahNameEnglish: String,
     surahMeaning: String,
     revelationType: RevelationType,
-    ayahCount: Int,
     showBismillah: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -67,40 +62,23 @@ internal fun SurahBanner(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = surahNameEnglish,
-                style = MaterialTheme.typography.titleLarge,
+                text = surahMeaning,
+                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = NimazColors.QuranColors.BannerAccent
             )
 
-            Text(
-                text = surahMeaning,
-                style = MaterialTheme.typography.bodySmall,
-                color = NimazColors.QuranColors.BannerAccent.copy(alpha = 0.8f)
-            )
-
             Spacer(modifier = Modifier.height(8.dp))
 
-            Row(
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = Color.White.copy(alpha = 0.15f)
             ) {
-                Surface(
-                    shape = RoundedCornerShape(8.dp),
-                    color = Color.White.copy(alpha = 0.15f)
-                ) {
-                    Text(
-                        text = if (revelationType == RevelationType.MECCAN) stringResource(R.string.quran_meccan) else stringResource(R.string.quran_medinan),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = Color.White,
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
-                    )
-                }
-                Spacer(modifier = Modifier.width(10.dp))
                 Text(
-                    text = stringResource(R.string.quran_ayahs_count_format, ayahCount),
+                    text = if (revelationType == RevelationType.MECCAN) stringResource(R.string.quran_meccan) else stringResource(R.string.quran_medinan),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color.White.copy(alpha = 0.8f)
+                    color = Color.White,
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                 )
             }
 
@@ -125,10 +103,8 @@ internal fun SurahBannerPreview() {
     NimazTheme {
         SurahBanner(
             surahNameArabic = "\u0627\u0644\u0641\u0627\u062A\u062D\u0629",
-            surahNameEnglish = "Al-Fatihah",
             surahMeaning = "The Opening",
             revelationType = RevelationType.MECCAN,
-            ayahCount = 7,
             showBismillah = true
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
@@ -809,10 +809,8 @@ fun QuranReaderScreen(
                             item(key = "banner") {
                                 SurahBanner(
                                     surahNameArabic = surahWithAyahs.surah.nameArabic,
-                                    surahNameEnglish = surahWithAyahs.surah.nameEnglish,
                                     surahMeaning = surahWithAyahs.surah.nameTransliteration,
                                     revelationType = surahWithAyahs.surah.revelationType,
-                                    ayahCount = surahWithAyahs.surah.numberOfAyahs,
                                     showBismillah = (surahNumber ?: 0) != 9 && (surahNumber
                                         ?: 0) != 1
                                 )

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBannerTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahBannerTest.kt
@@ -18,18 +18,14 @@ class QuranSurahBannerTest {
         composeRule.setThemedContent {
             SurahBanner(
                 surahNameArabic = "ArabicName",
-                surahNameEnglish = "Al-Fatihah",
                 surahMeaning = "The Opening",
                 revelationType = RevelationType.MECCAN,
-                ayahCount = 7,
                 showBismillah = true
             )
         }
         composeRule.onNodeWithText("ArabicName").assertExists()
-        composeRule.onNodeWithText("Al-Fatihah").assertExists()
         composeRule.onNodeWithText("The Opening").assertExists()
         composeRule.onNodeWithText("Meccan").assertExists()
-        composeRule.onNodeWithText("7 Ayahs").assertExists()
     }
 
     @Test
@@ -37,16 +33,13 @@ class QuranSurahBannerTest {
         composeRule.setThemedContent {
             SurahBanner(
                 surahNameArabic = "ArabicName2",
-                surahNameEnglish = "Al-Baqarah",
                 surahMeaning = "The Cow",
                 revelationType = RevelationType.MEDINAN,
-                ayahCount = 286,
                 showBismillah = false
             )
         }
-        composeRule.onNodeWithText("Al-Baqarah").assertExists()
+        composeRule.onNodeWithText("The Cow").assertExists()
         composeRule.onNodeWithText("Medinan").assertExists()
-        composeRule.onNodeWithText("286 Ayahs").assertExists()
         // Meccan label must not be present for a medinan surah
         composeRule.onNodeWithText("Meccan").assertDoesNotExist()
     }


### PR DESCRIPTION
## Summary

Fixes #213 — the surah banner repeated information already shown in the reader's top bar.

In the Quran reader (SURAH mode) the `TopAppBar` already displays:
- **Title**: the surah's English name (e.g. *Al-Fatihah*)
- **Subtitle**: `Surah N • M Ayahs`

The `SurahBanner` was independently rendering the **same English name** and the **same ayah count**, so each appeared twice on screen.

This mirrors the approach used for the Juz view: keep in the banner only the content the top bar does **not** cover.

## Changes

`SurahBanner` now shows only the non-duplicated content:
- ✅ Arabic name
- ✅ Meaning (promoted to `titleMedium` so it stays the banner's primary label)
- ✅ Meccan / Medinan badge
- ✅ Bismillah

Removed (already in the top bar):
- ❌ English name → duplicated the top bar **title**
- ❌ Ayah count → duplicated the top bar **subtitle**

The now-unused `surahNameEnglish` and `ayahCount` parameters were dropped from the composable, and the call site, preview, and unit tests were updated accordingly.

## Testing

`./gradlew :app:testDebugUnitTest` could not be run here (no Android SDK in this environment). Unit tests in `QuranSurahBannerTest` were updated to match the new API and assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJTvjiCrkTdx16tpoyKrGA)_