### PR TITLE
fix(dua): render category Arabic name with ArabicText, declutter banner

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
@@ -101,9 +101,7 @@ fun DuaCategoryScreen(
                     item {
                         CategoryHeaderCard(
                             nameArabic = category.nameArabic,
-                            nameEnglish = category.nameEnglish,
-                            description = category.description,
-                            duaCount = category.duaCount
+                            description = category.description
                         )
                     }
                 }
@@ -131,9 +129,7 @@ fun DuaCategoryScreen(
 @Composable
 private fun CategoryHeaderCard(
     nameArabic: String,
-    nameEnglish: String,
     description: String?,
-    duaCount: Int,
     modifier: Modifier = Modifier
 ) {
     NimazCard(
@@ -160,22 +156,15 @@ private fun CategoryHeaderCard(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                // Arabic name
-                Text(
+                // Arabic name (rendered with the dedicated Arabic text component
+                // for correct font + RTL shaping). The English name and dua count
+                // live in the top app bar, not here.
+                ArabicText(
                     text = nameArabic,
-                    style = MaterialTheme.typography.headlineMedium,
+                    size = ArabicTextSize.LARGE,
                     color = Color.White,
-                    textAlign = TextAlign.Center
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // English name
-                Text(
-                    text = nameEnglish,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.White.copy(alpha = 0.9f),
-                    fontWeight = FontWeight.SemiBold
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
                 )
 
                 // Description
@@ -187,22 +176,6 @@ private fun CategoryHeaderCard(
                         color = Color.White.copy(alpha = 0.8f),
                         textAlign = TextAlign.Center,
                         lineHeight = 22.sp
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // Dua count badge
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Color.White.copy(alpha = 0.2f))
-                        .padding(horizontal = 14.dp, vertical = 6.dp)
-                ) {
-                    Text(
-                        text = "$duaCount duas in this collection",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = Color.White
                     )
                 }
             }


### PR DESCRIPTION
The dua category banner rendered the Arabic chapter name with a plain
Text/headlineMedium style, producing incorrect shaping (no Arabic font,
no RTL). Switch to the dedicated ArabicText component.

Also remove the English name and the dua-count badge from the banner;
both already appear in the top app bar (title + subtitle), so the banner
now shows only the Arabic name and the optional description.

Closes #210

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XJ5Gs5kq2pXVEMvC5egvB7