### PR TITLE
Fix living sky sun timing to follow real sunrise/sunset

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeHero.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeHero.kt
@@ -72,7 +72,9 @@ fun HomeHero(
     nextPrayer: PrayerType?,
     nextPrayerTime: String,
     timeUntilNextPrayer: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    sunriseFraction: Float = 0.27f,
+    sunsetFraction: Float = 0.80f,
 ) {
     val use24Hour = LocalUse24HourFormat.current
     var timeOfDay by remember { mutableFloatStateOf(minuteFractionNow()) }
@@ -115,6 +117,8 @@ fun HomeHero(
                     bottomStart = HERO_BOTTOM_RADIUS,
                     bottomEnd = HERO_BOTTOM_RADIUS
                 ),
+                sunriseFraction = sunriseFraction,
+                sunsetFraction = sunsetFraction,
             )
             Column(
                 // Centre within the *visible* sky (below the status-bar band),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
@@ -78,6 +78,12 @@ import kotlin.math.sin
  * so the sun sits exactly where it should at any moment, not just at the
  * prayer anchors. Clouds drift slowly across.
  *
+ * The sun is locked to the *real* sun: [sunriseFraction]/[sunsetFraction]
+ * (today's sunrise/sunset, each as a fraction of the day) time-warp the scene
+ * so daybreak and dusk land on the user's actual sun times for their location
+ * and season — not fixed clock anchors. With the defaults the scene falls back
+ * to a generic ~6:30am/~7:12pm day.
+ *
  * Performance: the heavy work — gradients, blurred corona/rays, the moon's
  * [PathOperation] and soft terminator — is baked once into a small
  * [ImageBitmap] (via [drawWithCache], keyed on [timeOfDay]/[moonFraction]) and
@@ -89,6 +95,8 @@ import kotlin.math.sin
  * @param timeOfDay fraction through a 24h day, 0f→1f.
  * @param moonFraction synodic phase 0f→1f (see [MoonPhase]); used at night.
  * @param cloudsEnabled set false to freeze cloud motion (e.g. battery saver).
+ * @param sunriseFraction today's sunrise as a fraction of the day (0f→1f).
+ * @param sunsetFraction today's sunset (Maghrib) as a fraction of the day.
  */
 @Composable
 fun SkyBackground(
@@ -97,6 +105,8 @@ fun SkyBackground(
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(20.dp),
     cloudsEnabled: Boolean = true,
+    sunriseFraction: Float = SUNRISE_T,
+    sunsetFraction: Float = SUNSET_T,
 ) {
     val drift = rememberInfiniteTransition(label = "sky")
     val cloudPhase by drift.animateFloat(
@@ -118,11 +128,16 @@ fun SkyBackground(
                 val sw = (size.width * SPRITE_SCALE).roundToInt().coerceAtLeast(1)
                 val sh = (size.height * SPRITE_SCALE).roundToInt().coerceAtLeast(1)
 
-                // Baked once per (timeOfDay, moonFraction, size) change — not per frame.
+                // Warp real time so the actual sunrise/sunset land on the
+                // scene's canonical anchors — the sun, day/night ramp and sky
+                // gradient then all track the real sun, not fixed clock times.
+                val warped = remapDayFraction(timeOfDay, sunriseFraction, sunsetFraction)
+
+                // Baked once per (warped, moonFraction, size) change — not per frame.
                 val scene =
-                    bakeLayer(sw, sh, this, layoutDirection) { drawScene(timeOfDay, moonFraction) }
+                    bakeLayer(sw, sh, this, layoutDirection) { drawScene(warped, moonFraction) }
                 val clouds = bakeLayer(sw, sh, this, layoutDirection) { drawCloudLayer() }
-                val cloudTint = ColorFilter.tint(sampleCloud(timeOfDay), BlendMode.Modulate)
+                val cloudTint = ColorFilter.tint(sampleCloud(warped), BlendMode.Modulate)
                 val full = IntSize(w, h)
 
                 onDrawBehind {
@@ -158,6 +173,8 @@ fun PrayerSkyScene(
     moonFraction: Float = 0.5f,
     shape: Shape = RoundedCornerShape(20.dp),
     cloudsEnabled: Boolean = true,
+    sunriseFraction: Float = SUNRISE_T,
+    sunsetFraction: Float = SUNSET_T,
 ) {
     val backdrop = rememberGlassBackdrop()
     Box(modifier = modifier) {
@@ -169,6 +186,8 @@ fun PrayerSkyScene(
                 .glassBackdropSource(backdrop),
             shape = shape,
             cloudsEnabled = cloudsEnabled,
+            sunriseFraction = sunriseFraction,
+            sunsetFraction = sunsetFraction,
         )
         Column(
             modifier = Modifier.padding(16.dp),
@@ -200,6 +219,25 @@ fun PrayerSkyScene(
 private const val SPRITE_SCALE = 0.6f
 private const val SUNRISE_T = 0.27f
 private const val SUNSET_T = 0.80f
+
+/**
+ * Piecewise-linear time-warp from a real day-fraction [t] onto the scene's
+ * canonical timeline, so the real [sunrise]/[sunset] (each 0f→1f of the day)
+ * land exactly on [SUNRISE_T]/[SUNSET_T]. Midnight stays at 0f/1f. This keeps
+ * the sun arc, the day/night ramp and the sky gradient locked to the user's
+ * actual sun — the sun only dips below the horizon at real Maghrib, not at a
+ * fixed 7:12pm. Degenerate or polar inputs are clamped to a sane day.
+ */
+internal fun remapDayFraction(t: Float, sunrise: Float, sunset: Float): Float {
+    val tt = t.coerceIn(0f, 1f)
+    val sr = sunrise.coerceIn(0.02f, 0.96f)
+    val ss = sunset.coerceIn(sr + 0.02f, 0.98f)
+    return when {
+        tt <= sr -> lerpF(0f, SUNRISE_T, tt / sr)
+        tt <= ss -> lerpF(SUNRISE_T, SUNSET_T, (tt - sr) / (ss - sr))
+        else -> lerpF(SUNSET_T, 1f, (tt - ss) / (1f - ss))
+    }
+}
 
 /**
  * Moon phase from the date, after Jean Meeus, *Astronomical Algorithms*.

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -251,7 +251,9 @@ private fun HomeCompactContent(
                 gregorianDate = gregorianDate,
                 nextPrayer = state.nextPrayer,
                 nextPrayerTime = nextPrayerTime,
-                timeUntilNextPrayer = state.timeUntilNextPrayer
+                timeUntilNextPrayer = state.timeUntilNextPrayer,
+                sunriseFraction = state.sunriseFraction,
+                sunsetFraction = state.sunsetFraction,
             )
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
@@ -117,6 +117,8 @@ fun PrayerTimesScreen(
                     timeLabel = state.skyTimeLabel,
                     statusLabel = state.skyStatusLabel,
                     moonFraction = state.moonFraction,
+                    sunriseFraction = state.sunriseFraction,
+                    sunsetFraction = state.sunsetFraction,
                     shape = RoundedCornerShape(bottomStart = 28.dp, bottomEnd = 28.dp),
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -70,6 +70,10 @@ data class HomeUiState(
     // 0f→1f position of "now" along the Fajr→Isha timeline (drives the progress
     // card's fill); recomputed each tick so it advances with the clock.
     val prayerTimelineProgress: Float = 0f,
+    // Today's sunrise/sunset as fractions of the day — anchor the living sky's
+    // sun arc to the real sun instead of fixed clock times.
+    val sunriseFraction: Float = 0.27f,
+    val sunsetFraction: Float = 0.80f,
     val dailyDua: DailyDua? = null,
     val isFriday: Boolean = false,
     val jumuahTime: String = "",
@@ -565,6 +569,14 @@ class HomeViewModel @Inject constructor(
                     }
                 }
 
+                // Sunrise/sunset as day-fractions for the living sky's sun arc.
+                val sunriseFraction = prayerTimes.find { it.type == PrayerType.SUNRISE }?.time
+                    ?.toLocalDateTime(timeZone)
+                    ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.27f
+                val sunsetFraction = prayerTimes.find { it.type == PrayerType.MAGHRIB }?.time
+                    ?.toLocalDateTime(timeZone)
+                    ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.80f
+
                 // Apply prayer records to displays
                 val records = _prayerRecords.value
                 val displaysWithStatus = updatedDisplays.map { display ->
@@ -598,6 +610,8 @@ class HomeViewModel @Inject constructor(
                     it.copy(
                         prayerTimes = displaysWithStatus,
                         prayerTimelineProgress = timelineProgress,
+                        sunriseFraction = sunriseFraction,
+                        sunsetFraction = sunsetFraction,
                         currentPrayer = if (currentPrayerIndex >= 0) sortedPrayers[currentPrayerIndex].type else null,
                         nextPrayer = nextPrayer,
                         timeUntilNextPrayer = timeUntilNext,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -53,6 +53,8 @@ data class PrayerTimesUiState(
     // Living-sky inputs
     val timeOfDay: Float = 0.5f,        // minute-quantised fraction of the day
     val moonFraction: Float = 0.5f,     // moon phase for the selected date
+    val sunriseFraction: Float = 0.27f, // sunrise as a fraction of the day (sun arc)
+    val sunsetFraction: Float = 0.80f,  // sunset (Maghrib) as a fraction of the day
     val skyTimeLabel: String = "",
     val skyStatusLabel: String = "",
     // Day-info card
@@ -232,6 +234,14 @@ class PrayerTimesViewModel @Inject constructor(
             val mins = (maghribInstant - sunriseInstant).inWholeMinutes
             "${mins / 60}h ${mins % 60}m"
         } else ""
+        // Day-fractions for the living sky's sun arc — anchors the scene to the
+        // real sunrise/sunset for this location & date instead of fixed clock anchors.
+        val sunriseFraction = sunriseInstant?.let {
+            val l = it.toLocalDateTime(tz); (l.hour * 60 + l.minute) / 1440f
+        } ?: 0.27f
+        val sunsetFraction = maghribInstant?.let {
+            val l = it.toLocalDateTime(tz); (l.hour * 60 + l.minute) / 1440f
+        } ?: 0.80f
         val moon = MoonPhase.fractionForEpochMillis(
             date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
         )
@@ -243,6 +253,8 @@ class PrayerTimesViewModel @Inject constructor(
                 daylight = daylightStr,
                 methodLabel = "${calcMethod.shortName()} · ${asrCalc.shortName()}",
                 moonFraction = moon,
+                sunriseFraction = sunriseFraction,
+                sunsetFraction = sunsetFraction,
             )
         }
 

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkySceneTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkySceneTest.kt
@@ -67,4 +67,34 @@ class PrayerSkySceneTest {
     fun `MoonPhase new moon is dark`() {
         assertThat(MoonPhase.illumination(0f)).isWithin(0.01f).of(0f)
     }
+
+    // ── Sun timing (remapDayFraction) ───────────────────────────────────────
+    // Canonical anchors: sunrise → 0.27, sunset → 0.80 (see SUNRISE_T/SUNSET_T).
+
+    @Test
+    fun `remap anchors real sunrise and sunset to the canonical day`() {
+        // Summer day: sunrise 05:00 (0.2083), sunset 21:00 (0.875).
+        val sunrise = (5 * 60) / 1440f
+        val sunset = (21 * 60) / 1440f
+        assertThat(remapDayFraction(sunrise, sunrise, sunset)).isWithin(0.001f).of(0.27f)
+        assertThat(remapDayFraction(sunset, sunrise, sunset)).isWithin(0.001f).of(0.80f)
+    }
+
+    @Test
+    fun `remap keeps midnight fixed`() {
+        val sunrise = (5 * 60) / 1440f
+        val sunset = (21 * 60) / 1440f
+        assertThat(remapDayFraction(0f, sunrise, sunset)).isWithin(0.001f).of(0f)
+        assertThat(remapDayFraction(1f, sunrise, sunset)).isWithin(0.001f).of(1f)
+    }
+
+    @Test
+    fun `sun stays up an hour before real sunset`() {
+        // The reported bug: at 20:00 with Maghrib at 21:00, the sky must still
+        // map below the sunset anchor (sun above the horizon), not past it.
+        val sunrise = (5 * 60) / 1440f
+        val sunset = (21 * 60) / 1440f
+        val oneHourBeforeSunset = (20 * 60) / 1440f
+        assertThat(remapDayFraction(oneHourBeforeSunset, sunrise, sunset)).isLessThan(0.80f)
+    }
 }


### PR DESCRIPTION
The living sky drove the sun arc, day/night ramp, and sky gradient from
fixed clock-time anchors (SUNRISE_T 0.27 ≈ 6:28am, SUNSET_T 0.80 ≈ 7:12pm)
that ignored the user's location and season. In summer the sun would set
and the moon appear ~an hour before actual Maghrib.

Add remapDayFraction(), a piecewise-linear time-warp that maps the real
day-fraction onto the scene's canonical timeline so the user's actual
sunrise/Maghrib land on SUNRISE_T/SUNSET_T (midnight stays fixed). One
warp keeps the sun, night ramp, and gradient consistent. SkyBackground /
PrayerSkyScene / HomeHero take sunriseFraction/sunsetFraction params
(defaulting to the old anchors), and HomeViewModel / PrayerTimesViewModel
now supply today's real sunrise/Maghrib as day-fractions.

Add unit tests covering the anchoring, midnight invariance, and the
reported "sun still up before Maghrib" regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0124aNfkV33zMRjwz1dpGLFG