### PR TITLE
fix(widget): gold-tint past prayers and keep pill text legible

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
@@ -178,17 +178,32 @@ private fun PrayerPill(
     modifier: GlanceModifier = GlanceModifier,
 ) {
     val onPrimary = ColorProvider(R.color.widget_on_primary)
-    val nameColor = if (state == PrayerCellState.NEXT) onPrimary else textSecondary
+    val goldContainer = ColorProvider(R.color.widget_gold_container)
+    val onGoldContainer = ColorProvider(R.color.widget_on_gold_container)
+
+    // Each state pairs an explicit container with an on-container colour, so the
+    // text stays legible in both light and dark mode. Past prayers get a gold
+    // tint, the next prayer keeps the teal highlight, upcoming ones stay plain.
+    val container = when (state) {
+        PrayerCellState.PAST -> goldContainer
+        PrayerCellState.NEXT -> primaryColor
+        PrayerCellState.UPCOMING -> null
+    }
+    val nameColor = when (state) {
+        PrayerCellState.PAST -> onGoldContainer
+        PrayerCellState.NEXT -> onPrimary
+        PrayerCellState.UPCOMING -> textSecondary
+    }
     val timeColor = when (state) {
-        PrayerCellState.PAST -> textSecondary
+        PrayerCellState.PAST -> onGoldContainer
         PrayerCellState.NEXT -> onPrimary
         PrayerCellState.UPCOMING -> textColor
     }
-    val inner = GlanceModifier.let {
-        if (state == PrayerCellState.NEXT) {
-            it.background(primaryColor).cornerRadius(12.dp).padding(vertical = 6.dp, horizontal = 4.dp)
-        } else it
-    }
+    // Pad every pill identically so all five stay vertically aligned; only the
+    // tinted states actually paint a background behind that padding.
+    val inner = GlanceModifier
+        .let { if (container != null) it.background(container).cornerRadius(12.dp) else it }
+        .padding(vertical = 6.dp, horizontal = 4.dp)
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Column(modifier = inner.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
             Text(

--- a/app/src/main/res/values-night/widget_colors.xml
+++ b/app/src/main/res/values-night/widget_colors.xml
@@ -9,4 +9,7 @@
     <color name="widget_checked">#22C55E</color>
     <color name="widget_unchecked">#3F3F46</color>
     <color name="widget_on_primary">#FFFFFF</color>
+    <!-- Gold tint used for prayers that have already passed -->
+    <color name="widget_gold_container">#3D300E</color>
+    <color name="widget_on_gold_container">#F5C84B</color>
 </resources>

--- a/app/src/main/res/values/widget_colors.xml
+++ b/app/src/main/res/values/widget_colors.xml
@@ -9,4 +9,7 @@
     <color name="widget_checked">#22C55E</color>
     <color name="widget_unchecked">#E5E5E5</color>
     <color name="widget_on_primary">#FFFFFF</color>
+    <!-- Gold tint used for prayers that have already passed -->
+    <color name="widget_gold_container">#FBEFC9</color>
+    <color name="widget_on_gold_container">#6B4E00</color>
 </resources>

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -96,7 +96,9 @@ are monochrome vector drawables in `res/drawable/ic_widget_*.xml` drawn via `Wid
 widget picks a celestial icon per prayer via `prayerIconRes`; the Tracker uses a teal
 disc + `ic_widget_check` when prayed and a two-disc outline ring when not (Glance has no
 stroke modifier); Prayer Times is a clean 5-cell pill row with the next prayer filled
-teal and past prayers dimmed. A JVM regression test (`WidgetGlyphGuardTest`) fails the
+teal, past prayers tinted gold (`widget_gold_container` / `widget_on_gold_container`),
+and upcoming ones plain; every state pairs an explicit container with an on-container
+text colour so the text stays legible in both light and dark mode. A JVM regression test (`WidgetGlyphGuardTest`) fails the
 build if any widget source reintroduces a glyph.
 
 **Manifest/res.** Five `<receiver>`s + the non-exported `WidgetTickReceiver` in `AndroidManifest.xml`; provider-info XMLs in `res/xml/*_widget_info.xml`.


### PR DESCRIPTION
Past prayers in the Prayer Times widget previously reused dimmed
secondary text on no background, which read poorly. They now get a
dedicated gold container tint, while the next prayer keeps the teal
highlight and upcoming ones stay plain.

Every pill state pairs an explicit container colour with a matching
on-container text colour (light/dark variants), so the prayer name and
time stay legible in all states and both themes. All five pills are now
padded identically so they remain vertically aligned.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JQFi8CXtZyUX1hBFnp32Xt