### PR TITLE
feat(quran): rebuild favourites tab on shared saved-card components (#207)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranBookmarkItems.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranBookmarkItems.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,7 +30,6 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
-import com.arshadshah.nimaz.presentation.theme.NimazPalette
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -146,55 +144,6 @@ internal fun BookmarkCard(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun FavoriteAyahItem(
-    surahName: String,
-    ayahNumber: Int,
-    surahNumber: Int,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    NimazCard(
-        style = NimazCardStyle.FILLED,
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
-        colors = NimazCardDefaults.colors(
-            container = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        ),
-        elevation = 0.dp
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            NimazIcon(
-                imageVector = Icons.Default.Favorite,
-                contentDescription = null,
-                tint = NimazPalette.Red500,
-                size = NimazIconSize.LARGE
-            )
-            Spacer(modifier = Modifier.width(14.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = surahName,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = stringResource(R.string.quran_home_verse_format, ayahNumber),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun BookmarkListItemPreview() {
@@ -234,19 +183,6 @@ private fun BookmarkCardPreview() {
                 createdAt = 0,
                 updatedAt = 0
             ),
-            onClick = {}
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun FavoriteAyahItemPreview() {
-    NimazTheme {
-        FavoriteAyahItem(
-            surahName = "Al-Fatihah",
-            ayahNumber = 1,
-            surahNumber = 1,
             onClick = {}
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/AyahActionsBottomSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/AyahActionsBottomSheet.kt
@@ -170,6 +170,7 @@ fun AyahActionsContent(
                 actions = buildAyahActions(
                     ayah = ayah,
                     context = context,
+                    copiedMessage = stringResource(R.string.ayah_copied_to_clipboard),
                     isBookmarked = isBookmarked,
                     isFavorite = isFavorite,
                     isKhatamActive = isKhatamActive,
@@ -193,6 +194,7 @@ fun AyahActionsContent(
 private fun buildAyahActions(
     ayah: Ayah,
     context: Context,
+    copiedMessage: String,
     isBookmarked: Boolean,
     isFavorite: Boolean,
     isKhatamActive: Boolean,
@@ -236,7 +238,7 @@ private fun buildAyahActions(
             icon = Icons.Default.ContentCopy,
             label = stringResource(R.string.action_copy),
             onClick = {
-                copyAyahToClipboard(context, ayah)
+                copyAyahToClipboard(context, ayah, copiedMessage)
                 onCopyClick(ayah)
             }
         )
@@ -304,7 +306,7 @@ internal fun SajdaIndicator(
 /**
  * Copy ayah text to clipboard.
  */
-private fun copyAyahToClipboard(context: Context, ayah: Ayah) {
+private fun copyAyahToClipboard(context: Context, ayah: Ayah, copiedMessage: String) {
     val textToCopy = buildString {
         appendLine(ayah.textArabic)
         if (!ayah.translation.isNullOrBlank()) {
@@ -319,11 +321,7 @@ private fun copyAyahToClipboard(context: Context, ayah: Ayah) {
     val clip = ClipData.newPlainText("Quran Ayah", textToCopy)
     clipboard.setPrimaryClip(clip)
 
-    Toast.makeText(
-        context,
-        context.getString(R.string.ayah_copied_to_clipboard),
-        Toast.LENGTH_SHORT
-    ).show()
+    Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
 }
 
 /**

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafPage.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafPage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -91,6 +92,7 @@ fun MushafPage(
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
+    val copiedMessage = stringResource(R.string.ayah_copied_to_clipboard)
 
     // Tooltip state
     var tooltipAyah by remember { mutableStateOf<Ayah?>(null) }
@@ -215,7 +217,7 @@ fun MushafPage(
                     onFavoriteClick(ayah)
                 },
                 onCopyClick = {
-                    copyAyahToClipboard(context, ayah)
+                    copyAyahToClipboard(context, ayah, copiedMessage)
                     onCopyClick(ayah)
                     tooltipAyah = null
                 },
@@ -310,7 +312,7 @@ private fun MushafOrnamentalLine(modifier: Modifier = Modifier) {
     }
 }
 
-private fun copyAyahToClipboard(context: Context, ayah: Ayah) {
+private fun copyAyahToClipboard(context: Context, ayah: Ayah, copiedMessage: String) {
     val textToCopy = buildString {
         appendLine(ayah.textArabic)
         if (!ayah.translation.isNullOrBlank()) {
@@ -321,11 +323,7 @@ private fun copyAyahToClipboard(context: Context, ayah: Ayah) {
     }
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     clipboard.setPrimaryClip(ClipData.newPlainText("Quran Ayah", textToCopy))
-    Toast.makeText(
-        context,
-        context.getString(R.string.ayah_copied_to_clipboard),
-        Toast.LENGTH_SHORT
-    ).show()
+    Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
 }
 
 private fun shareAyah(context: Context, ayah: Ayah) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SwipeableSavedCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SwipeableSavedCard.kt
@@ -1,0 +1,272 @@
+package com.arshadshah.nimaz.presentation.components.organisms
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxDefaults
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
+import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownMenu
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownRow
+import com.arshadshah.nimaz.presentation.components.molecules.TafseerOrnamentalDivider
+
+/**
+ * The saved-item card family — one place for the swipe-to-delete plumbing, the overflow
+ * action menu and the card layout shared by the Bookmarks screen and the Quran Favourites
+ * tab. Two features that store ayah/hadith/dua references render identically because they
+ * lean on the same three pieces here:
+ *
+ * - [SwipeToDeleteBox] — the end→start swipe-to-delete gesture and its error-tinted backdrop.
+ * - [NimazOverflowMenu] — the `⋮` overflow button + anchored action menu, driven by a list
+ *   of [NimazMenuAction]s.
+ * - [SwipeableSavedCard] — the full card (swipe wrapper + header with a leading badge,
+ *   relative timestamp and overflow menu + title/subtitle/Arabic/note body).
+ */
+
+/**
+ * A single command in a [NimazOverflowMenu]. [destructive] tints irreversible actions
+ * (delete, remove) with the error colour.
+ */
+data class NimazMenuAction(
+    val text: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit,
+    val destructive: Boolean = false,
+)
+
+/**
+ * The app's `⋮` overflow control: a muted [Icons.Default.MoreVert] button that pops a
+ * [NimazDropdownMenu] of [actions]. The menu closes itself before each action fires, so
+ * callers only supply the work to do.
+ */
+@Composable
+fun NimazOverflowMenu(
+    actions: List<NimazMenuAction>,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = stringResource(R.string.cd_more_options),
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        IconButton(onClick = { expanded = true }, modifier = Modifier.size(36.dp)) {
+            NimazIcon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = contentDescription,
+                variant = NimazIconVariant.MUTED,
+                size = NimazIconSize.MEDIUM
+            )
+        }
+        NimazDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            actions.forEach { action ->
+                NimazDropdownRow(
+                    text = action.text,
+                    leadingIcon = action.icon,
+                    destructive = action.destructive,
+                    onClick = {
+                        expanded = false
+                        action.onClick()
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Wraps [content] in an end→start swipe-to-delete gesture. The swipe fires [onDelete]
+ * immediately (the caller is expected to back it with an Undo snackbar) and then resets so
+ * the row settles before the backing list flow removes it. Behind the row sits an
+ * error-container backdrop with a trailing delete icon.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SwipeToDeleteBox(
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundShape: Shape = RoundedCornerShape(16.dp),
+    content: @Composable () -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        initialValue = SwipeToDismissBoxValue.Settled,
+        positionalThreshold = SwipeToDismissBoxDefaults.positionalThreshold
+    )
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue == SwipeToDismissBoxValue.EndToStart) {
+            onDelete()
+            dismissState.reset()
+        }
+    }
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.errorContainer, backgroundShape)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                NimazIcon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.delete),
+                    tint = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+        },
+        content = { content() }
+    )
+}
+
+/**
+ * The shared saved-item card: a [SwipeToDeleteBox] wrapping a [NimazCard] whose header is a
+ * [leading] badge slot + relative "Added …" timestamp + [NimazOverflowMenu], followed by a
+ * bold [title], an optional [subtitle], an optional gold-divided [arabicText] preview and an
+ * optional italic [note] preview.
+ *
+ * @param title primary locator line (e.g. "Al-Fatihah · 1").
+ * @param timestamp epoch millis the item was saved, rendered as a relative "Added …" label.
+ * @param menuActions overflow-menu commands (share, edit note, delete/remove…).
+ * @param onClick tap on the card body (typically navigates to the item).
+ * @param onDelete fired by the swipe gesture; back it with an Undo snackbar.
+ * @param leading the header badge slot, drawn at the start of the header row.
+ */
+@Composable
+fun SwipeableSavedCard(
+    title: String,
+    timestamp: Long,
+    menuActions: List<NimazMenuAction>,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    arabicText: String? = null,
+    note: String? = null,
+    leading: @Composable () -> Unit,
+) {
+    SwipeToDeleteBox(onDelete = onDelete, modifier = modifier) {
+        NimazCard(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onClick,
+            colors = NimazCardDefaults.colors(
+                container = MaterialTheme.colorScheme.surfaceContainer
+            ),
+            elevation = 0.dp
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                // Header: leading badge + relative time + overflow.
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    leading()
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = stringResource(
+                            R.string.added_format,
+                            DateUtils.getRelativeTimeSpanString(
+                                timestamp,
+                                System.currentTimeMillis(),
+                                DateUtils.DAY_IN_MILLIS,
+                                DateUtils.FORMAT_ABBREV_RELATIVE
+                            )
+                        ),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    NimazOverflowMenu(actions = menuActions)
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Title (locator) — bold.
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                // Source / subtitle — only when the caller supplies one.
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                // Arabic preview, set off by a gold ornamental divider.
+                if (!arabicText.isNullOrBlank()) {
+                    TafseerOrnamentalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    ArabicText(
+                        text = arabicText,
+                        size = ArabicTextSize.SMALL,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                // Note preview.
+                if (!note.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
@@ -1,21 +1,15 @@
 package com.arshadshah.nimaz.presentation.screens.bookmarks
 
 import android.content.Intent
-import android.text.format.DateUtils
-import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -24,11 +18,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -36,12 +28,8 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxDefaults
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -55,30 +43,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
-import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
-import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownMenu
-import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownRow
 import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSheetFooterButtons
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSheetSectionLabel
-import com.arshadshah.nimaz.presentation.components.molecules.TafseerOrnamentalDivider
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.organisms.NimazMenuAction
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPillTabs
+import com.arshadshah.nimaz.presentation.components.organisms.SwipeableSavedCard
 import com.arshadshah.nimaz.presentation.viewmodel.BookmarkType
 import com.arshadshah.nimaz.presentation.viewmodel.BookmarksEvent
 import com.arshadshah.nimaz.presentation.viewmodel.BookmarksViewModel
@@ -99,7 +76,7 @@ fun BookmarksScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     // The bookmark whose note is being edited (null = no editor showing). The
-    // overflow menu is now an anchored dropdown owned by each card.
+    // overflow menu is an anchored dropdown owned by each card.
     var noteTarget by remember { mutableStateOf<UnifiedBookmark?>(null) }
     val context = LocalContext.current
     val shareChooser = stringResource(R.string.share)
@@ -185,7 +162,7 @@ fun BookmarksScreen(
                         items = state.filteredBookmarks,
                         key = { it.id }
                     ) { bookmark ->
-                        SwipeableBookmarkCard(
+                        BookmarkSavedCard(
                             bookmark = bookmark,
                             onClick = { bookmark.navigate(onNavigateToQuranAyah, onNavigateToHadith, onNavigateToDua) },
                             onDelete = { viewModel.onEvent(BookmarksEvent.DeleteBookmark(bookmark.id)) },
@@ -256,9 +233,8 @@ private fun BookmarkFilterTabs(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeableBookmarkCard(
+private fun BookmarkSavedCard(
     bookmark: UnifiedBookmark,
     onClick: () -> Unit,
     onDelete: () -> Unit,
@@ -266,188 +242,49 @@ private fun SwipeableBookmarkCard(
     onShare: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Swipe end→start to delete; the deletion fires immediately and the Undo
-    // snackbar lets the user reverse it. Reset so the row settles before the
-    // list flow removes it.
-    val dismissState = rememberSwipeToDismissBoxState(
-        initialValue = SwipeToDismissBoxValue.Settled,
-        positionalThreshold = SwipeToDismissBoxDefaults.positionalThreshold
-    )
-    LaunchedEffect(dismissState.currentValue) {
-        if (dismissState.currentValue == SwipeToDismissBoxValue.EndToStart) {
-            onDelete()
-            dismissState.reset()
-        }
-    }
-    SwipeToDismissBox(
-        state = dismissState,
-        modifier = modifier,
-        enableDismissFromStartToEnd = false,
-        enableDismissFromEndToStart = true,
-        backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.errorContainer, RoundedCornerShape(16.dp))
-                    .padding(horizontal = 24.dp),
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                NimazIcon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = stringResource(R.string.delete),
-                    tint = MaterialTheme.colorScheme.onErrorContainer
-                )
-            }
-        }
-    ) {
-        BookmarkCard(
-            bookmark = bookmark,
-            onClick = onClick,
-            onEditNote = onEditNote,
-            onShare = onShare,
-            onDelete = onDelete,
-        )
-    }
-}
-
-@Composable
-private fun BookmarkCard(
-    bookmark: UnifiedBookmark,
-    onClick: () -> Unit,
-    onEditNote: () -> Unit,
-    onShare: () -> Unit,
-    onDelete: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var menuExpanded by remember { mutableStateOf(false) }
     val typeColor = bookmark.type.color()
     val onTypeColor = bookmark.type.onColor()
     val typeLabel = bookmark.type.label()
-
-    NimazCard(
-        modifier = modifier.fillMaxWidth(),
+    SwipeableSavedCard(
+        title = bookmark.title,
+        timestamp = bookmark.createdAt,
+        // Source / subtitle — only when it adds information beyond the badge.
+        subtitle = bookmark.subtitle.takeIf {
+            it.isNotBlank() && !it.equals(typeLabel, ignoreCase = true)
+        },
+        arabicText = bookmark.arabicText,
+        note = bookmark.note,
         onClick = onClick,
-        colors = NimazCardDefaults.colors(
-            container = MaterialTheme.colorScheme.surfaceContainer
+        onDelete = onDelete,
+        menuActions = listOf(
+            NimazMenuAction(
+                text = stringResource(R.string.edit_note),
+                icon = Icons.Default.Edit,
+                onClick = onEditNote,
+            ),
+            NimazMenuAction(
+                text = stringResource(R.string.share),
+                icon = Icons.Default.Share,
+                onClick = onShare,
+            ),
+            NimazMenuAction(
+                text = stringResource(R.string.delete),
+                icon = Icons.Default.Delete,
+                onClick = onDelete,
+                destructive = true,
+            ),
         ),
-        elevation = 0.dp
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            // Header: type badge + time + overflow.
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                NimazBadge(
-                    text = typeLabel,
-                    backgroundColor = typeColor,
-                    textColor = onTypeColor,
-                    size = NimazBadgeSize.SMALL,
-                    shape = RoundedCornerShape(50)
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = stringResource(
-                        R.string.added_format,
-                        DateUtils.getRelativeTimeSpanString(
-                            bookmark.createdAt,
-                            System.currentTimeMillis(),
-                            DateUtils.DAY_IN_MILLIS,
-                            DateUtils.FORMAT_ABBREV_RELATIVE
-                        )
-                    ),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Box {
-                    IconButton(onClick = { menuExpanded = true }, modifier = Modifier.size(36.dp)) {
-                        NimazIcon(
-                            imageVector = Icons.Default.MoreVert,
-                            contentDescription = stringResource(R.string.cd_more_options),
-                            variant = NimazIconVariant.MUTED,
-                            size = NimazIconSize.MEDIUM
-                        )
-                    }
-                    NimazDropdownMenu(
-                        expanded = menuExpanded,
-                        onDismissRequest = { menuExpanded = false },
-                    ) {
-                        NimazDropdownRow(
-                            text = stringResource(R.string.edit_note),
-                            leadingIcon = Icons.Default.Edit,
-                            onClick = {
-                                menuExpanded = false
-                                onEditNote()
-                            },
-                        )
-                        NimazDropdownRow(
-                            text = stringResource(R.string.share),
-                            leadingIcon = Icons.Default.Share,
-                            onClick = {
-                                menuExpanded = false
-                                onShare()
-                            },
-                        )
-                        NimazDropdownRow(
-                            text = stringResource(R.string.delete),
-                            leadingIcon = Icons.Default.Delete,
-                            destructive = true,
-                            onClick = {
-                                menuExpanded = false
-                                onDelete()
-                            },
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Title (locator) — bold.
-            Text(
-                text = bookmark.title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+        modifier = modifier,
+        leading = {
+            NimazBadge(
+                text = typeLabel,
+                backgroundColor = typeColor,
+                textColor = onTypeColor,
+                size = NimazBadgeSize.SMALL,
+                shape = RoundedCornerShape(50)
             )
-
-            // Source / subtitle — only when it adds information beyond the badge.
-            if (bookmark.subtitle.isNotBlank() && !bookmark.subtitle.equals(typeLabel, ignoreCase = true)) {
-                Text(
-                    text = bookmark.subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-
-            // Arabic preview, set off by a gold ornamental divider.
-            bookmark.arabicText?.let { arabic ->
-                TafseerOrnamentalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                ArabicText(
-                    text = arabic,
-                    size = ArabicTextSize.SMALL,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            // Note preview.
-            bookmark.note?.let { note ->
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = note,
-                    style = MaterialTheme.typography.bodySmall,
-                    fontStyle = FontStyle.Italic,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
         }
-    }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -426,11 +426,10 @@ private fun HadithReaderBottomBar(
 
     val shareLabel = stringResource(R.string.share)
     val copiedMsg = stringResource(R.string.hadith_copied)
-    // stringResource is a @Composable call; avoid calling it from non-composable lambdas.
-    // Use Context.getString instead to build strings in non-composable helpers.
-    val narratedByFmt = { name: String ->
-        context.getString(R.string.hadith_narrated_by_format, name)
-    }
+    // Resolve the template in composable scope (stringResource can't be called from the
+    // non-composable text builder below), then format it per narrator name.
+    val narratedByTemplate = stringResource(R.string.hadith_narrated_by_format)
+    val narratedByFmt = { name: String -> String.format(narratedByTemplate, name) }
 
     fun buildHadithText(): String = buildString {
         appendLine(hadith.textArabic)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.screens.quran
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -27,10 +28,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
@@ -46,10 +49,15 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -64,6 +72,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -76,22 +85,27 @@ import java.time.LocalDate
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.QuranBookmark
-import com.arshadshah.nimaz.domain.model.QuranFavorite
 import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.molecules.BookmarkCard
 import com.arshadshah.nimaz.presentation.components.molecules.BookmarkListItem
 import com.arshadshah.nimaz.presentation.components.molecules.ContinueReadingCard
-import com.arshadshah.nimaz.presentation.components.molecules.FavoriteAyahItem
 import com.arshadshah.nimaz.presentation.components.molecules.KhatamProgressCard
+import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.molecules.QuranQuickActions
 import com.arshadshah.nimaz.presentation.components.molecules.QuranRecommendedSurahs
 import com.arshadshah.nimaz.presentation.components.molecules.SurahListItem
 import com.arshadshah.nimaz.presentation.components.molecules.VerseOfTheDayCard
 import com.arshadshah.nimaz.presentation.components.organisms.JuzGrid
+import com.arshadshah.nimaz.presentation.components.organisms.NimazMenuAction
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
+import com.arshadshah.nimaz.presentation.components.organisms.SwipeableSavedCard
 import com.arshadshah.nimaz.presentation.components.organisms.computeJuzHeaderIndices
 import com.arshadshah.nimaz.presentation.components.organisms.pageGridItems
+import com.arshadshah.nimaz.presentation.theme.NimazPalette
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import com.arshadshah.nimaz.presentation.viewmodel.FavoriteAyahUi
 import com.arshadshah.nimaz.presentation.viewmodel.QuranEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QuranHomeUiState
 import com.arshadshah.nimaz.presentation.viewmodel.QuranViewModel
@@ -119,9 +133,30 @@ fun QuranHomeScreen(
     val state by viewModel.homeState.collectAsState()
     val bookmarksState by viewModel.bookmarksState.collectAsState()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Drive the Undo snackbar off the most recently removed favourite.
+    val favoriteRemovedMessage = stringResource(R.string.favorite_removed)
+    val undoLabel = stringResource(R.string.undo)
+    val removedFavoriteId = state.recentlyRemovedFavorite?.ayahId
+    LaunchedEffect(removedFavoriteId) {
+        if (removedFavoriteId != null) {
+            val result = snackbarHostState.showSnackbar(
+                message = favoriteRemovedMessage,
+                actionLabel = undoLabel,
+                duration = SnackbarDuration.Short
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                viewModel.onEvent(QuranEvent.UndoRemoveFavorite)
+            } else {
+                viewModel.onEvent(QuranEvent.DismissFavoriteUndo)
+            }
+        }
+    }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             NimazTopAppBar(
                 title = stringResource(R.string.quran_home_title),
@@ -230,7 +265,8 @@ fun QuranHomeScreen(
                     2 -> FavoritesTabContent(
                         favorites = state.favorites,
                         surahs = state.surahs,
-                        onNavigateToQuranAyah = onNavigateToQuranAyah
+                        onNavigateToQuranAyah = onNavigateToQuranAyah,
+                        onRemoveFavorite = { viewModel.onEvent(QuranEvent.RemoveFavorite(it)) }
                     )
                 }
             }
@@ -663,58 +699,93 @@ private fun BrowseTabContent(
 
 @Composable
 private fun FavoritesTabContent(
-    favorites: List<QuranFavorite>,
+    favorites: List<FavoriteAyahUi>,
     surahs: List<Surah>,
-    onNavigateToQuranAyah: (Int, Int) -> Unit
+    onNavigateToQuranAyah: (Int, Int) -> Unit,
+    onRemoveFavorite: (FavoriteAyahUi) -> Unit
 ) {
+    if (favorites.isEmpty()) {
+        NimazEmptyState(
+            title = stringResource(R.string.quran_home_no_favorite_ayahs),
+            message = stringResource(R.string.quran_home_favorite_hint),
+            icon = Icons.Default.Favorite,
+            iconTint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(20.dp)
+        )
+        return
+    }
+
+    val context = LocalContext.current
+    val shareChooser = stringResource(R.string.share)
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        if (favorites.isEmpty()) {
-            item(key = "no_favorites") {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 32.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        NimazIcon(
-                            imageVector = Icons.Default.Favorite,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                            iconSize = 48.dp
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            text = stringResource(R.string.quran_home_no_favorite_ayahs),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Text(
-                            text = stringResource(R.string.quran_home_favorite_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                        )
-                    }
+        items(
+            items = favorites,
+            key = { "fav_${it.ayahId}" }
+        ) { favorite ->
+            val surahName = surahs.find { it.number == favorite.surahNumber }?.nameEnglish
+                ?: stringResource(R.string.quran_home_surah_fallback, favorite.surahNumber)
+            val verseLabel = stringResource(R.string.quran_home_verse_format, favorite.ayahNumber)
+            SwipeableSavedCard(
+                title = surahName,
+                subtitle = verseLabel,
+                timestamp = favorite.createdAt,
+                arabicText = favorite.arabicText,
+                onClick = { onNavigateToQuranAyah(favorite.surahNumber, favorite.ayahNumber) },
+                onDelete = { onRemoveFavorite(favorite) },
+                menuActions = listOf(
+                    NimazMenuAction(
+                        text = stringResource(R.string.share),
+                        icon = Icons.Default.Share,
+                        onClick = {
+                            context.startActivity(
+                                Intent.createChooser(
+                                    favoriteShareIntent(surahName, verseLabel, favorite.arabicText),
+                                    shareChooser
+                                )
+                            )
+                        },
+                    ),
+                    NimazMenuAction(
+                        text = stringResource(R.string.remove_from_favorites),
+                        icon = Icons.Default.Delete,
+                        onClick = { onRemoveFavorite(favorite) },
+                        destructive = true,
+                    ),
+                ),
+                leading = {
+                    NimazBadge(
+                        text = stringResource(R.string.favorite_type),
+                        backgroundColor = NimazPalette.Red500,
+                        textColor = Color.White,
+                        size = NimazBadgeSize.SMALL,
+                        shape = RoundedCornerShape(50)
+                    )
                 }
-            }
-        } else {
-            items(
-                items = favorites,
-                key = { "fav_${it.ayahId}" }
-            ) { favorite ->
-                val surahName = surahs.find { it.number == favorite.surahNumber }?.nameEnglish
-                    ?: stringResource(R.string.quran_home_surah_fallback, favorite.surahNumber)
-                FavoriteAyahItem(
-                    surahName = surahName,
-                    ayahNumber = favorite.ayahNumber,
-                    surahNumber = favorite.surahNumber,
-                    onClick = { onNavigateToQuranAyah(favorite.surahNumber, favorite.ayahNumber) }
-                )
-            }
+            )
         }
+    }
+}
+
+private fun favoriteShareIntent(
+    surahName: String,
+    verseLabel: String,
+    arabicText: String?
+): Intent {
+    val body = buildString {
+        append(surahName)
+        append(" · ")
+        append(verseLabel)
+        arabicText?.let { append("\n\n$it") }
+    }
+    return Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT, body)
+        type = "text/plain"
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
@@ -53,6 +53,9 @@ fun TafseerScreen(
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    // Resolved in composable scope so the share intent doesn't query resources off
+    // LocalContext.current from the (non-composable) coroutine below.
+    val shareChooserLabel = stringResource(R.string.tafseer_share_chooser)
 
     LaunchedEffect(surahNumber, ayahNumber) {
         viewModel.onEvent(TafseerEvent.LoadSurah(surahNumber, ayahNumber))
@@ -80,10 +83,7 @@ fun TafseerScreen(
                 val intent = TafseerPdfExporter.buildShareIntent(context, file)
                 withContext(Dispatchers.Main) {
                     context.startActivity(
-                        Intent.createChooser(
-                            intent,
-                            context.getString(R.string.tafseer_share_chooser)
-                        )
+                        Intent.createChooser(intent, shareChooserLabel)
                     )
                 }
             }.onFailure { CrashReporter.recordException(it) }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -46,6 +46,19 @@ import javax.inject.Inject
 
 enum class ReadingMode { SURAH, JUZ, PAGE }
 
+/**
+ * A Quran favourite enriched for the Favourites tab — the stored [QuranFavorite] plus the
+ * ayah's Arabic text, so the tab can show the same rich card (badge, timestamp, Arabic
+ * preview, overflow menu) as the Bookmarks screen.
+ */
+data class FavoriteAyahUi(
+    val ayahId: Int,
+    val surahNumber: Int,
+    val ayahNumber: Int,
+    val arabicText: String?,
+    val createdAt: Long,
+)
+
 data class QuranHomeUiState(
     val surahs: List<Surah> = emptyList(),
     val filteredSurahs: List<Surah> = emptyList(),
@@ -53,7 +66,10 @@ data class QuranHomeUiState(
     val topTab: Int = 0, // 0 = Home, 1 = Browse, 2 = Favorites, 3 = Bookmarks
     val selectedTab: Int = 0, // Browse sub-tab: 0=Surah, 1=Juz, 2=Page
     val readingProgress: ReadingProgress? = null,
-    val favorites: List<QuranFavorite> = emptyList(),
+    val favorites: List<FavoriteAyahUi> = emptyList(),
+    // Holds the most recently removed favourite so the tab can offer an Undo snackbar;
+    // cleared on undo, dismiss, or a subsequent removal.
+    val recentlyRemovedFavorite: FavoriteAyahUi? = null,
     val activeKhatam: Khatam? = null,
     val khatamReadAyahIds: Set<Int> = emptySet(),
     val completedKhatamCount: Int = 0,
@@ -110,6 +126,11 @@ sealed interface QuranEvent {
 
     data class ToggleFavorite(val ayahId: Int, val surahNumber: Int, val ayahNumber: Int) :
         QuranEvent
+
+    /** Remove a favourite from the Favourites tab; captures it for an Undo snackbar. */
+    data class RemoveFavorite(val favorite: FavoriteAyahUi) : QuranEvent
+    data object UndoRemoveFavorite : QuranEvent
+    data object DismissFavoriteUndo : QuranEvent
 
     data class UpdateReadingPosition(val surah: Int, val ayah: Int, val page: Int, val juz: Int) :
         QuranEvent
@@ -215,6 +236,11 @@ class QuranViewModel @Inject constructor(
                 event.surahNumber,
                 event.ayahNumber
             )
+
+            is QuranEvent.RemoveFavorite -> removeFavorite(event.favorite)
+            QuranEvent.UndoRemoveFavorite -> undoRemoveFavorite()
+            QuranEvent.DismissFavoriteUndo ->
+                _homeState.update { it.copy(recentlyRemovedFavorite = null) }
 
             is QuranEvent.UpdateReadingPosition -> updateReadingPosition(
                 event.surah,
@@ -599,9 +625,45 @@ class QuranViewModel @Inject constructor(
         viewModelScope.launch {
             quranUseCases.getFavorites()
                 .collect { favorites ->
-                    _homeState.update { it.copy(favorites = favorites) }
+                    // Enrich each favourite with its Arabic text so the Favourites tab can
+                    // render the same rich card as the Bookmarks screen.
+                    val enriched = favorites.map { fav ->
+                        FavoriteAyahUi(
+                            ayahId = fav.ayahId,
+                            surahNumber = fav.surahNumber,
+                            ayahNumber = fav.ayahNumber,
+                            arabicText = quranUseCases.getAyahById(fav.ayahId)?.textArabic,
+                            createdAt = fav.createdAt,
+                        )
+                    }
+                    _homeState.update { it.copy(favorites = enriched) }
                 }
         }
+    }
+
+    // toggleFavorite both removes and (on undo) re-adds, so the same call drives the
+    // swipe-to-delete removal and its Undo restore.
+    private fun removeFavorite(favorite: FavoriteAyahUi) {
+        viewModelScope.launch {
+            quranUseCases.toggleFavorite(
+                favorite.ayahId,
+                favorite.surahNumber,
+                favorite.ayahNumber
+            )
+        }
+        _homeState.update { it.copy(recentlyRemovedFavorite = favorite) }
+    }
+
+    private fun undoRemoveFavorite() {
+        val favorite = _homeState.value.recentlyRemovedFavorite ?: return
+        viewModelScope.launch {
+            quranUseCases.toggleFavorite(
+                favorite.ayahId,
+                favorite.surahNumber,
+                favorite.ayahNumber
+            )
+        }
+        _homeState.update { it.copy(recentlyRemovedFavorite = null) }
     }
 
     private fun loadFavoriteAyahIds() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -559,8 +559,10 @@
     <string name="quran_type">Quran</string>
     <string name="hadith_type">Hadith</string>
     <string name="dua_type">Dua</string>
+    <string name="favorite_type">Favorite</string>
     <string name="bookmarks_count">%1$d saved</string>
     <string name="bookmark_removed">Bookmark removed</string>
+    <string name="favorite_removed">Favorite removed</string>
     <string name="undo">Undo</string>
     <string name="edit_note">Edit note</string>
     <string name="note_hint">Add a note…</string>

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranBookmarkItemsTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranBookmarkItemsTest.kt
@@ -118,37 +118,4 @@ class QuranBookmarkItemsTest {
         composeRule.onNodeWithText("Al-Fatihah").performClick()
         assertThat(clicked).isTrue()
     }
-
-    // ----- FavoriteAyahItem -----
-
-    @Test
-    fun favoriteAyahItem_showsNameAndVerse() {
-        composeRule.setThemedContent {
-            FavoriteAyahItem(
-                surahName = "An-Nas",
-                ayahNumber = 6,
-                surahNumber = 114,
-                onClick = {}
-            )
-        }
-
-        composeRule.onNodeWithText("An-Nas").assertExists()
-        composeRule.onNodeWithText("Verse 6").assertExists()
-    }
-
-    @Test
-    fun favoriteAyahItem_click_invokesCallback() {
-        var clicked = false
-        composeRule.setThemedContent {
-            FavoriteAyahItem(
-                surahName = "An-Nas",
-                ayahNumber = 6,
-                surahNumber = 114,
-                onClick = { clicked = true }
-            )
-        }
-
-        composeRule.onNodeWithText("An-Nas").performClick()
-        assertThat(clicked).isTrue()
-    }
 }

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/TafseerHighlightableTextTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/TafseerHighlightableTextTest.kt
@@ -33,15 +33,16 @@ class TafseerHighlightableTextTest {
     )
 
     @Test
-    fun rendersPlainText_inViewMode() {
+    fun rendersPlainText_withoutSelection() {
         composeRule.setThemedContent {
             TafseerHighlightableText(
                 text = "Hello tafseer world",
                 highlights = emptyList(),
-                isHighlightMode = false,
-                selectedColor = "#FDE68A",
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightTapped = {}
+                selectionStart = -1,
+                selectionEnd = -1,
+                onSelectionChange = { _, _ -> },
+                onHighlightTapped = {},
+                clearSelectionToken = 0
             )
         }
 
@@ -54,10 +55,11 @@ class TafseerHighlightableTextTest {
             TafseerHighlightableText(
                 text = "Hello tafseer world",
                 highlights = listOf(highlight(startOffset = 0, endOffset = 5)),
-                isHighlightMode = false,
-                selectedColor = "#BBF7D0",
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightTapped = {}
+                selectionStart = -1,
+                selectionEnd = -1,
+                onSelectionChange = { _, _ -> },
+                onHighlightTapped = {},
+                clearSelectionToken = 0
             )
         }
 
@@ -71,10 +73,11 @@ class TafseerHighlightableTextTest {
             TafseerHighlightableText(
                 text = "Bismillah بسم الله الرحمن الرحيم end",
                 highlights = emptyList(),
-                isHighlightMode = false,
-                selectedColor = "#FDE68A",
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightTapped = {}
+                selectionStart = -1,
+                selectionEnd = -1,
+                onSelectionChange = { _, _ -> },
+                onHighlightTapped = {},
+                clearSelectionToken = 0
             )
         }
 
@@ -82,21 +85,20 @@ class TafseerHighlightableTextTest {
     }
 
     @Test
-    fun highlightMode_rendersText_withoutSelectionIndicatorInitially() {
+    fun rendersText_withActiveSelectionRange() {
         composeRule.setThemedContent {
             TafseerHighlightableText(
                 text = "Highlight me please",
                 highlights = emptyList(),
-                isHighlightMode = true,
-                selectedColor = "#BFDBFE",
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightTapped = {}
+                selectionStart = 0,
+                selectionEnd = 9,
+                onSelectionChange = { _, _ -> },
+                onHighlightTapped = {},
+                clearSelectionToken = 0
             )
         }
 
         composeRule.onNodeWithText("Highlight me please").assertExists()
-        // No tap yet -> selectionStart < 0 -> indicator hidden
-        composeRule.onNodeWithText("Tap end position to highlight").assertDoesNotExist()
     }
 
     @Test
@@ -106,10 +108,11 @@ class TafseerHighlightableTextTest {
             TafseerHighlightableText(
                 text = "short",
                 highlights = listOf(highlight(startOffset = 0, endOffset = 999)),
-                isHighlightMode = false,
-                selectedColor = "#FED7AA",
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightTapped = {}
+                selectionStart = -1,
+                selectionEnd = -1,
+                onSelectionChange = { _, _ -> },
+                onHighlightTapped = {},
+                clearSelectionToken = 0
             )
         }
 

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContentTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContentTest.kt
@@ -64,9 +64,9 @@ class TafseerPageContentTest {
                     TafseerSource.MAARIFUL_QURAN
                 ),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
@@ -85,9 +85,9 @@ class TafseerPageContentTest {
                 selectedSource = TafseerSource.IBN_KATHIR,
                 availableSources = setOf(TafseerSource.IBN_KATHIR),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
@@ -105,9 +105,9 @@ class TafseerPageContentTest {
                 selectedSource = TafseerSource.IBN_KATHIR,
                 availableSources = setOf(TafseerSource.IBN_KATHIR),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
@@ -125,9 +125,9 @@ class TafseerPageContentTest {
                 selectedSource = TafseerSource.IBN_KATHIR,
                 availableSources = setOf(TafseerSource.IBN_KATHIR),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
@@ -148,9 +148,9 @@ class TafseerPageContentTest {
                     TafseerSource.MAARIFUL_QURAN
                 ),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
@@ -173,36 +173,15 @@ class TafseerPageContentTest {
                     TafseerSource.MAARIFUL_QURAN
                 ),
                 onSourceSwitch = { switchedTo = it },
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }
 
         composeRule.onNodeWithText("Ma'arif al-Qur'an").performClick()
         assertThat(switchedTo).isEqualTo(TafseerSource.MAARIFUL_QURAN)
-    }
-
-    @Test
-    fun `enable highlighting control is present`() {
-        composeRule.setThemedContent {
-            TafseerPageContent(
-                ayah = ayah(),
-                tafseer = tafseer("Short commentary."),
-                highlights = emptyList(),
-                selectedSource = TafseerSource.IBN_KATHIR,
-                availableSources = setOf(TafseerSource.IBN_KATHIR),
-                onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
-                onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
-                onShare = {}
-            )
-        }
-
-        // Floating control toggle uses this contentDescription when off
-        composeRule.onNodeWithContentDescription("Enable highlighting").assertExists()
     }
 
     @Test
@@ -227,9 +206,9 @@ class TafseerPageContentTest {
                 selectedSource = TafseerSource.IBN_KATHIR,
                 availableSources = setOf(TafseerSource.IBN_KATHIR),
                 onSourceSwitch = {},
-                onHighlightCreated = { _, _, _ -> },
+                onHighlightCreated = { _, _, _, _ -> },
                 onHighlightDeleted = {},
-                onHighlightNoteUpdated = { _, _ -> },
+                onHighlightUpdated = { _, _, _ -> },
                 onShare = {}
             )
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -507,6 +507,16 @@ typed route object.
       Pass `onCheckedChange = null` when an enclosing clickable row owns the toggle (the
       `NimazSettingsItem` pattern — the row toggles, the switch just renders state). It centralised
       the settings/notification toggles, the tasbih left-handed switch and the calendar preview.
+    - a **swipe-to-delete saved-item row** (a stored ayah/hadith/dua reference shown with a badge,
+      relative timestamp, Arabic preview and overflow menu) is `SwipeableSavedCard(title, timestamp,
+      menuActions, onClick, onDelete, subtitle = …, arabicText = …, note = …) { leading }`
+      (`components/organisms/SwipeableSavedCard.kt`), **not** a hand-rolled `SwipeToDismissBox` +
+      `NimazCard` per screen. The same file owns the two pieces it is built from, reusable on their
+      own: `SwipeToDeleteBox(onDelete) { … }` (the end→start swipe gesture + error-tinted backdrop —
+      back it with an Undo snackbar) and `NimazOverflowMenu(actions = listOf(NimazMenuAction(text,
+      icon, onClick, destructive = …)))` (the `⋮` button + anchored action menu over `NimazDropdownMenu`).
+      It centralised the **Bookmarks** screen and the **Quran Favourites** tab so both render and
+      behave identically.
   Screen-local private composables are fine for **feature-specific** layout that isn't reused
   elsewhere; promote anything reused across screens into `components/`.
 


### PR DESCRIPTION
Give the Quran Favourites tab the same feature set as the Bookmarks
screen by centralising the shared UI and rebuilding favourites on top
of it.

New components/organisms/SwipeableSavedCard.kt centralises three pieces
both features now share:
- SwipeToDeleteBox — the end→start swipe-to-delete gesture + error-tinted
  backdrop (back it with an Undo snackbar).
- NimazOverflowMenu / NimazMenuAction — the ⋮ overflow button + anchored
  action menu over NimazDropdownMenu.
- SwipeableSavedCard — the full card (swipe wrapper + badge/timestamp/
  Arabic/note body + overflow menu).

BookmarksScreen now renders through SwipeableSavedCard (its hand-rolled
SwipeToDismissBox + card + inline menu are gone). The Quran Favourites
tab is rebuilt with the same card: swipe-to-delete with Undo, an overflow
menu (Share / Remove from favourites), a relative timestamp and an Arabic
preview. QuranViewModel enriches favourites with Arabic text and gains
RemoveFavorite/UndoRemoveFavorite events; the old bare FavoriteAyahItem
row (and its tests) are removed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015x1NHi2yzs8Fi8sgqEkrcp