### PR TITLE
test(e2e): fix content-drill tests that never reached their content

### DIFF
--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/HadithOpenCollectionTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/HadithOpenCollectionTest.kt
@@ -13,8 +13,10 @@ import org.junit.runner.RunWith
  * collection opens its book screen. Collections ship in the prepackaged asset DB, so
  * no seeding is needed. Read-only.
  *
- * The Hadith home renders `hadith_books.name_english` behind an `isLoading` gate, so
- * the tiles appear only after the async DB load — wait for the collection before tapping.
+ * The Hadith home renders `hadith_books.name_english` behind an `isLoading` gate, and the
+ * collections grid sits below the tall stats + hadith-of-the-day cards in the scrolling
+ * list — so the tiles both load async and start off-screen (uncomposed). Scroll the tagged
+ * list to the collection before tapping it.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
@@ -25,10 +27,10 @@ class HadithOpenCollectionTest : BaseAppTest() {
         launchApp()
         openFeatureFromMore(Selectors.More.hadith, ScreenTags.HadithHome)
 
-        // The collection tiles load async behind the isLoading gate; wait for the
-        // first collection (shipped as "Sahih al-Bukhari") before opening it.
-        waitForText("Sahih al-Bukhari")
-        clickText("Sahih al-Bukhari")
+        // The collection tiles load async behind the isLoading gate and start below the
+        // fold; scroll the tagged list to the first collection (shipped as
+        // "Sahih al-Bukhari") and open it via its card's OnClick semantics.
+        scrollListToAndTap(ScreenTags.HadithBookList, "Sahih al-Bukhari")
 
         assertScreen(ScreenTags.HadithBook)
     }

--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/QuranOpenSurahTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/QuranOpenSurahTest.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.behavior
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.support.BaseAppTest
+import com.arshadshah.nimaz.support.Selectors
 import com.arshadshah.nimaz.support.Selectors.NavLabel
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
@@ -25,8 +26,10 @@ class QuranOpenSurahTest : BaseAppTest() {
         tapBottomNav(NavLabel.QURAN)
         assertScreen(ScreenTags.Quran)
 
-        // Browse (Surah) is the default tab; scroll the tagged surah list to
-        // Al-Fatiha and open it via its card's OnClick semantics.
+        // The Quran home opens on the "Home" overview tab (topTab 0); the surah list
+        // lives under the "Browse" tab (topTab 1), so select it first. Then scroll the
+        // tagged surah list to Al-Fatiha and open it via its card's OnClick semantics.
+        clickText(Selectors.str(Selectors.Quran.browseTab))
         scrollListToAndTap(ScreenTags.QuranSurahList, "Al-Fatiha")
 
         assertScreen(ScreenTags.QuranReader)

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -104,6 +104,9 @@ object ScreenTags {
     /** Quran browse — the scrollable surah list (behavior tests scroll-to a surah). */
     const val QuranSurahList = "quran_surah_list"
 
+    /** Hadith home — the scrollable list holding the collections grid (scroll-to a book). */
+    const val HadithBookList = "hadith_book_list"
+
     /** Tag for a bottom-navigation tab, keyed by its label (e.g. "Home"). */
     fun bottomNav(label: String): String = "bottomnav_$label"
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -46,6 +47,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.core.share.ContentShareManager
 import com.arshadshah.nimaz.core.share.Shareables
 import com.arshadshah.nimaz.core.util.formatGrouped
@@ -113,7 +115,8 @@ fun HadithCollectionScreen(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(paddingValues),
+                    .padding(paddingValues)
+                    .testTag(ScreenTags.HadithBookList),
                 contentPadding = PaddingValues(bottom = 24.dp)
             ) {
                 item {


### PR DESCRIPTION
## Summary

Fixes the 2 failing `emulator.wtf` instrumentation tests on PR #233 (84/86 passed). Both new content-drill behavior tests timed out deterministically — not because of wrong strings (the shipped `Al-Fatiha` / `Sahih al-Bukhari` are correct, verified against the git-LFS prepopulated DB), but because the content they asserted on was **never composed** when the assertion ran.

## Root cause & fix

**Quran (`QuranOpenSurahTest`)** — the `quran_surah_list` tag lives only inside the "Browse" top-tab (`topTab == 1`), but the Quran home defaults to the "Home" overview tab (`topTab = 0`). The test drilled straight in without selecting Browse, so the tagged surah list never composed.
→ Select the Browse tab first.

**Hadith (`HadithOpenCollectionTest`)** — the collections grid is a `LazyColumn` item below the tall stats + hadith-of-the-day cards, so it starts off-screen and uncomposed. An in-place `waitForText` can never see an off-screen lazy node.
→ Tag the collections list (`ScreenTags.HadithBookList`) and scroll it into view with `scrollListToAndTap`, mirroring the Quran pattern.

## Changes

- `QuranOpenSurahTest.kt` — select the Browse tab before scrolling to the surah.
- `ScreenTags.kt` — add `HadithBookList` tag constant.
- `HadithCollectionScreen.kt` — tag the collections `LazyColumn`.
- `HadithOpenCollectionTest.kt` — scroll-and-tap the collection instead of waiting in place.

## Testing

Click paths verified to expose `OnClick` semantics (`SurahListItem` and the Hadith `BookCard` both use `NimazCard(onClick)` → Material3 `Card`/`OutlinedCard`). `"Sahih al-Bukhari"` confirmed unambiguous (hadith references are `bukhari:N`, fallback source is `Sahih al-Bukhari 6018`). Build validated on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LU3cuAtAoautwAxZaZHHgd)_