### PR TITLE
fix(about): generate aboutlibraries data so Licenses screen doesn't crash

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -156,7 +156,7 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-about-libs-plugin = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibs" }
+about-libs-plugin = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutLibs" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }


### PR DESCRIPTION
The Licenses screen crashed with IllegalStateException ("Please provide
the required library data via the available APIs") because
Libs.Builder().withContext(context).build() found no
res/raw/aboutlibraries.json in the APK.

aboutlibraries v13 split the Gradle plugin in two: the base plugin
(com.mikepenz.aboutlibraries.plugin) only registers manual export tasks,
while the Android plugin (com.mikepenz.aboutlibraries.plugin.android)
hooks into the Android build to auto-generate R.raw.aboutlibraries and
bundle it into resources. The project was on v14.2.1 but still applied
the base plugin, so the data file was never produced.

Switch the version-catalog plugin id to the .android variant. Both the
root and app build files reference this alias, so the auto-generation is
now wired into the build and the Licenses/LicenseDetail screens load.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X1U5PKwFXfVap7qG6CA2FD