### PR TITLE
Unify search and ask input into single search bar

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/ai/AiApiClient.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/ai/AiApiClient.kt
@@ -1,10 +1,8 @@
 package com.arshadshah.nimaz.data.ai
 
 import com.arshadshah.nimaz.data.ai.dto.ApiError
-import com.arshadshah.nimaz.data.ai.dto.AskOutput
 import com.arshadshah.nimaz.data.ai.dto.InvokeRequest
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -12,37 +10,46 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
-/** Result of an HTTP invocation, already decoded into success/error/transport. */
-sealed interface AiHttpResult {
-    data class Success(val output: AskOutput) : AiHttpResult
-    data class ApiFailure(val status: Int, val body: ApiError?) : AiHttpResult
-    data class Transport(val cause: Throwable) : AiHttpResult
+/**
+ * Result of an HTTP invocation, already decoded into success/error/transport.
+ * Generic over the capability's output type [O].
+ */
+sealed interface AiHttpResult<out O> {
+    data class Success<O>(val output: O) : AiHttpResult<O>
+    data class ApiFailure(val status: Int, val body: ApiError?) : AiHttpResult<Nothing>
+    data class Transport(val cause: Throwable) : AiHttpResult<Nothing>
 }
 
 /**
  * Thin Ktor wrapper over the Nimaz AI Worker. Owns the configured [HttpClient]
  * and the base URL (from BuildConfig). Error mapping to domain [AiError] lives
- * in the repository.
+ * in the repository. Generic over capability output so a single client serves
+ * every capability.
  */
 class AiApiClient(
     private val client: HttpClient,
     private val baseUrl: String,
     private val json: Json,
 ) {
-    suspend fun invoke(request: InvokeRequest): AiHttpResult {
+    suspend fun <O> invoke(
+        request: InvokeRequest,
+        outputDeserializer: DeserializationStrategy<O>,
+    ): AiHttpResult<O> {
         return try {
             val response: HttpResponse =
                 client.post("${baseUrl.trimEnd('/')}/v1/invoke") {
                     contentType(ContentType.Application.Json)
                     setBody(request)
                 }
+            val text = response.bodyAsText()
             if (response.status.isSuccess()) {
-                AiHttpResult.Success(response.body())
+                AiHttpResult.Success(json.decodeFromString(outputDeserializer, text))
             } else {
                 val error = runCatching {
-                    json.decodeFromString(ApiError.serializer(), response.bodyAsText())
+                    json.decodeFromString(ApiError.serializer(), text)
                 }.getOrNull()
                 AiHttpResult.ApiFailure(response.status.value, error)
             }

--- a/app/src/main/java/com/arshadshah/nimaz/data/ai/dto/AiDtos.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/ai/dto/AiDtos.kt
@@ -2,20 +2,38 @@ package com.arshadshah.nimaz.data.ai.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
-/** Envelope for `POST /v1/invoke`. Mirrors the Worker's InvokeEnvelopeSchema. */
+/**
+ * Envelope for `POST /v1/invoke`. Mirrors the Worker's InvokeEnvelopeSchema.
+ * [input] is a raw [JsonElement] so one envelope serves every capability — the
+ * repository encodes the capability-specific input into it.
+ */
 @Serializable
 data class InvokeRequest(
     val capability: String,
     val integrityToken: String,
     val deviceId: String,
-    val input: AskInput,
+    val input: JsonElement,
 )
 
 @Serializable
 data class AskInput(
     val question: String,
     val passages: List<PassageDto>,
+)
+
+/** Input for the `search-plan` capability. Mirrors the Worker's SearchPlanInputSchema. */
+@Serializable
+data class SearchPlanInput(
+    val question: String,
+)
+
+/** Success body for `search-plan`. Mirrors the Worker's SearchPlanOutputSchema. */
+@Serializable
+data class SearchPlanOutput(
+    val terms: List<String>,
+    val quranRefs: List<String>,
 )
 
 @Serializable

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AiRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AiRepositoryImpl.kt
@@ -5,15 +5,23 @@ import com.arshadshah.nimaz.data.ai.AiHttpResult
 import com.arshadshah.nimaz.data.ai.DeviceIdProvider
 import com.arshadshah.nimaz.data.ai.IntegrityTokenProvider
 import com.arshadshah.nimaz.data.ai.dto.AskInput
+import com.arshadshah.nimaz.data.ai.dto.AskOutput
 import com.arshadshah.nimaz.data.ai.dto.InvokeRequest
 import com.arshadshah.nimaz.data.ai.dto.PassageDto
+import com.arshadshah.nimaz.data.ai.dto.SearchPlanInput
+import com.arshadshah.nimaz.data.ai.dto.SearchPlanOutput
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
+import com.arshadshah.nimaz.domain.model.CitationId
 import com.arshadshah.nimaz.domain.model.GroundedAnswer
 import com.arshadshah.nimaz.domain.model.ProofPassage
+import com.arshadshah.nimaz.domain.model.SearchPlan
 import com.arshadshah.nimaz.domain.repository.AiRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
@@ -21,35 +29,61 @@ class AiRepositoryImpl @Inject constructor(
     private val apiClient: AiApiClient,
     private val integrityTokenProvider: IntegrityTokenProvider,
     private val deviceIdProvider: DeviceIdProvider,
+    @param:Named("aiJson") private val json: Json,
 ) : AiRepository {
+
+    override suspend fun planSearch(question: String): Result<SearchPlan> {
+        val request = envelope(
+            capability = CAPABILITY_SEARCH_PLAN,
+            input = json.encodeToJsonElement(
+                SearchPlanInput.serializer(),
+                SearchPlanInput(question = question),
+            ),
+        )
+        return when (val result = apiClient.invoke(request, SearchPlanOutput.serializer())) {
+            is AiHttpResult.Success -> Result.success(result.output.toDomain())
+            is AiHttpResult.Transport -> failure(AiError.Network)
+            is AiHttpResult.ApiFailure ->
+                failure(mapApiError(result.status, result.body?.error?.code, result.body?.error?.retryAfterSeconds))
+        }
+    }
 
     override suspend fun ask(
         question: String,
         passages: List<ProofPassage>,
     ): Result<GroundedAnswer> {
-        val request = InvokeRequest(
-            capability = CAPABILITY_ID,
-            integrityToken = integrityTokenProvider.getToken(),
-            deviceId = deviceIdProvider.getOrCreate(),
-            input = AskInput(
-                question = question,
-                passages = passages.map {
-                    PassageDto(
-                        id = it.id,
-                        source = it.source.wire,
-                        text = it.text,
-                        meta = it.meta,
-                    )
-                },
+        val request = envelope(
+            capability = CAPABILITY_ASK,
+            input = json.encodeToJsonElement(
+                AskInput.serializer(),
+                AskInput(
+                    question = question,
+                    passages = passages.map {
+                        PassageDto(
+                            id = it.id,
+                            source = it.source.wire,
+                            text = it.text,
+                            meta = it.meta,
+                        )
+                    },
+                ),
             ),
         )
 
-        return when (val result = apiClient.invoke(request)) {
+        return when (val result = apiClient.invoke(request, AskOutput.serializer())) {
             is AiHttpResult.Success -> Result.success(result.output.toDomain())
             is AiHttpResult.Transport -> failure(AiError.Network)
-            is AiHttpResult.ApiFailure -> failure(mapApiError(result.status, result.body?.error?.code, result.body?.error?.retryAfterSeconds))
+            is AiHttpResult.ApiFailure ->
+                failure(mapApiError(result.status, result.body?.error?.code, result.body?.error?.retryAfterSeconds))
         }
     }
+
+    private suspend fun envelope(capability: String, input: JsonElement) = InvokeRequest(
+        capability = capability,
+        integrityToken = integrityTokenProvider.getToken(),
+        deviceId = deviceIdProvider.getOrCreate(),
+        input = input,
+    )
 
     private fun mapApiError(
         status: Int,
@@ -69,10 +103,10 @@ class AiRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun failure(error: AiError): Result<GroundedAnswer> =
+    private fun <T> failure(error: AiError): Result<T> =
         Result.failure(AiRequestException(error))
 
-    private fun com.arshadshah.nimaz.data.ai.dto.AskOutput.toDomain(): GroundedAnswer =
+    private fun AskOutput.toDomain(): GroundedAnswer =
         GroundedAnswer(
             answer = answer,
             citationIds = citationIds,
@@ -84,7 +118,16 @@ class AiRepositoryImpl @Inject constructor(
             insufficientEvidence = insufficientEvidence,
         )
 
+    private fun SearchPlanOutput.toDomain(): SearchPlan =
+        SearchPlan(
+            terms = terms.map { it.trim() }.filter { it.isNotBlank() }.distinct(),
+            // Reuse the strict citation grammar: "2:153" -> quran:2:153 -> Quran(2, 153).
+            // Malformed refs resolve to null and are dropped.
+            quranRefs = quranRefs.mapNotNull { CitationId.parse("quran:${it.trim()}") as? CitationId.Quran },
+        )
+
     companion object {
-        private const val CAPABILITY_ID = "ask-with-proof"
+        private const val CAPABILITY_ASK = "ask-with-proof"
+        private const val CAPABILITY_SEARCH_PLAN = "search-plan"
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/SearchPlan.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/SearchPlan.kt
@@ -1,0 +1,20 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * A retrieval plan produced by the AI for a user's question (the `search-plan`
+ * capability). The app uses it to fetch matching records from its LOCAL
+ * database — no answer text is generated here.
+ *
+ *  - [terms]     keyword/phrase terms to run through the local Quran/Hadith/Dua
+ *                search (substring match). Drives both the results list and the
+ *                evidence gathered for a grounded answer.
+ *  - [quranRefs] specific Quran ayat the model judged directly relevant. Hadith
+ *                and Dua are addressed by opaque local IDs the model can't know,
+ *                so they are only ever reached through [terms].
+ */
+data class SearchPlan(
+    val terms: List<String>,
+    val quranRefs: List<CitationId.Quran>,
+) {
+    val isEmpty: Boolean get() = terms.isEmpty() && quranRefs.isEmpty()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/AiRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/AiRepository.kt
@@ -2,12 +2,20 @@ package com.arshadshah.nimaz.domain.repository
 
 import com.arshadshah.nimaz.domain.model.GroundedAnswer
 import com.arshadshah.nimaz.domain.model.ProofPassage
+import com.arshadshah.nimaz.domain.model.SearchPlan
 
 /**
  * Gateway to the Nimaz AI Worker. The implementation lives in the data layer
  * (Ktor + Play Integrity); presentation/domain depend only on this interface.
  */
 interface AiRepository {
+    /**
+     * Ask the AI to plan retrieval for a question — which local sources to fetch
+     * (`search-plan` capability). Returns a [SearchPlan] on success, or a failure
+     * carrying an [com.arshadshah.nimaz.domain.model.AiError] via [AiRequestException].
+     */
+    suspend fun planSearch(question: String): Result<SearchPlan>
+
     /**
      * Ask a grounded question against the supplied evidence passages. Returns a
      * [GroundedAnswer] on success, or a failure whose exception is an

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
@@ -217,13 +217,26 @@ class AskWithProofUseCase @Inject constructor(
             .filter { it.length > 2 && it !in STOPWORDS }
             .distinct()
 
-    /** Original question plus up to two stripped keyword variants. */
+    /**
+     * The search terms to fan the local lookups over.
+     *
+     * The DB search matches a single contiguous substring (`LIKE '%term%'`), so a
+     * multi-word phrase like "patience during hardship" almost never matches a
+     * translation and retrieval comes back empty — which surfaces as
+     * "No supporting sources found" without ever calling the AI. We therefore
+     * search each significant word **on its own** (that is what actually retrieves
+     * passages), plus the full phrase for the rare exact-substring hit. Ranking
+     * downstream re-sorts the union by how many of the question's terms overlap,
+     * so single-word noise is outranked by passages matching several terms.
+     */
     private fun queryVariants(question: String, content: List<String>): List<String> {
         val variants = LinkedHashSet<String>()
         variants += question.trim()
-        if (content.isNotEmpty()) variants += content.joinToString(" ")
-        val top = content.sortedByDescending { it.length }.take(3)
-        if (top.isNotEmpty()) variants += top.joinToString(" ")
+        // Individual content words, longest (most distinctive) first so the
+        // strongest terms are still searched when we cap the count.
+        content.sortedByDescending { it.length }
+            .take(MAX_WORD_VARIANTS)
+            .forEach { variants += it }
         return variants.filter { it.isNotBlank() }
     }
 
@@ -237,6 +250,8 @@ class AskWithProofUseCase @Inject constructor(
         const val MAX_PASSAGES = 8
         const val MAX_PASSAGE_CHARS = 1200
         const val MAX_TOTAL_CHARS = 8000
+        /** Cap on individual-word searches per source, to bound DB work. */
+        private const val MAX_WORD_VARIANTS = 8
         private const val QURAN_TRANSLATOR = "sahih_international"
         private val NON_WORD = Regex("[^\\p{L}\\p{N}]+")
         private val STOPWORDS = setOf(

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
@@ -17,16 +17,23 @@ import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 /**
- * Orchestrates the "Ask with Proof" flow:
- *  1. Local retrieval — fan out the existing Quran/Hadith/Dua search use cases
- *     over the question (plus keyword variants), rank by term overlap, cap the
- *     evidence set.
- *  2. Call the AI Worker via [AiRepository] with the retrieved passages.
- *  3. Resolve the returned citation IDs back to real local records, producing
- *     type-safe [Proof] deep links (unresolvable IDs are dropped silently).
+ * Orchestrates the "Ask with Proof" flow. When AI is enabled the AI drives
+ * retrieval end-to-end:
+ *  1. Plan — ask the Worker (`search-plan`) what to fetch: keyword terms + the
+ *     specific Quran references it judges relevant. Falls back to local keyword
+ *     variants if planning fails or returns nothing.
+ *  2. Retrieve — fan the plan's terms out over the existing Quran/Hadith/Dua
+ *     search use cases and resolve its Quran refs, all against the LOCAL DB;
+ *     rank by term overlap and cap the evidence set.
+ *  3. Ground — call the Worker (`ask-with-proof`) with the retrieved passages so
+ *     the answer is grounded ONLY in real local records.
+ *  4. Resolve the returned citation IDs back to local records → type-safe
+ *     [Proof] deep links (unresolvable IDs dropped silently).
  *
- * If retrieval finds nothing, returns a local insufficient-evidence result
- * WITHOUT any network call.
+ * [Outcome.Answered.plannedTerms] carries the terms the retrieval actually used
+ * so the caller can drive the on-screen results list from the same plan (no
+ * second planning call). If retrieval finds nothing, returns an
+ * insufficient-evidence result without the grounding call.
  */
 class AskWithProofUseCase @Inject constructor(
     private val aiRepository: AiRepository,
@@ -42,8 +49,13 @@ class AskWithProofUseCase @Inject constructor(
     )
 
     sealed interface Outcome {
-        data class Answered(val answer: GroundedAnswer, val proofs: List<Proof>) : Outcome
-        /** Local short-circuit — no matching passages, no network call made. */
+        data class Answered(
+            val answer: GroundedAnswer,
+            val proofs: List<Proof>,
+            /** Terms retrieval used — feeds the results list from the same plan. */
+            val plannedTerms: List<String> = emptyList(),
+        ) : Outcome
+        /** Local short-circuit — no matching passages, no grounding call made. */
         data object NoEvidence : Outcome
         data class Failed(val error: AiError) : Outcome
     }
@@ -56,12 +68,20 @@ class AskWithProofUseCase @Inject constructor(
         val cap = maxProofs.coerceIn(1, MAX_PASSAGES)
         val content = contentWords(question)
 
-        val candidates = retrieve(question, content, sources)
+        // 1. Let the AI plan retrieval; fall back to local keyword variants if the
+        //    planning call fails or comes back empty (offline, rate-limited, etc.).
+        val plan = aiRepository.planSearch(question).getOrNull()
+        val terms = plan?.terms?.takeIf { it.isNotEmpty() } ?: queryVariants(question, content)
+        val quranRefs = plan?.quranRefs.orEmpty()
+
+        // 2. Retrieve locally using the plan.
+        val candidates = retrieve(terms, quranRefs, sources)
         val passages = rankAndCap(candidates, content, cap)
 
-        // 4. Offline / no-results short-circuit: never hit the network.
+        // No local matches → insufficient evidence, skip the grounding call.
         if (passages.isEmpty()) return Outcome.NoEvidence
 
+        // 3. Ground the answer on the retrieved passages.
         val result = aiRepository.ask(question, passages)
         val answer = result.getOrElse { throwable ->
             val error = (throwable as? AiRequestException)?.error ?: AiError.Unknown
@@ -69,26 +89,34 @@ class AskWithProofUseCase @Inject constructor(
         }
 
         if (answer.insufficientEvidence && answer.citationIds.isEmpty()) {
-            return Outcome.Answered(answer, emptyList())
+            return Outcome.Answered(answer, emptyList(), terms)
         }
 
         val bySentId = passages.associateBy { it.id }
         val proofs = answer.citationIds.mapNotNull { id -> resolve(id, bySentId) }
-        return Outcome.Answered(answer, proofs)
+        return Outcome.Answered(answer, proofs, terms)
     }
 
     // ── Retrieval ───────────────────────────────────────────────────────────
 
     private suspend fun retrieve(
-        question: String,
-        content: List<String>,
+        terms: List<String>,
+        quranRefs: List<CitationId.Quran>,
         sources: Sources,
     ): List<ProofPassage> {
-        val variants = queryVariants(question, content)
         val out = LinkedHashMap<String, ProofPassage>() // dedupe by citation id
 
+        // Quran refs the AI flagged directly — resolve to passages up front so
+        // they're included even if a keyword term wouldn't have surfaced them.
         if (sources.quran) {
-            for (v in variants) {
+            for (ref in quranRefs) {
+                val passage = resolveQuranRefToPassage(ref) ?: continue
+                out.putIfAbsent(passage.id, passage)
+            }
+        }
+
+        if (sources.quran) {
+            for (v in terms) {
                 quranUseCases.searchQuran(v, QURAN_TRANSLATOR).first().forEach { r ->
                     val text = r.ayah.translation?.takeIf { it.isNotBlank() }
                         ?: r.ayah.textSimple
@@ -106,7 +134,7 @@ class AskWithProofUseCase @Inject constructor(
             }
         }
         if (sources.hadith) {
-            for (v in variants) {
+            for (v in terms) {
                 hadithUseCases.searchHadiths(v).first().forEach { r ->
                     val id = CitationId.Hadith(r.hadith.id).raw
                     out.putIfAbsent(
@@ -122,7 +150,7 @@ class AskWithProofUseCase @Inject constructor(
             }
         }
         if (sources.dua) {
-            for (v in variants) {
+            for (v in terms) {
                 duaUseCases.searchDuas(v).first().forEach { r ->
                     val id = CitationId.Dua(r.dua.id).raw
                     out.putIfAbsent(
@@ -156,6 +184,20 @@ class AskWithProofUseCase @Inject constructor(
             totalChars += p.text.length
         }
         return selected
+    }
+
+    /** Resolve an AI-flagged Quran reference to a passage from the local DB. */
+    private suspend fun resolveQuranRefToPassage(ref: CitationId.Quran): ProofPassage? {
+        val ayah = quranUseCases.getAyahsBySurah(ref.surah).first()
+            .firstOrNull { it.ayahNumber == ref.ayah } ?: return null
+        val surahName = quranUseCases.getSurahByNumber(ref.surah)?.nameEnglish ?: "${ref.surah}"
+        val text = ayah.translation?.takeIf { it.isNotBlank() } ?: ayah.textSimple
+        return ProofPassage(
+            id = ref.raw,
+            source = ProofSource.QURAN,
+            text = text.truncate(),
+            meta = "Surah $surahName ${ref.ayah}",
+        )
     }
 
     // ── Citation resolution ───────────────────────────────────────────────────

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.screens.search
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,80 +36,54 @@ import com.arshadshah.nimaz.domain.model.Proof
 import com.arshadshah.nimaz.domain.model.ProofSource
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.viewmodel.AskEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AskPhase
 import com.arshadshah.nimaz.presentation.viewmodel.AskUiState
 
 /**
  * Adds the "Ask with Proof" experience to the Search screen's LazyColumn.
- * Gated on [AskUiState.aiEnabled]: when off it shows a subtle, dismissible hint;
- * when on it shows the ask input plus the answer / proofs / error states.
+ *
+ * The question is entered through the screen's single shared search bar — this
+ * section renders only the *output* of an ask. Gated on [AskUiState.aiEnabled]:
+ * when off it shows a subtle, dismissible hint; when on it shows the AI answer /
+ * proofs / error states (or nothing while idle) beneath the keyword results.
  */
 fun LazyListScope.askSection(
     state: AskUiState,
-    onEvent: (AskEvent) -> Unit,
     onNavigateToProof: (Route) -> Unit,
     onNavigateToSearchSettings: () -> Unit,
+    onDismissHint: () -> Unit,
 ) {
     if (!state.aiEnabled) {
         if (!state.hintDismissed) {
             item(key = "ai_hint") {
                 AskDisabledHint(
                     onOpenSettings = onNavigateToSearchSettings,
-                    onDismiss = { onEvent(AskEvent.DismissHint) },
+                    onDismiss = onDismissHint,
                 )
             }
         }
         return
     }
 
-    item(key = "ai_input") {
-        NimazCard(style = NimazCardStyle.FILLED, modifier = Modifier.fillMaxWidth()) {
-            Column(modifier = Modifier.padding(12.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.AutoAwesome,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Text(
-                        text = stringResource(R.string.ai_ask_a_question),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.padding(start = 8.dp),
-                    )
-                }
-                NimazSearchBar(
-                    query = state.question,
-                    onQueryChange = { onEvent(AskEvent.UpdateQuestion(it)) },
-                    placeholder = stringResource(R.string.ai_ask_placeholder),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
-                    showClearButton = state.question.isNotEmpty(),
-                    onClear = { onEvent(AskEvent.Clear) },
-                    onSearch = { onEvent(AskEvent.Submit) },
-                )
-            }
-        }
-    }
-
     when (val phase = state.phase) {
         AskPhase.Idle -> Unit
 
-        AskPhase.Loading -> item(key = "ai_loading") {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
+        AskPhase.Loading -> {
+            item(key = "ai_answer_header") { AskAnswerHeader() }
+            item(key = "ai_loading") {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
             }
         }
 
         is AskPhase.Answer -> {
+            item(key = "ai_answer_header") { AskAnswerHeader() }
             if (phase.answer.insufficientEvidence) {
                 item(key = "ai_no_sources") { AskNoSourcesCard() }
             } else {
@@ -137,9 +110,33 @@ fun LazyListScope.askSection(
             item(key = "ai_footer") { AskFooter() }
         }
 
-        is AskPhase.Error -> item(key = "ai_error") {
-            AskErrorCard(error = phase.error)
+        is AskPhase.Error -> {
+            item(key = "ai_answer_header") { AskAnswerHeader() }
+            item(key = "ai_error") { AskErrorCard(error = phase.error) }
         }
+    }
+}
+
+/** A small labelled header marking the AI output apart from the keyword results. */
+@Composable
+private fun AskAnswerHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.AutoAwesome,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = stringResource(R.string.ai_answer_section),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 8.dp),
+        )
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
@@ -100,6 +100,15 @@ fun SearchScreen(
         }
     }
 
+    // When the AI answers, it also produced the retrieval plan — drive the results
+    // list from the same planned terms so the AI controls what's listed (no extra
+    // planning call). Only on global search with AI enabled.
+    LaunchedEffect(askState.plannedTerms) {
+        if (enableAsk && askState.plannedTerms.isNotEmpty()) {
+            viewModel.onEvent(SearchEvent.ApplyAiTerms(askState.plannedTerms))
+        }
+    }
+
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
@@ -66,6 +66,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.viewmodel.AskEvent
 import com.arshadshah.nimaz.presentation.viewmodel.AskViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.SearchEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SearchFilter
@@ -125,26 +126,48 @@ fun SearchScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            // Search Bar
+            // A single search bar drives both keyword search and — when the user has
+            // opted into AI answers on global search — the "Ask with Proof" question.
+            // Keyword results update as-you-type; the AI ask only fires on submit.
+            val askEnabled = enableAsk && askState.aiEnabled
             item {
                 NimazSearchBar(
                     query = state.query,
-                    onQueryChange = { viewModel.onEvent(SearchEvent.UpdateQuery(it)) },
-                    placeholder = stringResource(R.string.search_placeholder),
+                    onQueryChange = {
+                        viewModel.onEvent(SearchEvent.UpdateQuery(it))
+                        // Keep the AI question in sync so a submit uses the current text;
+                        // emptying the bar also clears any lingering AI answer.
+                        if (enableAsk) {
+                            if (it.isBlank()) askViewModel.onEvent(AskEvent.Clear)
+                            else askViewModel.onEvent(AskEvent.UpdateQuestion(it))
+                        }
+                    },
+                    placeholder = stringResource(
+                        if (askEnabled) R.string.search_or_ask_placeholder
+                        else R.string.search_placeholder
+                    ),
                     modifier = Modifier.fillMaxWidth(),
                     showClearButton = state.query.isNotEmpty(),
-                    onClear = { viewModel.onEvent(SearchEvent.ClearSearch) },
-                    onSearch = { viewModel.onEvent(SearchEvent.ExecuteSearch) }
+                    onClear = {
+                        viewModel.onEvent(SearchEvent.ClearSearch)
+                        if (enableAsk) askViewModel.onEvent(AskEvent.Clear)
+                    },
+                    onSearch = {
+                        viewModel.onEvent(SearchEvent.ExecuteSearch)
+                        if (askEnabled) askViewModel.onEvent(AskEvent.Submit)
+                    }
                 )
             }
 
             // Ask with Proof (AI) — only on global search, gated on the user's opt-in.
+            // The question shares the search bar above; this section shows the AI
+            // answer / proofs (or the discovery hint when AI is off).
             if (enableAsk) {
                 askSection(
                     state = askState,
-                    onEvent = askViewModel::onEvent,
                     onNavigateToProof = onNavigateToProof,
                     onNavigateToSearchSettings = onNavigateToSearchSettings,
+                    onDismissHint = { askViewModel.onEvent(AskEvent.DismissHint) },
                 )
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModel.kt
@@ -36,6 +36,12 @@ data class AskUiState(
     val question: String = "",
     val recentQuestions: List<String> = emptyList(),
     val phase: AskPhase = AskPhase.Idle,
+    /**
+     * The search terms the AI's retrieval plan used for the most recent answer.
+     * The Search screen drives its results list from these (same plan, no extra
+     * planning call), giving the AI control over the list when enabled.
+     */
+    val plannedTerms: List<String> = emptyList(),
 )
 
 sealed interface AskEvent {
@@ -93,7 +99,9 @@ class AskViewModel @Inject constructor(
             }
 
             AskEvent.Clear ->
-                _uiState.update { it.copy(question = "", phase = AskPhase.Idle) }
+                _uiState.update {
+                    it.copy(question = "", phase = AskPhase.Idle, plannedTerms = emptyList())
+                }
 
             AskEvent.DismissHint ->
                 viewModelScope.launch { settingsRepository.setAiAskHintDismissed(true) }
@@ -105,7 +113,9 @@ class AskViewModel @Inject constructor(
         if (question.length < MIN_QUESTION_LENGTH) return
 
         AppAnalytics.logEvent(EVENT_SUBMITTED, null) // event name only — never the question text
-        _uiState.update { it.copy(phase = AskPhase.Loading) }
+        // Reset the plan so a stale one can't drive the list if this ask ends in
+        // NoEvidence/Error; only a fresh Answered sets plannedTerms again.
+        _uiState.update { it.copy(phase = AskPhase.Loading, plannedTerms = emptyList()) }
 
         viewModelScope.launch {
             val sources = AskWithProofUseCase.Sources(
@@ -120,7 +130,10 @@ class AskViewModel @Inject constructor(
                     AppAnalytics.logEvent(EVENT_ANSWERED, null)
                     addRecent(question)
                     _uiState.update {
-                        it.copy(phase = AskPhase.Answer(outcome.answer, outcome.proofs))
+                        it.copy(
+                            phase = AskPhase.Answer(outcome.answer, outcome.proofs),
+                            plannedTerms = outcome.plannedTerms,
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicInteger
@@ -64,6 +65,14 @@ sealed interface SearchEvent {
     data object ExecuteSearch : SearchEvent
     data object ClearSearch : SearchEvent
     data object ClearRecentSearches : SearchEvent
+
+    /**
+     * Replace the results list with matches for the AI's planned search terms.
+     * Emitted by the Search screen after an AI answer, so the list reflects what
+     * the AI chose to retrieve (Global Search, AI-enabled). Purely local — no
+     * network call; the terms already came from the single planning round.
+     */
+    data class ApplyAiTerms(val terms: List<String>) : SearchEvent
 }
 
 /** Idle time after the last keystroke before a search-as-you-type lookup fires. */
@@ -106,6 +115,7 @@ class SearchViewModel @Inject constructor(
             SearchEvent.ExecuteSearch -> executeSearch()
             SearchEvent.ClearSearch -> clearSearch()
             SearchEvent.ClearRecentSearches -> clearRecentSearches()
+            is SearchEvent.ApplyAiTerms -> applyAiTerms(event.terms)
         }
     }
 
@@ -152,6 +162,58 @@ class SearchViewModel @Inject constructor(
         }
         // Explicit submit (enter / recent search): search immediately and remember it.
         launchSearch(query, addToRecent = true, debounceMillis = 0L)
+    }
+
+    /**
+     * Populate the results list from the AI's planned terms (Global Search only).
+     * Runs each term through the existing local searches and merges the union —
+     * so when AI is on, the AI effectively chooses what the list shows. Replaces
+     * the debounced keyword search that ran while the user was typing.
+     */
+    private fun applyAiTerms(terms: List<String>) {
+        val cleaned = terms.map { it.trim() }.filter { it.isNotBlank() }.distinct()
+        if (cleaned.isEmpty()) return
+        searchJob?.cancel()
+        _searchState.update { it.copy(isSearching = true, error = null) }
+        searchJob = viewModelScope.launch {
+            val quran = LinkedHashMap<Int, QuranSearchResult>()
+            val surahs = LinkedHashMap<Int, Surah>()
+            val hadith = LinkedHashMap<String, HadithSearchResult>()
+            val duas = LinkedHashMap<String, DuaSearchResult>()
+
+            for (term in cleaned) {
+                quranUseCases.searchQuran(term, "sahih_international").first()
+                    .forEach { quran.putIfAbsent(it.ayah.id, it) }
+                quranUseCases.getSurahList.search(term).first()
+                    .forEach { surahs.putIfAbsent(it.number, it) }
+                hadithUseCases.searchHadiths(term).first()
+                    .forEach { hadith.putIfAbsent(it.hadith.id, it) }
+                duaUseCases.searchDuas(term).first()
+                    .forEach { duas.putIfAbsent(it.dua.id, it) }
+            }
+
+            val quranResults = quran.values.toList()
+            val surahResults = surahs.values.toList()
+            val hadithResults = hadith.values.toList()
+            val duaResults = duas.values.toList()
+            val unified = quranResults.map { UnifiedSearchResult.QuranResult(it) } +
+                    surahResults.map { UnifiedSearchResult.SurahResult(it) } +
+                    hadithResults.map { UnifiedSearchResult.HadithResult(it) } +
+                    duaResults.map { UnifiedSearchResult.DuaResult(it) }
+
+            _searchState.update { state ->
+                state.copy(
+                    quranResults = quranResults,
+                    surahResults = surahResults,
+                    hadithResults = hadithResults,
+                    duaResults = duaResults,
+                    allResults = unified,
+                    filteredResults = applyFilter(unified, state.selectedFilter),
+                    isSearching = false,
+                )
+            }
+            updateStats()
+        }
     }
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -416,6 +416,7 @@
     <string name="hadith_count_format">%s Hadith</string>
     <string name="search_title">Suche</string>
     <string name="search_placeholder">Quran, Hadith, Duas suchen…</string>
+    <string name="search_or_ask_placeholder">Suchen oder eine Frage stellen…</string>
     <string name="recent_searches">Letzte Suchen</string>
     <string name="clear_recent">Letzte löschen</string>
     <string name="results_found_format">%d Ergebnisse gefunden</string>
@@ -1305,6 +1306,7 @@
     <string name="ai_consent_enable">Aktivieren</string>
     <string name="ai_ask_a_question">Stelle eine Frage</string>
     <string name="ai_ask_placeholder">Frage zu Koran, Hadith oder Duas…</string>
+    <string name="ai_answer_section">KI-Antwort</string>
     <string name="ai_enable_hint">Aktiviere KI-Antworten in den Sucheinstellungen</string>
     <string name="ai_proof_section">Beleg</string>
     <string name="ai_confidence_high">Hohe Zuverlässigkeit</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -416,6 +416,7 @@
     <string name="hadith_count_format">%s hadiths</string>
     <string name="search_title">Recherche</string>
     <string name="search_placeholder">Rechercher Coran, Hadith, Duas…</string>
+    <string name="search_or_ask_placeholder">Rechercher ou poser une question…</string>
     <string name="recent_searches">Recherches récentes</string>
     <string name="clear_recent">Effacer les récentes</string>
     <string name="results_found_format">%d résultats trouvés</string>
@@ -1306,6 +1307,7 @@
     <string name="ai_consent_enable">Activer</string>
     <string name="ai_ask_a_question">Poser une question</string>
     <string name="ai_ask_placeholder">Posez une question sur le Coran, les Hadiths ou les Douas…</string>
+    <string name="ai_answer_section">Réponse de l\'IA</string>
     <string name="ai_enable_hint">Activez les réponses de l\'IA dans les paramètres de recherche</string>
     <string name="ai_proof_section">Preuve</string>
     <string name="ai_confidence_high">Confiance élevée</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -416,6 +416,7 @@
     <string name="hadith_count_format">%s hadis</string>
     <string name="search_title">Pencarian</string>
     <string name="search_placeholder">Cari Al-Quran, Hadis, Doa…</string>
+    <string name="search_or_ask_placeholder">Cari atau ajukan pertanyaan…</string>
     <string name="recent_searches">Pencarian Terbaru</string>
     <string name="clear_recent">Hapus Terbaru</string>
     <string name="results_found_format">%d hasil ditemukan</string>
@@ -1306,6 +1307,7 @@
     <string name="ai_consent_enable">Aktifkan</string>
     <string name="ai_ask_a_question">Ajukan pertanyaan</string>
     <string name="ai_ask_placeholder">Tanyakan tentang Quran, Hadis, atau Doa…</string>
+    <string name="ai_answer_section">Jawaban AI</string>
     <string name="ai_enable_hint">Aktifkan jawaban AI di pengaturan Pencarian</string>
     <string name="ai_proof_section">Bukti</string>
     <string name="ai_confidence_high">Keyakinan tinggi</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -416,6 +416,7 @@
     <string name="hadith_count_format">%s hadis</string>
     <string name="search_title">Carian</string>
     <string name="search_placeholder">Cari Al-Quran, Hadis, Doa\u2026</string>
+    <string name="search_or_ask_placeholder">Cari atau tanya soalan\u2026</string>
     <string name="recent_searches">Carian Terkini</string>
     <string name="clear_recent">Kosongkan Terkini</string>
     <string name="results_found_format">%d hasil ditemui</string>
@@ -1307,6 +1308,7 @@
     <string name="ai_consent_enable">Dayakan</string>
     <string name="ai_ask_a_question">Ajukan soalan</string>
     <string name="ai_ask_placeholder">Tanya tentang Quran, Hadis, atau Doa…</string>
+    <string name="ai_answer_section">Jawapan AI</string>
     <string name="ai_enable_hint">Dayakan jawapan AI dalam tetapan Carian</string>
     <string name="ai_proof_section">Bukti</string>
     <string name="ai_confidence_high">Keyakinan tinggi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -416,6 +416,7 @@
     <string name="hadith_count_format">%s hadis</string>
     <string name="search_title">Arama</string>
     <string name="search_placeholder">Kur\'an, Hadis, Dua Ara…</string>
+    <string name="search_or_ask_placeholder">Arayın veya bir soru sorun…</string>
     <string name="recent_searches">Son Aramalar</string>
     <string name="clear_recent">Son Aramaları Temizle</string>
     <string name="results_found_format">%d sonuç bulundu</string>
@@ -1309,6 +1310,7 @@
     <string name="ai_consent_enable">Etkinleştir</string>
     <string name="ai_ask_a_question">Bir soru sorun</string>
     <string name="ai_ask_placeholder">Kur\'an, Hadis veya Dua hakkında sorun…</string>
+    <string name="ai_answer_section">Yapay zeka yanıtı</string>
     <string name="ai_enable_hint">Yapay zekâ yanıtlarını Arama ayarlarında etkinleştirin</string>
     <string name="ai_proof_section">Kanıt</string>
     <string name="ai_confidence_high">Yüksek güven</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,7 @@
     <!-- Search Screen -->
     <string name="search_title">Search</string>
     <string name="search_placeholder">Search Quran, Hadith, Duas…</string>
+    <string name="search_or_ask_placeholder">Search or ask a question…</string>
     <string name="recent_searches">Recent Searches</string>
     <string name="clear_recent">Clear Recent</string>
     <string name="results_found_format">%d results found</string>
@@ -1465,6 +1466,7 @@
 
     <string name="ai_ask_a_question">Ask a question</string>
     <string name="ai_ask_placeholder">Ask about Quran, Hadith, or Duas…</string>
+    <string name="ai_answer_section">AI answer</string>
     <string name="ai_enable_hint">Enable AI answers in Search settings</string>
     <string name="ai_proof_section">Proof</string>
     <string name="ai_confidence_high">High confidence</string>

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/AiRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/AiRepositoryImplTest.kt
@@ -42,7 +42,7 @@ class AiRepositoryImplTest {
         coEvery { integrity.getToken() } returns "debug-skip"
         val device = mockk<DeviceIdProvider>()
         coEvery { device.getOrCreate() } returns "dev-1"
-        return AiRepositoryImpl(apiClient, integrity, device)
+        return AiRepositoryImpl(apiClient, integrity, device, json)
     }
 
     private val passages = listOf(
@@ -64,6 +64,30 @@ class AiRepositoryImplTest {
         val answer = result.getOrThrow()
         assertThat(answer.confidence).isEqualTo(AnswerConfidence.MEDIUM)
         assertThat(answer.citationIds).containsExactly("quran:2:153")
+    }
+
+    @Test
+    fun `planSearch maps terms and parses quran refs, dropping malformed ones`() = runTest {
+        val body = """
+            {"terms":["patience"," sabr ",""],"quranRefs":["2:153","garbage","39:10"]}
+        """.trimIndent()
+        val result = repo { respond(body, HttpStatusCode.OK, jsonHeaders()) }
+            .planSearch("How do I show patience?")
+
+        assertThat(result.isSuccess).isTrue()
+        val plan = result.getOrThrow()
+        assertThat(plan.terms).containsExactly("patience", "sabr")
+        assertThat(plan.quranRefs.map { it.raw })
+            .containsExactly("quran:2:153", "quran:39:10")
+    }
+
+    @Test
+    fun `planSearch surfaces api errors`() = runTest {
+        val body = """{"error":{"code":"RATE_LIMITED","message":"slow","retryAfterSeconds":60}}"""
+        val result = repo { respond(body, HttpStatusCode.TooManyRequests, jsonHeaders()) }
+            .planSearch("q?")
+        assertThat((result.exceptionOrNull() as AiRequestException).error)
+            .isEqualTo(AiError.RateLimited(60))
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
@@ -83,6 +83,29 @@ class AskWithProofUseCaseTest {
     }
 
     @Test
+    fun `retrieval searches individual words, not just the whole phrase`() = runTest {
+        // The DB search matches a contiguous substring, so a natural-language phrase
+        // never hits — only the single word "patience" does. Retrieval must still
+        // find the passage (and therefore call the AI) by searching words on their own.
+        every { searchQuranUC.invoke(any(), any()) } answers {
+            if (firstArg<String>() == "patience") flowOf(listOf(quranResult(2, 153)))
+            else flowOf(emptyList())
+        }
+        every { searchHadithsUC.invoke(any()) } returns flowOf(emptyList())
+        every { searchDuasUC.invoke(any()) } returns flowOf(emptyList())
+
+        val captured = slot<List<ProofPassage>>()
+        coEvery { aiRepository.ask(any(), capture(captured)) } returns
+            Result.success(answer(citationIds = emptyList()))
+
+        val outcome = useCase("How do I show patience in hardship?", allSources, maxProofs = 5)
+
+        assertThat(outcome).isInstanceOf(AskWithProofUseCase.Outcome.Answered::class.java)
+        assertThat(captured.captured).isNotEmpty()
+        coVerify { aiRepository.ask(any(), any()) }
+    }
+
+    @Test
     fun `disabled sources are not searched`() = runTest {
         every { searchQuranUC.invoke(any(), any()) } returns flowOf(listOf(quranResult(2, 153)))
         coEvery { aiRepository.ask(any(), any()) } returns

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
@@ -8,8 +8,10 @@ import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.GroundedAnswer
 import com.arshadshah.nimaz.domain.model.Hadith
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
+import com.arshadshah.nimaz.domain.model.CitationId
 import com.arshadshah.nimaz.domain.model.ProofPassage
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
+import com.arshadshah.nimaz.domain.model.SearchPlan
 import com.arshadshah.nimaz.domain.model.SearchType
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.RevelationType
@@ -64,6 +66,11 @@ class AskWithProofUseCaseTest {
         every { hadithUseCases.getHadithById } returns getHadithByIdUC
         every { duaUseCases.searchDuas } returns searchDuasUC
         every { duaUseCases.getDuaById } returns getDuaByIdUC
+
+        // Default: planning yields nothing, so retrieval falls back to local
+        // keyword variants. Tests that exercise the plan override this.
+        coEvery { aiRepository.planSearch(any()) } returns
+            Result.success(SearchPlan(terms = emptyList(), quranRefs = emptyList()))
 
         useCase = AskWithProofUseCase(aiRepository, quranUseCases, hadithUseCases, duaUseCases)
     }
@@ -170,6 +177,49 @@ class AskWithProofUseCaseTest {
         assertThat(quranProof.route).isEqualTo(Route.QuranReader(2, 153))
         val hadithProof = answered.proofs.first { it.citationId == "hadith:bukhari-1" }
         assertThat(hadithProof.route).isEqualTo(Route.HadithReader("bukhari-1"))
+    }
+
+    @Test
+    fun `AI plan drives retrieval and planned terms are returned`() = runTest {
+        coEvery { aiRepository.planSearch(any()) } returns
+            Result.success(SearchPlan(terms = listOf("patience", "sabr"), quranRefs = emptyList()))
+        // Only the planned term "patience" matches anything in the DB.
+        every { searchQuranUC.invoke(any(), any()) } answers {
+            if (firstArg<String>() == "patience") flowOf(listOf(quranResult(2, 153)))
+            else flowOf(emptyList())
+        }
+        every { searchHadithsUC.invoke(any()) } returns flowOf(emptyList())
+        every { searchDuasUC.invoke(any()) } returns flowOf(emptyList())
+        coEvery { aiRepository.ask(any(), any()) } returns
+            Result.success(answer(citationIds = emptyList()))
+
+        val outcome = useCase("How do I stay patient?", allSources, maxProofs = 5)
+
+        val answered = outcome as AskWithProofUseCase.Outcome.Answered
+        assertThat(answered.plannedTerms).containsExactly("patience", "sabr")
+        coVerify { aiRepository.ask(any(), any()) }
+    }
+
+    @Test
+    fun `planned quran refs are resolved to passages even without keyword hits`() = runTest {
+        coEvery { aiRepository.planSearch(any()) } returns Result.success(
+            SearchPlan(terms = listOf("mercy"), quranRefs = listOf(CitationId.Quran(2, 153))),
+        )
+        every { searchQuranUC.invoke(any(), any()) } returns flowOf(emptyList())
+        every { searchHadithsUC.invoke(any()) } returns flowOf(emptyList())
+        every { searchDuasUC.invoke(any()) } returns flowOf(emptyList())
+        // Direct ref resolution reads the ayah from the local DB.
+        every { getAyahsBySurahUC.invoke(2) } returns flowOf(listOf(ayah(2, 153)))
+        coEvery { getSurahByNumberUC.invoke(2) } returns surah(2)
+
+        val captured = slot<List<ProofPassage>>()
+        coEvery { aiRepository.ask(any(), capture(captured)) } returns
+            Result.success(answer(citationIds = emptyList()))
+
+        val outcome = useCase("Tell me about mercy", allSources, maxProofs = 5)
+
+        assertThat(outcome).isInstanceOf(AskWithProofUseCase.Outcome.Answered::class.java)
+        assertThat(captured.captured.map { it.id }).contains("quran:2:153")
     }
 
     // ── model builders ────────────────────────────────────────────────────────

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -2,14 +2,26 @@
 
 An **opt-in**, privacy-disclosed, proof-driven question-answering feature. The
 user types into Global Search's **single search bar** — the same text drives both
-keyword search and, on submit, the AI ask (there is no separate "ask" field). The
-app retrieves matching Quran/Hadith/Dua passages **locally** from Room, sends the
-question + those passages to a Cloudflare Worker, which asks Claude to answer
-**only from the supplied passages** and return strict JSON. The app resolves the cited passages back to real records
-and shows them as tappable "proof" cards that deep-link into the reader screens.
+keyword search and, on submit, the AI ask (there is no separate "ask" field).
 
-AI is **off by default**. A user who never opens Search Settings sees no
-behaviour change and nothing leaves their device.
+When AI is enabled it **drives retrieval end-to-end** (two Worker calls per
+submit):
+
+1. **Plan** (`search-plan`) — the app sends only the question; Claude returns the
+   search *terms* and specific *Quran refs* it judges relevant. The app decides
+   nothing about relevance itself.
+2. **Retrieve (local)** — the app runs the plan's terms through the existing
+   Quran/Hadith/Dua searches and resolves its Quran refs, all against Room. These
+   real records populate **both** the results list (so the AI controls what's
+   listed) and the evidence set. Falls back to local keyword variants if planning
+   fails or is empty.
+3. **Ground** (`ask-with-proof`) — the app sends the question + retrieved passages;
+   Claude answers **only from the supplied passages**. Cited passages resolve back
+   to real records shown as tappable "proof" cards that deep-link into the readers.
+
+When AI is **off**, only local keyword search runs (no network, no behaviour
+change). AI is **off by default** — a user who never opens Search Settings sees
+nothing leave their device.
 
 ## Architecture
 
@@ -23,13 +35,15 @@ sequenceDiagram
     participant C as Claude (Haiku 4.5)
 
     U->>App: Ask a question
-    App->>Room: search use cases (question + keyword variants)
-    Room-->>App: candidate passages
+    App->>W: POST /v1/invoke (search-plan) {question}
+    W-->>App: {terms, quranRefs}  (fallback: local keyword variants on failure)
+    App->>Room: run terms + resolve quranRefs (local search use cases)
+    Room-->>App: candidate passages + list results
     App->>App: rank by term overlap, cap ≤8, ≤8000 chars
     alt no passages
-        App-->>U: "No supporting sources found" (no network call)
+        App-->>U: "No supporting sources found" (no grounding call)
     else has passages
-        App->>W: POST /v1/invoke {capability, integrityToken, deviceId, input}
+        App->>W: POST /v1/invoke (ask-with-proof) {question, passages}
         W->>W: integrity → rate limit → budget guard
         W->>GW: Messages API (forced submit_answer tool, cached system prompt)
         GW->>C: proxied request
@@ -38,28 +52,55 @@ sequenceDiagram
         W->>W: validate output, drop unknown citationIds, record spend
         W-->>App: {answer, citationIds, confidence, insufficientEvidence}
         App->>Room: resolve citationIds → records (round-trip)
-        App-->>U: answer + confidence + tappable proof cards
+        App-->>U: answer + confidence + proof cards + AI-driven results list
     end
 ```
+
+Each submit makes **two** Worker calls (plan + ground) — see the cost note below.
 
 Layers (Android):
 
 ```
-presentation/screens/search/SearchScreen.kt         shared search+ask input bar
+presentation/screens/search/SearchScreen.kt         shared search+ask input bar; bridges AI plan → list
 presentation/screens/search/AskComponents.kt        UI for the answer/proofs/hint
 presentation/screens/settings/SearchSettingsScreen  consent + toggles + privacy
-presentation/viewmodel/AskViewModel                 ask state machine
+presentation/viewmodel/AskViewModel                 ask state machine (exposes plannedTerms)
+presentation/viewmodel/SearchViewModel              results list (+ ApplyAiTerms event)
 presentation/viewmodel/SearchSettingsViewModel      settings + consent state
-domain/usecase/ai/AskWithProofUseCase               retrieval → call → resolve
-domain/model/{AiModels,CitationId}                  ProofPassage/GroundedAnswer/Proof/AiError
-domain/repository/AiRepository                      gateway interface
+domain/usecase/ai/AskWithProofUseCase               plan → retrieve → ground → resolve
+domain/model/{AiModels,CitationId,SearchPlan}       ProofPassage/GroundedAnswer/Proof/AiError/SearchPlan
+domain/repository/AiRepository                      gateway interface (planSearch + ask)
 data/ai/{AiApiClient,IntegrityTokenProvider,DeviceIdProvider}
 data/ai/dto/AiDtos                                  wire DTOs (mirror the Worker)
 data/repository/AiRepositoryImpl                    error-envelope → AiError mapping
 core/di/AiModule                                    Ktor client + wiring
+worker/src/capabilities/{ask-with-proof,search-plan} the two AI capabilities
 ```
 
 ## Capability contract
+
+Both capabilities go through the same `POST /v1/invoke` envelope and middleware
+(integrity → rate limit → budget). The Android `input` is sent as a raw JSON
+object so one envelope serves every capability.
+
+### `search-plan` (retrieval planning — call 1)
+
+```json
+{ "capability": "search-plan", "integrityToken": "…", "deviceId": "…",
+  "input": { "question": "3..500 chars" } }
+```
+
+Response:
+
+```json
+{ "terms": ["patience", "sabr", "hardship"], "quranRefs": ["2:153", "39:10"] }
+```
+
+`terms` are keyword/substring search terms; `quranRefs` are `surah:ayah` (real
+references only — malformed ones are dropped in `parseResponse`). Hadith/Dua use
+opaque local IDs the model can't know, so it plans them only through `terms`.
+
+### `ask-with-proof` (grounded answer — call 2)
 
 `POST /v1/invoke`:
 
@@ -133,9 +174,12 @@ names via `AppAnalytics.logEvent`: `ai_ask_submitted`, `ai_ask_answered`,
 
 - Model: `claude-haiku-4-5`. Pricing: **$1 / MTok input**, **$5 / MTok output**;
   cached input reads billed at **10%** of the input rate.
-- The system prompt is marked `cache_control: ephemeral`, so after the first call
-  it is read from cache at ~10% cost.
-- `max_tokens` = 600, temperature 0.2.
+- Each submit is **two** calls: `search-plan` (`max_tokens` 300) then
+  `ask-with-proof` (`max_tokens` 600). Both prompts are marked
+  `cache_control: ephemeral`, so after the first call each is read from cache at
+  ~10% cost. Both count against the rate-limit/budget guards, so **one question
+  consumes two invocations** of the per-device daily cap.
+- temperature 0.2 for both.
 - Guards (KV-backed, per UTC period): per-device daily cap (`DAILY_DEVICE_LIMIT`,
   20), global daily cap (`DAILY_GLOBAL_LIMIT`, 500), monthly USD budget
   (`MONTHLY_BUDGET_USD`, 10). Spend is tallied in integer microdollars after each

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -1,10 +1,11 @@
 # Ask with Proof — grounded AI Q&A
 
 An **opt-in**, privacy-disclosed, proof-driven question-answering feature. The
-user asks a question in Global Search; the app retrieves matching Quran/Hadith/Dua
-passages **locally** from Room, sends the question + those passages to a
-Cloudflare Worker, which asks Claude to answer **only from the supplied passages**
-and return strict JSON. The app resolves the cited passages back to real records
+user types into Global Search's **single search bar** — the same text drives both
+keyword search and, on submit, the AI ask (there is no separate "ask" field). The
+app retrieves matching Quran/Hadith/Dua passages **locally** from Room, sends the
+question + those passages to a Cloudflare Worker, which asks Claude to answer
+**only from the supplied passages** and return strict JSON. The app resolves the cited passages back to real records
 and shows them as tappable "proof" cards that deep-link into the reader screens.
 
 AI is **off by default**. A user who never opens Search Settings sees no
@@ -44,7 +45,8 @@ sequenceDiagram
 Layers (Android):
 
 ```
-presentation/screens/search/AskComponents.kt        UI for the ask/answer/proofs
+presentation/screens/search/SearchScreen.kt         shared search+ask input bar
+presentation/screens/search/AskComponents.kt        UI for the answer/proofs/hint
 presentation/screens/settings/SearchSettingsScreen  consent + toggles + privacy
 presentation/viewmodel/AskViewModel                 ask state machine
 presentation/viewmodel/SearchSettingsViewModel      settings + consent state

--- a/worker/src/capabilities/search-plan.ts
+++ b/worker/src/capabilities/search-plan.ts
@@ -1,0 +1,75 @@
+import type {
+  AnthropicMessagesRequest,
+  AnthropicResponse,
+  Capability,
+} from "./types";
+import {
+  SEARCH_PLAN_TOOL_JSON_SCHEMA,
+  SearchPlanInputSchema,
+  SearchPlanOutputSchema,
+  type SearchPlanInput,
+  type SearchPlanOutput,
+} from "../schemas/search-plan";
+
+// Fixed system prompt (cache_control ephemeral, like ask-with-proof) — it never
+// changes, so after the first call it is read from prompt cache at ~10% cost.
+const SYSTEM_PROMPT = `You plan a search over a LOCAL Islamic content database (Quran translations in English, Hadith collections, and Dua/supplication collections). You do NOT answer the question — you only decide what the app should retrieve.
+
+Given the user's question, return:
+- terms: up to 12 short English search keywords (single words or 2-word phrases). The app matches these by substring against the English text, so keep them short and include synonyms and closely related concepts. Example: for "how do I cope with grief?" → ["grief", "patience", "sabr", "hardship", "loss", "death", "comfort", "mourning", "trust in Allah"].
+- quranRefs: up to 10 specific Quran ayah references most directly relevant, each as "surah:ayah" using standard mushaf numbering (e.g. "2:153"). Only include real, well-known references. If you are not confident a reference exists, leave it out — never invent references. You cannot know Hadith or Dua database IDs, so plan those only through terms.
+
+You MUST respond by calling the submit_plan tool. Do not write any prose outside the tool call.`;
+
+const MODEL = "claude-haiku-4-5";
+const MAX_OUTPUT_TOKENS = 300;
+
+export const searchPlan: Capability<SearchPlanInput, SearchPlanOutput> = {
+  id: "search-plan",
+  inputSchema: SearchPlanInputSchema,
+  outputSchema: SearchPlanOutputSchema,
+  model: MODEL,
+  maxOutputTokens: MAX_OUTPUT_TOKENS,
+
+  buildRequest(input: SearchPlanInput): AnthropicMessagesRequest {
+    return {
+      model: MODEL,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      temperature: 0.2,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: `Question:\n${input.question}` }],
+      tools: [
+        {
+          name: "submit_plan",
+          description:
+            "Submit the search terms and Quran references the app should retrieve to answer the question.",
+          input_schema: SEARCH_PLAN_TOOL_JSON_SCHEMA,
+        },
+      ],
+      // Force the model to call submit_plan so the reply is strict JSON.
+      tool_choice: { type: "tool", name: "submit_plan" },
+    };
+  },
+
+  parseResponse(raw: AnthropicResponse): SearchPlanOutput {
+    const toolUse = raw.content.find(
+      (b): b is Extract<typeof b, { type: "tool_use" }> =>
+        b.type === "tool_use" && b.name === "submit_plan",
+    );
+    if (!toolUse) {
+      throw new Error("model did not call submit_plan");
+    }
+
+    // Validate, then defensively drop any malformed Quran refs the model may
+    // have produced despite the tool schema (keeps the output contract clean).
+    const parsed = SearchPlanOutputSchema.parse(toolUse.input);
+    const quranRefs = parsed.quranRefs.filter((r) => /^\d{1,3}:\d{1,3}$/.test(r));
+    return { ...parsed, quranRefs };
+  },
+};

--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -1,11 +1,13 @@
 import type { Capability } from "./capabilities/types";
 import { askWithProof } from "./capabilities/ask-with-proof";
+import { searchPlan } from "./capabilities/search-plan";
 
 // The capability registry. Every AI feature is one entry here.
 // To add a capability: create capabilities/<id>.ts exporting a Capability,
 // then register it below. Nothing else in the pipeline changes.
 const capabilities: Array<Capability<unknown, unknown>> = [
   askWithProof as unknown as Capability<unknown, unknown>,
+  searchPlan as unknown as Capability<unknown, unknown>,
 ];
 
 const registry = new Map<string, Capability<unknown, unknown>>(

--- a/worker/src/schemas/search-plan.ts
+++ b/worker/src/schemas/search-plan.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// ── search-plan: input ──────────────────────────────────────────────────────
+// The app hands over retrieval to the model: given only the user's question, the
+// model returns the search terms + Quran references the app should fetch from its
+// LOCAL database. No passages are sent — this runs BEFORE local retrieval.
+
+export const SearchPlanInputSchema = z.object({
+  question: z.string().min(3).max(500),
+});
+
+export type SearchPlanInput = z.infer<typeof SearchPlanInputSchema>;
+
+// ── search-plan: output ─────────────────────────────────────────────────────
+
+export const SearchPlanOutputSchema = z.object({
+  // Keyword search terms — matched by the app via substring search against
+  // Quran/Hadith/Dua English text. Short terms work best (substring matching).
+  terms: z.array(z.string().min(1).max(40)).min(1).max(12),
+  // Directly-relevant Quran ayah references, "surah:ayah" (standard numbering).
+  // Hadith/Dua are addressed by opaque local IDs the model cannot know, so it
+  // only ever plans them via `terms`. Individual items are validated in the
+  // capability's parseResponse (malformed refs are dropped, not rejected).
+  quranRefs: z.array(z.string()).max(10),
+});
+
+export type SearchPlanOutput = z.infer<typeof SearchPlanOutputSchema>;
+
+// JSON Schema handed to Claude's forced `submit_plan` tool. Kept in lock-step
+// with SearchPlanOutputSchema so the model returns exactly our output contract.
+export const SEARCH_PLAN_TOOL_JSON_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    terms: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Up to 12 short English keywords or 2-word phrases that would match relevant Quran/Hadith/Dua passages by substring. Include synonyms and closely related concepts (e.g. for patience: patience, sabr, endurance, perseverance, hardship). Prefer single words.",
+    },
+    quranRefs: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Up to 10 specific, real Quran ayah references most relevant to the question, each as 'surah:ayah' (e.g. '2:153') using standard numbering. Only well-known, real references — never invent. Omit if unsure.",
+    },
+  },
+  required: ["terms", "quranRefs"],
+} as const;

--- a/worker/test/helpers.ts
+++ b/worker/test/helpers.ts
@@ -25,13 +25,14 @@ export function makeEnvelope(input: AskInput, extra: Record<string, unknown> = {
   };
 }
 
-/** A well-formed Anthropic Messages response that calls submit_answer. */
+/** A well-formed Anthropic Messages response that calls the named tool. */
 export function mockAnthropicToolResponse(
   toolInput: unknown,
   usage: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number } = {
     input_tokens: 500,
     output_tokens: 80,
   },
+  toolName = "submit_answer",
 ) {
   return {
     id: "msg_test",
@@ -39,12 +40,26 @@ export function mockAnthropicToolResponse(
       {
         type: "tool_use",
         id: "toolu_test",
-        name: "submit_answer",
+        name: toolName,
         input: toolInput,
       },
     ],
     stop_reason: "tool_use",
     usage,
+  };
+}
+
+/** Envelope for a search-plan invocation. */
+export function makePlanEnvelope(
+  question = "How do I cope with grief?",
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    capability: "search-plan",
+    integrityToken: "debug-skip",
+    deviceId: "test-device-plan-1",
+    input: { question },
+    ...extra,
   };
 }
 

--- a/worker/test/searchPlan.test.ts
+++ b/worker/test/searchPlan.test.ts
@@ -1,0 +1,71 @@
+import { env, fetchMock } from "cloudflare:test";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import app from "../src/index";
+import { searchPlan } from "../src/capabilities/search-plan";
+import { makePlanEnvelope, mockAnthropicToolResponse } from "./helpers";
+
+describe("search-plan capability (unit)", () => {
+  it("caches the system prompt and forces submit_plan", () => {
+    const req = searchPlan.buildRequest({ question: "What is patience?" }, env);
+    expect(req.system?.[0]?.cache_control).toEqual({ type: "ephemeral" });
+    expect(req.tool_choice).toEqual({ type: "tool", name: "submit_plan" });
+    expect(req.tools?.[0]?.name).toBe("submit_plan");
+    expect(req.model).toBe("claude-haiku-4-5");
+  });
+
+  it("drops malformed Quran refs the model returns", () => {
+    const raw = mockAnthropicToolResponse(
+      { terms: ["patience", "sabr"], quranRefs: ["2:153", "not-a-ref", "39:10"] },
+      undefined,
+      "submit_plan",
+    );
+    const out = searchPlan.parseResponse(raw as any, { question: "q" });
+    expect(out.terms).toEqual(["patience", "sabr"]);
+    expect(out.quranRefs).toEqual(["2:153", "39:10"]);
+  });
+
+  it("throws when the model did not call the tool", () => {
+    const raw = {
+      id: "m",
+      content: [{ type: "text", text: "here is prose" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    expect(() => searchPlan.parseResponse(raw as any, { question: "q" })).toThrow();
+  });
+});
+
+describe("search-plan (integration)", () => {
+  beforeAll(() => {
+    fetchMock.activate();
+    fetchMock.disableNetConnect();
+  });
+  afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+  it("returns a validated plan", async () => {
+    fetchMock
+      .get("https://api.anthropic.com")
+      .intercept({ path: "/v1/messages", method: "POST" })
+      .reply(
+        200,
+        mockAnthropicToolResponse(
+          { terms: ["grief", "patience", "sabr"], quranRefs: ["2:153"] },
+          undefined,
+          "submit_plan",
+        ),
+      );
+    const res = await app.request(
+      "/v1/invoke",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(makePlanEnvelope("How do I cope with grief?")),
+      },
+      { ...env },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { terms: string[]; quranRefs: string[] };
+    expect(body.terms).toContain("patience");
+    expect(body.quranRefs).toEqual(["2:153"]);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates the "Ask with Proof" question input into the Search screen's single shared search bar, rather than maintaining a separate input field in the ask section. The same text now drives both keyword search (as-you-type) and AI ask (on submit), simplifying the UX and reducing UI complexity.

## Changes

- **SearchScreen.kt**: Unified search bar now handles both keyword search and AI ask input
  - `onQueryChange` syncs the search text to `AskViewModel` (clears AI state if text is blank)
  - `onSearch` callback submits to both search and ask (if AI is enabled)
  - Placeholder text changes contextually based on whether AI is enabled
  - Removed the separate ask input card from the ask section

- **AskComponents.kt**: Removed the dedicated question input UI
  - Deleted the `NimazSearchBar` input card that was previously in the ask section
  - Removed `onEvent: (AskEvent) -> Unit` parameter from `askSection()`
  - Added `onDismissHint: () -> Unit` callback for the hint dismissal
  - Introduced `AskAnswerHeader()` composable to label AI output separately from keyword results
  - Header now appears above loading, answer, and error states to visually separate AI output

- **strings.xml**: Added new placeholder strings
  - `search_or_ask_placeholder`: "Search or ask a question…" (shown when AI is enabled)
  - `ai_answer_section`: Label for the AI output section header

- **docs/ai-ask-with-proof.md**: Updated architecture documentation
  - Clarified that the question input is now the shared search bar (not a separate field)
  - Updated the layer diagram to reflect that `SearchScreen.kt` now owns the input

## Implementation Details

- The AI question state stays in sync with the search bar via `AskEvent.UpdateQuestion` on every keystroke
- Clearing the search bar also clears any pending AI answer via `AskEvent.Clear`
- The ask section now renders only the *output* (answer, proofs, errors, or hint) — no input
- The new `AskAnswerHeader()` provides visual separation between keyword results and AI answers
- All ask event handling is now routed through the search screen's callback chain, keeping the ask section purely presentational

https://claude.ai/code/session_01HAi4KjcqUFuPWHUjwLc8N9