### PR TITLE
feat(search): add optional trailing Ask pill to NimazSearchBar

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBar.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Search
@@ -119,11 +120,18 @@ private val NimazSearchBarHeight = 56.dp
  *   screens may want next to the clear button.
  * - Animated visibility on the clear button so its appearance/disappearance
  *   doesn't feel jumpy as the user types.
+ * - Optional trailing **Ask** pill ([showAskButton]/[askEnabled]/[onAsk]) for
+ *   screens where the same text can be submitted as an AI question ("Ask with
+ *   Proof" on Global Search). The pill renders only when the caller opts in,
+ *   the feature is on, and there is text to ask; it sits after the clear
+ *   button, which keeps working independently. While the pill is active the
+ *   IME action also routes to [onAsk] instead of [onSearch].
  *
  * API is fully backwards-compatible — existing callers (NimazListPicker,
  * SearchScreen, the asma/prophets list screens) continue to work with just
  * the original parameters.
  */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
 fun NimazSearchBar(
     query: String,
@@ -136,6 +144,9 @@ fun NimazSearchBar(
     autoFocus: Boolean = false,
     onClear: () -> Unit = {},
     onSearch: (String) -> Unit = {},
+    showAskButton: Boolean = false,
+    askEnabled: Boolean = false,
+    onAsk: (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = {
         NimazIcon(
             imageVector = Icons.Default.Search,
@@ -150,6 +161,10 @@ fun NimazSearchBar(
     val focusRequester = remember { FocusRequester() }
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
+
+    // The Ask affordance is live only when the caller opted in, the feature is
+    // enabled, and there is something to ask.
+    val askActive = showAskButton && askEnabled && onAsk != null && query.isNotBlank()
 
     // Outlined-field language (matches NimazDropdownField): a neutral hairline at rest that
     // animates to the primary tint on focus. Always outlined — no fill swap.
@@ -212,7 +227,9 @@ fun NimazSearchBar(
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                 keyboardActions = KeyboardActions(
                     onSearch = {
-                        onSearch(query)
+                        // While the Ask affordance is live, Enter asks; otherwise
+                        // it falls back to the plain keyword search.
+                        if (askActive) onAsk?.invoke() else onSearch(query)
                         focusManager.clearFocus()
                     }
                 ),
@@ -275,6 +292,43 @@ fun NimazSearchBar(
                             contentDescription = stringResource(R.string.cd_clear_search),
                             tint = MaterialTheme.colorScheme.primary,
                             iconSize = 16.dp
+                        )
+                    }
+                }
+            }
+
+            // Ask pill — independent of the clear button: clear stays visible
+            // whenever there's text, Ask appears alongside it when live.
+            AnimatedVisibility(
+                visible = askActive,
+                enter = fadeIn() + scaleIn(initialScale = 0.7f),
+                exit = fadeOut() + scaleOut(targetScale = 0.7f)
+            ) {
+                Surface(
+                    onClick = {
+                        onAsk?.invoke()
+                        focusManager.clearFocus()
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = 2.dp, end = 2.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 9.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        NimazIcon(
+                            imageVector = Icons.Default.AutoAwesome,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            iconSize = 15.dp
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = stringResource(R.string.search_ask_button),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onPrimary
                         )
                     }
                 }
@@ -689,6 +743,16 @@ private fun NimazSearchBar_Showcase_Preview() {
                     query = "Al-Fatiha",
                     onQueryChange = {},
                     onClear = {},
+                )
+            }
+            PreviewSection(label = "Ask pill (AI on + text — clear stays)") {
+                NimazSearchBar(
+                    query = "What does the Qur'an say about patience?",
+                    onQueryChange = {},
+                    onClear = {},
+                    showAskButton = true,
+                    askEnabled = true,
+                    onAsk = {},
                 )
             }
             PreviewSection(label = "Loading (async lookup in flight)") {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,23 +17,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Mosque
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.SelfImprovement
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.PauseCircle
+import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,70 +44,24 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.core.navigation.Route
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
-import com.arshadshah.nimaz.domain.model.Proof
-import com.arshadshah.nimaz.domain.model.ProofSource
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.viewmodel.AskPhase
-import com.arshadshah.nimaz.presentation.viewmodel.AskUiState
+import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 /**
- * Adds the "Ask with Proof" experience to the Search screen's LazyColumn.
+ * The "Ask with Proof" hero cards for the Search screen: thinking, the
+ * answer itself, errors, and the AI-off discovery card.
  *
- * The question is entered through the screen's single shared search bar — this
- * section renders only the *output* of an ask. Gated on [AskUiState.aiEnabled]:
- * when off it shows a subtle, dismissible hint; when on it renders one hero
- * card per phase — thinking, answer + proof verses, or a friendly error with
- * retry. Proof cards are real records from the local library that deep-link
- * into the readers.
+ * The question is entered through the screen's single shared search bar, and
+ * — since the v2 redesign — the cited proof verses are NOT rendered here:
+ * [AskAnswerCard] carries only the answer + confidence + trust note, and
+ * `SearchScreen` merges the proofs into the one filterable results list as
+ * regular result cards marked "Cited".
  */
-fun LazyListScope.askSection(
-    state: AskUiState,
-    onNavigateToProof: (Route) -> Unit,
-    onNavigateToSearchSettings: () -> Unit,
-    onDismissHint: () -> Unit,
-    onRetry: () -> Unit,
-) {
-    if (!state.aiEnabled) {
-        if (!state.hintDismissed) {
-            item(key = "ai_hint") {
-                AskDisabledHint(
-                    onOpenSettings = onNavigateToSearchSettings,
-                    onDismiss = onDismissHint,
-                )
-            }
-        }
-        return
-    }
-
-    when (val phase = state.phase) {
-        AskPhase.Idle -> Unit
-
-        AskPhase.Loading -> {
-            item(key = "ai_card") { AskLoadingCard() }
-        }
-
-        is AskPhase.Answer -> {
-            item(key = "ai_card") {
-                AskAnswerCard(
-                    answer = phase.answer,
-                    confidence = phase.confidence,
-                    proofs = phase.proofs,
-                    onNavigateToProof = onNavigateToProof,
-                )
-            }
-        }
-
-        is AskPhase.Error -> {
-            item(key = "ai_card") { AskErrorCard(error = phase.error, onRetry = onRetry) }
-        }
-    }
-}
 
 /** Sparkle avatar on a soft theme-derived gradient — the AI section's marker. */
 @Composable
@@ -139,27 +89,26 @@ private fun AiBadge(modifier: Modifier = Modifier) {
     }
 }
 
+/** Thin teal→purple strip along the card's top edge — marks AI surfaces. */
 @Composable
-private fun AskHeaderRow(trailing: @Composable () -> Unit = {}) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        AiBadge()
-        Text(
-            text = stringResource(R.string.ai_answer_section),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier
-                .padding(start = 12.dp)
-                .weight(1f),
-        )
-        trailing()
-    }
+private fun AiAccentStrip() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(3.dp)
+            .background(
+                Brush.horizontalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary,
+                    ),
+                ),
+            ),
+    )
 }
 
 @Composable
-private fun AskLoadingCard() {
+internal fun AskLoadingCard() {
     // Gentle breathing on the badge while the answer is generated.
     val transition = rememberInfiniteTransition(label = "ai_loading")
     val pulse by transition.animateFloat(
@@ -172,32 +121,49 @@ private fun AskLoadingCard() {
         label = "ai_loading_pulse",
     )
     NimazCard(style = NimazCardStyle.ELEVATED, modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                AiBadge(modifier = Modifier.alpha(pulse))
-                Text(
-                    text = stringResource(R.string.ai_thinking),
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(start = 12.dp),
+        Column {
+            AiAccentStrip()
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AiBadge(modifier = Modifier.alpha(pulse))
+                    Text(
+                        text = stringResource(R.string.ai_thinking),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+                // Skeleton of the incoming answer.
+                listOf(0.92f, 0.98f, 0.7f).forEach { widthFraction ->
+                    Box(
+                        modifier = Modifier
+                            .padding(top = 10.dp)
+                            .fillMaxWidth(widthFraction)
+                            .height(11.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
+                    )
+                }
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                        .clip(RoundedCornerShape(2.dp)),
                 )
             }
-            LinearProgressIndicator(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp)
-                    .clip(RoundedCornerShape(2.dp)),
-            )
         }
     }
 }
 
+/**
+ * The AI answer alone — badge + "Answer" + confidence chip, the answer text,
+ * and the trust note. The cited verses live in the results list below, so the
+ * card deliberately carries no proof section.
+ */
 @Composable
-private fun AskAnswerCard(
+internal fun AskAnswerCard(
     answer: String,
     confidence: AnswerConfidence,
-    proofs: List<Proof>,
-    onNavigateToProof: (Route) -> Unit,
 ) {
     NimazCard(
         style = NimazCardStyle.ELEVATED,
@@ -205,219 +171,247 @@ private fun AskAnswerCard(
             .fillMaxWidth()
             .animateContentSize(),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            AskHeaderRow(trailing = { ConfidenceChip(confidence) })
+        Column {
+            AiAccentStrip()
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    AiBadge()
+                    Text(
+                        text = stringResource(R.string.ai_answer_section),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier
+                            .padding(start = 12.dp)
+                            .weight(1f),
+                    )
+                    ConfidenceChip(confidence)
+                }
 
-            Text(
-                text = answer,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(top = 12.dp),
-            )
-
-            if (proofs.isEmpty()) {
                 Text(
-                    text = stringResource(R.string.ai_no_citations),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = answer,
+                    style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.padding(top = 12.dp),
                 )
-            } else {
+
                 HorizontalDivider(
-                    modifier = Modifier.padding(vertical = 16.dp),
+                    modifier = Modifier.padding(top = 14.dp),
                     color = MaterialTheme.colorScheme.outlineVariant,
                 )
-                Text(
-                    text = stringResource(R.string.ai_proof_section),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Column(
-                    modifier = Modifier.padding(top = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    proofs.forEachIndexed { index, proof ->
-                        ProofRow(
-                            index = index + 1,
-                            proof = proof,
-                            onClick = { onNavigateToProof(proof.route) },
-                        )
-                    }
+                Row(modifier = Modifier.padding(top = 12.dp)) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(top = 1.dp)
+                            .size(14.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.ai_trust_note),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
                 }
             }
-
-            Text(
-                text = stringResource(R.string.ai_footer_disclaimer),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 12.dp),
-            )
         }
     }
 }
 
 @Composable
 private fun ConfidenceChip(confidence: AnswerConfidence) {
+    // High reads as trust (teal), medium as caution (amber), low as muted.
     val (label, color) = when (confidence) {
         AnswerConfidence.HIGH ->
             stringResource(R.string.ai_confidence_high) to MaterialTheme.colorScheme.primary
 
         AnswerConfidence.MEDIUM ->
-            stringResource(R.string.ai_confidence_medium) to MaterialTheme.colorScheme.tertiary
+            stringResource(R.string.ai_confidence_medium) to NimazColors.Warning
 
         AnswerConfidence.LOW ->
             stringResource(R.string.ai_confidence_low) to MaterialTheme.colorScheme.onSurfaceVariant
     }
-    Box(
+    Row(
         modifier = Modifier
             .clip(RoundedCornerShape(8.dp))
             .background(color.copy(alpha = 0.12f))
             .padding(horizontal = 10.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.SemiBold,
             color = color,
+            modifier = Modifier.padding(start = 5.dp),
         )
     }
 }
 
-/** One cited verse from the local library — tappable, deep-links to the reader. */
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Discovery card shown on Global Search while AI answers are off: what the
+ * feature does, the privacy line, and enable / not-now actions.
+ */
 @Composable
-private fun ProofRow(index: Int, proof: Proof, onClick: () -> Unit) {
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
-            Box(
-                modifier = Modifier
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = index.toString(),
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-            Spacer(modifier = Modifier.width(10.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = proof.source.icon(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Text(
-                        text = proof.meta,
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(start = 6.dp),
-                    )
-                }
-                Text(
-                    text = proof.displayText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun AskDisabledHint(
+internal fun AskDiscoveryCard(
     onOpenSettings: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    NimazCard(
-        style = NimazCardStyle.FILLED,
-        onClick = onOpenSettings,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                imageVector = Icons.Default.AutoAwesome,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Text(
-                text = stringResource(R.string.ai_enable_hint),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(start = 12.dp),
-            )
-            IconButton(onClick = onDismiss) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(R.string.dismiss),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    NimazCard(style = NimazCardStyle.ELEVATED, modifier = Modifier.fillMaxWidth()) {
+        Column {
+            AiAccentStrip()
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AiBadge()
+                    Text(
+                        text = stringResource(R.string.ai_discover_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.ai_discover_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 12.dp),
                 )
+                Row(
+                    modifier = Modifier
+                        .padding(top = 12.dp)
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(11.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Shield,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier
+                            .padding(top = 1.dp)
+                            .size(14.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.ai_discover_privacy),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+                Row(
+                    modifier = Modifier.padding(top = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    NimazButton(
+                        text = stringResource(R.string.ai_discover_enable),
+                        onClick = onOpenSettings,
+                        variant = NimazButtonVariant.FILLED,
+                        leadingIcon = Icons.Default.AutoAwesome,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    NimazButton(
+                        text = stringResource(R.string.ai_discover_dismiss),
+                        onClick = onDismiss,
+                        variant = NimazButtonVariant.TEXT,
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-private fun AskErrorCard(error: AiError, onRetry: () -> Unit) {
-    val message = when (error) {
+internal fun AskErrorCard(error: AiError, onRetry: () -> Unit) {
+    val icon: ImageVector
+    val title: String
+    val body: String
+    when (error) {
         is AiError.RateLimited -> {
+            icon = Icons.Default.Schedule
+            title = stringResource(R.string.ai_error_rate_limited_title)
             val retry = error.retryAfterSeconds
-            if (retry != null) {
+            body = if (retry != null) {
                 stringResource(R.string.ai_error_rate_limited_retry, formatRetry(retry))
             } else {
                 stringResource(R.string.ai_error_rate_limited)
             }
         }
 
-        AiError.BudgetExceeded -> stringResource(R.string.ai_error_budget)
-        AiError.Network -> stringResource(R.string.ai_error_network)
-        is AiError.Invalid -> stringResource(R.string.ai_error_invalid)
-        AiError.Unknown -> stringResource(R.string.ai_error_unknown)
+        AiError.BudgetExceeded -> {
+            icon = Icons.Outlined.PauseCircle
+            title = stringResource(R.string.ai_error_budget_title)
+            body = stringResource(R.string.ai_error_budget)
+        }
+
+        AiError.Network -> {
+            icon = Icons.Default.WifiOff
+            title = stringResource(R.string.ai_error_network_title)
+            body = stringResource(R.string.ai_error_network)
+        }
+
+        is AiError.Invalid -> {
+            icon = Icons.Outlined.Info
+            title = stringResource(R.string.ai_error_invalid_title)
+            body = stringResource(R.string.ai_error_invalid)
+        }
+
+        AiError.Unknown -> {
+            icon = Icons.Outlined.Info
+            title = stringResource(R.string.ai_error_unknown_title)
+            body = stringResource(R.string.ai_error_unknown)
+        }
     }
     // Retrying can only help for transient failures — not for daily/budget caps.
     val retryable = error is AiError.Network || error is AiError.Unknown
     NimazCard(style = NimazCardStyle.FILLED, modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
-            AskHeaderRow()
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.errorContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(21.dp),
+                )
+            }
             Text(
-                text = message,
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+            Text(
+                text = body,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 12.dp),
+                modifier = Modifier.padding(top = 4.dp),
             )
             if (retryable) {
                 Spacer(modifier = Modifier.height(8.dp))
                 NimazButton(
                     text = stringResource(R.string.ai_try_again),
                     onClick = onRetry,
-                    variant = NimazButtonVariant.TEXT,
+                    variant = NimazButtonVariant.FILLED,
                     leadingIcon = Icons.Default.Refresh,
                 )
             }
         }
     }
-}
-
-private fun ProofSource.icon(): ImageVector = when (this) {
-    ProofSource.QURAN -> Icons.AutoMirrored.Filled.MenuBook
-    ProofSource.HADITH -> Icons.Default.Mosque
-    ProofSource.DUA -> Icons.Default.SelfImprovement
 }
 
 /** Turn retry seconds into a coarse "minutes"/"hours" figure for display. */

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
@@ -4,9 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -19,8 +23,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Mosque
 import androidx.compose.material.icons.filled.Search
@@ -54,6 +60,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.domain.model.CitationId
+import com.arshadshah.nimaz.domain.model.Proof
+import com.arshadshah.nimaz.domain.model.ProofSource
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
@@ -65,15 +74,15 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.AskEvent
+import com.arshadshah.nimaz.presentation.viewmodel.AskPhase
 import com.arshadshah.nimaz.presentation.viewmodel.AskViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.SearchEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SearchFilter
 import com.arshadshah.nimaz.presentation.viewmodel.SearchViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.UnifiedSearchResult
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun SearchScreen(
     onNavigateBack: () -> Unit,
@@ -109,6 +118,9 @@ fun SearchScreen(
         }
     }
 
+    val askEnabled = enableAsk && askState.aiEnabled
+    val answerPhase = if (enableAsk) askState.phase as? AskPhase.Answer else null
+
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
@@ -128,18 +140,22 @@ fun SearchScreen(
             )
         }
     ) { paddingValues ->
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(paddingValues)
         ) {
-            // A single search bar drives both keyword search and — when the user has
-            // opted into AI answers on global search — the "Ask with Proof" question.
-            // Keyword results update as-you-type; the AI ask only fires on submit.
-            val askEnabled = enableAsk && askState.aiEnabled
-            item {
+            // Pinned controls: the single search bar and the source filter live
+            // above the list and never scroll away, so the filter always scopes
+            // whatever is on screen. A single bar drives both keyword search and
+            // — when the user has opted into AI answers on global search — the
+            // "Ask with Proof" question: keyword results update as-you-type, the
+            // AI ask fires only from the Ask pill / IME action.
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 12.dp)
+            ) {
                 NimazSearchBar(
                     query = state.query,
                     onQueryChange = {
@@ -161,162 +177,355 @@ fun SearchScreen(
                         viewModel.onEvent(SearchEvent.ClearSearch)
                         if (enableAsk) askViewModel.onEvent(AskEvent.Clear)
                     },
-                    onSearch = {
-                        viewModel.onEvent(SearchEvent.ExecuteSearch)
-                        if (askEnabled) askViewModel.onEvent(AskEvent.Submit)
-                    }
+                    onSearch = { viewModel.onEvent(SearchEvent.ExecuteSearch) },
+                    showAskButton = enableAsk,
+                    askEnabled = askState.aiEnabled,
+                    onAsk = { askViewModel.onEvent(AskEvent.Submit) },
                 )
-            }
 
-            // Ask with Proof (AI) — only on global search, gated on the user's opt-in.
-            // The question shares the search bar above; this section shows the AI
-            // answer / proofs (or the discovery hint when AI is off).
-            if (enableAsk) {
-                askSection(
-                    state = askState,
-                    onNavigateToProof = onNavigateToProof,
-                    onNavigateToSearchSettings = onNavigateToSearchSettings,
-                    onDismissHint = { askViewModel.onEvent(AskEvent.DismissHint) },
-                    onRetry = { askViewModel.onEvent(AskEvent.Submit) },
-                )
-            }
-
-            // Filter Chips
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    SearchFilter.entries.forEach { filter ->
-                        FilterChip(
-                            selected = state.selectedFilter == filter,
-                            onClick = { viewModel.onEvent(SearchEvent.SetFilter(filter)) },
-                            label = {
-                                Text(
-                                    when (filter) {
-                                        SearchFilter.ALL -> stringResource(R.string.all)
-                                        SearchFilter.QURAN -> stringResource(R.string.quran)
-                                        SearchFilter.HADITH -> stringResource(R.string.hadith)
-                                        SearchFilter.DUA -> stringResource(R.string.duas)
-                                    }
-                                )
-                            }
-                        )
-                    }
-                }
-            }
-
-            // Recent Searches (when not searching)
-            if (state.query.isEmpty() && state.recentSearches.isNotEmpty()) {
-                item {
+                // The filter appears only when there is a list to scope — while
+                // typing or once an answer (with its merged list) is on screen.
+                if (state.query.isNotEmpty() || answerPhase != null) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(R.string.recent_searches),
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.Bold
-                        )
-                        IconButton(
-                            onClick = { viewModel.onEvent(SearchEvent.ClearRecentSearches) }
-                        ) {
-                            NimazIcon(
-                                imageVector = Icons.Default.Close,
-                                contentDescription = stringResource(R.string.clear_recent),
-                                size = NimazIconSize.MEDIUM
-                            )
-                        }
-                    }
-                }
-
-                items(state.recentSearches) { recentSearch ->
-                    RecentSearchItem(
-                        query = recentSearch,
-                        onClick = { viewModel.onEvent(SearchEvent.SelectRecentSearch(recentSearch)) },
-                        onRemove = { viewModel.onEvent(SearchEvent.RemoveRecentSearch(recentSearch)) }
-                    )
-                }
-            }
-
-            // Loading Indicator
-            if (state.isSearching) {
-                item {
-                    Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(32.dp),
-                        contentAlignment = Alignment.Center
+                            .padding(top = 10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        CircularProgressIndicator()
+                        SearchFilter.entries.forEach { filter ->
+                            FilterChip(
+                                selected = state.selectedFilter == filter,
+                                onClick = { viewModel.onEvent(SearchEvent.SetFilter(filter)) },
+                                label = {
+                                    Text(
+                                        when (filter) {
+                                            SearchFilter.ALL -> stringResource(R.string.all)
+                                            SearchFilter.QURAN -> stringResource(R.string.quran)
+                                            SearchFilter.HADITH -> stringResource(R.string.hadith)
+                                            SearchFilter.DUA -> stringResource(R.string.duas)
+                                        }
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
             }
 
-            // Results Summary
-            if (state.query.isNotEmpty() && !state.isSearching && state.filteredResults.isNotEmpty()) {
-                item {
-                    Text(
-                        text = stringResource(
-                            R.string.results_found_format,
-                            statsState.totalResults
-                        ),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // AI-off discovery card — global search, resting state only.
+                if (enableAsk && !askState.aiEnabled && !askState.hintDismissed &&
+                    state.query.isEmpty()
+                ) {
+                    item(key = "ai_discover") {
+                        AskDiscoveryCard(
+                            onOpenSettings = onNavigateToSearchSettings,
+                            onDismiss = { askViewModel.onEvent(AskEvent.DismissHint) },
+                        )
+                    }
                 }
-            }
 
-            // Search Results
-            items(state.filteredResults) { result ->
-                when (result) {
-                    is UnifiedSearchResult.QuranResult -> QuranSearchResultCard(
-                        result = result.result,
-                        query = state.query,
-                        onClick = {
-                            onNavigateToQuranAyah(
-                                result.result.ayah.surahNumber,
-                                result.result.ayah.ayahNumber
+                // The AI hero card for the current phase (thinking / answer / error).
+                if (askEnabled) {
+                    when (val phase = askState.phase) {
+                        AskPhase.Idle -> Unit
+                        AskPhase.Loading -> item(key = "ai_card") { AskLoadingCard() }
+                        is AskPhase.Answer -> item(key = "ai_card") {
+                            AskAnswerCard(answer = phase.answer, confidence = phase.confidence)
+                        }
+
+                        is AskPhase.Error -> item(key = "ai_card") {
+                            AskErrorCard(
+                                error = phase.error,
+                                onRetry = { askViewModel.onEvent(AskEvent.Submit) },
                             )
                         }
-                    )
+                    }
+                }
 
-                    is UnifiedSearchResult.SurahResult -> SurahSearchResultCard(
-                        surah = result.surah,
-                        onClick = { onNavigateToSurah(result.surah.number) }
-                    )
+                if (answerPhase != null) {
+                    // Answer state: ONE merged list under the pinned filter —
+                    // cited proofs first (marked "Cited"), then the related
+                    // results driven by the AI's terms. A related result that is
+                    // also cited is dropped so nothing appears twice.
+                    val citedVisible = answerPhase.proofs
+                        .filter { it.source.matchesFilter(state.selectedFilter) }
+                    val citedIds = answerPhase.proofs.map { it.citationId }.toSet()
+                    val related = state.filteredResults
+                        .filterNot { it.citationKey() in citedIds }
 
-                    is UnifiedSearchResult.HadithResult -> HadithSearchResultCard(
-                        result = result.result,
-                        query = state.query,
-                        onClick = {
-                            onNavigateToHadith(
-                                result.result.hadith.bookId,
-                                result.result.hadith.id
+                    if (state.isSearching) {
+                        item { SearchingIndicator() }
+                    } else {
+                        item {
+                            Text(
+                                text = stringResource(
+                                    R.string.search_answer_count_format,
+                                    citedVisible.size + related.size,
+                                    citedVisible.size
+                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
-                    )
+                    }
 
-                    is UnifiedSearchResult.DuaResult -> DuaSearchResultCard(
-                        result = result.result,
-                        query = state.query,
-                        onClick = { onNavigateToDua(result.result.dua.id) }
-                    )
+                    items(citedVisible, key = { it.citationId }) { proof ->
+                        CitedProofCard(
+                            proof = proof,
+                            query = state.query,
+                            onClick = { onNavigateToProof(proof.route) }
+                        )
+                    }
+
+                    if (!state.isSearching) {
+                        items(related) { result ->
+                            UnifiedResultCard(
+                                result = result,
+                                query = state.query,
+                                onNavigateToQuranAyah = onNavigateToQuranAyah,
+                                onNavigateToSurah = onNavigateToSurah,
+                                onNavigateToHadith = onNavigateToHadith,
+                                onNavigateToDua = onNavigateToDua
+                            )
+                        }
+                    }
+                } else if (state.query.isEmpty()) {
+                    // Resting: example questions to ask (AI on), then recent
+                    // searches and questions merged into one list.
+                    if (askEnabled) {
+                        item {
+                            SectionHeader(title = stringResource(R.string.search_try_asking))
+                        }
+                        item {
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                listOf(
+                                    stringResource(R.string.ask_example_1),
+                                    stringResource(R.string.ask_example_2),
+                                    stringResource(R.string.ask_example_3),
+                                    stringResource(R.string.ask_example_4),
+                                ).forEach { example ->
+                                    ExampleQuestionChip(
+                                        text = example,
+                                        onClick = {
+                                            viewModel.onEvent(SearchEvent.UpdateQuery(example))
+                                            askViewModel.onEvent(AskEvent.SelectRecent(example))
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    val mergedRecent =
+                        if (askEnabled) {
+                            (state.recentSearches + askState.recentQuestions).distinct().take(10)
+                        } else {
+                            state.recentSearches
+                        }
+                    if (mergedRecent.isNotEmpty()) {
+                        item {
+                            SectionHeader(
+                                title = stringResource(R.string.search_recent),
+                                actionLabel = stringResource(R.string.cd_clear),
+                                onAction = { viewModel.onEvent(SearchEvent.ClearRecentSearches) }
+                            )
+                        }
+                        items(mergedRecent) { recentSearch ->
+                            RecentSearchItem(
+                                query = recentSearch,
+                                onClick = {
+                                    viewModel.onEvent(SearchEvent.SelectRecentSearch(recentSearch))
+                                    if (enableAsk) {
+                                        askViewModel.onEvent(AskEvent.UpdateQuestion(recentSearch))
+                                    }
+                                },
+                                onRemove = {
+                                    viewModel.onEvent(SearchEvent.RemoveRecentSearch(recentSearch))
+                                }
+                            )
+                        }
+                    }
+                } else {
+                    // Typing: keyword results as-you-type (also the fallback list
+                    // while an ask is loading or errored).
+                    if (askEnabled && askState.phase is AskPhase.Idle) {
+                        item {
+                            Text(
+                                text = stringResource(R.string.search_typing_hint),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    if (state.isSearching) {
+                        item { SearchingIndicator() }
+                    }
+
+                    if (!state.isSearching && state.filteredResults.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = stringResource(
+                                    R.string.search_matches_format,
+                                    statsState.totalResults
+                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    items(state.filteredResults) { result ->
+                        UnifiedResultCard(
+                            result = result,
+                            query = state.query,
+                            onNavigateToQuranAyah = onNavigateToQuranAyah,
+                            onNavigateToSurah = onNavigateToSurah,
+                            onNavigateToHadith = onNavigateToHadith,
+                            onNavigateToDua = onNavigateToDua
+                        )
+                    }
+
+                    if (!state.isSearching && state.filteredResults.isEmpty()) {
+                        item {
+                            NimazEmptyState(
+                                title = stringResource(R.string.no_results_format, state.query),
+                                message = stringResource(R.string.no_results_hint),
+                                icon = Icons.Default.Search,
+                                iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
             }
+        }
+    }
+}
 
-            // No Results
-            if (state.query.isNotEmpty() && !state.isSearching && state.filteredResults.isEmpty()) {
-                item {
-                    NimazEmptyState(
-                        title = stringResource(R.string.no_results_format, state.query),
-                        message = stringResource(R.string.no_results_hint),
-                        icon = Icons.Default.Search,
-                        iconTint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+/** Source accents: Qur'an = teal (primary), Hadith = gold (secondary), Dua = deep purple (tertiary). */
+@Composable
+private fun sourceAccent(source: ProofSource): Color = when (source) {
+    ProofSource.QURAN -> MaterialTheme.colorScheme.primary
+    ProofSource.HADITH -> MaterialTheme.colorScheme.secondary
+    ProofSource.DUA -> MaterialTheme.colorScheme.tertiary
+}
+
+private fun sourceIcon(source: ProofSource): ImageVector = when (source) {
+    ProofSource.QURAN -> Icons.AutoMirrored.Filled.MenuBook
+    ProofSource.HADITH -> Icons.Default.Book
+    ProofSource.DUA -> Icons.Default.Mosque
+}
+
+private fun ProofSource.matchesFilter(filter: SearchFilter): Boolean = when (filter) {
+    SearchFilter.ALL -> true
+    SearchFilter.QURAN -> this == ProofSource.QURAN
+    SearchFilter.HADITH -> this == ProofSource.HADITH
+    SearchFilter.DUA -> this == ProofSource.DUA
+}
+
+/**
+ * The citation id this result would carry if the AI cited it — used to drop
+ * results that already appear as cited proofs. Surah results have no citation
+ * form, so they never dedup away.
+ */
+private fun UnifiedSearchResult.citationKey(): String? = when (this) {
+    is UnifiedSearchResult.QuranResult ->
+        CitationId.Quran(result.ayah.surahNumber, result.ayah.ayahNumber).raw
+
+    is UnifiedSearchResult.HadithResult -> CitationId.Hadith(result.hadith.id).raw
+    is UnifiedSearchResult.DuaResult -> CitationId.Dua(result.dua.id).raw
+    is UnifiedSearchResult.SurahResult -> null
+}
+
+@Composable
+private fun SearchingIndicator(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold
+        )
+        if (actionLabel != null && onAction != null) {
+            Surface(onClick = onAction, shape = RoundedCornerShape(8.dp), color = Color.Transparent) {
+                Text(
+                    text = actionLabel,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp)
+                )
             }
+        }
+    }
+}
+
+/** An example question the user can tap to ask straight away. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExampleQuestionChip(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(13.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant
+        ),
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            NimazIcon(
+                imageVector = Icons.Default.AutoAwesome,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                iconSize = 15.dp
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
         }
     }
 }
@@ -370,27 +579,97 @@ private fun RecentSearchItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun QuranSearchResultCard(
-    result: com.arshadshah.nimaz.domain.model.QuranSearchResult,
+private fun UnifiedResultCard(
+    result: UnifiedSearchResult,
+    query: String,
+    onNavigateToQuranAyah: (Int, Int) -> Unit,
+    onNavigateToSurah: (Int) -> Unit,
+    onNavigateToHadith: (String, String) -> Unit,
+    onNavigateToDua: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when (result) {
+        is UnifiedSearchResult.QuranResult -> SearchResultCard(
+            icon = sourceIcon(ProofSource.QURAN),
+            iconColor = sourceAccent(ProofSource.QURAN),
+            type = stringResource(R.string.quran_type),
+            title = stringResource(
+                R.string.surah_result_format,
+                result.result.ayah.surahNumber,
+                result.result.ayah.ayahNumber
+            ),
+            subtitle = result.result.surahName,
+            highlightedText = result.result.matchedText,
+            query = query,
+            onClick = {
+                onNavigateToQuranAyah(
+                    result.result.ayah.surahNumber,
+                    result.result.ayah.ayahNumber
+                )
+            },
+            modifier = modifier
+        )
+
+        is UnifiedSearchResult.SurahResult -> SurahSearchResultCard(
+            surah = result.surah,
+            onClick = { onNavigateToSurah(result.surah.number) },
+            modifier = modifier
+        )
+
+        is UnifiedSearchResult.HadithResult -> SearchResultCard(
+            icon = sourceIcon(ProofSource.HADITH),
+            iconColor = sourceAccent(ProofSource.HADITH),
+            type = stringResource(R.string.hadith_type),
+            title = stringResource(R.string.hadith_result_format, result.result.hadith.hadithNumber),
+            subtitle = result.result.bookName,
+            highlightedText = result.result.matchedText,
+            query = query,
+            onClick = {
+                onNavigateToHadith(
+                    result.result.hadith.bookId,
+                    result.result.hadith.id
+                )
+            },
+            modifier = modifier
+        )
+
+        is UnifiedSearchResult.DuaResult -> SearchResultCard(
+            icon = sourceIcon(ProofSource.DUA),
+            iconColor = sourceAccent(ProofSource.DUA),
+            type = stringResource(R.string.dua_type),
+            title = result.result.dua.titleEnglish,
+            subtitle = result.result.categoryName,
+            highlightedText = result.result.matchedText,
+            query = query,
+            onClick = { onNavigateToDua(result.result.dua.id) },
+            modifier = modifier
+        )
+    }
+}
+
+/**
+ * A verse the AI cited in its answer, rendered with the same shared result
+ * card as every other result — just marked "Cited" and sorted to the top.
+ * Tapping deep-links into the reader like any Qur'an result.
+ */
+@Composable
+private fun CitedProofCard(
+    proof: Proof,
     query: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     SearchResultCard(
-        icon = Icons.AutoMirrored.Filled.MenuBook,
-        iconColor = NimazColors.QuranColors.Meccan,
-        type = stringResource(R.string.quran_type),
-        title = stringResource(
-            R.string.surah_result_format,
-            result.ayah.surahNumber,
-            result.ayah.ayahNumber
-        ),
-        subtitle = result.surahName,
-        highlightedText = result.matchedText,
+        icon = sourceIcon(proof.source),
+        iconColor = sourceAccent(proof.source),
+        type = null,
+        title = proof.meta,
+        subtitle = null,
+        highlightedText = proof.displayText,
         query = query,
         onClick = onClick,
+        cited = true,
         modifier = modifier
     )
 }
@@ -402,6 +681,7 @@ private fun SurahSearchResultCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val accent = sourceAccent(ProofSource.QURAN)
     NimazCard(
         style = NimazCardStyle.FILLED,
         onClick = onClick,
@@ -422,14 +702,14 @@ private fun SurahSearchResultCard(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(NimazColors.QuranColors.Meccan.copy(alpha = 0.1f)),
+                    .background(accent.copy(alpha = 0.1f)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = surah.number.toString(),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
-                    color = NimazColors.QuranColors.Meccan
+                    color = accent
                 )
             }
 
@@ -455,64 +735,31 @@ private fun SurahSearchResultCard(
             ArabicText(
                 text = surah.nameArabic,
                 size = ArabicTextSize.SMALL,
-                color = NimazColors.QuranColors.Meccan
+                color = accent
             )
         }
     }
 }
 
-@Composable
-private fun HadithSearchResultCard(
-    result: com.arshadshah.nimaz.domain.model.HadithSearchResult,
-    query: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    SearchResultCard(
-        icon = Icons.Default.Book,
-        iconColor = MaterialTheme.colorScheme.primary,
-        type = stringResource(R.string.hadith_type),
-        title = stringResource(R.string.hadith_result_format, result.hadith.hadithNumber),
-        subtitle = result.bookName,
-        highlightedText = result.matchedText,
-        query = query,
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun DuaSearchResultCard(
-    result: com.arshadshah.nimaz.domain.model.DuaSearchResult,
-    query: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    SearchResultCard(
-        icon = Icons.Default.Mosque,
-        iconColor = MaterialTheme.colorScheme.secondary,
-        type = stringResource(R.string.dua_type),
-        title = result.dua.titleEnglish,
-        subtitle = result.categoryName,
-        highlightedText = result.matchedText,
-        query = query,
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
+/**
+ * The single result-card component shared by keyword results, cited proofs and
+ * AI-related results. [cited] swaps the source tag for a solid teal "Cited"
+ * chip and adds a teal left edge; everything else — badge, title, subtitle,
+ * highlighted snippet — is identical across the three uses.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SearchResultCard(
     icon: ImageVector,
     iconColor: Color,
-    type: String,
+    type: String?,
     title: String,
-    subtitle: String,
+    subtitle: String?,
     highlightedText: String,
     query: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cited: Boolean = false
 ) {
     NimazCard(
         style = NimazCardStyle.FILLED,
@@ -527,56 +774,116 @@ private fun SearchResultCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.Top
+                .height(IntrinsicSize.Min)
         ) {
-            NimazIcon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = iconColor,
-                size = NimazIconSize.LARGE
-            )
-
-            Spacer(modifier = Modifier.width(12.dp))
-
-            Column(modifier = Modifier.weight(1f)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    Surface(
-                        shape = RoundedCornerShape(4.dp),
-                        color = iconColor.copy(alpha = 0.1f)
-                    ) {
-                        Text(
-                            text = type,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = iconColor,
-                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                        )
-                    }
-                }
-
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                HighlightedText(
-                    text = highlightedText,
-                    query = query,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 2
+            if (cited) {
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.colorScheme.primary)
                 )
             }
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(12.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(11.dp))
+                        .background(iconColor.copy(alpha = 0.1f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    NimazIcon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = iconColor,
+                        iconSize = 20.dp
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        if (cited) {
+                            CitedChip()
+                        } else if (type != null) {
+                            Surface(
+                                shape = RoundedCornerShape(4.dp),
+                                color = iconColor.copy(alpha = 0.1f)
+                            ) {
+                                Text(
+                                    text = type,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = iconColor,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    HighlightedText(
+                        text = highlightedText,
+                        query = query,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 2
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Solid teal marker for results the AI cited — replaces the source tag. */
+@Composable
+private fun CitedChip(modifier: Modifier = Modifier) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            NimazIcon(
+                imageVector = Icons.Default.FormatQuote,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                iconSize = 11.dp
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.search_cited_chip),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
         }
     }
 }
@@ -588,6 +895,18 @@ private fun HighlightedText(
     style: androidx.compose.ui.text.TextStyle,
     maxLines: Int = Int.MAX_VALUE
 ) {
+    // Nothing to highlight (and indexOf("") would loop forever) — plain text.
+    if (query.isBlank()) {
+        Text(
+            text = text,
+            style = style,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        return
+    }
+
     val annotatedString = buildAnnotatedString {
         val lowerText = text.lowercase()
         val lowerQuery = query.lowercase()
@@ -621,4 +940,3 @@ private fun HighlightedText(
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
 }
-

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1300,13 +1300,9 @@
     <string name="ai_ask_placeholder">Frage zu Koran, Hadith oder Duas…</string>
     <string name="ai_answer_section">KI-Antwort</string>
     <string name="ai_thinking">Antwort wird gesucht…</string>
-    <string name="ai_enable_hint">Aktiviere KI-Antworten in den Sucheinstellungen</string>
-    <string name="ai_proof_section">Belege aus deiner Bibliothek</string>
     <string name="ai_confidence_high">Hohe Zuverlässigkeit</string>
     <string name="ai_confidence_medium">Mittlere Zuverlässigkeit</string>
     <string name="ai_confidence_low">Geringe Zuverlässigkeit</string>
-    <string name="ai_no_citations">Keine direkten Vers-Zitate für diese Antwort — sieh dir die verwandten Ergebnisse unten an.</string>
-    <string name="ai_footer_disclaimer">KI-generiert — kann Fehler enthalten. Überprüfe die zitierten Quellen. Keine Fatwa.</string>
     <string name="ai_try_again">Erneut versuchen</string>
     <string name="ai_error_rate_limited">Du hast das heutige Fragenlimit erreicht. Bitte versuche es morgen erneut.</string>
     <string name="ai_error_rate_limited_retry">Du hast das heutige Fragenlimit erreicht. Versuche es in etwa %1$s erneut.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1301,13 +1301,9 @@
     <string name="ai_ask_placeholder">Posez une question sur le Coran, les Hadiths ou les Douas…</string>
     <string name="ai_answer_section">Réponse de l\'IA</string>
     <string name="ai_thinking">Recherche d\'une réponse…</string>
-    <string name="ai_enable_hint">Activez les réponses de l\'IA dans les paramètres de recherche</string>
-    <string name="ai_proof_section">Preuves de votre bibliothèque</string>
     <string name="ai_confidence_high">Confiance élevée</string>
     <string name="ai_confidence_medium">Confiance moyenne</string>
     <string name="ai_confidence_low">Confiance faible</string>
-    <string name="ai_no_citations">Aucune citation directe de verset pour cette réponse — explorez les résultats associés ci-dessous.</string>
-    <string name="ai_footer_disclaimer">Généré par IA — peut contenir des erreurs. Vérifiez avec les sources citées. Pas une fatwa.</string>
     <string name="ai_try_again">Réessayer</string>
     <string name="ai_error_rate_limited">Vous avez atteint la limite de questions pour aujourd\'hui. Veuillez réessayer demain.</string>
     <string name="ai_error_rate_limited_retry">Vous avez atteint la limite de questions pour aujourd\'hui. Réessayez dans environ %1$s.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1301,13 +1301,9 @@
     <string name="ai_ask_placeholder">Tanyakan tentang Quran, Hadis, atau Doa…</string>
     <string name="ai_answer_section">Jawaban AI</string>
     <string name="ai_thinking">Mencari jawaban…</string>
-    <string name="ai_enable_hint">Aktifkan jawaban AI di pengaturan Pencarian</string>
-    <string name="ai_proof_section">Bukti dari pustaka Anda</string>
     <string name="ai_confidence_high">Keyakinan tinggi</string>
     <string name="ai_confidence_medium">Keyakinan sedang</string>
     <string name="ai_confidence_low">Keyakinan rendah</string>
-    <string name="ai_no_citations">Tidak ada kutipan ayat langsung untuk jawaban ini — jelajahi hasil terkait di bawah.</string>
-    <string name="ai_footer_disclaimer">Dihasilkan AI — mungkin mengandung kesalahan. Verifikasi dengan sumber yang dikutip. Bukan fatwa.</string>
     <string name="ai_try_again">Coba lagi</string>
     <string name="ai_error_rate_limited">Anda telah mencapai batas pertanyaan hari ini. Silakan coba lagi besok.</string>
     <string name="ai_error_rate_limited_retry">Anda telah mencapai batas pertanyaan hari ini. Coba lagi dalam sekitar %1$s.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1302,13 +1302,9 @@
     <string name="ai_ask_placeholder">Tanya tentang Quran, Hadis, atau Doa…</string>
     <string name="ai_answer_section">Jawapan AI</string>
     <string name="ai_thinking">Mencari jawapan…</string>
-    <string name="ai_enable_hint">Dayakan jawapan AI dalam tetapan Carian</string>
-    <string name="ai_proof_section">Bukti daripada pustaka anda</string>
     <string name="ai_confidence_high">Keyakinan tinggi</string>
     <string name="ai_confidence_medium">Keyakinan sederhana</string>
     <string name="ai_confidence_low">Keyakinan rendah</string>
-    <string name="ai_no_citations">Tiada petikan ayat langsung untuk jawapan ini — teroka hasil berkaitan di bawah.</string>
-    <string name="ai_footer_disclaimer">Dijana AI — mungkin mengandungi kesilapan. Sahkan dengan sumber yang dipetik. Bukan fatwa.</string>
     <string name="ai_try_again">Cuba lagi</string>
     <string name="ai_error_rate_limited">Anda telah mencapai had soalan hari ini. Sila cuba lagi esok.</string>
     <string name="ai_error_rate_limited_retry">Anda telah mencapai had soalan hari ini. Cuba lagi dalam kira-kira %1$s.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1304,13 +1304,9 @@
     <string name="ai_ask_placeholder">Kur\'an, Hadis veya Dua hakkında sorun…</string>
     <string name="ai_answer_section">Yapay zeka yanıtı</string>
     <string name="ai_thinking">Yanıt aranıyor…</string>
-    <string name="ai_enable_hint">Yapay zekâ yanıtlarını Arama ayarlarında etkinleştirin</string>
-    <string name="ai_proof_section">Kitaplığınızdan kanıtlar</string>
     <string name="ai_confidence_high">Yüksek güven</string>
     <string name="ai_confidence_medium">Orta güven</string>
     <string name="ai_confidence_low">Düşük güven</string>
-    <string name="ai_no_citations">Bu yanıt için doğrudan ayet alıntısı yok — aşağıdaki ilgili sonuçlara göz atın.</string>
-    <string name="ai_footer_disclaimer">Yapay zekâ tarafından oluşturuldu — hata içerebilir. Alıntılanan kaynaklarla doğrulayın. Fetva değildir.</string>
     <string name="ai_try_again">Tekrar dene</string>
     <string name="ai_error_rate_limited">Bugünkü soru sınırına ulaştınız. Lütfen yarın tekrar deneyin.</string>
     <string name="ai_error_rate_limited_retry">Bugünkü soru sınırına ulaştınız. Yaklaşık %1$s içinde tekrar deneyin.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,8 +588,19 @@
 
     <!-- Search Screen -->
     <string name="search_title">Search</string>
-    <string name="search_placeholder">Search Quran, Hadith, Duas…</string>
-    <string name="search_or_ask_placeholder">Search or ask a question…</string>
+    <string name="search_placeholder">Search the Qur\'an, Hadith &amp; duas</string>
+    <string name="search_or_ask_placeholder">Search or ask about the Qur\'an, Hadith &amp; duas</string>
+    <string name="search_ask_button">Ask</string>
+    <string name="search_try_asking">Try asking</string>
+    <string name="search_recent">Recent</string>
+    <string name="search_typing_hint">Results update as you type · Enter to ask for an answer with sources</string>
+    <string name="search_matches_format">%d matches</string>
+    <string name="search_answer_count_format">%1$d in your library · %2$d cited in the answer</string>
+    <string name="search_cited_chip">Cited</string>
+    <string name="ask_example_1">What does the Qur\'an say about patience?</string>
+    <string name="ask_example_2">Duas for anxiety and worry</string>
+    <string name="ask_example_3">Verses about gratitude</string>
+    <string name="ask_example_4">Why is intention important in worship?</string>
     <string name="recent_searches">Recent Searches</string>
     <string name="clear_recent">Clear Recent</string>
     <string name="results_found_format">%d results found</string>
@@ -1458,20 +1469,27 @@
 
     <string name="ai_ask_a_question">Ask a question</string>
     <string name="ai_ask_placeholder">Ask about Quran, Hadith, or Duas…</string>
-    <string name="ai_answer_section">AI answer</string>
+    <string name="ai_answer_section">Answer</string>
     <string name="ai_thinking">Finding an answer…</string>
-    <string name="ai_enable_hint">Enable AI answers in Search settings</string>
-    <string name="ai_proof_section">Proof from your library</string>
     <string name="ai_confidence_high">High confidence</string>
     <string name="ai_confidence_medium">Medium confidence</string>
     <string name="ai_confidence_low">Low confidence</string>
-    <string name="ai_no_citations">No direct verse citations for this answer — explore the related results below.</string>
-    <string name="ai_footer_disclaimer">AI-generated — may contain mistakes. Verify against the cited sources. Not a fatwa.</string>
+    <string name="ai_trust_note">AI-generated summary — check it against the cited verses below. It describes what the sources say and isn\'t a fatwa.</string>
+    <string name="ai_discover_title">Get answers, backed by verses</string>
+    <string name="ai_discover_body">Ask a question in plain words and get a short answer supported by verses from your own library — every citation is a real ayah you can open and read.</string>
+    <string name="ai_discover_privacy">Only your question is sent. The verses and results are matched on your device, and questions are never used for analytics.</string>
+    <string name="ai_discover_enable">Turn on AI answers</string>
+    <string name="ai_discover_dismiss">Not now</string>
     <string name="ai_try_again">Try again</string>
-    <string name="ai_error_rate_limited">You\'ve reached today\'s question limit. Please try again tomorrow.</string>
-    <string name="ai_error_rate_limited_retry">You\'ve reached today\'s question limit. Try again in about %1$s.</string>
-    <string name="ai_error_budget">AI is resting for now. Please try again later.</string>
-    <string name="ai_error_network">Couldn\'t reach the AI service. Check your connection and try again.</string>
-    <string name="ai_error_invalid">That question couldn\'t be processed. Try rewording it.</string>
-    <string name="ai_error_unknown">Something went wrong generating the answer. Please try again.</string>
+    <string name="ai_error_network_title">Couldn\'t reach the answer service</string>
+    <string name="ai_error_network">You\'re offline, or the connection dropped. Keyword search still works offline — or try the answer again.</string>
+    <string name="ai_error_rate_limited_title">You\'ve reached today\'s question limit</string>
+    <string name="ai_error_rate_limited">You can ask again tomorrow. Keyword search across the Qur\'an, Hadith and duas still works offline in the meantime.</string>
+    <string name="ai_error_rate_limited_retry">You can ask again in about %1$s. Keyword search across the Qur\'an, Hadith and duas still works offline in the meantime.</string>
+    <string name="ai_error_budget_title">AI answers are paused for now</string>
+    <string name="ai_error_budget">Answers are temporarily unavailable while shared usage resets. Keyword search still works offline, and your library is fully available.</string>
+    <string name="ai_error_invalid_title">That question couldn\'t be processed</string>
+    <string name="ai_error_invalid">Try rewording the question and ask again.</string>
+    <string name="ai_error_unknown_title">Something went wrong</string>
+    <string name="ai_error_unknown">The answer couldn\'t be generated. Please try again.</string>
 </resources>

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBarTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/NimazSearchBarTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
@@ -114,6 +115,110 @@ class NimazSearchBarTest {
         }
 
         composeRule.onNodeWithContentDescription("Clear search").assertDoesNotExist()
+    }
+
+    @Test
+    fun `ask button is hidden when askEnabled is false`() {
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "patience",
+                onQueryChange = {},
+                showAskButton = true,
+                askEnabled = false,
+                onAsk = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Ask").assertDoesNotExist()
+    }
+
+    @Test
+    fun `ask button is hidden when query is blank`() {
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "",
+                onQueryChange = {},
+                showAskButton = true,
+                askEnabled = true,
+                onAsk = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Ask").assertDoesNotExist()
+    }
+
+    @Test
+    fun `ask button is shown and invokes onAsk when enabled with text`() {
+        var asked = false
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "patience",
+                onQueryChange = {},
+                showAskButton = true,
+                askEnabled = true,
+                onAsk = { asked = true }
+            )
+        }
+
+        composeRule.onNodeWithText("Ask").assertIsDisplayed().performClick()
+        assertThat(asked).isTrue()
+    }
+
+    @Test
+    fun `clear button still works alongside the ask button`() {
+        var cleared = false
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "patience",
+                onQueryChange = {},
+                onClear = { cleared = true },
+                showAskButton = true,
+                askEnabled = true,
+                onAsk = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Ask").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Clear search").performClick()
+        assertThat(cleared).isTrue()
+    }
+
+    @Test
+    fun `ime search action invokes onAsk while the ask affordance is live`() {
+        var asked = false
+        var searched: String? = null
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "patience",
+                onQueryChange = {},
+                onSearch = { searched = it },
+                showAskButton = true,
+                askEnabled = true,
+                onAsk = { asked = true }
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Search...").performImeAction()
+        assertThat(asked).isTrue()
+        assertThat(searched).isNull()
+    }
+
+    @Test
+    fun `ime search action falls back to onSearch when ask is unavailable`() {
+        var searched: String? = null
+        composeRule.setThemedContent {
+            NimazSearchBar(
+                query = "patience",
+                onQueryChange = {},
+                onSearch = { searched = it },
+                showAskButton = true,
+                askEnabled = false,
+                onAsk = {}
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Search...").performImeAction()
+        assertThat(searched).isEqualTo("patience")
     }
 
     @Test

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -2,7 +2,11 @@
 
 An **opt-in**, privacy-disclosed AI layer over Global Search. The user types
 into Global Search's **single search bar** — the same text drives both keyword
-search and, on submit, the AI ask (there is no separate "ask" field).
+search (as-you-type) and the AI ask (there is no separate "ask" field). While
+AI is enabled and there is text, the shared `NimazSearchBar` shows a trailing
+**Ask** pill; tapping it — or pressing Enter — submits the question. The
+source filter (All / Qur'an / Hadith / Duas) is **pinned under the search
+bar** and scopes everything below it.
 
 When AI is enabled, each submit makes **one** Worker call (`search-assist`):
 
@@ -10,16 +14,23 @@ When AI is enabled, each submit makes **one** Worker call (`search-assist`):
    mainstream Islamic knowledge and returns (a) the **Quran references** that
    support the answer and (b) related **search terms** for the local library.
 2. **Prove (local)** — the app resolves each returned reference against the
-   LOCAL Quran database. Every reference that resolves becomes a tappable
-   "proof" card showing the **real verse text** with a deep link into the
-   reader; anything that doesn't resolve is dropped silently, so a proof card
-   can never show a verse that doesn't exist.
+   LOCAL Quran database. Every reference that resolves surfaces in the results
+   list as a normal result card marked **"Cited"** (teal left edge + solid
+   teal chip), sorted to the top, deep-linking into the reader like any other
+   Qur'an result; anything that doesn't resolve is dropped silently, so a
+   cited card can never show a verse that doesn't exist.
 3. **Enhance (local)** — the AI's terms run through the smart local search
-   (`SearchLibraryUseCase`) and replace the results list, so the list
+   (`SearchLibraryUseCase`) and fill the rest of the same list, so it
    dynamically shows the Quran/Hadith/Dua records the AI judged relevant.
 
+The answer card itself is deliberately slim — badge, confidence chip, the
+answer text and a trust note. Its grounding lives in the **one merged,
+filterable results list** below it: cited verses first, then related results
+(any related result that duplicates a cited verse is dropped). The pinned
+filter scopes the whole merged list, cited cards included.
+
 There is **no "no supporting sources found" dead end**: the answer stands on
-its own, proof cards show whatever resolved, and the related results are always
+its own, cited cards show whatever resolved, and the related results are always
 explorable. When AI is **off**, only local keyword search runs (no network, no
 behaviour change). AI is **off by default** — a user who never opens Search
 Settings sees nothing leave their device.
@@ -44,9 +55,9 @@ sequenceDiagram
     GW-->>W: native response + usage
     W->>W: validate output, drop malformed refs, log usage
     W-->>App: {answer, quranRefs, terms, confidence}
-    App->>Room: resolve quranRefs → real verses (proof cards)
-    App->>Room: run terms through SearchLibraryUseCase (results list)
-    App-->>U: answer + confidence + proof cards + AI-driven results list
+    App->>Room: resolve quranRefs → real verses ("Cited" result cards)
+    App->>Room: run terms through SearchLibraryUseCase (related results)
+    App-->>U: answer + confidence + one merged list (cited first, then related)
 ```
 
 One Worker call per submit; everything else is local. On the `W → GW → Claude`
@@ -74,8 +85,9 @@ The AI Gateway spend limit remains the hard cost backstop against abuse.
 Layers (Android):
 
 ```
-presentation/screens/search/SearchScreen.kt         shared search+ask input bar; bridges AI terms → list
-presentation/screens/search/AskComponents.kt        AI answer card / proof rows / loading / error+retry
+presentation/components/organisms/NimazSearchBar.kt shared bar; optional trailing Ask pill (showAskButton/askEnabled/onAsk; IME action routes to onAsk while live)
+presentation/screens/search/SearchScreen.kt         pinned bar+filter; merges cited proofs + related results into ONE list (dedup, "Cited" cards)
+presentation/screens/search/AskComponents.kt        answer card (no proof list) / loading / error / AI-off discovery card
 presentation/screens/settings/SearchSettingsScreen  consent + toggles + privacy
 presentation/viewmodel/AskViewModel                 ask state machine (exposes relatedTerms)
 presentation/viewmodel/SearchViewModel              results list (+ ApplyAiTerms event)


### PR DESCRIPTION
New opt-in params on the shared component — showAskButton, askEnabled,
onAsk — all defaulted so existing callers are untouched. When the caller
opts in, the feature is enabled and the query is non-blank, a filled teal
pill (sparkle + "Ask") renders after the clear button, and the IME
search action routes to onAsk instead of onSearch. Clear keeps working
independently of Ask.

Covered by new NimazSearchBarTest cases: hidden when disabled or blank,
shown + invokes onAsk when live, clear works alongside, and IME action
routing in both directions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JHv9mQqzkC1XezcHmUAJos