### PR TITLE
feat(ai): cite hadith as proof alongside Quran in Ask with Proof

### DIFF
--- a/.github/workflows/worker_deploy.yml
+++ b/.github/workflows/worker_deploy.yml
@@ -99,8 +99,9 @@ jobs:
       # Sends the same question twice through the real AI-binding → gateway →
       # Anthropic (Unified Billing) path and verifies the two Anthropic-native
       # features the capability depends on:
-      #   - forced tool use: a valid {answer, quranRefs, terms, confidence}
-      #     body means the submit_result tool_use block survived the gateway;
+      #   - forced tool use: a valid {answer, quranRefs, hadithRefs, terms,
+      #     confidence} body means the submit_result tool_use block survived
+      #     the gateway;
       #   - prompt caching: reported from the x-nimaz-usage header. NOTE this
       #     is informational, not an assertion — Haiku 4.5's minimum cacheable
       #     prefix is 4096 tokens and this capability's system prompt + tool
@@ -126,6 +127,7 @@ jobs:
             # Forced tool use survived → strict output contract holds.
             jq -e '.answer | length > 0' "resp$i.json" > /dev/null
             jq -e '.quranRefs | type == "array"' "resp$i.json" > /dev/null
+            jq -e '.hadithRefs | type == "array"' "resp$i.json" > /dev/null
             jq -e '.terms | length > 0' "resp$i.json" > /dev/null
             jq -e '.confidence | IN("high","medium","low")' "resp$i.json" > /dev/null
             echo "usage: $(grep -i '^x-nimaz-usage:' "headers$i.txt" || echo '<missing>')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ When adding a feature, copy an existing one that follows the patterns — good r
 > `domain/usecase/ai/AskWithProofUseCase`, `domain/usecase/SearchLibraryUseCase` (smart local
 > search, also the non-AI path), `core/di/AiModule`, the `Ask*`/`SearchSettings*`
 > ViewModels/screens, and `Route.SearchSettings`. One Worker call per question (only the question
-> text leaves the device); cited Quran refs are resolved locally into proof cards. It is **off by
-> default**. See `docs/ai-ask-with-proof.md`.
+> text leaves the device); cited Quran and Hadith refs are resolved locally into proof cards. It
+> is **off by default**. See `docs/ai-ask-with-proof.md`.
 
 > Naming: the app is **Nimaz** and the package is **`com.arshadshah.nimaz`**. The older
 > `docs/nimaz-pro-*.md` files are historical design/planning artifacts (they say "Nimaz Pro" /

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -602,6 +602,7 @@ object UseCaseModule {
             getHadithsByChapter = GetHadithsByChapterUseCase(repository),
             getHadithById = GetHadithByIdUseCase(repository),
             getHadithByNumber = GetHadithByNumberUseCase(repository),
+            getHadithByReference = GetHadithByReferenceUseCase(repository),
             getHadithsByGrade = GetHadithsByGradeUseCase(repository),
             getHadithOfTheDay = GetHadithOfTheDayUseCase(repository),
             searchHadiths = SearchHadithsUseCase(repository),

--- a/app/src/main/java/com/arshadshah/nimaz/data/ai/dto/AiDtos.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/ai/dto/AiDtos.kt
@@ -28,6 +28,9 @@ data class AssistInput(
 data class AssistOutput(
     val answer: String,
     val quranRefs: List<String>,
+    // Defaulted so a response from an older Worker (no hadith support yet)
+    // still deserializes.
+    val hadithRefs: List<String> = emptyList(),
     val terms: List<String>,
     val confidence: String,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/HadithDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/HadithDao.kt
@@ -42,6 +42,9 @@ interface HadithDao {
     @Query("SELECT * FROM hadiths WHERE book_id = :bookId AND number_in_book = :hadithNumber")
     suspend fun getHadithByNumber(bookId: Int, hadithNumber: Int): HadithEntity?
 
+    @Query("SELECT * FROM hadiths WHERE reference = :reference LIMIT 1")
+    suspend fun getHadithByReference(reference: String): HadithEntity?
+
     @Query("SELECT * FROM hadiths WHERE text_english LIKE '%' || :query || '%' OR text_arabic LIKE '%' || :query || '%'")
     fun searchHadiths(query: String): Flow<List<HadithEntity>>
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AiRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AiRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.arshadshah.nimaz.data.ai.dto.InvokeRequest
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
 import com.arshadshah.nimaz.domain.model.CitationId
+import com.arshadshah.nimaz.domain.model.HadithRef
 import com.arshadshah.nimaz.domain.model.SearchAssist
 import com.arshadshah.nimaz.domain.repository.AiRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
@@ -79,6 +80,8 @@ class AiRepositoryImpl @Inject constructor(
             quranRefs = quranRefs.mapNotNull {
                 CitationId.parse("quran:${it.trim()}") as? CitationId.Quran
             }.distinct(),
+            // Same strictness for "bukhari:6018"-style hadith refs.
+            hadithRefs = hadithRefs.mapNotNull(HadithRef::parse).distinct(),
             terms = terms.map { it.trim() }.filter { it.isNotBlank() }.distinct(),
             confidence = when (confidence.lowercase()) {
                 "high" -> AnswerConfidence.HIGH

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
@@ -128,6 +128,10 @@ class HadithRepositoryImpl @Inject constructor(
             ?.toDomain()
     }
 
+    override suspend fun getHadithByReference(reference: String): Hadith? {
+        return hadithDao.getHadithByReference(reference)?.toDomain()
+    }
+
     override fun getHadithsByGrade(grade: HadithGrade): Flow<List<Hadith>> {
         val gradeString = when (grade) {
             HadithGrade.SAHIH -> "sahih"

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
@@ -12,16 +12,43 @@ enum class ProofSource {
 enum class AnswerConfidence { HIGH, MEDIUM, LOW }
 
 /**
+ * A hadith reference as cited by the model — `collection:number`, where
+ * `collection` is the lowercase slug of one of the six canonical collections
+ * the app ships (bukhari, muslim, abudawud, tirmidhi, nasai, ibnmajah) and
+ * `number` is the hadith's standard reference number in that collection. The
+ * combined form matches the `reference` value stored on local hadith records,
+ * so a ref resolves with a single local lookup; anything that doesn't resolve
+ * is dropped silently, exactly like an unresolvable Quran ref.
+ */
+data class HadithRef(val collection: String, val number: Int) {
+    /** The exact `reference` value stored on local hadith records. */
+    val reference: String get() = "$collection:$number"
+
+    companion object {
+        private val FORMAT = Regex("^([a-z]+):([1-9]\\d{0,4})$")
+
+        /** Strict like [CitationId.parse]: malformed refs return null. */
+        fun parse(raw: String): HadithRef? {
+            val match = FORMAT.matchEntire(raw.trim().lowercase()) ?: return null
+            val number = match.groupValues[2].toIntOrNull() ?: return null
+            return HadithRef(match.groupValues[1], number)
+        }
+    }
+}
+
+/**
  * The result of the single `search-assist` Worker call: the model's answer to
- * the question, the Quran references it cited in support, and search terms for
- * the app's LOCAL library. Nothing in here is shown raw — [quranRefs] are
- * resolved against the local Quran database (unresolvable refs are dropped, so
- * only real verses ever surface as proof), and [terms] drive the local
- * keyword search that builds the related-results list.
+ * the question, the Quran and Hadith references it cited in support, and
+ * search terms for the app's LOCAL library. Nothing in here is shown raw —
+ * [quranRefs] and [hadithRefs] are resolved against the local database
+ * (unresolvable refs are dropped, so only real verses and hadiths ever surface
+ * as proof), and [terms] drive the local keyword search that builds the
+ * related-results list.
  */
 data class SearchAssist(
     val answer: String,
     val quranRefs: List<CitationId.Quran>,
+    val hadithRefs: List<HadithRef>,
     val terms: List<String>,
     val confidence: AnswerConfidence,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
@@ -26,6 +26,13 @@ interface HadithRepository {
     fun getHadithsByBook(bookId: String): Flow<List<Hadith>>
     suspend fun getHadithById(hadithId: String): Hadith?
     suspend fun getHadithByNumber(bookId: String, hadithNumber: Int): Hadith?
+
+    /**
+     * Looks a hadith up by its canonical `collection:number` reference (e.g.
+     * "bukhari:6018") — the `reference` value stored on every hadith record.
+     * Used to resolve AI-cited hadith references into local proof records.
+     */
+    suspend fun getHadithByReference(reference: String): Hadith?
     fun getHadithsByGrade(grade: HadithGrade): Flow<List<Hadith>>
 
     // Search operations

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
@@ -18,6 +18,7 @@ data class HadithUseCases(
     val getHadithsByChapter: GetHadithsByChapterUseCase,
     val getHadithById: GetHadithByIdUseCase,
     val getHadithByNumber: GetHadithByNumberUseCase,
+    val getHadithByReference: GetHadithByReferenceUseCase,
     val getHadithsByGrade: GetHadithsByGradeUseCase,
     val getHadithOfTheDay: GetHadithOfTheDayUseCase,
     val searchHadiths: SearchHadithsUseCase,
@@ -58,6 +59,12 @@ class GetHadithByIdUseCase @Inject constructor(private val repository: HadithRep
 class GetHadithByNumberUseCase @Inject constructor(private val repository: HadithRepository) {
     suspend operator fun invoke(bookId: String, hadithNumber: Int): Hadith? =
         repository.getHadithByNumber(bookId, hadithNumber)
+}
+
+/** Canonical `collection:number` lookup — resolves AI-cited hadith references. */
+class GetHadithByReferenceUseCase @Inject constructor(private val repository: HadithRepository) {
+    suspend operator fun invoke(reference: String): Hadith? =
+        repository.getHadithByReference(reference)
 }
 
 class GetHadithsByGradeUseCase @Inject constructor(private val repository: HadithRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
@@ -4,10 +4,12 @@ import com.arshadshah.nimaz.core.navigation.Route
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
 import com.arshadshah.nimaz.domain.model.CitationId
+import com.arshadshah.nimaz.domain.model.HadithRef
 import com.arshadshah.nimaz.domain.model.Proof
 import com.arshadshah.nimaz.domain.model.ProofSource
 import com.arshadshah.nimaz.domain.repository.AiRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -16,12 +18,15 @@ import javax.inject.Inject
  * Orchestrates the "Ask with Proof" flow — one AI call, everything else local:
  *
  *  1. `search-assist` — send ONLY the question to the Worker. The model answers
- *     from mainstream Islamic knowledge and returns the Quran references that
- *     support the answer plus search terms for the local library.
- *  2. Resolve each returned reference against the LOCAL Quran database. Every
- *     reference that resolves becomes a [Proof] with the real verse text and a
- *     type-safe deep link; anything that doesn't resolve is dropped silently —
- *     so the proof cards can never show a verse that doesn't exist.
+ *     from mainstream Islamic knowledge and returns the Quran and Hadith
+ *     references that support the answer plus search terms for the local
+ *     library.
+ *  2. Resolve each returned reference against the LOCAL database (Quran refs
+ *     against the Quran tables, hadith refs against the hadiths table via
+ *     their canonical `collection:number` reference). Every reference that
+ *     resolves becomes a [Proof] with the real local text and a type-safe deep
+ *     link; anything that doesn't resolve is dropped silently — so the proof
+ *     cards can never show a verse or hadith that doesn't exist.
  *  3. Hand the model's [Outcome.Answered.relatedTerms] back to the caller so the
  *     Search screen can drive its results list from them (related Quran/Hadith/
  *     Dua records found in the local DB — no extra AI call).
@@ -33,12 +38,13 @@ import javax.inject.Inject
 class AskWithProofUseCase @Inject constructor(
     private val aiRepository: AiRepository,
     private val quranUseCases: QuranUseCases,
+    private val hadithUseCases: HadithUseCases,
 ) {
     sealed interface Outcome {
         data class Answered(
             val answer: String,
             val confidence: AnswerConfidence,
-            /** AI-cited Quran references resolved to real local records. */
+            /** AI-cited Quran/Hadith references resolved to real local records. */
             val proofs: List<Proof>,
             /** Search terms for the local library — feeds the results list. */
             val relatedTerms: List<String>,
@@ -53,14 +59,17 @@ class AskWithProofUseCase @Inject constructor(
             return Outcome.Failed(error)
         }
 
-        val proofs = assist.quranRefs
+        val quranProofs = assist.quranRefs
             .mapNotNull { ref -> resolve(ref) }
             .take(MAX_PROOFS)
+        val hadithProofs = assist.hadithRefs
+            .mapNotNull { ref -> resolve(ref) }
+            .take(MAX_HADITH_PROOFS)
 
         return Outcome.Answered(
             answer = assist.answer,
             confidence = assist.confidence,
-            proofs = proofs,
+            proofs = quranProofs + hadithProofs,
             relatedTerms = assist.terms,
         )
     }
@@ -80,7 +89,25 @@ class AskWithProofUseCase @Inject constructor(
         )
     }
 
+    /** Resolve an AI-cited hadith reference to the real local record, or null. */
+    private suspend fun resolve(ref: HadithRef): Proof? {
+        val hadith = hadithUseCases.getHadithByReference(ref.reference) ?: return null
+        val bookName = hadithUseCases.getBookById(hadith.bookId)?.nameEnglish
+        val text = hadith.textEnglish.takeIf { it.isNotBlank() } ?: hadith.textArabic
+        return Proof(
+            // The proof carries the local hadith id (hadith:{id}) — the same
+            // citation key the results list derives for its hadith rows, so a
+            // cited hadith dedupes against the related results like a verse.
+            citationId = CitationId.Hadith(hadith.id).raw,
+            source = ProofSource.HADITH,
+            displayText = text,
+            meta = "${bookName ?: "Hadith"} • Hadith ${hadith.hadithNumberInBook}",
+            route = Route.HadithReader(hadith.id),
+        )
+    }
+
     companion object {
         const val MAX_PROOFS = 8
+        const val MAX_HADITH_PROOFS = 6
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1286,10 +1286,10 @@
     <string name="dismiss">Schließen</string>
     <string name="ai_answers">KI-Antworten</string>
     <string name="ai_answers_enable">KI-Antworten aktivieren</string>
-    <string name="ai_answers_enable_subtitle">Stelle eine Frage und erhalte eine Antwort mit Versen aus deiner Bibliothek als Beleg</string>
+    <string name="ai_answers_enable_subtitle">Stelle eine Frage und erhalte eine Antwort mit Versen und Hadithen aus deiner Bibliothek als Beleg</string>
     <string name="ai_privacy">Datenschutz</string>
     <string name="ai_what_gets_shared">Was geteilt wird</string>
-    <string name="ai_disclosure_full">Wenn du eine Frage stellst, wird nur der Fragetext über eine verschlüsselte Verbindung an den Nimaz-Server (gehostet auf Cloudflare) und an die Claude-API von Anthropic gesendet, um die Antwort zu erzeugen. Nichts anderes verlässt dein Gerät — die zitierten Verse und Suchergebnisse werden in der Bibliothek auf deinem Telefon nachgeschlagen. Deine Fragen werden niemals für Analysen verwendet. KI-Antworten können falsch sein — überprüfe sie stets anhand der zitierten Quellen. Dies ist kein religiöses Rechtsgutachten (Fatwa).</string>
+    <string name="ai_disclosure_full">Wenn du eine Frage stellst, wird nur der Fragetext über eine verschlüsselte Verbindung an den Nimaz-Server (gehostet auf Cloudflare) und an die Claude-API von Anthropic gesendet, um die Antwort zu erzeugen. Nichts anderes verlässt dein Gerät — die zitierten Verse, Hadithe und Suchergebnisse werden in der Bibliothek auf deinem Telefon nachgeschlagen. Deine Fragen werden niemals für Analysen verwendet. KI-Antworten können falsch sein — überprüfe sie stets anhand der zitierten Quellen. Dies ist kein religiöses Rechtsgutachten (Fatwa).</string>
     <string name="ai_history">Verlauf der KI-Fragen</string>
     <string name="ai_history_subtitle">Aktuelle KI-Fragen auf diesem Gerät behalten. Wenn deaktiviert, werden sie nur im Speicher gehalten.</string>
     <string name="ai_clear_history">KI-Verlauf löschen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1287,10 +1287,10 @@
     <string name="dismiss">Ignorer</string>
     <string name="ai_answers">Réponses de l\'IA</string>
     <string name="ai_answers_enable">Activer les réponses de l\'IA</string>
-    <string name="ai_answers_enable_subtitle">Posez une question et obtenez une réponse avec des versets de votre bibliothèque comme preuve</string>
+    <string name="ai_answers_enable_subtitle">Posez une question et obtenez une réponse avec des versets et des hadiths de votre bibliothèque comme preuve</string>
     <string name="ai_privacy">Confidentialité</string>
     <string name="ai_what_gets_shared">Ce qui est partagé</string>
-    <string name="ai_disclosure_full">Lorsque vous posez une question, seul le texte de la question est envoyé via une connexion chiffrée au serveur Nimaz (hébergé sur Cloudflare) et à l\'API Claude d\'Anthropic pour générer la réponse. Rien d\'autre ne quitte votre appareil — les versets cités et les résultats de recherche sont consultés dans la bibliothèque de votre téléphone. Vos questions ne sont jamais utilisées à des fins d\'analyse. Les réponses de l\'IA peuvent être erronées — vérifiez-les toujours avec les sources citées. Ceci n\'est pas un avis religieux (fatwa).</string>
+    <string name="ai_disclosure_full">Lorsque vous posez une question, seul le texte de la question est envoyé via une connexion chiffrée au serveur Nimaz (hébergé sur Cloudflare) et à l\'API Claude d\'Anthropic pour générer la réponse. Rien d\'autre ne quitte votre appareil — les versets et hadiths cités ainsi que les résultats de recherche sont consultés dans la bibliothèque de votre téléphone. Vos questions ne sont jamais utilisées à des fins d\'analyse. Les réponses de l\'IA peuvent être erronées — vérifiez-les toujours avec les sources citées. Ceci n\'est pas un avis religieux (fatwa).</string>
     <string name="ai_history">Historique des questions à l\'IA</string>
     <string name="ai_history_subtitle">Conserver les questions récentes à l\'IA sur cet appareil. Une fois désactivé, elles ne sont conservées qu\'en mémoire.</string>
     <string name="ai_clear_history">Effacer l\'historique de l\'IA</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1287,10 +1287,10 @@
     <string name="dismiss">Tutup</string>
     <string name="ai_answers">Jawaban AI</string>
     <string name="ai_answers_enable">Aktifkan jawaban AI</string>
-    <string name="ai_answers_enable_subtitle">Ajukan pertanyaan dan dapatkan jawaban dengan ayat dari pustaka Anda sebagai bukti</string>
+    <string name="ai_answers_enable_subtitle">Ajukan pertanyaan dan dapatkan jawaban dengan ayat dan hadis dari pustaka Anda sebagai bukti</string>
     <string name="ai_privacy">Privasi</string>
     <string name="ai_what_gets_shared">Apa yang dibagikan</string>
-    <string name="ai_disclosure_full">Saat Anda mengajukan pertanyaan, hanya teks pertanyaan yang dikirim melalui koneksi terenkripsi ke server Nimaz (dihosting di Cloudflare) dan ke API Claude milik Anthropic untuk menghasilkan jawaban. Tidak ada hal lain yang meninggalkan perangkat Anda — ayat yang dikutip dan hasil pencarian dicari di pustaka pada ponsel Anda. Pertanyaan Anda tidak pernah digunakan untuk analitik. Jawaban AI bisa salah — selalu verifikasi dengan sumber yang dikutip. Ini bukan fatwa.</string>
+    <string name="ai_disclosure_full">Saat Anda mengajukan pertanyaan, hanya teks pertanyaan yang dikirim melalui koneksi terenkripsi ke server Nimaz (dihosting di Cloudflare) dan ke API Claude milik Anthropic untuk menghasilkan jawaban. Tidak ada hal lain yang meninggalkan perangkat Anda — ayat dan hadis yang dikutip serta hasil pencarian dicari di pustaka pada ponsel Anda. Pertanyaan Anda tidak pernah digunakan untuk analitik. Jawaban AI bisa salah — selalu verifikasi dengan sumber yang dikutip. Ini bukan fatwa.</string>
     <string name="ai_history">Riwayat pertanyaan AI</string>
     <string name="ai_history_subtitle">Simpan pertanyaan AI terbaru di perangkat ini. Saat dimatikan, pertanyaan hanya disimpan di memori.</string>
     <string name="ai_clear_history">Hapus riwayat AI</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1288,10 +1288,10 @@
     <string name="dismiss">Tutup</string>
     <string name="ai_answers">Jawapan AI</string>
     <string name="ai_answers_enable">Dayakan jawapan AI</string>
-    <string name="ai_answers_enable_subtitle">Ajukan soalan dan dapatkan jawapan dengan ayat daripada pustaka anda sebagai bukti</string>
+    <string name="ai_answers_enable_subtitle">Ajukan soalan dan dapatkan jawapan dengan ayat dan hadis daripada pustaka anda sebagai bukti</string>
     <string name="ai_privacy">Privasi</string>
     <string name="ai_what_gets_shared">Apa yang dikongsi</string>
-    <string name="ai_disclosure_full">Apabila anda bertanya, hanya teks soalan dihantar melalui sambungan tersulit ke pelayan Nimaz (dihoskan di Cloudflare) dan ke API Claude milik Anthropic untuk menjana jawapan. Tiada apa-apa lagi meninggalkan peranti anda — ayat yang dipetik dan hasil carian dicari dalam pustaka pada telefon anda. Soalan anda tidak pernah digunakan untuk analitik. Jawapan AI boleh salah — sentiasa sahkan dengan sumber yang dipetik. Ini bukan fatwa.</string>
+    <string name="ai_disclosure_full">Apabila anda bertanya, hanya teks soalan dihantar melalui sambungan tersulit ke pelayan Nimaz (dihoskan di Cloudflare) dan ke API Claude milik Anthropic untuk menjana jawapan. Tiada apa-apa lagi meninggalkan peranti anda — ayat dan hadis yang dipetik serta hasil carian dicari dalam pustaka pada telefon anda. Soalan anda tidak pernah digunakan untuk analitik. Jawapan AI boleh salah — sentiasa sahkan dengan sumber yang dipetik. Ini bukan fatwa.</string>
     <string name="ai_history">Sejarah soalan AI</string>
     <string name="ai_history_subtitle">Simpan soalan AI terkini pada peranti ini. Apabila dimatikan, ia disimpan dalam ingatan sahaja.</string>
     <string name="ai_clear_history">Kosongkan sejarah AI</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1290,10 +1290,10 @@
     <string name="dismiss">Kapat</string>
     <string name="ai_answers">Yapay zekâ yanıtları</string>
     <string name="ai_answers_enable">Yapay zekâ yanıtlarını etkinleştir</string>
-    <string name="ai_answers_enable_subtitle">Bir soru sorun, kitaplığınızdaki ayetlerle kanıtlanmış bir yanıt alın</string>
+    <string name="ai_answers_enable_subtitle">Bir soru sorun, kitaplığınızdaki ayet ve hadislerle kanıtlanmış bir yanıt alın</string>
     <string name="ai_privacy">Gizlilik</string>
     <string name="ai_what_gets_shared">Neler paylaşılır</string>
-    <string name="ai_disclosure_full">Bir soru sorduğunuzda, yalnızca soru metni şifreli bir bağlantı üzerinden Nimaz sunucusuna (Cloudflare üzerinde barındırılır) ve yanıtı oluşturmak için Anthropic\'in Claude API\'sine gönderilir. Başka hiçbir şey cihazınızdan ayrılmaz — alıntılanan ayetler ve arama sonuçları telefonunuzdaki kitaplıkta aranır. Sorularınız asla analiz için kullanılmaz. Yapay zekâ yanıtları hatalı olabilir — her zaman alıntılanan kaynaklarla doğrulayın. Bu bir fetva değildir.</string>
+    <string name="ai_disclosure_full">Bir soru sorduğunuzda, yalnızca soru metni şifreli bir bağlantı üzerinden Nimaz sunucusuna (Cloudflare üzerinde barındırılır) ve yanıtı oluşturmak için Anthropic\'in Claude API\'sine gönderilir. Başka hiçbir şey cihazınızdan ayrılmaz — alıntılanan ayetler, hadisler ve arama sonuçları telefonunuzdaki kitaplıkta aranır. Sorularınız asla analiz için kullanılmaz. Yapay zekâ yanıtları hatalı olabilir — her zaman alıntılanan kaynaklarla doğrulayın. Bu bir fetva değildir.</string>
     <string name="ai_history">Yapay zekâ soru geçmişi</string>
     <string name="ai_history_subtitle">Son yapay zekâ sorularını bu cihazda tutun. Kapalıyken yalnızca bellekte tutulur.</string>
     <string name="ai_clear_history">Yapay zekâ geçmişini temizle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1456,10 +1456,10 @@
     <string name="dismiss">Dismiss</string>
     <string name="ai_answers">AI answers</string>
     <string name="ai_answers_enable">Enable AI answers</string>
-    <string name="ai_answers_enable_subtitle">Ask a question and get an answer with verses from your library as proof</string>
+    <string name="ai_answers_enable_subtitle">Ask a question and get an answer with verses and hadiths from your library as proof</string>
     <string name="ai_privacy">Privacy</string>
     <string name="ai_what_gets_shared">What gets shared</string>
-    <string name="ai_disclosure_full">When you ask a question, only the question text is sent over an encrypted connection to the Nimaz server (hosted on Cloudflare) and to Anthropic\'s Claude API to generate the answer. Nothing else leaves your device — the cited verses and search results are looked up in the library on your phone. Your questions are never used for analytics. AI answers can be wrong — always verify them against the cited sources. This is not a religious ruling (fatwa).</string>
+    <string name="ai_disclosure_full">When you ask a question, only the question text is sent over an encrypted connection to the Nimaz server (hosted on Cloudflare) and to Anthropic\'s Claude API to generate the answer. Nothing else leaves your device — the cited verses, hadiths and search results are looked up in the library on your phone. Your questions are never used for analytics. AI answers can be wrong — always verify them against the cited sources. This is not a religious ruling (fatwa).</string>
     <string name="ai_history">AI question history</string>
     <string name="ai_history_subtitle">Keep recent AI questions on this device. When off, they are kept only in memory.</string>
     <string name="ai_clear_history">Clear AI history</string>
@@ -1474,10 +1474,10 @@
     <string name="ai_confidence_high">High confidence</string>
     <string name="ai_confidence_medium">Medium confidence</string>
     <string name="ai_confidence_low">Low confidence</string>
-    <string name="ai_trust_note">AI-generated summary — check it against the cited verses below. It describes what the sources say and isn\'t a fatwa.</string>
-    <string name="ai_discover_title">Get answers, backed by verses</string>
-    <string name="ai_discover_body">Ask a question in plain words and get a short answer supported by verses from your own library — every citation is a real ayah you can open and read.</string>
-    <string name="ai_discover_privacy">Only your question is sent. The verses and results are matched on your device, and questions are never used for analytics.</string>
+    <string name="ai_trust_note">AI-generated summary — check it against the cited sources below. It describes what the sources say and isn\'t a fatwa.</string>
+    <string name="ai_discover_title">Get answers, backed by your library</string>
+    <string name="ai_discover_body">Ask a question in plain words and get a short answer supported by verses and hadiths from your own library — every citation is a real source you can open and read.</string>
+    <string name="ai_discover_privacy">Only your question is sent. The cited sources and results are matched on your device, and questions are never used for analytics.</string>
     <string name="ai_discover_enable">Turn on AI answers</string>
     <string name="ai_discover_dismiss">Not now</string>
     <string name="ai_try_again">Try again</string>

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/AiRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/AiRepositoryImplTest.kt
@@ -50,6 +50,7 @@ class AiRepositoryImplTest {
         val body = """
             {"answer":" Patience is virtuous. ",
              "quranRefs":["2:153","garbage","39:10","2:153"],
+             "hadithRefs":["bukhari:6018","Muslim:2999","not-a-ref","bukhari:6018","bukhari:0"],
              "terms":["patience"," sabr ","","patience"],
              "confidence":"medium"}
         """.trimIndent()
@@ -63,7 +64,23 @@ class AiRepositoryImplTest {
         // Malformed refs and blank/duplicate terms are dropped.
         assertThat(assist.quranRefs.map { it.raw })
             .containsExactly("quran:2:153", "quran:39:10")
+        assertThat(assist.hadithRefs.map { it.reference })
+            .containsExactly("bukhari:6018", "muslim:2999")
         assertThat(assist.terms).containsExactly("patience", "sabr")
+    }
+
+    @Test
+    fun `a response without hadithRefs (older Worker) still parses`() = runTest {
+        val body = """
+            {"answer":"Patience is virtuous.",
+             "quranRefs":["2:153"],
+             "terms":["patience"],
+             "confidence":"high"}
+        """.trimIndent()
+        val result = repo { respond(body, HttpStatusCode.OK, jsonHeaders()) }
+            .assist("q?")
+
+        assertThat(result.getOrThrow().hadithRefs).isEmpty()
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/HadithRefTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/HadithRefTest.kt
@@ -1,0 +1,32 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class HadithRefTest {
+
+    @Test
+    fun `parses a canonical collection ref and round-trips the reference`() {
+        val parsed = HadithRef.parse("bukhari:6018")
+        assertThat(parsed).isEqualTo(HadithRef("bukhari", 6018))
+        assertThat(parsed!!.reference).isEqualTo("bukhari:6018")
+    }
+
+    @Test
+    fun `normalizes case and whitespace`() {
+        assertThat(HadithRef.parse("  Muslim:2564 ")).isEqualTo(HadithRef("muslim", 2564))
+    }
+
+    @Test
+    fun `malformed refs return null`() {
+        assertThat(HadithRef.parse("")).isNull()
+        assertThat(HadithRef.parse("bukhari")).isNull()
+        assertThat(HadithRef.parse("bukhari:")).isNull()
+        assertThat(HadithRef.parse(":6018")).isNull()
+        assertThat(HadithRef.parse("bukhari:0")).isNull()
+        assertThat(HadithRef.parse("bukhari:-1")).isNull()
+        assertThat(HadithRef.parse("bukhari:12:34")).isNull()
+        assertThat(HadithRef.parse("bukhari:abc")).isNull()
+        assertThat(HadithRef.parse("2:153")).isNull() // a Quran ref is not a hadith ref
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
@@ -5,13 +5,20 @@ import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.CitationId
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithBook
+import com.arshadshah.nimaz.domain.model.HadithRef
+import com.arshadshah.nimaz.domain.model.ProofSource
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.SearchAssist
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.repository.AiRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
 import com.arshadshah.nimaz.domain.usecase.GetAyahsBySurahUseCase
+import com.arshadshah.nimaz.domain.usecase.GetBookByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.GetHadithByReferenceUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahByNumberUseCase
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
@@ -28,6 +35,9 @@ class AskWithProofUseCaseTest {
     private val getAyahsBySurahUC = mockk<GetAyahsBySurahUseCase>()
     private val getSurahByNumberUC = mockk<GetSurahByNumberUseCase>()
     private val quranUseCases = mockk<QuranUseCases>()
+    private val getHadithByReferenceUC = mockk<GetHadithByReferenceUseCase>()
+    private val getBookByIdUC = mockk<GetBookByIdUseCase>()
+    private val hadithUseCases = mockk<HadithUseCases>()
 
     private lateinit var useCase: AskWithProofUseCase
 
@@ -35,7 +45,9 @@ class AskWithProofUseCaseTest {
     fun setUp() {
         every { quranUseCases.getAyahsBySurah } returns getAyahsBySurahUC
         every { quranUseCases.getSurahByNumber } returns getSurahByNumberUC
-        useCase = AskWithProofUseCase(aiRepository, quranUseCases)
+        every { hadithUseCases.getHadithByReference } returns getHadithByReferenceUC
+        every { hadithUseCases.getBookById } returns getBookByIdUC
+        useCase = AskWithProofUseCase(aiRepository, quranUseCases, hadithUseCases)
     }
 
     @Test
@@ -86,6 +98,55 @@ class AskWithProofUseCaseTest {
     }
 
     @Test
+    fun `cited hadith refs resolve to real local records after the quran proofs`() = runTest {
+        coEvery { aiRepository.assist(any()) } returns Result.success(
+            assist(
+                refs = listOf(CitationId.Quran(2, 153)),
+                hadithRefs = listOf(HadithRef("bukhari", 6018)),
+            ),
+        )
+        every { getAyahsBySurahUC.invoke(2) } returns flowOf(listOf(ayah(2, 153)))
+        coEvery { getSurahByNumberUC.invoke(2) } returns surah(2)
+        coEvery { getHadithByReferenceUC.invoke("bukhari:6018") } returns
+            hadith(id = "6041", numberInBook = 6018)
+        coEvery { getBookByIdUC.invoke("1") } returns book()
+
+        val outcome = useCase("q?") as AskWithProofUseCase.Outcome.Answered
+
+        // Quran proofs first, then hadith proofs — the proof carries the LOCAL
+        // hadith id so the results list can dedupe it, plus a reader deep link.
+        assertThat(outcome.proofs.map { it.citationId })
+            .containsExactly("quran:2:153", "hadith:6041")
+            .inOrder()
+        val hadithProof = outcome.proofs.last()
+        assertThat(hadithProof.source).isEqualTo(ProofSource.HADITH)
+        assertThat(hadithProof.displayText).isEqualTo("Actions are judged by intentions.")
+        assertThat(hadithProof.meta).isEqualTo("Sahih al-Bukhari • Hadith 6018")
+        assertThat(hadithProof.route).isEqualTo(Route.HadithReader("6041"))
+    }
+
+    @Test
+    fun `hadith refs that do not resolve locally are dropped silently`() = runTest {
+        coEvery { aiRepository.assist(any()) } returns Result.success(
+            assist(
+                refs = emptyList(),
+                hadithRefs = listOf(
+                    HadithRef("bukhari", 6018), // resolves
+                    HadithRef("muslim", 99999), // no such row -> dropped
+                ),
+            ),
+        )
+        coEvery { getHadithByReferenceUC.invoke("bukhari:6018") } returns
+            hadith(id = "6041", numberInBook = 6018)
+        coEvery { getHadithByReferenceUC.invoke("muslim:99999") } returns null
+        coEvery { getBookByIdUC.invoke("1") } returns book()
+
+        val outcome = useCase("q?") as AskWithProofUseCase.Outcome.Answered
+
+        assertThat(outcome.proofs.map { it.citationId }).containsExactly("hadith:6041")
+    }
+
+    @Test
     fun `an answer with no citations is still an answer, never a dead end`() = runTest {
         coEvery { aiRepository.assist(any()) } returns Result.success(
             assist(refs = emptyList(), terms = listOf("charity")),
@@ -121,28 +182,66 @@ class AskWithProofUseCaseTest {
     }
 
     @Test
-    fun `proofs are capped at MAX_PROOFS`() = runTest {
+    fun `proofs are capped at MAX_PROOFS per source`() = runTest {
         val refs = (1..12).map { CitationId.Quran(2, it) }
-        coEvery { aiRepository.assist(any()) } returns Result.success(assist(refs = refs))
+        val hadithRefs = (1..9).map { HadithRef("bukhari", it) }
+        coEvery { aiRepository.assist(any()) } returns
+            Result.success(assist(refs = refs, hadithRefs = hadithRefs))
         every { getAyahsBySurahUC.invoke(2) } returns
             flowOf((1..12).map { ayah(2, it) })
         coEvery { getSurahByNumberUC.invoke(2) } returns surah(2)
+        coEvery { getHadithByReferenceUC.invoke(any()) } answers {
+            val number = firstArg<String>().substringAfter(':').toInt()
+            hadith(id = number.toString(), numberInBook = number)
+        }
+        coEvery { getBookByIdUC.invoke("1") } returns book()
 
         val outcome = useCase("q?") as AskWithProofUseCase.Outcome.Answered
 
-        assertThat(outcome.proofs).hasSize(AskWithProofUseCase.MAX_PROOFS)
+        assertThat(outcome.proofs).hasSize(
+            AskWithProofUseCase.MAX_PROOFS + AskWithProofUseCase.MAX_HADITH_PROOFS,
+        )
     }
 
     // ── model builders ────────────────────────────────────────────────────────
 
     private fun assist(
         refs: List<CitationId.Quran>,
+        hadithRefs: List<HadithRef> = emptyList(),
         terms: List<String> = listOf("patience"),
     ) = SearchAssist(
         answer = "Patience is encouraged.",
         quranRefs = refs,
+        hadithRefs = hadithRefs,
         terms = terms,
         confidence = AnswerConfidence.HIGH,
+    )
+
+    private fun hadith(id: String, numberInBook: Int, bookId: String = "1") = Hadith(
+        id = id,
+        bookId = bookId,
+        chapterId = "1_0",
+        hadithNumber = 1,
+        hadithNumberInBook = numberInBook,
+        textArabic = "arabic",
+        textEnglish = "Actions are judged by intentions.",
+        narratorChain = null,
+        narratorName = "Umar ibn al-Khattab",
+        grade = null,
+        gradeArabic = null,
+        reference = "bukhari:$numberInBook",
+    )
+
+    private fun book(id: String = "1", name: String = "Sahih al-Bukhari") = HadithBook(
+        id = id,
+        nameArabic = "صحيح البخاري",
+        nameEnglish = name,
+        authorName = "Imam al-Bukhari",
+        authorArabic = "",
+        totalHadiths = 7563,
+        totalChapters = 97,
+        description = null,
+        displayOrder = 1,
     )
 
     private fun ayah(surah: Int, ayahNumber: Int, translation: String = "Be patient.") = Ayah(

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -11,23 +11,27 @@ bar** and scopes everything below it.
 When AI is enabled, each submit makes **one** Worker call (`search-assist`):
 
 1. **Ask** — the app sends ONLY the question text. Claude answers from
-   mainstream Islamic knowledge and returns (a) the **Quran references** that
-   support the answer and (b) related **search terms** for the local library.
+   mainstream Islamic knowledge and returns (a) the **Quran references** and
+   **Hadith references** that support the answer and (b) related **search
+   terms** for the local library.
 2. **Prove (local)** — the app resolves each returned reference against the
-   LOCAL Quran database. Every reference that resolves surfaces in the results
-   list as a normal result card marked **"Cited"** (teal left edge + solid
-   teal chip), sorted to the top, deep-linking into the reader like any other
-   Qur'an result; anything that doesn't resolve is dropped silently, so a
-   cited card can never show a verse that doesn't exist.
+   LOCAL database: Quran refs against the Quran tables, hadith refs against
+   the six shipped collections (by their canonical `collection:number`
+   reference). Every reference that resolves surfaces in the results list as a
+   normal result card marked **"Cited"** (accent left edge + solid chip),
+   sorted to the top, deep-linking into its reader like any other result;
+   anything that doesn't resolve is dropped silently, so a cited card can
+   never show a verse or hadith that doesn't exist.
 3. **Enhance (local)** — the AI's terms run through the smart local search
    (`SearchLibraryUseCase`) and fill the rest of the same list, so it
    dynamically shows the Quran/Hadith/Dua records the AI judged relevant.
 
 The answer card itself is deliberately slim — badge, confidence chip, the
 answer text and a trust note. Its grounding lives in the **one merged,
-filterable results list** below it: cited verses first, then related results
-(any related result that duplicates a cited verse is dropped). The pinned
-filter scopes the whole merged list, cited cards included.
+filterable results list** below it: cited verses and hadiths first, then
+related results (any related result that duplicates a cited record is
+dropped). The pinned filter scopes the whole merged list, cited cards
+included.
 
 There is **no "no supporting sources found" dead end**: the answer stands on
 its own, cited cards show whatever resolved, and the related results are always
@@ -54,8 +58,8 @@ sequenceDiagram
     C-->>GW: tool_use JSON
     GW-->>W: native response + usage
     W->>W: validate output, drop malformed refs, log usage
-    W-->>App: {answer, quranRefs, terms, confidence}
-    App->>Room: resolve quranRefs → real verses ("Cited" result cards)
+    W-->>App: {answer, quranRefs, hadithRefs, terms, confidence}
+    App->>Room: resolve quranRefs + hadithRefs → real records ("Cited" result cards)
     App->>Room: run terms through SearchLibraryUseCase (related results)
     App-->>U: answer + confidence + one merged list (cited first, then related)
 ```
@@ -94,7 +98,7 @@ presentation/viewmodel/SearchViewModel              results list (+ ApplyAiTerms
 presentation/viewmodel/SearchSettingsViewModel      settings + consent state
 domain/usecase/ai/AskWithProofUseCase               ask → resolve refs → proofs (+ related terms)
 domain/usecase/SearchLibraryUseCase                 smart multi-word local search (also non-AI path)
-domain/model/{AiModels,CitationId,LibrarySearch}    SearchAssist/Proof/AiError/LibrarySearchResults
+domain/model/{AiModels,CitationId,LibrarySearch}    SearchAssist/HadithRef/Proof/AiError/LibrarySearchResults
 domain/repository/AiRepository                      gateway interface (assist)
 data/ai/{AiApiClient,IntegrityTokenProvider,DeviceIdProvider}
 data/ai/dto/AiDtos                                  wire DTOs (mirror the Worker)
@@ -122,14 +126,20 @@ Response (validated against a Zod schema before returning):
 {
   "answer": "≤120 words, descriptive, never a fatwa",
   "quranRefs": ["2:153", "39:10"],
+  "hadithRefs": ["bukhari:6018", "muslim:2564"],
   "terms": ["patience", "sabr", "hardship"],
   "confidence": "high|medium|low"
 }
 ```
 
 `quranRefs` are `surah:ayah` (standard mushaf numbering); the Worker drops
-malformed/impossible refs (surah 1–114) and the app only surfaces refs that
-resolve against its local database. Hadith/Dua use opaque local IDs the model
+malformed/impossible refs (surah 1–114). `hadithRefs` are
+`collection:number`, where collection is one of the six canonical collections
+the app ships — `bukhari`, `muslim`, `abudawud`, `tirmidhi`, `nasai`,
+`ibnmajah` — and number is the hadith's standard reference number in that
+collection (the `reference` value on every local hadith row); the Worker
+drops refs outside those collections. Either way the app only surfaces refs
+that resolve against its local database. Duas use opaque local IDs the model
 can't know, so they are reached only through `terms` in the results list.
 
 Error envelope (HTTP 400/429/502/503):
@@ -150,8 +160,13 @@ Round-trips cleanly so a citation resolves back to a local record and a deep lin
 | hadith | `hadith:{hadithId}`    | `getHadithById`                | `Route.HadithReader(hadithId)`   |
 | dua    | `dua:{duaId}`          | `getDuaById`                   | `Route.DuaReader(duaId)`         |
 
-Unparseable or unresolvable IDs are dropped silently. (The current AI flow
-only produces `quran:` citations; the grammar keeps hadith/dua for future use.)
+Unparseable or unresolvable IDs are dropped silently. The AI flow produces
+`quran:` citations directly and `hadith:` citations indirectly: the model
+cites a hadith as `collection:number` (`domain/model/HadithRef`), the app
+resolves it via the hadiths table's `reference` column, and the resulting
+proof carries the local `hadith:{hadithId}` citation id — the same key the
+results list derives, so cited hadiths dedupe like verses. `dua:` remains
+reserved for future use.
 
 ## Smart local search (`SearchLibraryUseCase`)
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -86,6 +86,7 @@ Success `200`:
 {
   "answer": "The Quran repeatedly encourages patience (sabr)...",
   "quranRefs": ["2:153", "39:10"],
+  "hadithRefs": ["bukhari:1469", "muslim:2999"],
   "terms": ["patience", "sabr", "hardship", "perseverance"],
   "confidence": "high"
 }
@@ -93,6 +94,10 @@ Success `200`:
 
 - `quranRefs`: up to 8 `surah:ayah` references (surah 1–114 enforced; the app
   drops anything that doesn't resolve in its local Quran database).
+- `hadithRefs`: up to 6 `collection:number` references limited to the six
+  collections the app ships (`bukhari`, `muslim`, `abudawud`, `tirmidhi`,
+  `nasai`, `ibnmajah`); the app drops anything that doesn't resolve in its
+  local Hadith database.
 - `terms`: 4–10 short keywords the app runs through its local library search.
 
 Errors use a typed envelope with the matching HTTP status:
@@ -183,9 +188,9 @@ curl -s http://localhost:8787/v1/invoke \
   }' | jq
 ```
 
-Expected: a JSON body with `answer`, `quranRefs` (e.g. `["2:153"]`), `terms`,
-and `confidence`, plus an `x-nimaz-usage` response header with the token
-usage. A valid body proves the forced `submit_result` tool survived the
+Expected: a JSON body with `answer`, `quranRefs` (e.g. `["2:153"]`),
+`hadithRefs` (e.g. `["bukhari:1469"]`), `terms`, and `confidence`, plus an
+`x-nimaz-usage` response header with the token usage. A valid body proves the forced `submit_result` tool survived the
 gateway. Note on caching: `cache_read_input_tokens` in the header is expected
 to be 0 for now — Haiku 4.5 only caches prefixes ≥ 4096 tokens and this
 capability's prompt + tool schema is well below that, so `cache_control` is

--- a/worker/src/capabilities/search-assist.ts
+++ b/worker/src/capabilities/search-assist.ts
@@ -21,13 +21,15 @@ const SYSTEM_PROMPT = `You are the search assistant inside Nimaz, an Islamic com
 
 For each user question you return, via the submit_result tool:
 
-1. answer — a concise answer (120 words or fewer) based on mainstream Islamic knowledge, in the same language as the question. Describe what the Quran and Sunnah say. NEVER issue a personal religious ruling (fatwa) or tell the user what they personally must do; where scholars differ, say so briefly. If the question is not about Islam, the Quran, Hadith, or Islamic practice, politely say you can only help with Islamic topics, and return an empty quranRefs array.
+1. answer — a concise answer (120 words or fewer) based on mainstream Islamic knowledge, in the same language as the question. Describe what the Quran and Sunnah say. NEVER issue a personal religious ruling (fatwa) or tell the user what they personally must do; where scholars differ, say so briefly. If the question is not about Islam, the Quran, Hadith, or Islamic practice, politely say you can only help with Islamic topics, and return empty quranRefs and hadithRefs arrays.
 
 2. quranRefs — up to 8 real Quran ayah references ("surah:ayah", standard mushaf numbering) that directly support your answer, ordered by relevance. The app shows the actual verse text to the user right next to your answer, so cite ONLY references you are certain exist and genuinely support what you said — a wrong citation is immediately visible. When unsure, cite fewer. If none apply, return [].
 
-3. terms — 4 to 10 short English search keywords (single words or 2-word phrases) the app will match against its local library to surface related passages, hadiths, and duas: the key concepts, synonyms, and common Arabic transliterations (e.g. for a question about patience: "patience", "sabr", "hardship", "perseverance", "trial").
+3. hadithRefs — up to 6 real hadith references ("collection:number") that directly support your answer, ordered by relevance. collection MUST be exactly one of: bukhari, muslim, abudawud, tirmidhi, nasai, ibnmajah (the six canonical collections in the app's library); number is the hadith's standard reference number in that collection (sunnah.com numbering, e.g. "bukhari:6018", "muslim:2564"). The app shows the actual hadith text right next to your answer, so cite ONLY hadiths you are certain exist under that exact number and genuinely support what you said. When unsure of the number, leave the hadith out. If none apply, return [].
 
-4. confidence — "high" only when the answer is well-established and directly supported by the cited ayat; "medium" for partial support; "low" when support is indirect or you are unsure.
+4. terms — 4 to 10 short English search keywords (single words or 2-word phrases) the app will match against its local library to surface related passages, hadiths, and duas: the key concepts, synonyms, and common Arabic transliterations (e.g. for a question about patience: "patience", "sabr", "hardship", "perseverance", "trial").
+
+5. confidence — "high" only when the answer is well-established and directly supported by the cited sources; "medium" for partial support; "low" when support is indirect or you are unsure.
 
 You MUST respond by calling the submit_result tool. Do not write any prose outside the tool call.`;
 
@@ -45,6 +47,16 @@ function isPlausibleQuranRef(ref: string): boolean {
   const surah = Number.parseInt(m[1], 10);
   const ayah = Number.parseInt(m[2], 10);
   return surah >= 1 && surah <= 114 && ayah >= 1;
+}
+
+// "collection:number" limited to the six canonical collections the app ships.
+// The number is verified by the app against its local database, so a wrong or
+// out-of-range number simply never resolves into a proof card.
+const HADITH_REF =
+  /^(bukhari|muslim|abudawud|tirmidhi|nasai|ibnmajah):([1-9]\d{0,4})$/;
+
+function isPlausibleHadithRef(ref: string): boolean {
+  return HADITH_REF.test(ref);
 }
 
 export const searchAssist: Capability<SearchAssistInput, SearchAssistOutput> = {
@@ -71,7 +83,7 @@ export const searchAssist: Capability<SearchAssistInput, SearchAssistOutput> = {
         {
           name: "submit_result",
           description:
-            "Submit the answer, the Quran references that support it, related search terms, and a confidence level.",
+            "Submit the answer, the Quran and Hadith references that support it, related search terms, and a confidence level.",
           input_schema: SEARCH_ASSIST_TOOL_JSON_SCHEMA,
         },
       ],
@@ -89,15 +101,18 @@ export const searchAssist: Capability<SearchAssistInput, SearchAssistOutput> = {
       throw new Error("model did not call submit_result");
     }
 
-    // Validate, then defensively drop malformed/impossible Quran refs and
-    // blank terms the model may have produced despite the tool schema.
+    // Validate, then defensively drop malformed/impossible Quran and Hadith
+    // refs and blank terms the model may have produced despite the tool schema.
     const parsed = SearchAssistOutputSchema.parse(toolUse.input);
     const quranRefs = [
       ...new Set(parsed.quranRefs.map((r) => r.trim())),
     ].filter(isPlausibleQuranRef);
+    const hadithRefs = [
+      ...new Set(parsed.hadithRefs.map((r) => r.trim().toLowerCase())),
+    ].filter(isPlausibleHadithRef);
     const terms = [
       ...new Set(parsed.terms.map((t) => t.trim()).filter((t) => t.length > 0)),
     ];
-    return { ...parsed, quranRefs, terms };
+    return { ...parsed, quranRefs, hadithRefs, terms };
   },
 };

--- a/worker/src/capabilities/types.ts
+++ b/worker/src/capabilities/types.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from "zod";
+import type { ZodType, ZodTypeDef } from "zod";
 
 // ── Anthropic Messages API shapes (only the fields we use) ──────────────────
 
@@ -48,7 +48,9 @@ export interface AnthropicResponse {
 export interface Capability<I, O> {
   id: string;
   inputSchema: ZodType<I>;
-  outputSchema: ZodType<O>;
+  // The schema's input type is left open so output schemas may use defaults
+  // (z.default(...)), where the pre-parse shape differs from the parsed O.
+  outputSchema: ZodType<O, ZodTypeDef, unknown>;
   model: string;
   maxOutputTokens: number;
   buildRequest(input: I, env: Env): AnthropicMessagesRequest;

--- a/worker/src/schemas/search-assist.ts
+++ b/worker/src/schemas/search-assist.ts
@@ -3,9 +3,10 @@ import { z } from "zod";
 // ── search-assist: input ─────────────────────────────────────────────────────
 // The app's single AI capability: one call per submitted question. Only the
 // question text is sent — no passages, no retrieval round-trip. The model
-// answers from mainstream Islamic knowledge and returns the Quran references
-// that support the answer plus search terms; the app then resolves both against
-// its LOCAL database (real records become the proof cards and the results list).
+// answers from mainstream Islamic knowledge and returns the Quran and Hadith
+// references that support the answer plus search terms; the app then resolves
+// all of them against its LOCAL database (real records become the proof cards
+// and the results list).
 
 export const SearchAssistInputSchema = z.object({
   question: z.string().min(3).max(500),
@@ -22,6 +23,13 @@ export const SearchAssistOutputSchema = z.object({
   // mushaf numbering). The app resolves each against its local Quran database;
   // anything that doesn't resolve is dropped, so only real verses ever surface.
   quranRefs: z.array(z.string()).max(8),
+  // Hadith references that support the answer, "collection:number" where
+  // collection is one of the six canonical collections the app ships
+  // (bukhari, muslim, abudawud, tirmidhi, nasai, ibnmajah) and number is the
+  // hadith's standard reference number in that collection. Resolved against
+  // the local Hadith database exactly like quranRefs — unresolvable refs are
+  // dropped. Defaulted so an output without the field still validates.
+  hadithRefs: z.array(z.string()).max(6).default([]),
   // Short English keywords / 2-word phrases (incl. Arabic transliterations)
   // the app runs through its local Quran/Hadith/Dua search to build the
   // related-results list.
@@ -47,6 +55,12 @@ export const SEARCH_ASSIST_TOOL_JSON_SCHEMA = {
       description:
         "Up to 8 real Quran ayah references that directly support the answer, each as 'surah:ayah' (e.g. '2:153') in standard mushaf numbering, ordered by relevance. Cite only references you are certain exist and genuinely support the answer — the app displays the actual verse text beside the answer. When unsure, cite fewer. Empty array if none apply.",
     },
+    hadithRefs: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Up to 6 real hadith references that directly support the answer, each as 'collection:number' (e.g. 'bukhari:6018') where collection is exactly one of: bukhari, muslim, abudawud, tirmidhi, nasai, ibnmajah — and number is the hadith's standard reference number in that collection (sunnah.com numbering), ordered by relevance. Cite only hadiths you are certain exist with that number and genuinely support the answer — the app displays the actual hadith text beside the answer, so a wrong number is immediately visible. When unsure, cite fewer. Empty array if none apply.",
+    },
     terms: {
       type: "array",
       items: { type: "string" },
@@ -57,8 +71,8 @@ export const SEARCH_ASSIST_TOOL_JSON_SCHEMA = {
       type: "string",
       enum: ["high", "medium", "low"],
       description:
-        "high = well-established and directly supported by the cited ayat; medium = partial support; low = indirect or uncertain.",
+        "high = well-established and directly supported by the cited sources; medium = partial support; low = indirect or uncertain.",
     },
   },
-  required: ["answer", "quranRefs", "terms", "confidence"],
+  required: ["answer", "quranRefs", "hadithRefs", "terms", "confidence"],
 } as const;

--- a/worker/test/helpers.ts
+++ b/worker/test/helpers.ts
@@ -15,6 +15,7 @@ export function makeAssistOutput(overrides: Record<string, unknown> = {}) {
     answer:
       "The Quran repeatedly encourages patience (sabr), promising that Allah is with the patient.",
     quranRefs: ["2:153", "39:10"],
+    hadithRefs: ["bukhari:1469", "muslim:2999"],
     terms: ["patience", "sabr", "hardship", "perseverance"],
     confidence: "high",
     ...overrides,

--- a/worker/test/searchAssist.test.ts
+++ b/worker/test/searchAssist.test.ts
@@ -32,6 +32,31 @@ describe("search-assist capability (unit)", () => {
     expect(out.quranRefs).toEqual(["2:153", "39:10"]);
   });
 
+  it("drops malformed and unknown-collection hadith refs, dedupes, keeps order", () => {
+    const raw = mockAnthropicToolResponse(
+      makeAssistOutput({
+        hadithRefs: [
+          "bukhari:6018",
+          "Muslim:2564", // uppercase is normalised, kept
+          "bukhari:6018", // duplicate
+          "riyadussalihin:1", // not one of the six shipped collections
+          "bukhari:0", // impossible number
+          "nasai:5758",
+        ],
+      }),
+    );
+    const out = searchAssist.parseResponse(raw as any, makeAssistInput());
+    expect(out.hadithRefs).toEqual(["bukhari:6018", "muslim:2564", "nasai:5758"]);
+  });
+
+  it("defaults hadithRefs to [] when the model omits the field", () => {
+    const output = makeAssistOutput() as Record<string, unknown>;
+    delete output.hadithRefs;
+    const raw = mockAnthropicToolResponse(output);
+    const out = searchAssist.parseResponse(raw as any, makeAssistInput());
+    expect(out.hadithRefs).toEqual([]);
+  });
+
   it("trims and dedupes terms, dropping blanks", () => {
     const raw = mockAnthropicToolResponse(
       makeAssistOutput({ terms: [" patience ", "sabr", "patience", "  "] }),
@@ -82,11 +107,13 @@ describe("search-assist (integration, AI Gateway Unified Billing)", () => {
     const body = (await res.json()) as {
       answer: string;
       quranRefs: string[];
+      hadithRefs: string[];
       terms: string[];
       confidence: string;
     };
     expect(body.answer.length).toBeGreaterThan(0);
     expect(body.quranRefs).toEqual(["2:153", "39:10"]);
+    expect(body.hadithRefs).toEqual(["bukhari:1469", "muslim:2999"]);
     expect(body.terms).toContain("patience");
     expect(body.confidence).toBe("high");
     // Usage is echoed for the smoke test / ops.
@@ -132,6 +159,7 @@ describe("search-assist (integration, AI Gateway Unified Billing)", () => {
           makeAssistOutput({
             answer: "I can only help with Islamic topics.",
             quranRefs: [],
+            hadithRefs: [],
             terms: ["quran", "hadith"],
             confidence: "low",
           }),
@@ -139,8 +167,12 @@ describe("search-assist (integration, AI Gateway Unified Billing)", () => {
       );
     const res = await invoke("assist-dev-3");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { quranRefs: string[] };
+    const body = (await res.json()) as {
+      quranRefs: string[];
+      hadithRefs: string[];
+    };
     expect(body.quranRefs).toEqual([]);
+    expect(body.hadithRefs).toEqual([]);
   });
 
   it("maps a gateway 5xx to UPSTREAM_ERROR/502", async () => {


### PR DESCRIPTION
The search-assist capability now also returns hadithRefs — up to 6
'collection:number' references limited to the six canonical collections
the app ships (bukhari, muslim, abudawud, tirmidhi, nasai, ibnmajah).
The app resolves each ref locally via the hadiths table's canonical
reference column; every hadith that resolves surfaces in the merged
results list as the same Cited card (gold hadith accent), deep-linking
into the hadith reader, and dedupes against related results exactly
like a cited verse. Unresolvable refs are dropped silently, so a cited
card can never show a hadith that doesn't exist.

- Worker: hadithRefs in the output schema + forced tool schema, system
  prompt instructions, slug/number plausibility filter, tests
- Android: AssistOutput.hadithRefs (defaulted for old-Worker compat),
  HadithRef domain model, getHadithByReference DAO/repo/use case,
  AskWithProofUseCase resolves hadith refs into Proofs (source=HADITH)
- UI unchanged — the existing Cited card, source filter and dedup were
  already source-generic
- Copy: consent/disclosure/discovery strings now say verses and hadiths
  (base + de/fr/id/ms/tr)
- Docs: ai-ask-with-proof.md contract/flow/grammar, worker README,
  CLAUDE.md map; CI smoke test asserts hadithRefs

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gjwpg5hHhSgFK4wthWhntv