### PR TITLE
fix(ai): use standard Play Integrity API so legit devices stay verified

### DIFF
--- a/.github/workflows/worker_deploy.yml
+++ b/.github/workflows/worker_deploy.yml
@@ -40,12 +40,9 @@ jobs:
   deploy:
     name: Deploy to Cloudflare
     needs: test
-    # TEMPORARY: also deploy from pull_request for the initial ai.arshadshah.com
-    # bring-up so we can verify the Worker + custom domain from this PR. Same-repo
-    # PRs have access to the Cloudflare secrets; fork PRs do not and will no-op.
-    # REVERT to `if: github.event_name == 'push'` once the Worker is live so
-    # unreviewed PR code is never published to production again.
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    # Deploy ONLY on push to dev (i.e. after merge). PRs run typecheck/tests but
+    # must never publish unreviewed code to production.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +79,7 @@ jobs:
   smoke-test:
     name: Live smoke test (search-assist)
     needs: deploy
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # No checkout here, so the workflow-level `working-directory: worker`
     # default would point at a nonexistent dir — run from the workspace root.

--- a/app/src/main/java/com/arshadshah/nimaz/data/ai/IntegrityTokenProvider.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/ai/IntegrityTokenProvider.kt
@@ -4,58 +4,100 @@ import android.content.Context
 import com.arshadshah.nimaz.BuildConfig
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.google.android.play.core.integrity.IntegrityManagerFactory
-import com.google.android.play.core.integrity.IntegrityTokenRequest
+import com.google.android.play.core.integrity.StandardIntegrityManager.PrepareIntegrityTokenRequest
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Fetches a Play Integrity token for the current request. Uses the standard
- * request (cloud project number from [BuildConfig.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER]).
+ * Fetches a Play Integrity token for the current request via the **standard**
+ * API (cloud project number from [BuildConfig.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER]).
  *
- * If a token cannot be obtained (project number not configured yet, Play
+ * Standard, not classic: classic requests ([com.google.android.play.core.integrity.IntegrityTokenRequest])
+ * are throttled per app-instance by Play services after a handful of calls in a
+ * short window (TOO_MANY_REQUESTS). Making one per question meant a few asks
+ * worked, then every token fetch failed → empty token → the Worker's
+ * "unverified" 5/day cap for perfectly legitimate installs. The standard API is
+ * built for frequent, per-action checks: one heavier [prepareProvider] warm-up,
+ * then cheap [StandardIntegrityTokenProvider.request] calls that Play services
+ * serves from its own cache. The Worker decodes both token kinds through the
+ * same `decodeIntegrityToken` endpoint, so nothing changes server-side.
+ *
+ * If a token still cannot be obtained (project number not configured yet, Play
  * services unavailable, offline) the behaviour depends on the build type:
  *  - debug builds fall back to the literal `"debug-skip"` token, which the
  *    Worker honours ONLY when it runs with `SKIP_ATTESTATION=true`;
- *  - release builds return an empty token, which the Worker rejects with
- *    ATTESTATION_FAILED.
+ *  - release builds return an empty token, which the Worker runs at the
+ *    unverified tier (smaller daily cap, never an error).
  */
 @Singleton
 class IntegrityTokenProvider @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
+    private val providerMutex = Mutex()
+    private var cachedProvider: StandardIntegrityTokenProvider? = null
+
     suspend fun getToken(): String {
         val projectNumber = BuildConfig.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER
         // Placeholder project number → Integrity isn't wired up yet.
         if (projectNumber <= 0L) return debugFallback()
 
         return try {
-            requestToken(projectNumber)
+            try {
+                requestToken(obtainProvider(projectNumber))
+            } catch (e: Exception) {
+                // The warmed-up provider can go stale (Play services updated or
+                // evicted its state) — re-prepare once and retry before giving up.
+                invalidateProvider()
+                requestToken(obtainProvider(projectNumber))
+            }
         } catch (e: Exception) {
             CrashReporter.recordException(e)
             debugFallback()
         }
     }
 
-    private suspend fun requestToken(projectNumber: Long): String =
+    private suspend fun obtainProvider(projectNumber: Long): StandardIntegrityTokenProvider =
+        providerMutex.withLock {
+            cachedProvider ?: prepareProvider(projectNumber).also { cachedProvider = it }
+        }
+
+    private suspend fun invalidateProvider() {
+        providerMutex.withLock { cachedProvider = null }
+    }
+
+    private suspend fun prepareProvider(projectNumber: Long): StandardIntegrityTokenProvider =
         suspendCancellableCoroutine { cont ->
-            val manager = IntegrityManagerFactory.create(context)
-            manager
-                .requestIntegrityToken(
-                    IntegrityTokenRequest.builder()
+            IntegrityManagerFactory.createStandard(context)
+                .prepareIntegrityToken(
+                    PrepareIntegrityTokenRequest.builder()
                         .setCloudProjectNumber(projectNumber)
                         .build()
                 )
+                .addOnSuccessListener { provider ->
+                    if (cont.isActive) cont.resume(provider)
+                }
+                .addOnFailureListener { e ->
+                    if (cont.isActive) cont.resumeWithException(e)
+                }
+        }
+
+    private suspend fun requestToken(provider: StandardIntegrityTokenProvider): String =
+        suspendCancellableCoroutine { cont ->
+            provider
+                .request(StandardIntegrityTokenRequest.builder().build())
                 .addOnSuccessListener { response ->
                     if (cont.isActive) cont.resume(response.token())
                 }
                 .addOnFailureListener { e ->
-                    if (cont.isActive) {
-                        CrashReporter.recordException(e)
-                        cont.resume(debugFallback())
-                    }
+                    if (cont.isActive) cont.resumeWithException(e)
                 }
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -18,9 +20,13 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.arshadshah.nimaz.R
@@ -29,6 +35,9 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogDestructiveButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
@@ -44,6 +53,7 @@ fun SearchSettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    var showClearHistoryDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -100,15 +110,60 @@ fun SearchSettingsScreen(
                         },
                     )
                     NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    // An in-place destructive action, not navigation — no
+                    // trailing arrow; disabled while there is nothing to clear.
                     NimazMenuItem(
                         title = stringResource(R.string.ai_clear_history),
                         subtitle = stringResource(R.string.ai_clear_history_subtitle),
-                        onClick = { viewModel.onEvent(SearchSettingsEvent.ClearHistory) },
+                        trailingIcon = null,
+                        enabled = state.savedQuestions.isNotEmpty(),
+                        onClick = { showClearHistoryDialog = true },
                     )
                 }
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
+    }
+
+    if (showClearHistoryDialog) {
+        NimazDialog(
+            title = stringResource(R.string.ai_clear_history_dialog_title),
+            titleIcon = Icons.Default.Delete,
+            accentColor = MaterialTheme.colorScheme.error,
+            showCloseButton = false,
+            onDismiss = { showClearHistoryDialog = false },
+            content = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.ai_clear_history_dialog_message),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    state.savedQuestions.forEach { question ->
+                        Text(
+                            text = "•  $question",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            },
+            actions = {
+                NimazDialogCancelButton(
+                    text = stringResource(R.string.cancel),
+                    onClick = { showClearHistoryDialog = false },
+                )
+                NimazDialogDestructiveButton(
+                    text = stringResource(R.string.delete),
+                    onClick = {
+                        viewModel.onEvent(SearchSettingsEvent.ClearHistory)
+                        showClearHistoryDialog = false
+                    },
+                )
+            },
+        )
     }
 
     if (state.showConsentSheet) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModel.kt
@@ -12,11 +12,16 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 data class SearchSettingsUiState(
     val aiEnabled: Boolean = false,
     val historyEnabled: Boolean = false,
+    /** Persisted recent questions — shown in the clear-history confirm dialog. */
+    val savedQuestions: List<String> = emptyList(),
     val showConsentSheet: Boolean = false,
 )
 
@@ -34,6 +39,8 @@ class SearchSettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
+    private val json = Json { ignoreUnknownKeys = true }
+
     private val _uiState = MutableStateFlow(SearchSettingsUiState())
     val uiState: StateFlow<SearchSettingsUiState> = _uiState.asStateFlow()
 
@@ -41,10 +48,27 @@ class SearchSettingsViewModel @Inject constructor(
         combine(
             settingsRepository.aiAskEnabled,
             settingsRepository.aiHistoryEnabled,
-        ) { enabled, history ->
-            _uiState.update { it.copy(aiEnabled = enabled, historyEnabled = history) }
+            settingsRepository.aiQuestionHistory,
+        ) { enabled, history, historyJson ->
+            _uiState.update {
+                it.copy(
+                    aiEnabled = enabled,
+                    historyEnabled = history,
+                    savedQuestions = decodeHistory(historyJson),
+                )
+            }
         }.launchIn(viewModelScope)
     }
+
+    // Same wire format as AskViewModel's encodeHistory: a JSON string list.
+    private fun decodeHistory(raw: String): List<String> =
+        if (raw.isBlank()) {
+            emptyList()
+        } else {
+            runCatching {
+                json.decodeFromString(ListSerializer(String.serializer()), raw)
+            }.getOrDefault(emptyList())
+        }
 
     fun onEvent(event: SearchSettingsEvent) {
         when (event) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1310,4 +1310,29 @@
     <string name="ai_error_network">Der KI-Dienst konnte nicht erreicht werden. Prüfe deine Verbindung und versuche es erneut.</string>
     <string name="ai_error_invalid">Diese Frage konnte nicht verarbeitet werden. Formuliere sie um.</string>
     <string name="ai_error_unknown">Beim Erzeugen der Antwort ist etwas schiefgelaufen. Bitte versuche es erneut.</string>
+
+    <string name="search_ask_button">Fragen</string>
+    <string name="search_try_asking">Frag zum Beispiel</string>
+    <string name="search_recent">Zuletzt</string>
+    <string name="search_typing_hint">Ergebnisse werden beim Tippen aktualisiert · Enter für eine Antwort mit Quellen</string>
+    <string name="search_matches_format">%d Treffer</string>
+    <string name="search_answer_count_format">%1$d in deiner Bibliothek · %2$d in der Antwort zitiert</string>
+    <string name="search_cited_chip">Zitiert</string>
+    <string name="ask_example_1">Was sagt der Koran über Geduld?</string>
+    <string name="ask_example_2">Bittgebete bei Angst und Sorgen</string>
+    <string name="ask_example_3">Verse über Dankbarkeit</string>
+    <string name="ask_example_4">Warum ist die Absicht im Gottesdienst wichtig?</string>
+    <string name="ai_clear_history_dialog_title">KI-Verlauf löschen?</string>
+    <string name="ai_clear_history_dialog_message">Diese gespeicherten Fragen werden dauerhaft von diesem Gerät entfernt:</string>
+    <string name="ai_trust_note">KI-generierte Zusammenfassung — prüfe sie anhand der unten zitierten Quellen. Sie beschreibt, was die Quellen sagen, und ist keine Fatwa.</string>
+    <string name="ai_discover_title">Antworten, gestützt auf deine Bibliothek</string>
+    <string name="ai_discover_body">Stelle eine Frage in einfachen Worten und erhalte eine kurze Antwort, gestützt auf Verse und Hadithe aus deiner eigenen Bibliothek — jedes Zitat ist eine echte Quelle, die du öffnen und lesen kannst.</string>
+    <string name="ai_discover_privacy">Nur deine Frage wird gesendet. Die zitierten Quellen und Ergebnisse werden auf deinem Gerät zugeordnet, und Fragen werden nie für Analysen verwendet.</string>
+    <string name="ai_discover_enable">KI-Antworten aktivieren</string>
+    <string name="ai_discover_dismiss">Jetzt nicht</string>
+    <string name="ai_error_network_title">Antwortdienst nicht erreichbar</string>
+    <string name="ai_error_rate_limited_title">Du hast das heutige Fragenlimit erreicht</string>
+    <string name="ai_error_budget_title">KI-Antworten sind vorerst pausiert</string>
+    <string name="ai_error_invalid_title">Diese Frage konnte nicht verarbeitet werden</string>
+    <string name="ai_error_unknown_title">Etwas ist schiefgelaufen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1311,4 +1311,29 @@
     <string name="ai_error_network">Impossible de joindre le service d\'IA. Vérifiez votre connexion et réessayez.</string>
     <string name="ai_error_invalid">Cette question n\'a pas pu être traitée. Essayez de la reformuler.</string>
     <string name="ai_error_unknown">Une erreur s\'est produite lors de la génération de la réponse. Veuillez réessayer.</string>
+
+    <string name="search_ask_button">Demander</string>
+    <string name="search_try_asking">Essayez de demander</string>
+    <string name="search_recent">Récents</string>
+    <string name="search_typing_hint">Les résultats se mettent à jour pendant la saisie · Entrée pour une réponse avec sources</string>
+    <string name="search_matches_format">%d résultats</string>
+    <string name="search_answer_count_format">%1$d dans votre bibliothèque · %2$d cités dans la réponse</string>
+    <string name="search_cited_chip">Cité</string>
+    <string name="ask_example_1">Que dit le Coran sur la patience ?</string>
+    <string name="ask_example_2">Invocations contre l\'anxiété et l\'inquiétude</string>
+    <string name="ask_example_3">Versets sur la gratitude</string>
+    <string name="ask_example_4">Pourquoi l\'intention est-elle importante dans l\'adoration ?</string>
+    <string name="ai_clear_history_dialog_title">Effacer l\'historique de l\'IA ?</string>
+    <string name="ai_clear_history_dialog_message">Ces questions enregistrées seront définitivement supprimées de cet appareil :</string>
+    <string name="ai_trust_note">Résumé généré par l\'IA — vérifiez-le à l\'aide des sources citées ci-dessous. Il décrit ce que disent les sources et ne constitue pas une fatwa.</string>
+    <string name="ai_discover_title">Des réponses appuyées sur votre bibliothèque</string>
+    <string name="ai_discover_body">Posez une question en termes simples et obtenez une courte réponse appuyée par des versets et des hadiths de votre propre bibliothèque — chaque citation est une source réelle que vous pouvez ouvrir et lire.</string>
+    <string name="ai_discover_privacy">Seule votre question est envoyée. Les sources citées et les résultats sont associés sur votre appareil, et les questions ne sont jamais utilisées à des fins d\'analyse.</string>
+    <string name="ai_discover_enable">Activer les réponses de l\'IA</string>
+    <string name="ai_discover_dismiss">Pas maintenant</string>
+    <string name="ai_error_network_title">Impossible de joindre le service de réponses</string>
+    <string name="ai_error_rate_limited_title">Vous avez atteint la limite de questions du jour</string>
+    <string name="ai_error_budget_title">Les réponses de l\'IA sont suspendues pour le moment</string>
+    <string name="ai_error_invalid_title">Cette question n\'a pas pu être traitée</string>
+    <string name="ai_error_unknown_title">Une erreur s\'est produite</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1311,4 +1311,29 @@
     <string name="ai_error_network">Tidak dapat menjangkau layanan AI. Periksa koneksi Anda dan coba lagi.</string>
     <string name="ai_error_invalid">Pertanyaan itu tidak dapat diproses. Coba susun ulang.</string>
     <string name="ai_error_unknown">Terjadi kesalahan saat menghasilkan jawaban. Silakan coba lagi.</string>
+
+    <string name="search_ask_button">Tanya</string>
+    <string name="search_try_asking">Coba tanyakan</string>
+    <string name="search_recent">Terbaru</string>
+    <string name="search_typing_hint">Hasil diperbarui saat Anda mengetik · Tekan Enter untuk jawaban dengan sumber</string>
+    <string name="search_matches_format">%d hasil cocok</string>
+    <string name="search_answer_count_format">%1$d di pustaka Anda · %2$d dikutip dalam jawaban</string>
+    <string name="search_cited_chip">Dikutip</string>
+    <string name="ask_example_1">Apa kata Al-Qur\'an tentang kesabaran?</string>
+    <string name="ask_example_2">Doa untuk kecemasan dan kekhawatiran</string>
+    <string name="ask_example_3">Ayat-ayat tentang rasa syukur</string>
+    <string name="ask_example_4">Mengapa niat penting dalam ibadah?</string>
+    <string name="ai_clear_history_dialog_title">Hapus riwayat AI?</string>
+    <string name="ai_clear_history_dialog_message">Pertanyaan tersimpan berikut akan dihapus permanen dari perangkat ini:</string>
+    <string name="ai_trust_note">Ringkasan buatan AI — periksa dengan sumber yang dikutip di bawah. Ringkasan ini menjelaskan isi sumber dan bukan fatwa.</string>
+    <string name="ai_discover_title">Dapatkan jawaban yang didukung pustaka Anda</string>
+    <string name="ai_discover_body">Ajukan pertanyaan dengan kata-kata sederhana dan dapatkan jawaban singkat yang didukung ayat dan hadis dari pustaka Anda sendiri — setiap kutipan adalah sumber asli yang dapat Anda buka dan baca.</string>
+    <string name="ai_discover_privacy">Hanya pertanyaan Anda yang dikirim. Sumber yang dikutip dan hasil dicocokkan di perangkat Anda, dan pertanyaan tidak pernah digunakan untuk analitik.</string>
+    <string name="ai_discover_enable">Aktifkan jawaban AI</string>
+    <string name="ai_discover_dismiss">Nanti saja</string>
+    <string name="ai_error_network_title">Tidak dapat menjangkau layanan jawaban</string>
+    <string name="ai_error_rate_limited_title">Anda telah mencapai batas pertanyaan hari ini</string>
+    <string name="ai_error_budget_title">Jawaban AI dijeda untuk saat ini</string>
+    <string name="ai_error_invalid_title">Pertanyaan itu tidak dapat diproses</string>
+    <string name="ai_error_unknown_title">Terjadi kesalahan</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1312,4 +1312,29 @@
     <string name="ai_error_network">Tidak dapat menghubungi perkhidmatan AI. Semak sambungan anda dan cuba lagi.</string>
     <string name="ai_error_invalid">Soalan itu tidak dapat diproses. Cuba susun semula.</string>
     <string name="ai_error_unknown">Sesuatu tidak kena semasa menjana jawapan. Sila cuba lagi.</string>
+
+    <string name="search_ask_button">Tanya</string>
+    <string name="search_try_asking">Cuba tanya</string>
+    <string name="search_recent">Terkini</string>
+    <string name="search_typing_hint">Keputusan dikemas kini semasa anda menaip · Tekan Enter untuk jawapan dengan sumber</string>
+    <string name="search_matches_format">%d padanan</string>
+    <string name="search_answer_count_format">%1$d dalam perpustakaan anda · %2$d dipetik dalam jawapan</string>
+    <string name="search_cited_chip">Dipetik</string>
+    <string name="ask_example_1">Apakah yang Al-Qur\'an katakan tentang kesabaran?</string>
+    <string name="ask_example_2">Doa untuk kegelisahan dan kebimbangan</string>
+    <string name="ask_example_3">Ayat-ayat tentang kesyukuran</string>
+    <string name="ask_example_4">Mengapa niat penting dalam ibadah?</string>
+    <string name="ai_clear_history_dialog_title">Padam sejarah AI?</string>
+    <string name="ai_clear_history_dialog_message">Soalan tersimpan berikut akan dipadamkan secara kekal daripada peranti ini:</string>
+    <string name="ai_trust_note">Ringkasan janaan AI — semak dengan sumber yang dipetik di bawah. Ia menerangkan apa yang dinyatakan oleh sumber dan bukan fatwa.</string>
+    <string name="ai_discover_title">Dapatkan jawapan yang disokong perpustakaan anda</string>
+    <string name="ai_discover_body">Ajukan soalan dengan perkataan mudah dan dapatkan jawapan ringkas yang disokong oleh ayat dan hadis daripada perpustakaan anda sendiri — setiap petikan ialah sumber sebenar yang boleh anda buka dan baca.</string>
+    <string name="ai_discover_privacy">Hanya soalan anda yang dihantar. Sumber yang dipetik dan keputusan dipadankan pada peranti anda, dan soalan tidak pernah digunakan untuk analitik.</string>
+    <string name="ai_discover_enable">Hidupkan jawapan AI</string>
+    <string name="ai_discover_dismiss">Bukan sekarang</string>
+    <string name="ai_error_network_title">Tidak dapat menghubungi perkhidmatan jawapan</string>
+    <string name="ai_error_rate_limited_title">Anda telah mencapai had soalan hari ini</string>
+    <string name="ai_error_budget_title">Jawapan AI dijeda buat masa ini</string>
+    <string name="ai_error_invalid_title">Soalan itu tidak dapat diproses</string>
+    <string name="ai_error_unknown_title">Berlaku ralat</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1314,4 +1314,29 @@
     <string name="ai_error_network">Yapay zekâ hizmetine ulaşılamadı. Bağlantınızı kontrol edip tekrar deneyin.</string>
     <string name="ai_error_invalid">Bu soru işlenemedi. Yeniden ifade etmeyi deneyin.</string>
     <string name="ai_error_unknown">Yanıt oluşturulurken bir sorun oluştu. Lütfen tekrar deneyin.</string>
+
+    <string name="search_ask_button">Sor</string>
+    <string name="search_try_asking">Şunları sormayı deneyin</string>
+    <string name="search_recent">Son aramalar</string>
+    <string name="search_typing_hint">Sonuçlar siz yazarken güncellenir · Kaynaklı yanıt için Enter tuşuna basın</string>
+    <string name="search_matches_format">%d eşleşme</string>
+    <string name="search_answer_count_format">%1$d kitaplığınızda · %2$d yanıtta alıntılandı</string>
+    <string name="search_cited_chip">Alıntı</string>
+    <string name="ask_example_1">Kur\'an sabır hakkında ne söylüyor?</string>
+    <string name="ask_example_2">Kaygı ve endişe için dualar</string>
+    <string name="ask_example_3">Şükürle ilgili ayetler</string>
+    <string name="ask_example_4">İbadette niyet neden önemlidir?</string>
+    <string name="ai_clear_history_dialog_title">Yapay zekâ geçmişi silinsin mi?</string>
+    <string name="ai_clear_history_dialog_message">Bu kayıtlı sorular bu cihazdan kalıcı olarak kaldırılacak:</string>
+    <string name="ai_trust_note">Yapay zekâ tarafından oluşturulan özet — aşağıda alıntılanan kaynaklarla karşılaştırın. Kaynakların ne söylediğini açıklar ve bir fetva değildir.</string>
+    <string name="ai_discover_title">Kitaplığınıza dayanan yanıtlar alın</string>
+    <string name="ai_discover_body">Sorunuzu sade sözcüklerle sorun ve kendi kitaplığınızdaki ayet ve hadislerle desteklenen kısa bir yanıt alın — her alıntı, açıp okuyabileceğiniz gerçek bir kaynaktır.</string>
+    <string name="ai_discover_privacy">Yalnızca sorunuz gönderilir. Alıntılanan kaynaklar ve sonuçlar cihazınızda eşleştirilir ve sorular hiçbir zaman analiz için kullanılmaz.</string>
+    <string name="ai_discover_enable">Yapay zekâ yanıtlarını aç</string>
+    <string name="ai_discover_dismiss">Şimdi değil</string>
+    <string name="ai_error_network_title">Yanıt hizmetine ulaşılamadı</string>
+    <string name="ai_error_rate_limited_title">Bugünkü soru sınırına ulaştınız</string>
+    <string name="ai_error_budget_title">Yapay zekâ yanıtları şimdilik duraklatıldı</string>
+    <string name="ai_error_invalid_title">Bu soru işlenemedi</string>
+    <string name="ai_error_unknown_title">Bir şeyler ters gitti</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1464,6 +1464,8 @@
     <string name="ai_history_subtitle">Keep recent AI questions on this device. When off, they are kept only in memory.</string>
     <string name="ai_clear_history">Clear AI history</string>
     <string name="ai_clear_history_subtitle">Remove all saved AI questions</string>
+    <string name="ai_clear_history_dialog_title">Clear AI history?</string>
+    <string name="ai_clear_history_dialog_message">These saved questions will be permanently removed from this device:</string>
     <string name="ai_consent_title">Enable AI answers?</string>
     <string name="ai_consent_enable">Enable</string>
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
@@ -57,6 +57,7 @@ fun buildHadithUseCases(repository: HadithRepository) = HadithUseCases(
     getHadithsByChapter = GetHadithsByChapterUseCase(repository),
     getHadithById = GetHadithByIdUseCase(repository),
     getHadithByNumber = GetHadithByNumberUseCase(repository),
+    getHadithByReference = GetHadithByReferenceUseCase(repository),
     getHadithsByGrade = GetHadithsByGradeUseCase(repository),
     getHadithOfTheDay = GetHadithOfTheDayUseCase(repository),
     searchHadiths = SearchHadithsUseCase(repository),

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -113,7 +113,7 @@ Layers (Android):
 presentation/components/organisms/NimazSearchBar.kt shared bar; optional trailing Ask pill (showAskButton/askEnabled/onAsk; IME action routes to onAsk while live)
 presentation/screens/search/SearchScreen.kt         pinned bar+filter; merges cited proofs + related results into ONE list (dedup, "Cited" cards)
 presentation/screens/search/AskComponents.kt        answer card (no proof list) / loading / error banner (NimazBanner) / AI-off discovery card
-presentation/screens/settings/SearchSettingsScreen  consent + toggles + privacy
+presentation/screens/settings/SearchSettingsScreen  consent + toggles + privacy; clear-history opens a destructive NimazDialog listing the saved questions
 presentation/viewmodel/AskViewModel                 ask state machine (exposes relatedTerms)
 presentation/viewmodel/SearchViewModel              results list (+ ApplyAiTerms event)
 presentation/viewmodel/SearchSettingsViewModel      settings + consent state

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -96,6 +96,17 @@ instead of gating on it:
 Every failure path degrades to `unverified` — a smaller cap, never an error.
 The AI Gateway spend limit remains the hard cost backstop against abuse.
 
+The app fetches tokens with the **standard** Play Integrity API (warm up a
+`StandardIntegrityTokenProvider` once, then a cheap `request()` per question),
+not the classic one. Classic requests are throttled per app-instance by Play
+services after a few calls in a short window, so fetching one per question
+meant legitimate installs "worked for a while" and then every token fetch
+failed → empty token → stuck at the unverified 5/day cap. The standard API is
+designed for frequent per-action checks; if the warmed-up provider goes stale,
+`IntegrityTokenProvider` re-prepares it once before falling back. The Worker is
+unaffected: `decodeIntegrityToken` decodes classic and standard tokens alike,
+and the verdict fields it checks are identical.
+
 Layers (Android):
 
 ```


### PR DESCRIPTION
Classic integrity requests are throttled per app-instance by Play services
after a few calls in a short window. Fetching one per question meant a few
asks worked, then every token fetch failed silently, the app sent an empty
token, and legitimate installs got pinned to the Worker's unverified 5/day
cap. Switch to the standard API: warm up a StandardIntegrityTokenProvider
once (re-prepared once on staleness), then a cheap request() per question.
The Worker decodes classic and standard tokens through the same
decodeIntegrityToken endpoint, so no server-side change is needed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MPMntKrc8dmt4HXrjVJUVX