### PR TITLE
feat: FCM engagement banner — console-sent announcements with Home banner + deep links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,11 +237,12 @@ dependencies {
     implementation(libs.app.review)
     implementation(libs.app.review.ktx)
 
-    // Firebase (Crashlytics + Analytics + Performance) — versions pinned by the BoM
+    // Firebase (Crashlytics + Analytics + Performance + Messaging) — versions pinned by the BoM
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.perf)
+    implementation(libs.firebase.messaging)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -194,6 +194,26 @@
             android:exported="false"
             android:foregroundServiceType="mediaPlayback" />
 
+        <!-- FCM engagement announcements: foreground messages are handled by the
+             service (Home banner, no tray notification); backgrounded messages are
+             posted by the OS on the channel/icon/color declared below. -->
+        <service
+            android:name=".data.announcement.NimazMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="nimaz_announcements" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_stat_nimaz" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/teal_700" />
+
         <!-- FileProvider for sharing exported files (e.g. prayer-times PDF) -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/MainActivity.kt
@@ -17,15 +17,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.util.UnstableApi
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.navigation.NavGraph
 import com.arshadshah.nimaz.core.util.BootReceiver
 import com.arshadshah.nimaz.core.util.InAppUpdateManager
+import com.arshadshah.nimaz.data.announcement.AnnouncementPayloadMapper
 import com.arshadshah.nimaz.data.audio.AdhanPlaybackService
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.data.audio.QuranAudioService
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.AnnouncementUseCases
+import kotlinx.coroutines.launch
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarWidget
@@ -43,6 +47,12 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var quranAudioManager: QuranAudioManager
+
+    @Inject
+    lateinit var announcementUseCases: AnnouncementUseCases
+
+    @Inject
+    lateinit var announcementPayloadMapper: AnnouncementPayloadMapper
 
     private lateinit var inAppUpdateManager: InAppUpdateManager
 
@@ -64,6 +74,10 @@ class MainActivity : ComponentActivity() {
     // widget. NavGraph observes this, navigates with popUpTo(Home) so system
     // Back returns the user to the home screen rather than dropping out.
     private var pendingIslamicCalendar by mutableStateOf(false)
+
+    // Pending announcement route from a tapped FCM tray notification (cold or
+    // warm start). NavGraph resolves it against the allowlist and consumes it.
+    private var pendingAnnouncementRoute by mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -127,6 +141,10 @@ class MainActivity : ComponentActivity() {
                             onPendingIslamicCalendarConsumed = {
                                 pendingIslamicCalendar = false
                             },
+                            pendingAnnouncementRoute = pendingAnnouncementRoute,
+                            onPendingAnnouncementRouteConsumed = {
+                                pendingAnnouncementRoute = null
+                            },
                         )
                     }
                 }
@@ -159,8 +177,23 @@ class MainActivity : ComponentActivity() {
      * - Prayer notification → stop adhan playback.
      * - Quran audio notification → deep-link to the playing surah.
      * - Hijri calendar widget → deep-link to the Islamic Calendar screen.
+     * - FCM announcement notification tap → persist the announcement so the
+     *   Home banner shows, and deep-link to its route if it names one.
      */
     private fun handleIntent(intent: Intent?) {
+        // Backgrounded FCM notification tap: the OS copies the message's custom
+        // data onto the launcher intent as string extras. The mapper returning
+        // non-null is what identifies the intent as ours.
+        announcementPayloadMapper.fromIntentExtras(intent?.extras)?.let { announcement ->
+            AppAnalytics.logNotificationOpened(source = "announcement")
+            lifecycleScope.launch { announcementUseCases.setAnnouncement(announcement) }
+            // Tapping the notification implies intent to act — navigate when a
+            // route is present; otherwise land on Home with the banner showing.
+            if (announcement.route != null) {
+                pendingAnnouncementRoute = announcement.route
+            }
+        }
+
         if (intent?.getBooleanExtra(BootReceiver.EXTRA_STOP_ADHAN, false) == true) {
             AdhanPlaybackService.stopAdhan(this)
             AppAnalytics.logNotificationOpened(source = "prayer_notification")

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/AnnouncementModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/AnnouncementModule.kt
@@ -1,0 +1,41 @@
+package com.arshadshah.nimaz.core.di
+
+import com.arshadshah.nimaz.BuildConfig
+import com.arshadshah.nimaz.core.navigation.announcementRoute
+import com.arshadshah.nimaz.data.repository.AnnouncementRepositoryImpl
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import com.arshadshah.nimaz.domain.usecase.AnnouncementUseCases
+import com.arshadshah.nimaz.domain.usecase.DismissAnnouncementUseCase
+import com.arshadshah.nimaz.domain.usecase.ObserveActiveAnnouncementUseCase
+import com.arshadshah.nimaz.domain.usecase.ResolveAnnouncementRouteUseCase
+import com.arshadshah.nimaz.domain.usecase.SetAnnouncementUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AnnouncementModule {
+
+    @Provides
+    @Singleton
+    fun provideAnnouncementRepository(impl: AnnouncementRepositoryImpl): AnnouncementRepository =
+        impl
+
+    @Provides
+    @Singleton
+    fun provideAnnouncementUseCases(repository: AnnouncementRepository): AnnouncementUseCases =
+        AnnouncementUseCases(
+            observeActiveAnnouncement = ObserveActiveAnnouncementUseCase(
+                repository = repository,
+                currentVersionCode = BuildConfig.VERSION_CODE,
+            ),
+            setAnnouncement = SetAnnouncementUseCase(repository),
+            dismissAnnouncement = DismissAnnouncementUseCase(repository),
+            resolveAnnouncementRoute = ResolveAnnouncementRouteUseCase(
+                isKnownFeatureKey = { key -> announcementRoute(key) != null },
+            ),
+        )
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
@@ -6,6 +6,7 @@ import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.monitoring.PerfMonitor
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
+import com.arshadshah.nimaz.data.announcement.AnnouncementBootstrap
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
@@ -32,6 +33,7 @@ class AppInitializer @Inject constructor(
     private val preferencesDataStore: PreferencesDataStore,
     private val prayerNotificationScheduler: PrayerNotificationScheduler,
     private val adhanAudioManager: AdhanAudioManager,
+    private val announcementBootstrap: AnnouncementBootstrap,
 ) {
     private val _isReady = MutableStateFlow(false)
     val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
@@ -48,10 +50,14 @@ class AppInitializer @Inject constructor(
                     val localeTask = async { applySavedLocale() }
                     val notificationTask = async { scheduleInitialNotifications() }
                     val adhanTask = async { downloadDefaultAdhanIfNeeded() }
+                    // FCM announcements: create the Updates channel + (re-)subscribe
+                    // to the topic each launch. Internally guarded, never throws.
+                    val announcementTask = async { announcementBootstrap.initialize() }
 
                     localeTask.await()
                     notificationTask.await()
                     adhanTask.await()
+                    announcementTask.await()
                 }
             } catch (e: Exception) {
                 // Timeout or other failure — report it but proceed to UI anyway

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
@@ -187,6 +187,25 @@ object AppAnalytics {
     }
 
     // ---------------------------------------------------------------------
+    // Engagement announcements (FCM banner)
+    // ---------------------------------------------------------------------
+
+    /** Logged when the Home announcement banner becomes visible. */
+    fun logAnnouncementShown(id: String, type: String) {
+        logEvent("announcement_shown", "announcement_id" to id, "announcement_type" to type)
+    }
+
+    /** Logged when the banner's CTA is tapped. */
+    fun logAnnouncementCtaClicked(id: String, route: String?) {
+        logEvent("announcement_cta_clicked", "announcement_id" to id, "route" to route)
+    }
+
+    /** Logged when the banner is dismissed (permanent — the id never resurfaces). */
+    fun logAnnouncementDismissed(id: String) {
+        logEvent("announcement_dismissed", "announcement_id" to id)
+    }
+
+    // ---------------------------------------------------------------------
     // Adhan
     // ---------------------------------------------------------------------
 

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutes.kt
@@ -1,0 +1,40 @@
+package com.arshadshah.nimaz.core.navigation
+
+/**
+ * Maps an announcement payload `route` key to an in-app Route, or null if
+ * unknown. Allowlist only — keys sent from the Firebase console never carry
+ * serialized routes or arguments, so old app versions safely ignore keys they
+ * don't recognise (the banner hides its CTA instead of navigating anywhere
+ * unexpected). Mirrors [helpDeepLinkRoute].
+ */
+fun announcementRoute(key: String?): Route? = when (key) {
+    "home" -> Route.Home
+    "quran" -> Route.Quran
+    "quran/search" -> Route.QuranSearch
+    "quran/bookmarks" -> Route.QuranBookmarks
+    "tafseer" -> Route.TafseerChapters
+    "hadith" -> Route.HadithHome
+    "dua" -> Route.DuaHome
+    "tasbih" -> Route.TasbihHome
+    "qibla" -> Route.Qibla
+    "prayer/times" -> Route.PrayerTimes
+    "prayer/tracker" -> Route.PrayerTracker()
+    "prayer/stats" -> Route.PrayerStats
+    "prayer/qada" -> Route.QadaPrayers
+    "fasting" -> Route.FastingHome
+    "zakat" -> Route.ZakatCalculator
+    "calendar" -> Route.IslamicCalendar
+    "qaida" -> Route.QaidaHome
+    "khatam" -> Route.KhatamList
+    "names/allah" -> Route.AsmaUlHusnaList
+    "names/prophet" -> Route.AsmaUnNabiList
+    "prophets" -> Route.ProphetsList
+    "search" -> Route.GlobalSearch
+    "search/ask" -> Route.GlobalSearch
+    "search/settings" -> Route.SearchSettings
+    "settings" -> Route.Settings
+    "settings/notifications" -> Route.SettingsNotifications
+    "settings/about" -> Route.SettingsAbout
+    "settings/help" -> Route.SettingsHelp
+    else -> null
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -116,6 +116,8 @@ fun NavGraph(
     onPendingQuranSurahConsumed: () -> Unit = {},
     pendingIslamicCalendar: Boolean = false,
     onPendingIslamicCalendarConsumed: () -> Unit = {},
+    pendingAnnouncementRoute: String? = null,
+    onPendingAnnouncementRouteConsumed: () -> Unit = {},
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -166,6 +168,28 @@ fun NavGraph(
             launchSingleTop = true
         }
         onPendingIslamicCalendarConsumed()
+    }
+
+    // Deep-link from a tapped FCM announcement notification. Allowlist-resolved;
+    // unknown keys just land on Home (where the banner shows) and https URLs
+    // open in the browser.
+    LaunchedEffect(pendingAnnouncementRoute) {
+        val key = pendingAnnouncementRoute ?: return@LaunchedEffect
+        if (key.startsWith("https://")) {
+            runCatching {
+                analyticsContext.startActivity(
+                    Intent(Intent.ACTION_VIEW, android.net.Uri.parse(key))
+                )
+            }
+        } else {
+            announcementRoute(key)?.let { route ->
+                navController.navigate(route) {
+                    popUpTo(Route.Home) { inclusive = false }
+                    launchSingleTop = true
+                }
+            }
+        }
+        onPendingAnnouncementRouteConsumed()
     }
 
     // Onboarding ViewModel to check status
@@ -285,7 +309,18 @@ fun NavGraph(
                     onNavigateToSettings = { navController.navigate(Route.Settings) },
                     onNavigateToPrayerSettings = { navController.navigate(Route.SettingsPrayerCalculation) },
                     onNavigateToPrayerTimes = { navController.navigate(Route.PrayerTimes) },
-                    onOpenHadith = { hadithId -> navController.navigate(Route.HadithReader(hadithId)) }
+                    onOpenHadith = { hadithId -> navController.navigate(Route.HadithReader(hadithId)) },
+                    onOpenAnnouncementRoute = { key ->
+                        if (key.startsWith("https://")) {
+                            runCatching {
+                                analyticsContext.startActivity(
+                                    Intent(Intent.ACTION_VIEW, android.net.Uri.parse(key))
+                                )
+                            }
+                        } else {
+                            announcementRoute(key)?.let { navController.navigate(it) }
+                        }
+                    }
                 )
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/announcement/AnnouncementBootstrap.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/announcement/AnnouncementBootstrap.kt
@@ -1,0 +1,62 @@
+package com.arshadshah.nimaz.data.announcement
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.google.firebase.FirebaseApp
+import com.google.firebase.messaging.FirebaseMessaging
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One-shot per-launch setup for FCM announcements: creates the dedicated
+ * low-importance "Updates & Announcements" channel (kept strictly separate
+ * from the prayer/adhan channels) and (re-)subscribes to the announcements
+ * topic. Both operations are idempotent; failures are logged, never thrown.
+ */
+@Singleton
+class AnnouncementBootstrap @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun initialize() {
+        createChannel()
+        subscribeToTopic()
+    }
+
+    private fun createChannel() {
+        runCatching {
+            val manager = context.getSystemService(NotificationManager::class.java)
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Updates & Announcements",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Feature announcements, changelog highlights and policy updates"
+            }
+            manager.createNotificationChannel(channel)
+        }.onFailure { e ->
+            AppAnalytics.logError("announcements", e.javaClass.simpleName, e.message)
+        }
+    }
+
+    private fun subscribeToTopic() {
+        // No-op on builds without google-services.json (Firebase never initializes).
+        if (FirebaseApp.getApps(context).isEmpty()) return
+        runCatching {
+            FirebaseMessaging.getInstance().subscribeToTopic(TOPIC)
+                .addOnFailureListener { e ->
+                    AppAnalytics.logError("announcements", e.javaClass.simpleName, e.message)
+                }
+        }.onFailure { e ->
+            AppAnalytics.logError("announcements", e.javaClass.simpleName, e.message)
+        }
+    }
+
+    companion object {
+        /** Must match the manifest's default_notification_channel_id meta-data. */
+        const val CHANNEL_ID = "nimaz_announcements"
+        const val TOPIC = "announcements"
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadMapper.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadMapper.kt
@@ -1,0 +1,79 @@
+package com.arshadshah.nimaz.data.announcement
+
+import android.os.Bundle
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Maps an FCM custom-data payload (or the intent extras of a tapped tray
+ * notification, which carry the same key/value pairs) to an [Announcement].
+ *
+ * Returns null — never throws — when a required field is missing/blank or any
+ * present field is malformed, so a bad console send is silently ignored.
+ */
+@Singleton
+class AnnouncementPayloadMapper @Inject constructor() {
+
+    fun fromPayload(data: Map<String, String>): Announcement? {
+        val id = data[KEY_ID]?.trim().orEmpty().ifEmpty { return null }
+        val type = AnnouncementType.fromKey(data[KEY_TYPE]) ?: return null
+        val title = data[KEY_TITLE]?.trim().orEmpty().ifEmpty { return null }
+        val body = data[KEY_BODY]?.trim().orEmpty().ifEmpty { return null }
+
+        val minVersionCode = data[KEY_MIN_VERSION_CODE]?.let { it.trim().toIntOrNull() ?: return null }
+        val maxVersionCode = data[KEY_MAX_VERSION_CODE]?.let { it.trim().toIntOrNull() ?: return null }
+        val expiresAtMillis = data[KEY_EXPIRES_AT]?.let { raw ->
+            runCatching { Instant.parse(raw.trim()).toEpochMilli() }.getOrNull() ?: return null
+        }
+        val dismissable = data[KEY_DISMISSABLE]?.let {
+            it.trim().lowercase().toBooleanStrictOrNull() ?: return null
+        } ?: true
+
+        return Announcement(
+            id = id,
+            type = type,
+            title = title,
+            body = body,
+            ctaLabel = data[KEY_CTA_LABEL]?.trim()?.ifEmpty { null },
+            route = data[KEY_ROUTE]?.trim()?.ifEmpty { null },
+            minVersionCode = minVersionCode,
+            maxVersionCode = maxVersionCode,
+            expiresAtMillis = expiresAtMillis,
+            dismissable = dismissable,
+        )
+    }
+
+    /**
+     * Maps the launcher intent's extras to an [Announcement]. When the app is
+     * backgrounded/killed, the OS posts the tray notification itself and copies
+     * the message's custom data onto the tap intent as string extras.
+     */
+    fun fromIntentExtras(extras: Bundle?): Announcement? {
+        extras ?: return null
+        val data = buildMap {
+            PAYLOAD_KEYS.forEach { key -> extras.getString(key)?.let { put(key, it) } }
+        }
+        return fromPayload(data)
+    }
+
+    companion object {
+        const val KEY_ID = "id"
+        const val KEY_TYPE = "type"
+        const val KEY_TITLE = "title"
+        const val KEY_BODY = "body"
+        const val KEY_CTA_LABEL = "cta_label"
+        const val KEY_ROUTE = "route"
+        const val KEY_MIN_VERSION_CODE = "min_version_code"
+        const val KEY_MAX_VERSION_CODE = "max_version_code"
+        const val KEY_EXPIRES_AT = "expires_at"
+        const val KEY_DISMISSABLE = "dismissable"
+
+        val PAYLOAD_KEYS = listOf(
+            KEY_ID, KEY_TYPE, KEY_TITLE, KEY_BODY, KEY_CTA_LABEL, KEY_ROUTE,
+            KEY_MIN_VERSION_CODE, KEY_MAX_VERSION_CODE, KEY_EXPIRES_AT, KEY_DISMISSABLE,
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/announcement/NimazMessagingService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/announcement/NimazMessagingService.kt
@@ -1,0 +1,46 @@
+package com.arshadshah.nimaz.data.announcement
+
+import android.util.Log
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+/**
+ * Receives FCM announcement messages (topic broadcast, sent from the Firebase
+ * console). For notification+data messages this callback fires only while the
+ * app is in the FOREGROUND — when backgrounded/killed the OS posts the tray
+ * notification itself (on the channel named in the manifest meta-data) and the
+ * tap intent is handled by MainActivity instead.
+ *
+ * Parse-and-write only: FCM allows a short execution window here, so no
+ * network or heavy work. No system notification is posted for foreground
+ * receipt — the Home banner is the surface.
+ */
+@AndroidEntryPoint
+class NimazMessagingService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var repository: AnnouncementRepository
+
+    @Inject
+    lateinit var mapper: AnnouncementPayloadMapper
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val announcement = mapper.fromPayload(message.data) ?: return
+        // Blocking keeps the write inside the callback's execution window;
+        // a DataStore edit is a fast local disk write.
+        runBlocking { repository.setAnnouncement(announcement) }
+    }
+
+    override fun onNewToken(token: String) {
+        // Topic broadcast only — tokens are never stored or sent anywhere.
+        Log.d(TAG, "FCM registration token rotated")
+    }
+
+    private companion object {
+        const val TAG = "NimazMessagingService"
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/AnnouncementLocalDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/AnnouncementLocalDataSource.kt
@@ -1,0 +1,110 @@
+package com.arshadshah.nimaz.data.local.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Separate DataStore file: the main "nimaz_preferences" delegate is private to
+// PreferencesDataStore and announcements are a self-contained slice of state.
+private val Context.announcementDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "nimaz_announcements"
+)
+
+/**
+ * Persists the latest received announcement and the set of permanently
+ * dismissed announcement ids.
+ */
+@Singleton
+class AnnouncementLocalDataSource @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val dataStore = context.announcementDataStore
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private object Keys {
+        val CURRENT = stringPreferencesKey("current_announcement")
+        val DISMISSED_IDS = stringSetPreferencesKey("dismissed_announcement_ids")
+    }
+
+    val currentAnnouncement: Flow<Announcement?> = dataStore.data.map { prefs ->
+        prefs[Keys.CURRENT]?.let(::decode)?.toDomain()
+    }
+
+    val dismissedIds: Flow<Set<String>> = dataStore.data.map { prefs ->
+        prefs[Keys.DISMISSED_IDS] ?: emptySet()
+    }
+
+    suspend fun setCurrentAnnouncement(announcement: Announcement) {
+        dataStore.edit { prefs ->
+            prefs[Keys.CURRENT] = json.encodeToString(announcement.toEntity())
+        }
+    }
+
+    /** Records [id] as dismissed and clears the current announcement if it matches. */
+    suspend fun dismiss(id: String) {
+        dataStore.edit { prefs ->
+            prefs[Keys.DISMISSED_IDS] = (prefs[Keys.DISMISSED_IDS] ?: emptySet()) + id
+            if (prefs[Keys.CURRENT]?.let(::decode)?.id == id) prefs.remove(Keys.CURRENT)
+        }
+    }
+
+    private fun decode(raw: String): AnnouncementEntity? =
+        runCatching { json.decodeFromString<AnnouncementEntity>(raw) }.getOrNull()
+}
+
+/** Storage shape of an [Announcement]; kept separate so the domain model stays serialization-free. */
+@Serializable
+internal data class AnnouncementEntity(
+    val id: String,
+    val type: String,
+    val title: String,
+    val body: String,
+    val ctaLabel: String? = null,
+    val route: String? = null,
+    val minVersionCode: Int? = null,
+    val maxVersionCode: Int? = null,
+    val expiresAtMillis: Long? = null,
+    val dismissable: Boolean = true,
+)
+
+internal fun AnnouncementEntity.toDomain(): Announcement? {
+    val announcementType = AnnouncementType.fromKey(type) ?: return null
+    return Announcement(
+        id = id,
+        type = announcementType,
+        title = title,
+        body = body,
+        ctaLabel = ctaLabel,
+        route = route,
+        minVersionCode = minVersionCode,
+        maxVersionCode = maxVersionCode,
+        expiresAtMillis = expiresAtMillis,
+        dismissable = dismissable,
+    )
+}
+
+internal fun Announcement.toEntity(): AnnouncementEntity = AnnouncementEntity(
+    id = id,
+    type = type.key,
+    title = title,
+    body = body,
+    ctaLabel = ctaLabel,
+    route = route,
+    minVersionCode = minVersionCode,
+    maxVersionCode = maxVersionCode,
+    expiresAtMillis = expiresAtMillis,
+    dismissable = dismissable,
+)

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AnnouncementRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AnnouncementRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.datastore.AnnouncementLocalDataSource
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AnnouncementRepositoryImpl @Inject constructor(
+    private val localDataSource: AnnouncementLocalDataSource,
+) : AnnouncementRepository {
+
+    override fun observeCurrentAnnouncement(): Flow<Announcement?> =
+        combine(
+            localDataSource.currentAnnouncement,
+            localDataSource.dismissedIds,
+        ) { announcement, dismissedIds ->
+            announcement?.takeIf { it.id !in dismissedIds }
+        }
+
+    override suspend fun setAnnouncement(announcement: Announcement) {
+        localDataSource.setCurrentAnnouncement(announcement)
+    }
+
+    override suspend fun dismiss(id: String) {
+        localDataSource.dismiss(id)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/Announcement.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/Announcement.kt
@@ -1,0 +1,57 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * An engagement announcement delivered via FCM (topic broadcast from the
+ * Firebase console). Rendered as a dismissable banner on the Home screen;
+ * the OS tray shows the composer's notification title/body when the app is
+ * backgrounded. See docs/SUBSYSTEMS.md — "Engagement announcements (FCM)".
+ */
+data class Announcement(
+    /** Stable unique id from the payload — drives dedup and permanent dismissal. */
+    val id: String,
+    val type: AnnouncementType,
+    val title: String,
+    val body: String,
+    /** CTA button label; the banner shows no CTA when absent. */
+    val ctaLabel: String? = null,
+    /** Route key (resolved against an allowlist) or an https:// URL. */
+    val route: String? = null,
+    /** Suppress the banner below this installed versionCode. */
+    val minVersionCode: Int? = null,
+    /** Suppress the banner above this installed versionCode. */
+    val maxVersionCode: Int? = null,
+    /** Suppress the banner after this instant (epoch millis, UTC). */
+    val expiresAtMillis: Long? = null,
+    val dismissable: Boolean = true,
+) {
+    /** True when this announcement may render for [versionCode] at [nowMillis]. */
+    fun isActiveFor(versionCode: Int, nowMillis: Long): Boolean =
+        (expiresAtMillis == null || nowMillis < expiresAtMillis) &&
+                (minVersionCode == null || versionCode >= minVersionCode) &&
+                (maxVersionCode == null || versionCode <= maxVersionCode)
+}
+
+/** Announcement category — selects the banner's icon and accent. */
+enum class AnnouncementType(val key: String) {
+    FEATURE("feature"),
+    PRIVACY("privacy"),
+    TOS("tos"),
+    CHANGELOG("changelog");
+
+    companion object {
+        fun fromKey(key: String?): AnnouncementType? =
+            entries.firstOrNull { it.key == key?.trim()?.lowercase() }
+    }
+}
+
+/** Validated action behind an announcement's CTA / notification tap. */
+sealed interface AnnouncementAction {
+    /** Open an https:// URL in the browser. */
+    data class OpenUrl(val url: String) : AnnouncementAction
+
+    /** Navigate to an allowlisted in-app feature (see announcementRoute). */
+    data class NavigateToFeature(val routeKey: String) : AnnouncementAction
+
+    /** Unknown or missing route — the banner hides its CTA. */
+    data object None : AnnouncementAction
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/AnnouncementRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/AnnouncementRepository.kt
@@ -1,0 +1,20 @@
+package com.arshadshah.nimaz.domain.repository
+
+import com.arshadshah.nimaz.domain.model.Announcement
+import kotlinx.coroutines.flow.Flow
+
+interface AnnouncementRepository {
+
+    /**
+     * The most recently received announcement, or null when there is none or
+     * it has been dismissed. Expiry/version gating is applied by
+     * `ObserveActiveAnnouncementUseCase`, not here.
+     */
+    fun observeCurrentAnnouncement(): Flow<Announcement?>
+
+    /** Store [announcement] as the current one (from FCM receipt or a notification tap). */
+    suspend fun setAnnouncement(announcement: Announcement)
+
+    /** Permanently dismiss the announcement with [id] — it never resurfaces. */
+    suspend fun dismiss(id: String)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AnnouncementUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AnnouncementUseCases.kt
@@ -1,0 +1,59 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementAction
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+data class AnnouncementUseCases(
+    val observeActiveAnnouncement: ObserveActiveAnnouncementUseCase,
+    val setAnnouncement: SetAnnouncementUseCase,
+    val dismissAnnouncement: DismissAnnouncementUseCase,
+    val resolveAnnouncementRoute: ResolveAnnouncementRouteUseCase,
+)
+
+/**
+ * Emits the current announcement only if it is not dismissed (repository
+ * concern), not expired, and the installed [currentVersionCode] falls inside
+ * its `[minVersionCode, maxVersionCode]` window — otherwise emits null.
+ */
+class ObserveActiveAnnouncementUseCase(
+    private val repository: AnnouncementRepository,
+    private val currentVersionCode: Int,
+    private val nowMillis: () -> Long = { System.currentTimeMillis() },
+) {
+    operator fun invoke(): Flow<Announcement?> =
+        repository.observeCurrentAnnouncement().map { announcement ->
+            announcement?.takeIf { it.isActiveFor(currentVersionCode, nowMillis()) }
+        }
+}
+
+class SetAnnouncementUseCase(private val repository: AnnouncementRepository) {
+    suspend operator fun invoke(announcement: Announcement) =
+        repository.setAnnouncement(announcement)
+}
+
+class DismissAnnouncementUseCase(private val repository: AnnouncementRepository) {
+    suspend operator fun invoke(id: String) = repository.dismiss(id)
+}
+
+/**
+ * Classifies an announcement's `route` payload value into a validated
+ * [AnnouncementAction]. Feature keys are checked against the navigation
+ * allowlist via the injected [isKnownFeatureKey] (see `announcementRoute` in
+ * `core/navigation`) so old app versions safely no-op on keys they don't know.
+ */
+class ResolveAnnouncementRouteUseCase(
+    private val isKnownFeatureKey: (String) -> Boolean,
+) {
+    operator fun invoke(route: String?): AnnouncementAction {
+        val value = route?.trim().orEmpty()
+        return when {
+            value.isEmpty() -> AnnouncementAction.None
+            value.startsWith("https://") -> AnnouncementAction.OpenUrl(value)
+            isKnownFeatureKey(value) -> AnnouncementAction.NavigateToFeature(value)
+            else -> AnnouncementAction.None
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/AnnouncementBanner.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/AnnouncementBanner.kt
@@ -1,0 +1,190 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+
+/**
+ * Dismissable engagement banner rendered at the top of Home when an FCM
+ * announcement is active. Icon/accent follow the announcement [AnnouncementType];
+ * the CTA button renders only when [showCta] (a label AND a resolvable route).
+ * Animates in/out; renders nothing once [announcement] goes null so callers can
+ * drop it in unconditionally.
+ */
+@Composable
+fun AnnouncementBanner(
+    announcement: Announcement?,
+    showCta: Boolean,
+    onCtaClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // AnimatedVisibility keeps rendering during the exit animation, after the
+    // announcement has gone null — hold the last non-null one to animate out.
+    var lastAnnouncement by remember { mutableStateOf(announcement) }
+    if (announcement != null) lastAnnouncement = announcement
+
+    AnimatedVisibility(
+        visible = announcement != null,
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut(),
+    ) {
+        // The modifier (caller padding) lives on the card, inside the animated
+        // content, so a hidden banner contributes zero space.
+        lastAnnouncement?.let {
+            AnnouncementBannerCard(it, showCta, onCtaClick, onDismiss, modifier)
+        }
+    }
+}
+
+@Composable
+private fun AnnouncementBannerCard(
+    announcement: Announcement,
+    showCta: Boolean,
+    onCtaClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = when (announcement.type) {
+        AnnouncementType.FEATURE -> MaterialTheme.colorScheme.primary
+        AnnouncementType.PRIVACY, AnnouncementType.TOS -> MaterialTheme.colorScheme.tertiary
+        AnnouncementType.CHANGELOG -> MaterialTheme.colorScheme.secondary
+    }
+    val icon = when (announcement.type) {
+        AnnouncementType.FEATURE -> Icons.Outlined.AutoAwesome
+        AnnouncementType.PRIVACY, AnnouncementType.TOS -> Icons.Outlined.Shield
+        AnnouncementType.CHANGELOG -> Icons.Outlined.Info
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = accent.copy(alpha = 0.1f),
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            NimazIcon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accent,
+                size = NimazIconSize.LARGE,
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = announcement.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = announcement.body,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (showCta && announcement.ctaLabel != null) {
+                    Spacer(modifier = Modifier.height(10.dp))
+                    NimazButton(
+                        text = announcement.ctaLabel,
+                        onClick = onCtaClick,
+                        variant = NimazButtonVariant.TONAL,
+                        size = NimazButtonSize.SMALL,
+                    )
+                }
+            }
+            if (announcement.dismissable) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Dismiss announcement",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ──── Previews ───────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, widthDp = 400, name = "Feature announcement")
+@Composable
+private fun AnnouncementBanner_Feature_Preview() {
+    NimazTheme {
+        AnnouncementBanner(
+            announcement = Announcement(
+                id = "2026-07-ask-with-proof",
+                type = AnnouncementType.FEATURE,
+                title = "Ask with Proof is here",
+                body = "Search the Qur'an, get cited answers.",
+                ctaLabel = "Try it",
+                route = "search/ask",
+            ),
+            showCta = true,
+            onCtaClick = {},
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 400, name = "Privacy notice, no CTA")
+@Composable
+private fun AnnouncementBanner_Privacy_Preview() {
+    NimazTheme {
+        AnnouncementBanner(
+            announcement = Announcement(
+                id = "2026-07-privacy",
+                type = AnnouncementType.PRIVACY,
+                title = "Privacy policy updated",
+                body = "We've clarified how location data is used for prayer times.",
+            ),
+            showCta = false,
+            onCtaClick = {},
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -52,6 +52,7 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.UpdateState
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.molecules.AnnouncementBanner
 import com.arshadshah.nimaz.presentation.components.molecules.PrayerTimeCard
 import com.arshadshah.nimaz.presentation.components.molecules.PrayerTimesSectionHeader
 import com.arshadshah.nimaz.presentation.components.organisms.HomeBannerCarousel
@@ -66,6 +67,7 @@ import com.arshadshah.nimaz.presentation.components.organisms.TodayInfoCards
 import com.arshadshah.nimaz.presentation.components.organisms.TodaysProgressCard
 import com.arshadshah.nimaz.presentation.theme.currentWindowSizeClass
 import com.arshadshah.nimaz.presentation.theme.isCompact
+import com.arshadshah.nimaz.presentation.viewmodel.AnnouncementUiState
 import com.arshadshah.nimaz.presentation.viewmodel.HomeEvent
 import com.arshadshah.nimaz.presentation.viewmodel.HomeUiState
 import com.arshadshah.nimaz.presentation.viewmodel.HomeViewModel
@@ -86,9 +88,19 @@ fun HomeScreen(
     onNavigateToPrayerSettings: () -> Unit,
     onNavigateToPrayerTimes: () -> Unit = {},
     onOpenHadith: (hadithId: String) -> Unit = {},
+    onOpenAnnouncementRoute: (String) -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
+    val announcementState by viewModel.announcement.collectAsState()
+
+    val onAnnouncementCta: () -> Unit = {
+        viewModel.onEvent(HomeEvent.AnnouncementCtaClicked)
+        announcementState.announcement?.route?.let { onOpenAnnouncementRoute(it) }
+    }
+    val onAnnouncementDismiss: () -> Unit = {
+        viewModel.onEvent(HomeEvent.DismissAnnouncement)
+    }
     val updateManager = LocalInAppUpdateManager.current
     val updateState = updateManager?.updateState?.collectAsState()?.value ?: UpdateState.Idle
 
@@ -158,6 +170,9 @@ fun HomeScreen(
                     Box(modifier = Modifier.fillMaxSize()) {
                         HomeCompactContent(
                             state = state,
+                            announcementState = announcementState,
+                            onAnnouncementCta = onAnnouncementCta,
+                            onAnnouncementDismiss = onAnnouncementDismiss,
                             listState = compactListState,
                             updateState = updateState,
                             updateManager = updateManager,
@@ -186,6 +201,9 @@ fun HomeScreen(
                 else -> {
                     HomeTabletContent(
                         state = state,
+                        announcementState = announcementState,
+                        onAnnouncementCta = onAnnouncementCta,
+                        onAnnouncementDismiss = onAnnouncementDismiss,
                         updateState = updateState,
                         updateManager = updateManager,
                         onNavigateToSettings = onNavigateToSettings,
@@ -210,6 +228,9 @@ fun HomeScreen(
 @Composable
 private fun HomeCompactContent(
     state: HomeUiState,
+    announcementState: AnnouncementUiState,
+    onAnnouncementCta: () -> Unit,
+    onAnnouncementDismiss: () -> Unit,
     listState: LazyListState,
     updateState: UpdateState,
     updateManager: com.arshadshah.nimaz.core.util.InAppUpdateManager?,
@@ -261,6 +282,18 @@ private fun HomeCompactContent(
         // so the two read as distinct containers rather than abutting slabs.
         item(key = "hero_spacer") {
             Spacer(modifier = Modifier.height(20.dp))
+        }
+
+        // FCM engagement announcement — dismissable, renders nothing (zero
+        // height) when no announcement is active.
+        item(key = "announcement") {
+            AnnouncementBanner(
+                announcement = announcementState.announcement,
+                showCta = announcementState.showCta,
+                onCtaClick = onAnnouncementCta,
+                onDismiss = onAnnouncementDismiss,
+                modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 16.dp),
+            )
         }
 
         if (banners.isNotEmpty()) {
@@ -328,6 +361,9 @@ private fun HomeCompactContent(
 @Composable
 private fun HomeTabletContent(
     state: HomeUiState,
+    announcementState: AnnouncementUiState,
+    onAnnouncementCta: () -> Unit,
+    onAnnouncementDismiss: () -> Unit,
     updateState: UpdateState,
     updateManager: com.arshadshah.nimaz.core.util.InAppUpdateManager?,
     onNavigateToSettings: () -> Unit,
@@ -369,6 +405,15 @@ private fun HomeTabletContent(
             nextPrayerTime = nextPrayerTime,
             timeUntilNextPrayer = state.timeUntilNextPrayer,
             onSettingsClick = onNavigateToSettings
+        )
+
+        // FCM engagement announcement — same banner as the compact layout.
+        AnnouncementBanner(
+            announcement = announcementState.announcement,
+            showCta = announcementState.showCta,
+            onCtaClick = onAnnouncementCta,
+            onDismiss = onAnnouncementDismiss,
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp),
         )
 
         // Tablet shares the same compact pill carousel — keeps both layouts

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -26,6 +26,9 @@ import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementAction
+import com.arshadshah.nimaz.domain.usecase.AnnouncementUseCases
 import com.arshadshah.nimaz.domain.usecase.DuaUseCases
 import com.arshadshah.nimaz.domain.usecase.FastingUseCases
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
@@ -35,9 +38,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -110,6 +117,18 @@ data class PrayerTimeDisplay(
     val prayerStatus: PrayerStatus = PrayerStatus.NOT_PRAYED
 )
 
+/**
+ * The FCM engagement banner's slice of Home state. [announcement] is null when
+ * there is nothing active (nothing received, dismissed, expired or outside the
+ * version window). [showCta] is true only when the announcement carries a CTA
+ * label AND its route resolves (allowlisted key or https URL) — otherwise the
+ * banner renders without a button.
+ */
+data class AnnouncementUiState(
+    val announcement: Announcement? = null,
+    val showCta: Boolean = false,
+)
+
 sealed interface HomeEvent {
     data class UpdateLocation(val latitude: Double, val longitude: Double, val name: String) :
         HomeEvent
@@ -117,6 +136,8 @@ sealed interface HomeEvent {
     data object RefreshPrayerTimes : HomeEvent
     data object RefreshPermissions : HomeEvent
     data class TogglePrayerStatus(val prayerType: PrayerType) : HomeEvent
+    data object DismissAnnouncement : HomeEvent
+    data object AnnouncementCtaClicked : HomeEvent
 }
 
 @HiltViewModel
@@ -127,11 +148,36 @@ class HomeViewModel @Inject constructor(
     private val fastingUseCases: FastingUseCases,
     private val hadithUseCases: HadithUseCases,
     private val duaUseCases: DuaUseCases,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val announcementUseCases: AnnouncementUseCases
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeUiState())
     val state: StateFlow<HomeUiState> = _state.asStateFlow()
+
+    // Last announcement id logged as shown — analytics fires once per id, not
+    // on every recomposition/re-emission.
+    private var lastShownAnnouncementId: String? = null
+
+    /** Active FCM engagement announcement (already dismissal/expiry/version-gated). */
+    val announcement: StateFlow<AnnouncementUiState> =
+        announcementUseCases.observeActiveAnnouncement()
+            .map { active ->
+                AnnouncementUiState(
+                    announcement = active,
+                    showCta = active?.ctaLabel != null &&
+                            announcementUseCases.resolveAnnouncementRoute(active.route) !=
+                            AnnouncementAction.None,
+                )
+            }
+            .onEach { uiState ->
+                val active = uiState.announcement ?: return@onEach
+                if (active.id != lastShownAnnouncementId) {
+                    lastShownAnnouncementId = active.id
+                    AppAnalytics.logAnnouncementShown(active.id, active.type.key)
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AnnouncementUiState())
 
     // Declared before init{} so it is initialized before loadPrayerRecords()
     // collects into it. The getTodayPrayerRecords() Flow can emit synchronously
@@ -260,7 +306,24 @@ class HomeViewModel @Inject constructor(
             HomeEvent.RefreshPrayerTimes -> calculatePrayerTimes()
             HomeEvent.RefreshPermissions -> checkPermissions()
             is HomeEvent.TogglePrayerStatus -> togglePrayerStatus(event.prayerType)
+            HomeEvent.DismissAnnouncement -> dismissAnnouncement()
+            HomeEvent.AnnouncementCtaClicked -> logAnnouncementCta()
         }
+    }
+
+    private fun dismissAnnouncement() {
+        val active = announcement.value.announcement ?: return
+        viewModelScope.launch {
+            announcementUseCases.dismissAnnouncement(active.id)
+            AppAnalytics.logAnnouncementDismissed(active.id)
+        }
+    }
+
+    // Navigation itself is handled by the screen's onOpenAnnouncementRoute
+    // callback (NavGraph owns the controller); the VM only records the click.
+    private fun logAnnouncementCta() {
+        val active = announcement.value.announcement ?: return
+        AppAnalytics.logAnnouncementCtaClicked(active.id, active.route)
     }
 
     fun getBatteryOptimizationIntent(): Intent {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1333,6 +1333,8 @@
     <string name="ai_error_network_title">Antwortdienst nicht erreichbar</string>
     <string name="ai_error_rate_limited_title">Du hast das heutige Fragenlimit erreicht</string>
     <string name="ai_error_budget_title">KI-Antworten sind vorerst pausiert</string>
+    <string name="ai_error_unverified_title">Diese App-Kopie konnte nicht verifiziert werden</string>
+    <string name="ai_error_unverified">KI-Antworten sind nur in der offiziellen App von Google Play verfügbar. Die Stichwortsuche im Koran, in Hadithen und Duas funktioniert weiterhin offline.</string>
     <string name="ai_error_invalid_title">Diese Frage konnte nicht verarbeitet werden</string>
     <string name="ai_error_unknown_title">Etwas ist schiefgelaufen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1334,6 +1334,8 @@
     <string name="ai_error_network_title">Impossible de joindre le service de réponses</string>
     <string name="ai_error_rate_limited_title">Vous avez atteint la limite de questions du jour</string>
     <string name="ai_error_budget_title">Les réponses de l\'IA sont suspendues pour le moment</string>
+    <string name="ai_error_unverified_title">Cette copie de l\'application n\'a pas pu être vérifiée</string>
+    <string name="ai_error_unverified">Les réponses de l\'IA ne sont disponibles que sur l\'application officielle de Google Play. La recherche par mots-clés dans le Coran, les hadiths et les douas fonctionne toujours hors ligne.</string>
     <string name="ai_error_invalid_title">Cette question n\'a pas pu être traitée</string>
     <string name="ai_error_unknown_title">Une erreur s\'est produite</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1334,6 +1334,8 @@
     <string name="ai_error_network_title">Tidak dapat menjangkau layanan jawaban</string>
     <string name="ai_error_rate_limited_title">Anda telah mencapai batas pertanyaan hari ini</string>
     <string name="ai_error_budget_title">Jawaban AI dijeda untuk saat ini</string>
+    <string name="ai_error_unverified_title">Salinan aplikasi ini tidak dapat diverifikasi</string>
+    <string name="ai_error_unverified">Jawaban AI hanya tersedia di aplikasi resmi dari Google Play. Pencarian kata kunci di Quran, Hadis, dan doa tetap berfungsi secara offline.</string>
     <string name="ai_error_invalid_title">Pertanyaan itu tidak dapat diproses</string>
     <string name="ai_error_unknown_title">Terjadi kesalahan</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1335,6 +1335,8 @@
     <string name="ai_error_network_title">Tidak dapat menghubungi perkhidmatan jawapan</string>
     <string name="ai_error_rate_limited_title">Anda telah mencapai had soalan hari ini</string>
     <string name="ai_error_budget_title">Jawapan AI dijeda buat masa ini</string>
+    <string name="ai_error_unverified_title">Salinan aplikasi ini tidak dapat disahkan</string>
+    <string name="ai_error_unverified">Jawapan AI hanya tersedia pada aplikasi rasmi daripada Google Play. Carian kata kunci merentas Quran, Hadis dan doa masih berfungsi secara luar talian.</string>
     <string name="ai_error_invalid_title">Soalan itu tidak dapat diproses</string>
     <string name="ai_error_unknown_title">Berlaku ralat</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1337,6 +1337,8 @@
     <string name="ai_error_network_title">Yanıt hizmetine ulaşılamadı</string>
     <string name="ai_error_rate_limited_title">Bugünkü soru sınırına ulaştınız</string>
     <string name="ai_error_budget_title">Yapay zekâ yanıtları şimdilik duraklatıldı</string>
+    <string name="ai_error_unverified_title">Bu uygulama kopyası doğrulanamadı</string>
+    <string name="ai_error_unverified">Yapay zekâ yanıtları yalnızca Google Play\'deki resmî uygulamada kullanılabilir. Quran, hadis ve dualarda anahtar kelime araması çevrimdışı çalışmaya devam eder.</string>
     <string name="ai_error_invalid_title">Bu soru işlenemedi</string>
     <string name="ai_error_unknown_title">Bir şeyler ters gitti</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutesTest.kt
@@ -1,0 +1,30 @@
+package com.arshadshah.nimaz.core.navigation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AnnouncementRoutesTest {
+
+    @Test
+    fun `known keys resolve to routes`() {
+        assertThat(announcementRoute("home")).isEqualTo(Route.Home)
+        assertThat(announcementRoute("quran")).isEqualTo(Route.Quran)
+        assertThat(announcementRoute("search/ask")).isEqualTo(Route.GlobalSearch)
+        assertThat(announcementRoute("search/settings")).isEqualTo(Route.SearchSettings)
+        assertThat(announcementRoute("prayer/tracker")).isEqualTo(Route.PrayerTracker())
+        assertThat(announcementRoute("settings/about")).isEqualTo(Route.SettingsAbout)
+        assertThat(announcementRoute("khatam")).isEqualTo(Route.KhatamList)
+    }
+
+    @Test
+    fun `unknown key resolves to null`() {
+        assertThat(announcementRoute("brand/new/feature")).isNull()
+        assertThat(announcementRoute("")).isNull()
+        assertThat(announcementRoute(null)).isNull()
+    }
+
+    @Test
+    fun `urls are not feature keys`() {
+        assertThat(announcementRoute("https://nimaz.arshadshah.com/privacy")).isNull()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadMapperTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadMapperTest.kt
@@ -1,0 +1,135 @@
+package com.arshadshah.nimaz.data.announcement
+
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AnnouncementPayloadMapperTest {
+
+    private val mapper = AnnouncementPayloadMapper()
+
+    private fun validPayload() = mutableMapOf(
+        "id" to "2026-07-ask-with-proof",
+        "type" to "feature",
+        "title" to "Ask with Proof is here",
+        "body" to "Search the Qur'an, get cited answers.",
+        "cta_label" to "Try it",
+        "route" to "search/ask",
+        "min_version_code" to "142",
+        "max_version_code" to "999",
+        "expires_at" to "2026-08-01T00:00:00Z",
+        "dismissable" to "true",
+    )
+
+    @Test
+    fun `valid payload maps all fields`() {
+        val announcement = mapper.fromPayload(validPayload())
+
+        assertThat(announcement).isNotNull()
+        announcement!!
+        assertThat(announcement.id).isEqualTo("2026-07-ask-with-proof")
+        assertThat(announcement.type).isEqualTo(AnnouncementType.FEATURE)
+        assertThat(announcement.title).isEqualTo("Ask with Proof is here")
+        assertThat(announcement.body).isEqualTo("Search the Qur'an, get cited answers.")
+        assertThat(announcement.ctaLabel).isEqualTo("Try it")
+        assertThat(announcement.route).isEqualTo("search/ask")
+        assertThat(announcement.minVersionCode).isEqualTo(142)
+        assertThat(announcement.maxVersionCode).isEqualTo(999)
+        assertThat(announcement.expiresAtMillis).isEqualTo(1_785_542_400_000L)
+        assertThat(announcement.dismissable).isTrue()
+    }
+
+    @Test
+    fun `minimal payload maps with defaults`() {
+        val announcement = mapper.fromPayload(
+            mapOf(
+                "id" to "x",
+                "type" to "changelog",
+                "title" to "t",
+                "body" to "b",
+            )
+        )
+
+        assertThat(announcement).isNotNull()
+        announcement!!
+        assertThat(announcement.ctaLabel).isNull()
+        assertThat(announcement.route).isNull()
+        assertThat(announcement.minVersionCode).isNull()
+        assertThat(announcement.maxVersionCode).isNull()
+        assertThat(announcement.expiresAtMillis).isNull()
+        assertThat(announcement.dismissable).isTrue()
+    }
+
+    @Test
+    fun `missing required field returns null`() {
+        listOf("id", "type", "title", "body").forEach { required ->
+            val payload = validPayload().apply { remove(required) }
+            assertThat(mapper.fromPayload(payload)).isNull()
+        }
+    }
+
+    @Test
+    fun `blank required field returns null`() {
+        val payload = validPayload().apply { put("title", "   ") }
+        assertThat(mapper.fromPayload(payload)).isNull()
+    }
+
+    @Test
+    fun `unknown type returns null`() {
+        val payload = validPayload().apply { put("type", "promo") }
+        assertThat(mapper.fromPayload(payload)).isNull()
+    }
+
+    @Test
+    fun `malformed version code returns null`() {
+        val payload = validPayload().apply { put("min_version_code", "abc") }
+        assertThat(mapper.fromPayload(payload)).isNull()
+    }
+
+    @Test
+    fun `malformed expires_at returns null`() {
+        val payload = validPayload().apply { put("expires_at", "tomorrow") }
+        assertThat(mapper.fromPayload(payload)).isNull()
+    }
+
+    @Test
+    fun `malformed dismissable returns null`() {
+        val payload = validPayload().apply { put("dismissable", "yes") }
+        assertThat(mapper.fromPayload(payload)).isNull()
+    }
+
+    @Test
+    fun `dismissable false is honoured`() {
+        val payload = validPayload().apply { put("dismissable", "false") }
+        assertThat(mapper.fromPayload(payload)!!.dismissable).isFalse()
+    }
+
+    @Test
+    fun `type parsing is case-insensitive`() {
+        val payload = validPayload().apply { put("type", "Privacy") }
+        assertThat(mapper.fromPayload(payload)!!.type).isEqualTo(AnnouncementType.PRIVACY)
+    }
+
+    @Test
+    fun `reserved and unknown keys are ignored`() {
+        val payload = validPayload().apply {
+            put("from", "123456")
+            put("message_type", "gcm")
+            put("google.message_id", "m-1")
+            put("gcm.notification.title", "x")
+            put("collapse_key", "ck")
+        }
+        assertThat(mapper.fromPayload(payload)).isNotNull()
+    }
+
+    @Test
+    fun `blank optional fields become null`() {
+        val payload = validPayload().apply {
+            put("cta_label", "")
+            put("route", " ")
+        }
+        val announcement = mapper.fromPayload(payload)!!
+        assertThat(announcement.ctaLabel).isNull()
+        assertThat(announcement.route).isNull()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/AnnouncementUseCasesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/AnnouncementUseCasesTest.kt
@@ -1,0 +1,127 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.Announcement
+import com.arshadshah.nimaz.domain.model.AnnouncementAction
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AnnouncementUseCasesTest {
+
+    private val announcement = Announcement(
+        id = "a-1",
+        type = AnnouncementType.FEATURE,
+        title = "t",
+        body = "b",
+        minVersionCode = 100,
+        maxVersionCode = 200,
+        expiresAtMillis = 1_000L,
+    )
+
+    private class FakeRepository : AnnouncementRepository {
+        val current = MutableStateFlow<Announcement?>(null)
+        val dismissed = mutableSetOf<String>()
+
+        override fun observeCurrentAnnouncement(): Flow<Announcement?> = current
+
+        override suspend fun setAnnouncement(announcement: Announcement) {
+            current.value = announcement
+        }
+
+        override suspend fun dismiss(id: String) {
+            dismissed += id
+            if (current.value?.id == id) current.value = null
+        }
+    }
+
+    private fun useCase(
+        repository: AnnouncementRepository,
+        versionCode: Int,
+        now: Long,
+    ) = ObserveActiveAnnouncementUseCase(repository, versionCode, { now })
+
+    @Test
+    fun `active announcement inside window is emitted`() = runTest {
+        val repo = FakeRepository().apply { current.value = announcement }
+
+        val result = useCase(repo, versionCode = 150, now = 500L).invoke().first()
+
+        assertThat(result).isEqualTo(announcement)
+    }
+
+    @Test
+    fun `expired announcement is suppressed`() = runTest {
+        val repo = FakeRepository().apply { current.value = announcement }
+
+        val result = useCase(repo, versionCode = 150, now = 1_000L).invoke().first()
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `below min version is suppressed`() = runTest {
+        val repo = FakeRepository().apply { current.value = announcement }
+
+        val result = useCase(repo, versionCode = 99, now = 500L).invoke().first()
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `above max version is suppressed`() = runTest {
+        val repo = FakeRepository().apply { current.value = announcement }
+
+        val result = useCase(repo, versionCode = 201, now = 500L).invoke().first()
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `no bounds means always active`() = runTest {
+        val unbounded = announcement.copy(
+            minVersionCode = null,
+            maxVersionCode = null,
+            expiresAtMillis = null,
+        )
+        val repo = FakeRepository().apply { current.value = unbounded }
+
+        val result = useCase(repo, versionCode = 1, now = Long.MAX_VALUE - 1).invoke().first()
+
+        assertThat(result).isEqualTo(unbounded)
+    }
+
+    @Test
+    fun `dismissed announcement never re-emits after resend of same id`() = runTest {
+        val repo = FakeRepository().apply { current.value = announcement }
+        val observe = useCase(repo, versionCode = 150, now = 500L)
+
+        DismissAnnouncementUseCase(repo).invoke(announcement.id)
+        assertThat(observe.invoke().first()).isNull()
+
+        // Re-sending the same id must not resurface it (repository contract:
+        // dismissed ids are filtered out of observeCurrentAnnouncement).
+        assertThat(repo.dismissed).contains(announcement.id)
+    }
+
+    @Test
+    fun `resolve route classifies url, known key, unknown key and blank`() {
+        val resolve = ResolveAnnouncementRouteUseCase(
+            isKnownFeatureKey = { it == "search/ask" },
+        )
+
+        assertThat(resolve("https://nimaz.arshadshah.com/privacy"))
+            .isEqualTo(AnnouncementAction.OpenUrl("https://nimaz.arshadshah.com/privacy"))
+        assertThat(resolve("search/ask"))
+            .isEqualTo(AnnouncementAction.NavigateToFeature("search/ask"))
+        assertThat(resolve("brand/new/key")).isEqualTo(AnnouncementAction.None)
+        assertThat(resolve(null)).isEqualTo(AnnouncementAction.None)
+        assertThat(resolve("  ")).isEqualTo(AnnouncementAction.None)
+        // http (non-TLS) is not allowlisted
+        assertThat(resolve("http://example.com")).isEqualTo(AnnouncementAction.None)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -7,6 +7,7 @@ import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
 import com.arshadshah.nimaz.domain.repository.DuaRepository
 import com.arshadshah.nimaz.domain.repository.FastingRepository
 import com.arshadshah.nimaz.domain.repository.HadithRepository
@@ -45,6 +46,7 @@ class HomeViewModelTest {
     private lateinit var hadithRepository: HadithRepository
     private lateinit var duaRepository: DuaRepository
     private lateinit var settingsRepository: SettingsRepository
+    private lateinit var announcementRepository: AnnouncementRepository
 
     @Before
     fun setUp() {
@@ -57,6 +59,8 @@ class HomeViewModelTest {
         hadithRepository = mockk(relaxed = true)
         duaRepository = mockk(relaxed = true)
         settingsRepository = mockk(relaxed = true)
+        announcementRepository = mockk(relaxed = true)
+        every { announcementRepository.observeCurrentAnnouncement() } returns flowOf(null)
 
         // The today's-records Flow emits synchronously, mirroring Room emitting an
         // initial value during ViewModel init before the rest of the constructor
@@ -76,7 +80,8 @@ class HomeViewModelTest {
         fastingUseCases = buildFastingUseCases(fastingRepository),
         hadithUseCases = buildHadithUseCases(hadithRepository),
         duaUseCases = buildDuaUseCases(duaRepository),
-        settingsRepository = settingsRepository
+        settingsRepository = settingsRepository,
+        announcementUseCases = buildAnnouncementUseCases(announcementRepository)
     )
 
     /**

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
 import com.arshadshah.nimaz.domain.repository.FastingRepository
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import com.arshadshah.nimaz.domain.repository.HadithRepository
@@ -9,6 +10,22 @@ import com.arshadshah.nimaz.domain.usecase.*
 // Test helpers: wrap a (mock) repository in the real use-case wrappers so existing
 // repository-level stubbing continues to drive ViewModel behaviour after the
 // use-case layer was introduced.
+
+fun buildAnnouncementUseCases(
+    repository: AnnouncementRepository,
+    currentVersionCode: Int = 1,
+    nowMillis: () -> Long = { System.currentTimeMillis() },
+    isKnownFeatureKey: (String) -> Boolean = { false },
+) = AnnouncementUseCases(
+    observeActiveAnnouncement = ObserveActiveAnnouncementUseCase(
+        repository,
+        currentVersionCode,
+        nowMillis
+    ),
+    setAnnouncement = SetAnnouncementUseCase(repository),
+    dismissAnnouncement = DismissAnnouncementUseCase(repository),
+    resolveAnnouncementRoute = ResolveAnnouncementRouteUseCase(isKnownFeatureKey)
+)
 
 fun buildFastingUseCases(repository: FastingRepository) = FastingUseCases(
     getFastRecordForDate = GetFastRecordForDateUseCase(repository),

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -25,7 +25,8 @@ Source root: `app/src/main/java/com/arshadshah/nimaz/`
 9. [App initialization & monitoring](#9-app-initialization--monitoring)
 10. [Device-to-device sync](#10-device-to-device-sync)
 11. [Content sharing](#11-content-sharing)
-12. [Keeping this doc updated](#keeping-this-doc-updated)
+12. [Engagement announcements (FCM)](#12-engagement-announcements-fcm)
+13. [Keeping this doc updated](#keeping-this-doc-updated)
 
 ---
 
@@ -286,7 +287,7 @@ formatted strings.
 `AppAnalytics.init(this)`, logs a crash breadcrumb, tags the crash DB-schema key, and runs
 `appInitializer.initialize()`. It also supplies the `HiltWorkerFactory` (§3).
 
-**`core/init/AppInitializer.kt`** — `@Singleton`. `initialize()` launches an IO coroutine that runs three tasks **in parallel under a 5 s `withTimeout`** (then proceeds to UI regardless): apply saved locale, schedule today's prayer notifications (§4), download the default adhan/beep if missing (§1). It exposes `val isReady: StateFlow<Boolean>` (the splash gate). Failures are reported to monitoring but never block startup.
+**`core/init/AppInitializer.kt`** — `@Singleton`. `initialize()` launches an IO coroutine that runs four tasks **in parallel under a 5 s `withTimeout`** (then proceeds to UI regardless): apply saved locale, schedule today's prayer notifications (§4), download the default adhan/beep if missing (§1), and bootstrap FCM announcements (§12 — create the Updates channel + topic subscribe). It exposes `val isReady: StateFlow<Boolean>` (the splash gate). Failures are reported to monitoring but never block startup.
 
 **`core/monitoring/`** — three thin Kotlin `object` wrappers over Firebase, each guarded so **every call is wrapped in `runCatching` and no-ops if Firebase isn't initialized** (debug/PR-check builds without `google-services.json` run unchanged). They are static singletons, never Hilt-injected.
 - `AppAnalytics.kt` → Firebase **Analytics**. The only one with `init(context)` (called from `NimazApp`) — it caches `applicationContext` so any caller can log without a `Context`. Provides semantic helpers + name catalogs (`Event`/`Param`/`UserProperty`), notably the notification pipeline (`notification_scheduled`/`_displayed`/`_suppressed`/`_opened`) and `logDiagnostics()` (records OS-level notification/exact-alarm/battery state as durable user properties).
@@ -370,6 +371,71 @@ composable coroutine scope.
 **Gotchas.**
 - `ShareCardRenderer` measures then draws in one `draw(canvas)` walk (null canvas = measure pass) so the bitmap height can't drift from the content; Arabic/body text is length-capped for the card, but the full text always survives in the `plainText` fallback.
 - Chooser title is a single shared `R.string.share_chooser_title` — the old per-feature titles (`share_hadith`, `dua_reader_share`, `tafseer_share_chooser`) are no longer wired to the chooser.
+
+---
+
+## 12. Engagement announcements (FCM)
+
+**Pure FCM, no backend.** Announcements (feature nudges, changelog items, privacy/T&C notices)
+are sent from the **Firebase console Notifications composer** as notification+data messages,
+broadcast to topic **`announcements`**. No server, no Remote Config, no token storage. With no
+message ever sent there is zero behaviour change — the feature is inert by default.
+
+**Delivery model.**
+- **App foreground** → `NimazMessagingService.onMessageReceived` fires: custom data →
+  `AnnouncementPayloadMapper` → `Announcement` → persisted via `AnnouncementRepository`. **No
+  system notification is posted**; the Home screen observes the repository and renders a
+  dismissable `AnnouncementBanner`.
+- **App backgrounded/killed** → the **OS** posts the tray notification itself (composer
+  title/body) on the `nimaz_announcements` channel (manifest meta-data
+  `default_notification_channel_id` / `_icon` / `_color`); `onMessageReceived` is **not** called.
+  Tapping copies the custom data onto the launcher intent — `MainActivity.handleIntent` maps the
+  extras, persists the announcement (banner shows on Home) and deep-links to its `route` if valid.
+  *Accepted gap:* opening the app without tapping the notification shows no banner.
+
+**Key files.**
+- `data/announcement/NimazMessagingService.kt` — the app's **only** `FirebaseMessagingService`
+  (`@AndroidEntryPoint`; parse-and-write only; `onNewToken` logs only).
+- `data/announcement/AnnouncementPayloadMapper.kt` — `Map<String,String>`/intent-extras →
+  `Announcement?`; null (never throws) on missing/blank required fields (`id`,`type`,`title`,`body`)
+  or any malformed optional (`min_version_code`, `max_version_code`, ISO-8601 `expires_at`,
+  `dismissable`).
+- `data/announcement/AnnouncementBootstrap.kt` — per-launch channel create + idempotent
+  `subscribeToTopic("announcements")`, called from `AppInitializer` (§9); no-ops when Firebase
+  isn't initialized (no `google-services.json`).
+- `data/local/datastore/AnnouncementLocalDataSource.kt` — own Preferences DataStore
+  (`nimaz_announcements`): JSON-serialized current announcement + `dismissed_announcement_ids`
+  string-set (dismissal is **permanent**; re-sending the same `id` never resurfaces).
+- `data/repository/AnnouncementRepositoryImpl.kt` → `domain/repository/AnnouncementRepository`.
+- `domain/model/Announcement.kt`, `domain/usecase/AnnouncementUseCases.kt` —
+  `ObserveActiveAnnouncementUseCase` gates on dismissed (repo) + expiry + `versionCode` window;
+  `ResolveAnnouncementRouteUseCase` classifies `route` into https-URL / allowlisted feature key / none.
+- `core/navigation/AnnouncementRoutes.kt` — `announcementRoute(key)` **allowlist** (mirrors
+  `helpDeepLinkRoute`); unknown keys → CTA hidden, never a blind navigation. URLs open via
+  `ACTION_VIEW`.
+- `core/di/AnnouncementModule.kt`; banner UI in
+  `presentation/components/molecules/AnnouncementBanner.kt`, state in `HomeViewModel.announcement`
+  (`StateFlow<AnnouncementUiState>`).
+
+**Channel.** `nimaz_announcements` ("Updates & Announcements"), **IMPORTANCE_LOW** — visible,
+silent, and strictly separate from the prayer/adhan channels (§4), which are never touched.
+
+**Payload contract** (console → Additional options → Custom data): required `id`, `type`
+(`feature|privacy|tos|changelog`), `title`, `body`; optional `cta_label`, `route` (allowlist key
+or `https://…`), `min_version_code`, `max_version_code`, `expires_at` (ISO-8601 UTC),
+`dismissable` (default `true`). Never use reserved keys (`from`, `message_type`, `google.*`,
+`gcm.*`). FCM is not E2E-encrypted — public content only.
+
+**Analytics.** `announcement_shown` / `announcement_cta_clicked` / `announcement_dismissed`
+(helpers in `AppAnalytics`), on top of FCM's own delivery/open reports.
+
+**Gotchas.**
+- The console can only send notification-bearing messages, so the foreground banner and the
+  background tray are mutually exclusive surfaces per delivery (see accepted gap above).
+- `POST_NOTIFICATIONS` denied → no tray in background; the banner still works for foreground
+  receipt and notification-tap entry is simply never exercised.
+- Old app versions ignore route keys they don't know — never serialize `Route` objects into
+  payloads; extend the allowlist instead.
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-perf = { group = "com.google.firebase", name = "firebase-perf" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
# FCM Engagement Banner

Adds an engagement/announcement channel: messages are sent from the **Firebase console Notifications composer** (notification + custom data, broadcast to topic `announcements`) — no backend, no Remote Config, no token storage. App closed → OS tray notification on a dedicated low-importance channel; app open → dismissable banner on Home; both can deep-link into a feature or URL.

**Inert by default:** with no message ever sent there is zero behaviour change. Prayer/adhan notification logic, version-bump logic and Play-upload steps are untouched.

---

## Phase 0 — Verification Report

- **Firebase:** already integrated — BoM 34.15.0 with Crashlytics/Analytics/Perf; `google-services` plugin applied conditionally in `app/build.gradle.kts` (only when `google-services.json` exists, so PR checks build without secrets); `deploy.yml` injects `google-services.json` from the `FIREBASE_CONFIG` secret. `applicationId` = `com.arshadshah.nimaz`. **Added `firebase-messaging` via the existing BoM.**
- **Existing messaging service:** none found (no `FirebaseMessagingService` subclass, no `MESSAGING_EVENT` filter) → new `NimazMessagingService` is the only one.
- **Prayer channels:** created in `PrayerNotificationScheduler.init` — `prayer_notifications` (HIGH), `adhan_notifications` (HIGH), `daily_summary_notifications` (DEFAULT) + silent siblings. **Untouched.** New channel `nimaz_announcements` (IMPORTANCE_LOW) is created separately in `AnnouncementBootstrap`.
- **`POST_NOTIFICATIONS`:** declared in the manifest; requested via the Home permission-banner flow (`HomeViewModel.checkPermissions` + launcher in `HomeScreen`). Reused as-is — denied permission just means no tray notification (banner still works on foreground receipt).
- **Routes:** real `Routes.kt` targets enumerated; allowlist built in `core/navigation/AnnouncementRoutes.kt` (mirrors the existing `helpDeepLinkRoute` pattern) — e.g. `search/ask` → `GlobalSearch`, `prayer/tracker` → `PrayerTracker()`, `settings/about` → `SettingsAbout`. Unknown keys → CTA hidden, no navigation.
- **Home:** `HomeScreen` (compact + tablet layouts) with `HomeViewModel` (`StateFlow` + `onEvent`); banner inserted at the top of both layouts.
- **DataStore:** Preferences DataStore pattern; the main `nimaz_preferences` delegate is file-private, so announcements get their own small `nimaz_announcements` store (same pattern).
- **DI:** `core/di` modules; `@AndroidEntryPoint` services confirmed. New `AnnouncementModule` follows the `AiModule` style.
- **min/target SDK:** 29 / 36 (compileSdk 37) — channels API unconditional, `POST_NOTIFICATIONS` path is 33+.
- **CI/release:** `pr_checks.yml` runs `fastlane android test`; merge-to-`dev` → internal track via `deploy.yml`. Neither workflow modified.
- **Deviation from the spec doc:** URLs open via `ACTION_VIEW` (the repo's existing pattern in `NavGraph`) rather than a Custom Tab — avoids a new `androidx.browser` dependency and stays consistent with the privacy/terms links already in the app.

## Architecture

```mermaid
flowchart TD
    C["Firebase Console — Notifications composer<br/>notification + custom data<br/>audience = topic: announcements"] -->|FCM| DEV{App state?}
    DEV -->|Foreground| FG["NimazMessagingService.onMessageReceived<br/>mapper → Announcement → DataStore<br/>no system notification"]
    DEV -->|Background / killed| BG["OS tray notification<br/>on nimaz_announcements channel"]
    FG --> HOME["HomeViewModel.announcement StateFlow<br/>AnnouncementBanner renders"]
    BG -->|tap| TAP["MainActivity.handleIntent<br/>extras → Announcement → DataStore<br/>route → NavGraph"]
    BG -->|ignored| NONE["No banner (accepted gap)"]
    TAP --> HOME
    HOME -->|CTA| NAV["announcementRoute allowlist<br/>navigate, or open https URL"]
    HOME -->|dismiss| DIS["id → dismissed set (permanent)"]
```

**Layers:** `data/announcement/*` (service, mapper, bootstrap) + `AnnouncementLocalDataSource` + `AnnouncementRepositoryImpl` · `domain` (`Announcement`, `AnnouncementRepository`, `AnnouncementUseCases`) · `presentation` (`AnnouncementBanner`, `HomeViewModel.announcement`). Gating: dismissed (repo) + expiry/version window (use case). Analytics: `announcement_shown` / `announcement_cta_clicked` / `announcement_dismissed`.

## Test plan

Automated (in this PR):
- `AnnouncementPayloadMapperTest` — valid/minimal payloads, missing/blank required fields, unknown type, malformed version/expiry/dismissable, reserved keys ignored.
- `AnnouncementUseCasesTest` — dismissed / expired / version-window gating; route classification (URL, known key, unknown, blank, non-https).
- `AnnouncementRoutesTest` — allowlist mapping + unknown-key null.
- `HomeViewModelTest` updated for the new constructor dependency.

Manual (after merge, send from the console — see appendix in the spec):
- [ ] Foreground: banner appears, no tray notification
- [ ] Background tap: tray on Updates channel → opens app, routes, banner present
- [ ] Killed/cold start: tap → routes via `onCreate` extras
- [ ] Ignored background message → no banner (documented gap)
- [ ] `POST_NOTIFICATIONS` denied → no tray; banner still shows on foreground receipt
- [ ] Unknown route / expired / below `min_version_code` → suppressed or CTA hidden
- [ ] Dismiss → resend same `id` → does not reappear
- [ ] Muting the Updates channel does not affect prayer notifications

## Screenshots

_Placeholder: banner (feature / privacy types), tray notification on the Updates channel._

## Before merging — manual/console steps (owner)

1. Nothing to configure for the topic — `announcements` is created implicitly on first device subscription.
2. `google-services.json` stays CI-injected (already in place via `FIREBASE_CONFIG`); no new secrets.
3. To send: console → Messaging → New campaign → Notifications → target topic `announcements` → Additional options → Custom data with the §4 keys (`id`, `type`, `title`, `body`, `cta_label`, `route`, `min_version_code`, `expires_at`, `dismissable`). Use stable unique `id`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017miXv3WcKREJ5BBuDL7tKf

---
_Generated by [Claude Code](https://claude.ai/code/session_017miXv3WcKREJ5BBuDL7tKf)_