### PR TITLE
Change default Quran reciter from Mishary to Abdul Rahman Al-Sudais

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
@@ -144,7 +144,7 @@ class AppInitializer @Inject constructor(
             adhanAudioManager.cleanupTempFiles()
             adhanAudioManager.invalidateStaleDownloads()
 
-            val defaultSound = AdhanSound.MISHARY
+            val defaultSound = AdhanSound.ABDUL_BASIT
             val beepReady = adhanAudioManager.isDownloaded(AdhanSound.SIMPLE_BEEP, false)
 
             if (!adhanAudioManager.isFullyDownloaded(defaultSound) || !beepReady) {

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadService.kt
@@ -162,7 +162,7 @@ class AdhanDownloadService : Service() {
         serviceScope.launch {
             try {
                 adhanAudioManager.cleanupTempFiles()
-                val sound = AdhanSound.MISHARY
+                val sound = AdhanSound.ABDUL_BASIT
                 val results = downloadBothVariants(sound)
                 ensureBeepExists()
                 showCompletionNotification(sound.displayName, results)

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanDownloadWorker.kt
@@ -41,7 +41,7 @@ class AdhanDownloadWorker @AssistedInject constructor(
 
             val sound = inputData.getString(KEY_ADHAN_SOUND)
                 ?.let { AdhanSound.fromName(it) }
-                ?: AdhanSound.MISHARY
+                ?: AdhanSound.ABDUL_BASIT
 
             // Download both variants; failures are tolerated per-variant so a
             // single bad URL doesn't abort the whole job.

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanPlaybackService.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanPlaybackService.kt
@@ -119,7 +119,7 @@ class AdhanPlaybackService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_PLAY -> {
-                val soundName = intent.getStringExtra(EXTRA_ADHAN_SOUND) ?: AdhanSound.MISHARY.name
+                val soundName = intent.getStringExtra(EXTRA_ADHAN_SOUND) ?: AdhanSound.ABDUL_BASIT.name
                 val isFajr = intent.getBooleanExtra(EXTRA_IS_FAJR, false)
                 val prayerName = intent.getStringExtra(EXTRA_PRAYER_NAME) ?: "Prayer"
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanSound.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AdhanSound.kt
@@ -12,16 +12,6 @@ enum class AdhanSound(
     val downloadUrl: String,
     val fajrDownloadUrl: String
 ) {
-    MISHARY(
-        displayName = "Mishary Rashid Alafasy",
-        origin = "Kuwait",
-        fileName = "adhan_mishary.mp3",
-        fajrFileName = "adhan_mishary_fajr.mp3",
-        // Source: Assabile.com - Regular adhan (Kuwait)
-        downloadUrl = "https://media.assabile.com/assabile/adhan_3435370/b45e93f1efb3.mp3",
-        // Source: Assabile.com - Fajr adhan (Kuwait)
-        fajrDownloadUrl = "https://media.assabile.com/assabile/adhan_3435370/ddb21f7363eb.mp3"
-    ),
     ABDUL_BASIT(
         displayName = "Abdul Basit Abdul Samad",
         origin = "Egypt",
@@ -66,7 +56,7 @@ enum class AdhanSound(
 
     companion object {
         fun fromName(name: String): AdhanSound {
-            return entries.find { it.name == name } ?: MISHARY
+            return entries.find { it.name == name } ?: ABDUL_BASIT
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
@@ -40,7 +40,7 @@ data class AudioState(
     val position: Long = 0L,
     val currentTitle: String = "",
     val currentSubtitle: String? = null,
-    val reciterName: String = "Mishary Rashid Alafasy",
+    val reciterName: String = "Abdul Rahman Al-Sudais",
     val isActive: Boolean = false,
     val error: String? = null,
     // Playlist progress for surah-level tracking
@@ -70,8 +70,8 @@ class QuranAudioManager @Inject constructor(
     val audioState: StateFlow<AudioState> = _audioState.asStateFlow()
 
     // Reciter CDN ID and bitrate - dynamically set from preferences
-    private var reciterCdnId = "ar.alafasy" // Default: Mishary Rashid Alafasy
-    private var reciterBitrate = 128 // Default bitrate
+    private var reciterCdnId = "ar.abdurrahmaansudais" // Default: Abdul Rahman Al-Sudais
+    private var reciterBitrate = 64 // Default bitrate
 
     // Sequential playback state
     private var ayahPlaylist: List<AyahAudioItem> = emptyList()
@@ -158,8 +158,6 @@ class QuranAudioManager @Inject constructor(
         // CDN identifiers and bitrates from https://api.alquran.cloud/v1/edition?format=audio&type=versebyverse
         // Pair: (cdnId, bitrate) - some reciters only have 64kbps, others have 128kbps
         val RECITER_CDN_MAP = mapOf(
-            "alafasy" to Pair("ar.alafasy", 128),
-            "mishary" to Pair("ar.alafasy", 128),
             "sudais" to Pair("ar.abdurrahmaansudais", 64),
             "abdulbasit" to Pair("ar.abdulsamad", 64),
             "muaiqly" to Pair("ar.mahermuaiqly", 128),
@@ -177,7 +175,7 @@ class QuranAudioManager @Inject constructor(
     }
 
     fun setReciter(reciterId: String?) {
-        val (cdnId, bitrate) = RECITER_CDN_MAP[reciterId] ?: Pair("ar.alafasy", 128)
+        val (cdnId, bitrate) = RECITER_CDN_MAP[reciterId] ?: Pair("ar.abdurrahmaansudais", 64)
         reciterCdnId = cdnId
         reciterBitrate = bitrate
         _audioState.update {
@@ -187,7 +185,6 @@ class QuranAudioManager @Inject constructor(
 
     private fun getReciterDisplayName(reciterId: String?): String {
         return when (reciterId) {
-            "alafasy", "mishary" -> "Mishary Rashid Alafasy"
             "sudais" -> "Abdul Rahman Al-Sudais"
             "abdulbasit" -> "Abdul Basit Abdul Samad"
             "muaiqly", "maher" -> "Maher Al-Muaiqly"
@@ -200,7 +197,7 @@ class QuranAudioManager @Inject constructor(
             "jibreel" -> "Muhammad Jibreel"
             "shaatree" -> "Abu Bakr Al-Shaatree"
             "basfar" -> "Abdullah Basfar"
-            else -> "Mishary Rashid Alafasy"
+            else -> "Abdul Rahman Al-Sudais"
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -399,7 +399,7 @@ class PreferencesDataStore @Inject constructor(
         put(PreferencesKeys.ADHAN_ENABLED, enabled)
 
     override val selectedAdhanSound: Flow<String> =
-        preference(PreferencesKeys.SELECTED_ADHAN_SOUND, "MISHARY")
+        preference(PreferencesKeys.SELECTED_ADHAN_SOUND, "ABDUL_BASIT")
 
     override suspend fun setSelectedAdhanSound(sound: String) =
         put(PreferencesKeys.SELECTED_ADHAN_SOUND, sound)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/VoiceOptionCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/VoiceOptionCard.kt
@@ -285,7 +285,7 @@ private fun PreviewButton(
     }
 }
 
-/** First letters of up to two leading words, e.g. "Mishary Rashid …" → "MR". */
+/** First letters of up to two leading words, e.g. "Abdul Rahman …" → "AR". */
 fun voiceInitials(name: String): String {
     val words = name
         .split(' ', '-', '—', '(', ')', '–')
@@ -309,9 +309,9 @@ private fun VoiceOptionCardShowcase() {
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         VoiceOptionCard(
-            name = "Mishary Rashid Alafasy",
+            name = "Abdul Rahman Al-Sudais",
             primaryTag = "Murattal",
-            secondaryTag = "Kuwait",
+            secondaryTag = "Saudi Arabia",
             isSelected = true,
             isPlaying = false,
             onClick = {}, onPreviewClick = {},

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreen.kt
@@ -66,7 +66,6 @@ data class ReciterInfo(
 )
 
 private val popularReciters = listOf(
-    ReciterInfo("mishary", "Mishary Rashid Alafasy", "Kuwait", "Murattal"),
     ReciterInfo("sudais", "Abdul Rahman Al-Sudais", "Saudi Arabia", "Murattal"),
     ReciterInfo("abdulbasit", "Abdul Basit Abdul Samad", "Egypt", "Mujawwad"),
     ReciterInfo("maher", "Maher Al Muaiqly", "Saudi Arabia", "Murattal"),
@@ -86,7 +85,7 @@ fun SelectReciterScreen(
     quranViewModel: QuranViewModel = hiltViewModel()
 ) {
     val quranState by viewModel.quranState.collectAsState()
-    val selectedReciterId = quranState.selectedReciterId ?: "mishary"
+    val selectedReciterId = quranState.selectedReciterId ?: "sudais"
     var searchQuery by remember { mutableStateOf("") }
     LocalContext.current
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
@@ -288,14 +288,13 @@ fun QuranSettingsScreen(
                             Text(
                                 text = quranState.selectedReciterId?.let { id ->
                                     when (id) {
-                                        "alafasy" -> "Mishary Rashid Alafasy"
                                         "sudais" -> "Abdul Rahman Al-Sudais"
                                         "ghamdi" -> "Saad Al-Ghamdi"
                                         "muaiqly" -> "Maher Al-Muaiqly"
                                         "abdulbasit" -> "Abdul Basit Abdul Samad"
                                         else -> id
                                     }
-                                } ?: "Mishary Rashid Alafasy",
+                                } ?: "Abdul Rahman Al-Sudais",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -114,7 +114,7 @@ data class NotificationSettingsUiState(
     val fridayReminderMinutes: Int = 60,
     val khatamReminderEnabled: Boolean = false,
     val khatamReminderTime: String = "06:00",
-    val selectedAdhanSound: String = "MISHARY"
+    val selectedAdhanSound: String = "ABDUL_BASIT"
 )
 
 /**

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -48,7 +48,7 @@ Adhan, Qaida tap-to-hear) plus an Adhan **download** pipeline. They share no pla
 | `data/audio/AdhanDownloadService.kt` | foreground `dataSync` service that downloads both adhan variants with a progress notification (channel `adhan_download_channel`, id 7777) |
 | `data/audio/AdhanDownloadWorker.kt` | `@HiltWorker` background fallback for the download (see §3) |
 | `data/audio/QaidaAudioManager.kt` | `@Singleton`; stripped-down `ExoPlayer` for single Qaida tokens — **no service/notification/MediaSession/CDN**; exposes `val state: StateFlow<QaidaAudioState>` |
-| `data/audio/AdhanSound.kt` | enum of adhans (MISHARY, ABDUL_BASIT, MAKKAH, SIMPLE_BEEP) with per-variant file names + download URLs |
+| `data/audio/AdhanSound.kt` | enum of adhans (ABDUL_BASIT, MAKKAH, SIMPLE_BEEP) with per-variant file names + download URLs |
 
 **Wiring.** None of these have a DI module — the managers are `@Singleton @Inject constructor(@ApplicationContext …)` (Hilt provides them automatically) and the services are `@AndroidEntryPoint` field-injecting their manager. Services are declared in `AndroidManifest.xml` with `foregroundServiceType` `mediaPlayback`/`dataSync`; permissions `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `FOREGROUND_SERVICE_DATA_SYNC`.
 


### PR DESCRIPTION
## Summary
Changes the default Quran reciter throughout the app from Mishary Rashid Alafasy to Abdul Rahman Al-Sudais, and removes all references to Mishary as a selectable option. Also updates the default adhan sound from Mishary to Abdul Basit Abdul Samad.

## Key Changes

**Quran Audio:**
- Updated `AudioState.reciterName` default from "Mishary Rashid Alafasy" to "Abdul Rahman Al-Sudais"
- Changed `QuranAudioManager` default CDN ID from `ar.alafasy` (128 kbps) to `ar.abdurrahmaansudais` (64 kbps)
- Removed "alafasy" and "mishary" entries from `RECITER_CDN_MAP`
- Updated fallback reciter in `setReciter()` and `getReciterDisplayName()` to use Al-Sudais
- Updated `SelectReciterScreen` default selection from "mishary" to "sudais"
- Removed Mishary from the popular reciters list

**Adhan Audio:**
- Removed `MISHARY` enum entry from `AdhanSound`
- Updated all default adhan sound references from `AdhanSound.MISHARY` to `AdhanSound.ABDUL_BASIT` across:
  - `AppInitializer`
  - `AdhanDownloadService`
  - `AdhanDownloadWorker`
  - `AdhanPlaybackService`
- Updated `AdhanSound.fromName()` fallback to `ABDUL_BASIT`
- Updated `PreferencesDataStore` default from "MISHARY" to "ABDUL_BASIT"
- Updated `SettingsViewModel` default from "MISHARY" to "ABDUL_BASIT"

**UI & Settings:**
- Updated `QuranSettingsScreen` reciter display logic and fallback
- Updated `VoiceOptionCard` preview from Mishary (Kuwait) to Al-Sudais (Saudi Arabia)
- Updated documentation in `docs/SUBSYSTEMS.md` to reflect removed Mishary adhan option

## Implementation Details
- Bitrate for Al-Sudais is 64 kbps (vs. Mishary's 128 kbps), reflecting CDN availability
- All user-facing strings and preferences updated consistently
- Fallback behavior preserved for unknown reciter IDs

https://claude.ai/code/session_01Gx93kzumbuu12JtiZRopNc