### PR TITLE
ci: add guardrails to Claude Code GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,15 +10,29 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Guardrail: never run more than one review per PR at a time. A new push
+# cancels the in-flight review so we don't burn credits reviewing stale diffs.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Guardrail: default to no token scopes; each job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Guardrail: only review the repo owner's own PRs, and never bot PRs.
+    # This blocks forked/external and bot-authored PRs (e.g. dependabot) from
+    # triggering Claude runs that consume credits or execute in a trusted context.
+    # To open this up later, prefer author_association (OWNER / MEMBER / COLLABORATOR)
+    # over hard-coded logins.
+    if: |
+      github.event.pull_request.user.login == 'arshad-shah' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
+    # Guardrail: cap runaway jobs so a stuck run can't hold resources indefinitely.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,14 +10,34 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Guardrail: default to no token scopes; the job opts in to exactly what it needs.
+permissions: {}
+
+# Guardrail: one Claude run at a time per issue/PR thread, but don't cancel an
+# in-flight run (a reply may already be posting) — just queue the next one.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
+    # Guardrail: only the repo owner can trigger Claude, AND the trigger must
+    # contain an explicit @claude mention. github.actor is the login that fired
+    # the event, so this covers comments, reviews, and issues in one check and
+    # stops anyone else (or a bot) from spending credits / running in a trusted
+    # context. To widen access later, prefer author_association over logins.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'arshad-shah' &&
+      github.actor != 'dependabot[bot]' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
+    # Guardrail: cap runaway jobs so a stuck run can't hold resources indefinitely.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Restrict the interactive @claude workflow and the automated PR review
workflow to the repo owner's own activity, and never bots.

- claude.yml: gate on github.actor == 'arshad-shah' (covers comments,
  reviews, and issues in one check) in addition to the existing @claude
  mention, so only the owner can spend credits / run in a trusted context.
- claude-code-review.yml: activate the PR-author filter
  (arshad-shah, never dependabot) instead of leaving it commented out.
- Both: default top-level permissions to {} (least privilege), add
  timeout-minutes: 30 to cap runaway jobs, and add concurrency groups
  (cancel stale reviews; queue @claude replies without cancelling).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019tsQbKypiwYKieeARb8BMA