### PR TITLE
docs: source research and schema scaffold for 16-line IndoPak Quran data (#265)

### DIFF
--- a/docs/nimaz-pro-data-guide.md
+++ b/docs/nimaz-pro-data-guide.md
@@ -110,6 +110,82 @@ nimaz-pro-data/
 - Pickthall (optional)
 - Yusuf Ali (optional)
 
+## 16-line IndoPak Mushaf data (issue #265 — sub-task 1/7 of #263)
+
+> **Status: sourcing plan + schema only, data not yet acquired.** This automated pass ran with no
+> outbound network access, so it could not download, validate, or license-clear the actual
+> dataset — that work still needs a run with network access plus a human sign-off on licensing
+> (the parent issue's own estimate — "3–5 days, dominated by data validation + license
+> verification" — assumes a human in the loop). What follows is the sourcing research, target
+> schema, and an acquisition script scaffold so that follow-up work doesn't start from zero. See
+> `nimaz-pro-data/scripts/download_indopak_mushaf_data.py` and
+> `nimaz-pro-data/json/LICENSES_INDOPAK.md`.
+
+**Why existing `ayahs.json` isn't enough.** `ayahs.json` / `AyahEntity` (`text_arabic` /
+`text_uthmani`, `page`) is keyed to the **604-page Madani Mushaf** in Uthmani script. A
+line-accurate "16-line" IndoPak display needs, per the printed 16-line Mushaf: IndoPak glyph text
+for every ayah, and a **548-page, ≤16-lines-per-page** layout map (page, line, line type,
+word/segment position). Neither exists anywhere in this repo today.
+
+**Candidate sources** (re-verify license terms live at acquisition time — not re-checked in this
+pass):
+
+| Source | What it provides | License note |
+|---|---|---|
+| [Quranic Universal Library (QUL) / Tarteel.ai](https://qul.tarteel.ai/docs/mushaf-layout) | Mushaf-layout exports (SQLite/JSON) for multiple standard editions, including a 16-line IndoPak layout across 548 pages | Positioned for building open Quran apps, but requires requesting/downloading from QUL and reading their current terms before redistributing content in-app. |
+| [Quran Foundation Content API](https://api-docs.quran.foundation/docs/tutorials/fonts/page-layout/) | `page-layout` endpoint, including an `INDOPAK_16_LINES` mushaf type across 548 pages | Requires registering an app for OAuth2 client credentials. Confirm whether the ToS permits **baking a full bulk extract into a shipped app** vs. only live per-request calls before using this as the shipped-data source. |
+| Tanzil.net | Uthmani Arabic text (already the source for `ayahs.json`) | Does **not** provide IndoPak script glyphs or any line-layout data — not sufficient alone for this task. |
+
+**Do not copy a specific commercial edition's typesetting** (e.g. Taj Company) as the layout
+source — the issue itself flags this as copyrighted. QUL's and Quran Foundation's own
+line-break determinations (structured data, not scanned page images) are the safer path, but
+their redistribution terms still need explicit confirmation.
+
+**Target files & schema**, reconciled against the existing 6,236-ayah id space
+(`AyahEntity.id`):
+
+`nimaz-pro-data/json/ayahs_indopak.json` — one row per existing ayah id:
+```json
+[
+  { "ayah_id": 1, "text_indopak": "..." }
+]
+```
+
+`nimaz-pro-data/json/mushaf_layout_indopak16.json` — one row per line-segment (a line may hold
+one or more ayahs/partial ayahs, a surah header, or a basmalah):
+```json
+[
+  {
+    "page_number": 1,
+    "line_number": 1,
+    "line_type": "surah_header",
+    "surah_id": 1,
+    "ayah_id": null,
+    "first_word_position": null,
+    "last_word_position": null
+  },
+  {
+    "page_number": 1,
+    "line_number": 3,
+    "line_type": "ayah",
+    "surah_id": 1,
+    "ayah_id": 1,
+    "first_word_position": 1,
+    "last_word_position": 4
+  }
+]
+```
+`line_type` is one of `ayah` / `surah_header` / `basmalah`. `ayah_id` is null for `surah_header`
+lines. Word positions are 1-based within the ayah, so a line spanning part of a long ayah records
+just the word range it covers.
+
+**Acceptance criteria (from #265, not yet met by this pass):**
+- [ ] `ayahs_indopak.json` covers all 6,236 ayah ids.
+- [ ] `mushaf_layout_indopak16.json` covers all 548 pages, each with ≤16 lines.
+- [ ] `nimaz-pro-data/json/LICENSES_INDOPAK.md` records the exact source, version/commit, and
+  license actually used — this pass ships a template only; fields must be filled in from the real
+  source at acquisition time, not assumed.
+
 ---
 
 # 2. Hadith Data

--- a/nimaz-pro-data/json/LICENSES_INDOPAK.md
+++ b/nimaz-pro-data/json/LICENSES_INDOPAK.md
@@ -1,0 +1,41 @@
+# Licenses & attribution — 16-line IndoPak Quran data
+
+Tracks the exact source, version, and license for `ayahs_indopak.json` and
+`mushaf_layout_indopak16.json` (sub-task 1/7 of #263, tracked in issue #265).
+
+> **Template only.** No data has been acquired yet in this pass (no outbound network access was
+> available — see the issue/PR discussion). Every field below must be filled in with the *real*
+> values from the source actually used, verified against that source's current terms at the time
+> of acquisition — do not assume the notes in `docs/nimaz-pro-data-guide.md` are still accurate by
+> then; re-check.
+
+## `ayahs_indopak.json` (IndoPak ayah text)
+
+- **Source:** _TBD — e.g. Quranic Universal Library (QUL) / Tarteel.ai_
+- **URL:** _TBD_
+- **Version / commit / export date:** _TBD_
+- **License:** _TBD — quote or link the exact license/terms text_
+- **Redistribution confirmed for:** offline, open-source Android app, bundled as a shipped asset
+- **Acquired by / date:** _TBD_
+- **Notes:** _TBD — any normalisation applied, diacritic handling, encoding_
+
+## `mushaf_layout_indopak16.json` (16-line page/line layout map)
+
+- **Source:** _TBD — e.g. QUL mushaf-layout export or Quran Foundation `page-layout` API
+  (`INDOPAK_16_LINES`)_
+- **URL:** _TBD_
+- **Version / commit / API response date:** _TBD_
+- **License:** _TBD — quote or link the exact license/terms text_
+- **Redistribution confirmed for:** offline, open-source Android app, bundled as a shipped asset
+  (note: API-sourced data may only license *live* per-request use — confirm bulk bake-in is
+  covered before shipping)
+- **Acquired by / date:** _TBD_
+- **Notes:** _TBD — confirm this is a QUL/Quran Foundation line-break determination, not a
+  transcription of a specific commercial edition's typesetting (e.g. Taj Company), which is
+  copyrighted and must not be copied_
+
+## Validation performed
+
+- [ ] All 114 surahs / 6,236 ayahs present in `ayahs_indopak.json`, ids match `AyahEntity.id`
+- [ ] All 548 pages present in `mushaf_layout_indopak16.json`, each with ≤16 lines
+- [ ] Spot-checked against a printed/reference 16-line Mushaf for a sample of pages

--- a/nimaz-pro-data/scripts/download_indopak_mushaf_data.py
+++ b/nimaz-pro-data/scripts/download_indopak_mushaf_data.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Nimaz - 16-line IndoPak Mushaf data acquisition scaffold (issue #265, sub-task 1/7 of #263)
+
+STATUS: scaffold only. The endpoints/auth below are NOT verified against live docs — this was
+written without outbound network access. Before running this for real:
+
+  1. Re-read https://qul.tarteel.ai/docs/mushaf-layout and/or
+     https://api-docs.quran.foundation/docs/tutorials/fonts/page-layout/ for the CURRENT export
+     format, auth flow, and exact field names (they may have changed).
+  2. Re-confirm the license explicitly permits bundling a full bulk extract into a shipped,
+     offline, open-source Android app (not just live per-request API use) — see
+     nimaz-pro-data/json/LICENSES_INDOPAK.md and fill it in with the real source/version/license
+     once acquired.
+  3. Do NOT source the line-layout from a scanned/typeset commercial edition (e.g. Taj Company) -
+     that typesetting is copyrighted. Use a source's own structured line-break data.
+
+This script normalises whatever source is used into the two target files and then validates them
+against the acceptance criteria in issue #265:
+  - nimaz-pro-data/json/ayahs_indopak.json           (6,236 rows, keyed by existing ayah_id)
+  - nimaz-pro-data/json/mushaf_layout_indopak16.json (548 pages, each with <=16 lines)
+"""
+
+import json
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+BASE_DIR = Path(__file__).parent.parent
+JSON_DIR = BASE_DIR / "json"
+
+EXPECTED_SURAHS = 114
+EXPECTED_AYAHS = 6236
+EXPECTED_PAGES = 548
+MAX_LINES_PER_PAGE = 16
+
+VALID_LINE_TYPES = {"ayah", "surah_header", "basmalah"}
+
+
+def download_json(url: str, headers: Optional[Dict[str, str]] = None, retries: int = 3) -> Any:
+    """Download and parse JSON from URL with retries. Mirrors download_full_data.py conventions."""
+    req_headers = {"User-Agent": "Mozilla/5.0"}
+    if headers:
+        req_headers.update(headers)
+    for attempt in range(retries):
+        try:
+            print(f"    Downloading: {url}")
+            req = urllib.request.Request(url, headers=req_headers)
+            with urllib.request.urlopen(req, timeout=120) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except Exception as e:  # noqa: BLE001 - best-effort acquisition script
+            print(f"    Attempt {attempt + 1} failed: {e}")
+    return None
+
+
+def save_json(data: Any, filename: str) -> None:
+    filepath = JSON_DIR / filename
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    print(f"    Saved: {filename}")
+
+
+def load_existing_ayah_ids() -> Set[int]:
+    """Existing 6,236 ayah ids from ayahs.json — ayahs_indopak.json must reconcile against these."""
+    with open(JSON_DIR / "ayahs.json", encoding="utf-8") as f:
+        ayahs = json.load(f)
+    return {a["id"] for a in ayahs}
+
+
+def fetch_indopak_ayah_text() -> List[Dict[str, Any]]:
+    """
+    TODO: replace with a real call against the chosen source (QUL export or Quran Foundation
+    Content API, e.g. a verses-by-page or verses-by-chapter endpoint with `text_indopak` /
+    equivalent script field). Must return exactly EXPECTED_AYAHS rows, one per existing ayah_id.
+    """
+    raise NotImplementedError(
+        "Wire this up to the chosen, license-verified source before running. "
+        "See nimaz-pro-data/json/LICENSES_INDOPAK.md."
+    )
+
+
+def fetch_mushaf_layout_16line() -> List[Dict[str, Any]]:
+    """
+    TODO: replace with a real call against the chosen source's 16-line ("INDOPAK_16_LINES")
+    mushaf-layout export, normalised into the schema documented in
+    docs/nimaz-pro-data-guide.md (page_number, line_number, line_type, surah_id, ayah_id,
+    first_word_position, last_word_position). Must cover all EXPECTED_PAGES pages.
+    """
+    raise NotImplementedError(
+        "Wire this up to the chosen, license-verified source before running. "
+        "See nimaz-pro-data/json/LICENSES_INDOPAK.md."
+    )
+
+
+def validate_ayahs_indopak(rows: List[Dict[str, Any]], existing_ayah_ids: Set[int]) -> List[str]:
+    errors = []
+    row_ids = {r["ayah_id"] for r in rows}
+    if len(rows) != EXPECTED_AYAHS:
+        errors.append(f"expected {EXPECTED_AYAHS} rows, got {len(rows)}")
+    missing = existing_ayah_ids - row_ids
+    if missing:
+        errors.append(f"{len(missing)} existing ayah_ids missing (e.g. {sorted(missing)[:5]})")
+    extra = row_ids - existing_ayah_ids
+    if extra:
+        errors.append(f"{len(extra)} ayah_ids not in existing ayahs.json (e.g. {sorted(extra)[:5]})")
+    empty_text = [r["ayah_id"] for r in rows if not r.get("text_indopak", "").strip()]
+    if empty_text:
+        errors.append(f"{len(empty_text)} rows have empty text_indopak (e.g. {empty_text[:5]})")
+    return errors
+
+
+def validate_mushaf_layout(rows: List[Dict[str, Any]]) -> List[str]:
+    errors = []
+    pages: Dict[int, Set[int]] = {}
+    surah_ids: Set[int] = set()
+    for r in rows:
+        if r["line_type"] not in VALID_LINE_TYPES:
+            errors.append(f"invalid line_type {r['line_type']!r} on page {r['page_number']}")
+        pages.setdefault(r["page_number"], set()).add(r["line_number"])
+        surah_ids.add(r["surah_id"])
+
+    if len(pages) != EXPECTED_PAGES:
+        errors.append(f"expected {EXPECTED_PAGES} pages, got {len(pages)}")
+    missing_pages = set(range(1, EXPECTED_PAGES + 1)) - set(pages)
+    if missing_pages:
+        errors.append(f"{len(missing_pages)} pages missing (e.g. {sorted(missing_pages)[:5]})")
+    over_limit = {p: len(lines) for p, lines in pages.items() if len(lines) > MAX_LINES_PER_PAGE}
+    if over_limit:
+        errors.append(f"{len(over_limit)} pages exceed {MAX_LINES_PER_PAGE} lines: {dict(list(over_limit.items())[:5])}")
+    if len(surah_ids) != EXPECTED_SURAHS:
+        errors.append(f"expected {EXPECTED_SURAHS} distinct surah_ids referenced, got {len(surah_ids)}")
+    return errors
+
+
+def main() -> None:
+    print("=" * 60)
+    print("16-line IndoPak Mushaf data acquisition (issue #265)")
+    print("=" * 60)
+
+    existing_ayah_ids = load_existing_ayah_ids()
+    print(f"  Existing ayah id space: {len(existing_ayah_ids)} ayahs (expected {EXPECTED_AYAHS})")
+
+    ayah_rows = fetch_indopak_ayah_text()
+    ayah_errors = validate_ayahs_indopak(ayah_rows, existing_ayah_ids)
+    if ayah_errors:
+        print("\n[FAIL] ayahs_indopak.json validation:")
+        for e in ayah_errors:
+            print(f"  - {e}")
+    else:
+        save_json(ayah_rows, "ayahs_indopak.json")
+
+    layout_rows = fetch_mushaf_layout_16line()
+    layout_errors = validate_mushaf_layout(layout_rows)
+    if layout_errors:
+        print("\n[FAIL] mushaf_layout_indopak16.json validation:")
+        for e in layout_errors:
+            print(f"  - {e}")
+    else:
+        save_json(layout_rows, "mushaf_layout_indopak16.json")
+
+    if ayah_errors or layout_errors:
+        raise SystemExit(1)
+
+    print("\n[OK] Both files generated and validated. Now fill in LICENSES_INDOPAK.md with the "
+          "real source/version/license before committing the data.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary**
- Documents reputable sources for 16-line IndoPak Quran text/layout data (QUL/Tarteel mushaf-layout, Quran Foundation page-layout API) and their licensing considerations in `docs/nimaz-pro-data-guide.md`.
- Defines the target JSON schema for `ayahs_indopak.json` and `mushaf_layout_indopak16.json`, reconciled against the existing 6,236-ayah id space (`AyahEntity.id`).
- Adds `nimaz-pro-data/scripts/download_indopak_mushaf_data.py`, an acquisition + validation scaffold (checks 114 surahs / 6,236 ayahs / 548 pages / <=16 lines per page) to run once a source is wired up.
- Adds `nimaz-pro-data/json/LICENSES_INDOPAK.md`, an attribution template to fill in with the exact source, version, and license once data is acquired.

**Why this does not include the actual data yet**
This automated pass ran with no outbound network access (WebFetch/WebSearch/curl/git fetch/gh api all required approval that was not available), so it could not download the real IndoPak text or 16-line layout data, nor verify licensing live. Per the issues own estimate (3-5 days, dominated by data validation and license verification), this was expected to need a human in the loop regardless. This PR delivers the validated sourcing research, schema, and tooling so the next pass (with network access) can go straight to acquisition and validation instead of starting from zero.

**Note on branch target**
The request asked for this PR to point at an integration branch for the parent epic. This automated run can only push to its pre-checked-out branch (branch/ref creation requires interactive approval not available here), so this PR targets dev. If you create an integration branch for #263, this PRs base can be retargeted to it without new commits.

Refs #265, parent epic #263.

Generated with Claude Code (https://claude.ai/code)