### PR TITLE
fix(home): stop the 1-second countdown flashing the loading spinner

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreen.kt
@@ -107,10 +107,20 @@ fun WidgetsScreen(
     // State for dynamic widget preview data
     var previewData by remember { mutableStateOf(WidgetPreviewData()) }
 
-    // Load real prayer times data
+    // The location behind the preview is read once. It cannot change while this
+    // screen is open, and re-reading it on every countdown tick meant constructing
+    // a PreferencesDataStore and doing file I/O once a second.
+    var previewLocation by remember { mutableStateOf<PreviewLocation?>(null) }
     LaunchedEffect(Unit) {
+        previewLocation = loadPreviewLocation(context)
+    }
+
+    // Only the countdown moves per second; it is derived in memory from the
+    // location above, with no I/O on the tick.
+    LaunchedEffect(previewLocation) {
+        val location = previewLocation ?: return@LaunchedEffect
         while (true) {
-            previewData = loadWidgetPreviewData(context)
+            previewData = buildWidgetPreviewData(context, location)
             delay(1000) // Update every second for countdown
         }
     }
@@ -887,16 +897,40 @@ private fun HowToAddCard(modifier: Modifier = Modifier) {
     }
 }
 
-private suspend fun loadWidgetPreviewData(context: android.content.Context): WidgetPreviewData {
-    return try {
-        val prefs = PreferencesDataStore(context)
-        val userPrefs = prefs.userPreferences.first()
+/** The stored location the widget preview is rendered for. Read once per screen. */
+private data class PreviewLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val name: String,
+)
 
-        val latitude = userPrefs.latitude.takeIf { it != 0.0 } ?: 53.3498
-        val longitude = userPrefs.longitude.takeIf { it != 0.0 } ?: -6.2603
-        val locationName =
-            userPrefs.locationName.takeIf { it.isNotBlank() }?.split(",")?.firstOrNull()?.trim()
-                ?: "Dublin"
+/** One-off DataStore read of the location backing the widget previews. */
+private suspend fun loadPreviewLocation(context: android.content.Context): PreviewLocation {
+    return try {
+        val userPrefs = PreferencesDataStore(context).userPreferences.first()
+        PreviewLocation(
+            latitude = userPrefs.latitude.takeIf { it != 0.0 } ?: 53.3498,
+            longitude = userPrefs.longitude.takeIf { it != 0.0 } ?: -6.2603,
+            name = userPrefs.locationName.takeIf { it.isNotBlank() }
+                ?.split(",")?.firstOrNull()?.trim() ?: "Dublin",
+        )
+    } catch (_: Exception) {
+        PreviewLocation(53.3498, -6.2603, "Dublin")
+    }
+}
+
+/**
+ * Build the widget preview for "now". Pure and non-suspending: it runs once a
+ * second to advance the countdown, so it must not touch DataStore.
+ */
+private fun buildWidgetPreviewData(
+    context: android.content.Context,
+    location: PreviewLocation,
+): WidgetPreviewData {
+    return try {
+        val latitude = location.latitude
+        val longitude = location.longitude
+        val locationName = location.name
 
         val calculator = PrayerTimeCalculator()
         val prayerTimes = calculator.getPrayerTimes(latitude, longitude)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -22,7 +22,6 @@ import com.arshadshah.nimaz.core.util.WorshipReminderContent
 import com.arshadshah.nimaz.core.util.formatClockTime
 import com.arshadshah.nimaz.domain.model.WorshipReminderType
 import com.arshadshah.nimaz.presentation.components.organisms.WorshipCardUi
-import kotlinx.coroutines.flow.first
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.Announcement
 import com.arshadshah.nimaz.domain.model.AnnouncementAction
@@ -35,7 +34,9 @@ import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.HomeEventCard
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerTime
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.WorshipReminderOccurrence
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.AnnouncementUseCases
 import com.arshadshah.nimaz.domain.usecase.DuaUseCases
@@ -67,6 +68,7 @@ import java.time.LocalTime
 import javax.inject.Inject
 import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 data class HomeUiState(
     val currentDate: LocalDate = LocalDate.now(),
@@ -232,6 +234,7 @@ class HomeViewModel @Inject constructor(
         loadDailyDua()
         observeCelebrationCards()
         startTimeUpdates()
+        startWorshipUpdates()
     }
 
     /** Local calendar occasions merged with any pushed CELEBRATION announcement. */
@@ -557,191 +560,77 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    // ── Cached heavy results ────────────────────────────────────────────────
+    // Today's prayer instants and tomorrow's Fajr, plus the date they were
+    // computed for. Recomputed only when their inputs change (location,
+    // calculation settings, time format, date roll-over) — never on a countdown
+    // tick, which re-derives everything below from these cached values.
+    private var dayTimes: List<PrayerTime> = emptyList()
+    private var dayTimesDate: LocalDate? = null
+    private var tomorrowFajr: Instant? = null
+
+    // Nearest upcoming worship reminder. Resolving one costs ~30 sequential
+    // DataStore reads, but `eventAt` is a fixed instant and the card's countdown
+    // renders in whole minutes — so we resolve rarely and reformat in between.
+    private var worshipOccurrence: WorshipReminderOccurrence? = null
+    private var worshipStale: Boolean = true
+
+    /**
+     * Full recompute of the day's prayer instants — the *expensive* path, running
+     * the astronomical calculation for today and tomorrow. Called only when its
+     * inputs actually change: location, calculation settings, time format, or the
+     * date rolling over. The per-second countdown goes through [renderTick]
+     * instead, which never calls this.
+     */
     private fun calculatePrayerTimes() {
         val latitude = _state.value.latitude.takeIf { it != 0.0 } ?: DEFAULT_LATITUDE
         val longitude = _state.value.longitude.takeIf { it != 0.0 } ?: DEFAULT_LONGITUDE
 
         viewModelScope.launch {
             try {
-                _state.update { it.copy(isLoading = true) }
+                // `isLoading` means "nothing to show yet", not "busy". Only the
+                // genuine first load may show the full-screen spinner; a refresh
+                // over existing data updates in place. Setting it on every refresh
+                // is what made the screen flash a spinner once a second, since any
+                // suspension before it is cleared makes the `true` observable.
+                if (dayTimes.isEmpty()) {
+                    _state.update { it.copy(isLoading = true) }
+                }
 
+                val today = LocalDate.now()
                 val prayerTimes = prayerTimeCalculator.getPrayerTimes(
                     latitude = latitude,
                     longitude = longitude,
+                    date = today,
                     calculationMethod = cachedCalcMethod,
                     asrCalculation = cachedAsrCalc,
                     highLatitudeRule = cachedHighLatRule,
                     adjustments = cachedAdjustments
                 )
-                val currentTime = Clock.System.now()
-                val timeZone = TimeZone.currentSystemDefault()
-                val localTime = currentTime.toLocalDateTime(timeZone)
+                // Tomorrow's Fajr, for the after-Isha wrap. Computed here rather
+                // than lazily in the tick so the hot path stays branch-free.
+                tomorrowFajr = prayerTimeCalculator.getPrayerTimes(
+                    latitude = latitude,
+                    longitude = longitude,
+                    date = today.plusDays(1),
+                    calculationMethod = cachedCalcMethod,
+                    asrCalculation = cachedAsrCalc,
+                    highLatitudeRule = cachedHighLatRule,
+                    adjustments = cachedAdjustments
+                ).find { it.type == PrayerType.FAJR }?.time
+                dayTimes = prayerTimes
+                dayTimesDate = today
 
-                val prayerTimeDisplays = prayerTimes.map { prayerTime ->
-                    val prayerLocalTime = prayerTime.time.toLocalDateTime(timeZone)
-                    val isPassed = prayerLocalTime.time < localTime.time
+                // Location/calculation settings feed the worship reminders too.
+                worshipStale = true
 
-                    PrayerTimeDisplay(
-                        type = prayerTime.type,
-                        name = prayerTime.type.displayName,
-                        time = formatTime(prayerLocalTime.hour, prayerLocalTime.minute),
-                        isPassed = isPassed,
-                        isCurrent = false,
-                        isNext = false
-                    )
-                }
+                renderTick()
+                // No suspension between renderTick()'s emission and this one, so
+                // StateFlow conflates them into a single update.
+                _state.update { it.copy(isLoading = false, error = null) }
 
-                // Find current and next prayer
-                val sortedPrayers = prayerTimeDisplays.sortedBy {
-                    prayerTimes.find { pt -> pt.type == it.type }?.time
-                }
-
-                val nextPrayerIndex = sortedPrayers.indexOfFirst { !it.isPassed }
-                val currentPrayerIndex =
-                    if (nextPrayerIndex > 0) nextPrayerIndex - 1 else sortedPrayers.lastIndex
-
-                val updatedDisplays = sortedPrayers.mapIndexed { index, display ->
-                    display.copy(
-                        isCurrent = index == currentPrayerIndex,
-                        isNext = index == nextPrayerIndex
-                    )
-                }
-
-                val nextPrayer: PrayerType?
-                val timeUntilNext: String
-
-                if (nextPrayerIndex >= 0) {
-                    // There's a future prayer today
-                    nextPrayer = sortedPrayers[nextPrayerIndex].type
-                    val nextPrayerTime = prayerTimes.find { it.type == nextPrayer }?.time
-                    timeUntilNext = if (nextPrayerTime != null) {
-                        val diff: Duration = nextPrayerTime - currentTime
-                        val totalSeconds = diff.inWholeSeconds
-                        val hours = totalSeconds / 3600
-                        val minutes = (totalSeconds % 3600) / 60
-                        val seconds = totalSeconds % 60
-                        when {
-                            hours > 0 -> "${hours}h ${minutes}m ${seconds}s"
-                            minutes > 0 -> "${minutes}m ${seconds}s"
-                            else -> "${seconds}s"
-                        }
-                    } else ""
-                } else {
-                    // All prayers passed — wrap to tomorrow's Fajr
-                    nextPrayer = PrayerType.FAJR
-                    val tomorrowDate = LocalDate.now().plusDays(1)
-                    val tomorrowPrayers = prayerTimeCalculator.getPrayerTimes(
-                        latitude = latitude,
-                        longitude = longitude,
-                        date = tomorrowDate,
-                        calculationMethod = cachedCalcMethod,
-                        asrCalculation = cachedAsrCalc,
-                        highLatitudeRule = cachedHighLatRule,
-                        adjustments = cachedAdjustments
-                    )
-                    val tomorrowFajr = tomorrowPrayers.find { it.type == PrayerType.FAJR }?.time
-                    timeUntilNext = if (tomorrowFajr != null) {
-                        val diff: Duration = tomorrowFajr - currentTime
-                        val totalSeconds = diff.inWholeSeconds
-                        val hours = totalSeconds / 3600
-                        val minutes = (totalSeconds % 3600) / 60
-                        val seconds = totalSeconds % 60
-                        when {
-                            hours > 0 -> "${hours}h ${minutes}m ${seconds}s"
-                            minutes > 0 -> "${minutes}m ${seconds}s"
-                            else -> "${seconds}s"
-                        }
-                    } else ""
-                }
-
-                // Where "now" sits along the Fajr→Isha timeline (0f at Fajr, 1f
-                // at Isha), interpolated within the current interval. Drives the
-                // progress card's fill independently of which prayers are prayed.
-                val timelineProgress: Float = run {
-                    val order = listOf(
-                        PrayerType.FAJR, PrayerType.DHUHR, PrayerType.ASR,
-                        PrayerType.MAGHRIB, PrayerType.ISHA
-                    )
-                    val ts = order.mapNotNull { type ->
-                        prayerTimes.find { it.type == type }?.time
-                    }
-                    when {
-                        ts.size < 2 -> 0f
-                        currentTime <= ts.first() -> 0f
-                        currentTime >= ts.last() -> 1f
-                        else -> {
-                            var result = 1f
-                            for (k in 0 until ts.size - 1) {
-                                if (currentTime >= ts[k] && currentTime < ts[k + 1]) {
-                                    val frac = (currentTime - ts[k]).inWholeSeconds.toFloat() /
-                                            (ts[k + 1] - ts[k]).inWholeSeconds.toFloat()
-                                    result = ((k + frac) / (ts.size - 1)).coerceIn(0f, 1f)
-                                    break
-                                }
-                            }
-                            result
-                        }
-                    }
-                }
-
-                // Sunrise/sunset as day-fractions for the living sky's sun arc.
-                val sunriseFraction = prayerTimes.find { it.type == PrayerType.SUNRISE }?.time
-                    ?.toLocalDateTime(timeZone)
-                    ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.27f
-                val sunsetFraction = prayerTimes.find { it.type == PrayerType.MAGHRIB }?.time
-                    ?.toLocalDateTime(timeZone)
-                    ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.80f
-
-                // Apply prayer records to displays
-                val records = _prayerRecords.value
-                val displaysWithStatus = updatedDisplays.map { display ->
-                    val prayerName = PrayerName.valueOf(display.type.name)
-                    val status = records[prayerName] ?: PrayerStatus.NOT_PRAYED
-                    display.copy(prayerStatus = status)
-                }
-
-                // Friday / Jumu'ah detection
-                val today = LocalDate.now()
-                val isFriday = today.dayOfWeek == DayOfWeek.FRIDAY
-                val dhuhrDisplay = displaysWithStatus.find { it.type == PrayerType.DHUHR }
-                val dhuhrInstant = prayerTimes.find { it.type == PrayerType.DHUHR }?.time
-
-                val jumuahTime = if (isFriday) dhuhrDisplay?.time ?: "" else ""
-                val isJumuahPassed = if (isFriday) dhuhrDisplay?.isPassed == true else false
-                val timeUntilJumuah = if (isFriday && !isJumuahPassed && dhuhrInstant != null) {
-                    val diff: Duration = dhuhrInstant - currentTime
-                    val totalSeconds = diff.inWholeSeconds
-                    val hours = totalSeconds / 3600
-                    val minutes = (totalSeconds % 3600) / 60
-                    val seconds = totalSeconds % 60
-                    when {
-                        hours > 0 -> "${hours}h ${minutes}m ${seconds}s"
-                        minutes > 0 -> "${minutes}m ${seconds}s"
-                        else -> "${seconds}s"
-                    }
-                } else ""
-
-                val worshipCard = runCatching { buildWorshipCard(LocalDateTime.now()) }.getOrNull()
-
-                _state.update {
-                    it.copy(
-                        prayerTimes = displaysWithStatus,
-                        prayerTimelineProgress = timelineProgress,
-                        sunriseFraction = sunriseFraction,
-                        sunsetFraction = sunsetFraction,
-                        currentPrayer = if (currentPrayerIndex >= 0) sortedPrayers[currentPrayerIndex].type else null,
-                        nextPrayer = nextPrayer,
-                        timeUntilNextPrayer = timeUntilNext,
-                        hijriDate = calculateHijriDate(),
-                        isFriday = isFriday,
-                        jumuahTime = jumuahTime,
-                        timeUntilJumuah = timeUntilJumuah,
-                        isJumuahPassed = isJumuahPassed,
-                        worshipCard = worshipCard,
-                        isLoading = false,
-                        error = null
-                    )
-                }
+                // Suspends (DataStore), but only after isLoading is already false.
+                refreshWorshipCard()
             } catch (e: Exception) {
                 CrashReporter.recordException(e)
                 AppAnalytics.logError("home", "calculate_prayer_times", e.message)
@@ -750,13 +639,204 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Re-derive everything that moves with the clock — countdowns, which prayer is
+     * current/next, timeline progress — from the already-computed [dayTimes].
+     *
+     * Deliberately non-suspending and free of I/O: this runs once a second, and a
+     * suspension point here would let any transient state set by its caller become
+     * observable to the UI.
+     */
+    private fun renderTick() {
+        val prayerTimes = dayTimes
+        if (prayerTimes.isEmpty()) return
+
+        val currentTime = Clock.System.now()
+        val timeZone = TimeZone.currentSystemDefault()
+        val localTime = currentTime.toLocalDateTime(timeZone)
+
+        val prayerTimeDisplays = prayerTimes.map { prayerTime ->
+            val prayerLocalTime = prayerTime.time.toLocalDateTime(timeZone)
+            PrayerTimeDisplay(
+                type = prayerTime.type,
+                name = prayerTime.type.displayName,
+                time = formatTime(prayerLocalTime.hour, prayerLocalTime.minute),
+                isPassed = prayerLocalTime.time < localTime.time,
+                isCurrent = false,
+                isNext = false
+            )
+        }
+
+        // Find current and next prayer
+        val sortedPrayers = prayerTimeDisplays.sortedBy {
+            prayerTimes.find { pt -> pt.type == it.type }?.time
+        }
+
+        val nextPrayerIndex = sortedPrayers.indexOfFirst { !it.isPassed }
+        val currentPrayerIndex =
+            if (nextPrayerIndex > 0) nextPrayerIndex - 1 else sortedPrayers.lastIndex
+
+        val updatedDisplays = sortedPrayers.mapIndexed { index, display ->
+            display.copy(
+                isCurrent = index == currentPrayerIndex,
+                isNext = index == nextPrayerIndex
+            )
+        }
+
+        // Either the next prayer today, or — once Isha has passed — a wrap to
+        // tomorrow's Fajr, precomputed by calculatePrayerTimes so this stays pure.
+        val nextPrayer: PrayerType
+        val nextPrayerInstant: Instant?
+        if (nextPrayerIndex >= 0) {
+            nextPrayer = sortedPrayers[nextPrayerIndex].type
+            nextPrayerInstant = prayerTimes.find { it.type == nextPrayer }?.time
+        } else {
+            nextPrayer = PrayerType.FAJR
+            nextPrayerInstant = tomorrowFajr
+        }
+        val timeUntilNext = nextPrayerInstant?.let { formatCountdown(it - currentTime) } ?: ""
+
+        // Where "now" sits along the Fajr→Isha timeline (0f at Fajr, 1f
+        // at Isha), interpolated within the current interval. Drives the
+        // progress card's fill independently of which prayers are prayed.
+        val timelineProgress: Float = run {
+            val order = listOf(
+                PrayerType.FAJR, PrayerType.DHUHR, PrayerType.ASR,
+                PrayerType.MAGHRIB, PrayerType.ISHA
+            )
+            val ts = order.mapNotNull { type ->
+                prayerTimes.find { it.type == type }?.time
+            }
+            when {
+                ts.size < 2 -> 0f
+                currentTime <= ts.first() -> 0f
+                currentTime >= ts.last() -> 1f
+                else -> {
+                    var result = 1f
+                    for (k in 0 until ts.size - 1) {
+                        if (currentTime >= ts[k] && currentTime < ts[k + 1]) {
+                            val frac = (currentTime - ts[k]).inWholeSeconds.toFloat() /
+                                    (ts[k + 1] - ts[k]).inWholeSeconds.toFloat()
+                            result = ((k + frac) / (ts.size - 1)).coerceIn(0f, 1f)
+                            break
+                        }
+                    }
+                    result
+                }
+            }
+        }
+
+        // Sunrise/sunset as day-fractions for the living sky's sun arc.
+        val sunriseFraction = prayerTimes.find { it.type == PrayerType.SUNRISE }?.time
+            ?.toLocalDateTime(timeZone)
+            ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.27f
+        val sunsetFraction = prayerTimes.find { it.type == PrayerType.MAGHRIB }?.time
+            ?.toLocalDateTime(timeZone)
+            ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.80f
+
+        // Apply prayer records to displays
+        val records = _prayerRecords.value
+        val displaysWithStatus = updatedDisplays.map { display ->
+            val prayerName = PrayerName.valueOf(display.type.name)
+            val status = records[prayerName] ?: PrayerStatus.NOT_PRAYED
+            display.copy(prayerStatus = status)
+        }
+
+        // Friday / Jumu'ah detection
+        val today = LocalDate.now()
+        val isFriday = today.dayOfWeek == DayOfWeek.FRIDAY
+        val dhuhrDisplay = displaysWithStatus.find { it.type == PrayerType.DHUHR }
+        val dhuhrInstant = prayerTimes.find { it.type == PrayerType.DHUHR }?.time
+
+        val jumuahTime = if (isFriday) dhuhrDisplay?.time ?: "" else ""
+        val isJumuahPassed = if (isFriday) dhuhrDisplay?.isPassed == true else false
+        val timeUntilJumuah = if (isFriday && !isJumuahPassed && dhuhrInstant != null) {
+            formatCountdown(dhuhrInstant - currentTime)
+        } else ""
+
+        _state.update {
+            it.copy(
+                prayerTimes = displaysWithStatus,
+                prayerTimelineProgress = timelineProgress,
+                sunriseFraction = sunriseFraction,
+                sunsetFraction = sunsetFraction,
+                currentPrayer = if (currentPrayerIndex >= 0) sortedPrayers[currentPrayerIndex].type else null,
+                nextPrayer = nextPrayer,
+                timeUntilNextPrayer = timeUntilNext,
+                hijriDate = calculateHijriDate(),
+                isFriday = isFriday,
+                jumuahTime = jumuahTime,
+                timeUntilJumuah = timeUntilJumuah,
+                isJumuahPassed = isJumuahPassed,
+            )
+        }
+    }
+
+    /**
+     * "1h 4m 22s" / "4m 22s" / "22s" — the countdown format shared by the next
+     * prayer and Jumu'ah. Clamped at zero so an instant that has just elapsed
+     * between the `isPassed` check and here never renders as a negative time.
+     */
+    private fun formatCountdown(remaining: Duration): String {
+        val totalSeconds = remaining.inWholeSeconds.coerceAtLeast(0)
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val seconds = totalSeconds % 60
+        return when {
+            hours > 0 -> "${hours}h ${minutes}m ${seconds}s"
+            minutes > 0 -> "${minutes}m ${seconds}s"
+            else -> "${seconds}s"
+        }
+    }
+
     private fun startTimeUpdates() {
         viewModelScope.launch {
             while (isActive) {
                 delay(1_000) // Update every second for smooth countdown
-                calculatePrayerTimes()
+                // The tick is pure: it re-derives the countdown from instants that
+                // are already in memory. The expensive recompute runs only when the
+                // date rolls over past midnight.
+                if (dayTimes.isNotEmpty() && dayTimesDate != LocalDate.now()) {
+                    calculatePrayerTimes()
+                } else {
+                    renderTick()
+                }
             }
         }
+    }
+
+    /**
+     * The "Next Worship" card refreshes on its own, much slower loop. Its countdown
+     * renders in whole minutes ([renderWorshipCard]), so a 1-second cadence would
+     * produce an identical string 59 times out of 60 — at ~30 DataStore reads each.
+     */
+    private fun startWorshipUpdates() {
+        viewModelScope.launch {
+            while (isActive) {
+                refreshWorshipCard()
+                delay(60_000)
+            }
+        }
+    }
+
+    /**
+     * Resolve + render the "Next Worship" card. [NextWorshipResolver.nearest] reads
+     * every worship preference plus location and calculation settings — ~30
+     * sequential DataStore reads — so the resolved occurrence is cached and
+     * re-resolved only when it is missing, has elapsed, or its settings changed
+     * ([worshipStale]). In between, only the countdown string is reformatted.
+     */
+    private suspend fun refreshWorshipCard() {
+        val now = LocalDateTime.now()
+        val cached = worshipOccurrence
+        if (worshipStale || cached == null || !cached.eventAt.isAfter(now)) {
+            worshipOccurrence = runCatching { nextWorshipResolver.nearest(now) }
+                .onFailure { CrashReporter.recordException(it) }
+                .getOrNull()
+            worshipStale = false
+        }
+        val card = worshipOccurrence?.let { renderWorshipCard(it, now) }
+        _state.update { it.copy(worshipCard = card) }
     }
 
     private var use24HourFormat: Boolean = false
@@ -779,15 +859,16 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * Resolve the nearest upcoming enabled worship reminder into ready-to-render card data, or
-     * null when none is enabled/near. Countdown is to the event instant ([eventAt]); the time
-     * label is shown only where it adds meaning (Tahajjud's "Begins").
+     * Render an already-resolved worship occurrence into card data. Countdown is to the event
+     * instant ([WorshipReminderOccurrence.eventAt]); the time label is shown only where it adds
+     * meaning (Tahajjud's "Begins").
+     *
+     * Pure and non-suspending — resolution and settings reads happen in [refreshWorshipCard], so
+     * re-rendering the countdown costs nothing.
      */
-    private suspend fun buildWorshipCard(now: LocalDateTime): WorshipCardUi? {
-        val occ = nextWorshipResolver.nearest(now) ?: return null
-        val use24 = settingsRepository.use24HourFormat.first()
+    private fun renderWorshipCard(occ: WorshipReminderOccurrence, now: LocalDateTime): WorshipCardUi {
         val et = occ.eventAt.toLocalTime()
-        val eventTime = formatClockTime(et.hour, et.minute, use24)
+        val eventTime = formatClockTime(et.hour, et.minute, use24HourFormat)
         val secs = java.time.Duration.between(now, occ.eventAt).seconds.coerceAtLeast(0)
         val hours = secs / 3600
         val minutes = (secs % 3600) / 60

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -827,15 +827,18 @@ class HomeViewModel @Inject constructor(
      * ([worshipStale]). In between, only the countdown string is reformatted.
      */
     private suspend fun refreshWorshipCard() {
-        val now = LocalDateTime.now()
-        val cached = worshipOccurrence
-        if (worshipStale || cached == null || !cached.eventAt.isAfter(now)) {
-            worshipOccurrence = runCatching { nextWorshipResolver.nearest(now) }
-                .onFailure { CrashReporter.recordException(it) }
-                .getOrNull()
-            worshipStale = false
-        }
-        val card = worshipOccurrence?.let { renderWorshipCard(it, now) }
+        // Guarded end-to-end: this runs from a bare viewModelScope loop, so an
+        // escaping exception would reach the uncaught handler and crash the app.
+        // The card is optional — on failure we simply show nothing.
+        val card = runCatching {
+            val now = LocalDateTime.now()
+            val cached = worshipOccurrence
+            if (worshipStale || cached == null || !cached.eventAt.isAfter(now)) {
+                worshipOccurrence = nextWorshipResolver.nearest(now)
+                worshipStale = false
+            }
+            worshipOccurrence?.let { renderWorshipCard(it, now) }
+        }.onFailure { CrashReporter.recordException(it) }.getOrNull()
         _state.update { it.copy(worshipCard = card) }
     }
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -3,24 +3,36 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.util.NextWorshipResolver
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerTime
+import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
 import com.arshadshah.nimaz.domain.repository.DuaRepository
 import com.arshadshah.nimaz.domain.repository.FastingRepository
 import com.arshadshah.nimaz.domain.repository.HadithRepository
 import com.arshadshah.nimaz.domain.repository.PrayerRepository
 import com.google.common.truth.Truth.assertThat
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -47,6 +59,7 @@ class HomeViewModelTest {
     private lateinit var duaRepository: DuaRepository
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var announcementRepository: AnnouncementRepository
+    private lateinit var nextWorshipResolver: NextWorshipResolver
 
     @Before
     fun setUp() {
@@ -60,6 +73,7 @@ class HomeViewModelTest {
         duaRepository = mockk(relaxed = true)
         settingsRepository = mockk(relaxed = true)
         announcementRepository = mockk(relaxed = true)
+        nextWorshipResolver = mockk(relaxed = true)
         every { announcementRepository.observeCurrentAnnouncement() } returns flowOf(null)
 
         // The today's-records Flow emits synchronously, mirroring Room emitting an
@@ -85,7 +99,7 @@ class HomeViewModelTest {
             settingsRepository = settingsRepository,
             announcementUseCases = announcementUseCases,
             observeEventCards = buildObserveEventCardsUseCase(announcementUseCases),
-            nextWorshipResolver = mockk(relaxed = true),
+            nextWorshipResolver = nextWorshipResolver,
         )
     }
 
@@ -134,4 +148,80 @@ class HomeViewModelTest {
 
         assertThat(uncaught).isNull()
     }
+
+    /** Six prayer instants spread either side of "now", so a next prayer exists. */
+    private fun samplePrayerTimes(): List<PrayerTime> {
+        val base = Clock.System.now()
+        return listOf(
+            PrayerTime(PrayerType.FAJR, base - 5.hours),
+            PrayerTime(PrayerType.SUNRISE, base - 4.hours),
+            PrayerTime(PrayerType.DHUHR, base - 1.hours),
+            PrayerTime(PrayerType.ASR, base + 2.hours),
+            PrayerTime(PrayerType.MAGHRIB, base + 5.hours),
+            PrayerTime(PrayerType.ISHA, base + 6.hours),
+        )
+    }
+
+    @Test
+    fun `refreshing over loaded data never re-emits the loading state`() =
+        runTest(testDispatcher.scheduler) {
+            // Regression test for the home screen flashing a full-screen spinner
+            // once a second. calculatePrayerTimes() set isLoading = true on every
+            // call, including the per-second countdown refresh. That was invisible
+            // while the whole body ran without suspending, but PR #319 added the
+            // worship-card resolution — real DataStore I/O — in the middle of it,
+            // which let the transient `true` reach the UI on every tick.
+            every {
+                prayerTimeCalculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any())
+            } returns samplePrayerTimes()
+            // Make the worship resolution genuinely suspend, exactly as the real
+            // DataStore-backed resolver does. Without this the bug is unobservable.
+            coEvery { nextWorshipResolver.nearest(any()) } coAnswers {
+                delay(50)
+                null
+            }
+
+            val viewModel = createViewModel()
+            val seen = mutableListOf<Boolean>()
+            val job = launch(testDispatcher) {
+                viewModel.state.collect { seen += it.isLoading }
+            }
+
+            // First load: a spinner here is legitimate — there is nothing to show.
+            viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
+            advanceTimeBy(1_000)
+            assertThat(viewModel.state.value.prayerTimes).isNotEmpty()
+
+            // Everything from here on is a refresh over data already on screen.
+            seen.clear()
+            repeat(5) {
+                viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
+                advanceTimeBy(1_000)
+            }
+
+            assertThat(seen).doesNotContain(true)
+            job.cancel()
+        }
+
+    @Test
+    fun `countdown ticks do not re-resolve the worship card every second`() =
+        runTest(testDispatcher.scheduler) {
+            // The worship card's countdown renders in whole minutes, but resolving
+            // it costs ~30 sequential DataStore reads. Ticking the countdown must
+            // not drag that resolution along with it once a second.
+            every {
+                prayerTimeCalculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any())
+            } returns samplePrayerTimes()
+            coEvery { nextWorshipResolver.nearest(any()) } returns null
+
+            val viewModel = createViewModel()
+            viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
+            advanceTimeBy(1_000)
+            clearMocks(nextWorshipResolver, answers = false)
+
+            // Thirty seconds of countdown ticks, well inside the 60s worship loop.
+            advanceTimeBy(30_000)
+
+            coVerify(exactly = 0) { nextWorshipResolver.nearest(any()) }
+        }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -21,15 +21,16 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
@@ -162,9 +163,28 @@ class HomeViewModelTest {
         )
     }
 
+    /**
+     * Runs [body] against the shared test scheduler.
+     *
+     * Deliberately **not** `runTest`: `HomeViewModel` keeps two endless
+     * `while (isActive) { delay(...) }` loops alive in `viewModelScope`, and
+     * `runTest` drains its scheduler to idle when the body returns — which with an
+     * endless delay loop means advancing virtual time forever, hanging the suite.
+     * Here time is advanced only in bounded steps, and the collector scope is
+     * cancelled explicitly.
+     */
+    private fun withScheduler(body: (TestCoroutineScheduler, CoroutineScope) -> Unit) {
+        val scope = CoroutineScope(testDispatcher)
+        try {
+            body(testDispatcher.scheduler, scope)
+        } finally {
+            scope.cancel()
+        }
+    }
+
     @Test
     fun `refreshing over loaded data never re-emits the loading state`() =
-        runTest(testDispatcher.scheduler) {
+        withScheduler { scheduler, scope ->
             // Regression test for the home screen flashing a full-screen spinner
             // once a second. calculatePrayerTimes() set isLoading = true on every
             // call, including the per-second countdown refresh. That was invisible
@@ -183,29 +203,26 @@ class HomeViewModelTest {
 
             val viewModel = createViewModel()
             val seen = mutableListOf<Boolean>()
-            val job = launch(testDispatcher) {
-                viewModel.state.collect { seen += it.isLoading }
-            }
+            scope.launch { viewModel.state.collect { seen += it.isLoading } }
 
             // First load: a spinner here is legitimate — there is nothing to show.
             viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
-            advanceTimeBy(1_000)
+            scheduler.advanceTimeBy(1_000)
             assertThat(viewModel.state.value.prayerTimes).isNotEmpty()
 
             // Everything from here on is a refresh over data already on screen.
             seen.clear()
             repeat(5) {
                 viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
-                advanceTimeBy(1_000)
+                scheduler.advanceTimeBy(1_000)
             }
 
             assertThat(seen).doesNotContain(true)
-            job.cancel()
         }
 
     @Test
     fun `countdown ticks do not re-resolve the worship card every second`() =
-        runTest(testDispatcher.scheduler) {
+        withScheduler { scheduler, _ ->
             // The worship card's countdown renders in whole minutes, but resolving
             // it costs ~30 sequential DataStore reads. Ticking the countdown must
             // not drag that resolution along with it once a second.
@@ -216,11 +233,11 @@ class HomeViewModelTest {
 
             val viewModel = createViewModel()
             viewModel.onEvent(HomeEvent.RefreshPrayerTimes)
-            advanceTimeBy(1_000)
+            scheduler.advanceTimeBy(1_000)
             clearMocks(nextWorshipResolver, answers = false)
 
             // Thirty seconds of countdown ticks, well inside the 60s worship loop.
-            advanceTimeBy(30_000)
+            scheduler.advanceTimeBy(30_000)
 
             coVerify(exactly = 0) { nextWorshipResolver.nearest(any()) }
         }

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -157,7 +157,10 @@ This one is **pervasive and lower priority** — listed so it's tracked, not bec
   inject `SettingsRepository`; bound via `@Binds` in `RepositoryModule`. Data-layer consumers
   (seeders, sync, workers, `AppInitializer`, `BootReceiver`) keep the concrete class.
   - [ ] **Minor leftover:** `settings/WidgetsScreen.kt` still *instantiates* `PreferencesDataStore(context)`
-    inline (line ~793) instead of going through DI/a ViewModel — convert when that screen is next touched.
+    inline instead of going through DI/a ViewModel — convert when that screen is next touched.
+    Partially mitigated: the read is now a one-off (`loadPreviewLocation`) rather than being repeated
+    inside the preview's 1-second refresh loop, which was constructing the class and re-reading the
+    DataStore file every second. The per-tick `buildWidgetPreviewData` is now pure.
 - [ ] **Audio managers expose data-layer `AudioState`.** `QuranViewModel` /
   `QaidaReaderViewModel` surface `audioManager.state` (a `data.audio` type) to the UI. This is an
   **accepted pattern** for playback features (see `ARCHITECTURE.md` §9). If desired, mirror the

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -203,6 +203,15 @@ on the dedicated `WorshipRemindersScreen` (`Route.SettingsWorshipReminders`), an
 one. Ramadan-category reminders are Ramadan-gated and their settings group auto-hides outside
 Ramadan.
 
+> **Home refresh cadence.** `NextWorshipResolver.nearest()` reads every worship pref plus location
+> and calculation settings — ~30 sequential DataStore reads per call — so it must never sit on a
+> per-second path. `HomeViewModel` caches the resolved `WorshipReminderOccurrence` and re-resolves
+> it only when it is missing, has elapsed, or its settings changed; the card itself refreshes on a
+> 60s loop (`startWorshipUpdates`), which matches its whole-minute countdown. The 1s prayer
+> countdown (`renderTick`) is pure and I/O-free, deriving everything from prayer instants cached by
+> `calculatePrayerTimes`. Keep it that way: a suspension point in the tick makes any transient
+> state set around it — notably `isLoading` — observable to the UI on every tick.
+
 **Wiring.** `PrayerNotificationScheduler` is constructor-injected (`@Singleton @Inject`, deps: `PrayerTimeCalculator`, `SettingsRepository`). Called by `AppInitializer` on startup and by `SettingsViewModel.rescheduleNotifications()` when prayer/notification settings change. Permissions in `AndroidManifest.xml`: `POST_NOTIFICATIONS`, `SCHEDULE_EXACT_ALARM`, `USE_EXACT_ALARM`, `RECEIVE_BOOT_COMPLETED`, `WAKE_LOCK`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`.
 
 **Gotchas.**


### PR DESCRIPTION
## The bug

The Home screen swapped its entire tree for a `CircularProgressIndicator` once per second, in time with the countdown.

## Root cause — and why it only started recently

`calculatePrayerTimes()` opened with `_state.update { it.copy(isLoading = true) }` and cleared it at the end, and `startTimeUpdates()` called it every second. That line is old — but the bug is new, because the flag was never *observable*:

`PrayerTimeCalculator.getPrayerTimes` is a plain, non-suspend function. The whole body of `calculatePrayerTimes()` used to run start-to-finish without a single suspension point, so `StateFlow` conflation swallowed the transient `true` before any collector saw it. The code was always wrong; nothing exposed it.

**#319 inserted `buildWorshipCard()` into the middle of that previously-atomic block.** It calls `NextWorshipResolver.nearest()`, which performs ~25–36 sequential `DataStore` `.first()` reads (2 for location, 11 for the per-type enabled flags, 4 calculation settings, 6 adjustments, up to 11 offsets, the Witr mode) plus one more for `use24HourFormat`. That real disk I/O held `isLoading = true` open long enough to render, on every tick.

## The fix

Both halves — the visible flicker and the per-second I/O storm underneath it.

- **Split the expensive recompute from the per-second render**, matching the pattern `PrayerTimesViewModel` already uses. `calculatePrayerTimes()` now caches today's prayer instants plus tomorrow's Fajr and runs only when its inputs actually change: location, calculation settings, time format, or the date rolling over at midnight. The new `renderTick()` is pure and non-suspending, deriving countdowns, current/next prayer and timeline progress from those cached instants.
- **`isLoading` now means "nothing to show yet"**, not "busy" — set only on a genuine first load, never on a refresh over data already on screen.
- **The worship card moved to its own 60s loop.** Its countdown renders in whole minutes, so a 1s cadence produced an identical string 59 times out of 60. The resolved occurrence is cached and re-resolved only when missing, elapsed, or its settings changed; in between only the countdown string is reformatted, from the already-observed `use24HourFormat` rather than a fresh DataStore read. **Per-second DataStore reads on Home: ~30 → 0.**
- Extracted the h/m/s countdown formatting that was duplicated three times.

## App-wide audit

Checked all 28 `isLoading = true` sites across 15 ViewModels, and every `while` loop under `main/`.

- `HomeViewModel` was the **only** ticker-driven case.
- One more instance of the same anti-pattern found elsewhere: **`WidgetsScreen`**'s preview loop called `loadWidgetPreviewData()` every second, constructing a `PreferencesDataStore` and re-reading the file each time. The location read is now a one-off (`loadPreviewLocation`); the per-tick `buildWidgetPreviewData()` is pure.
- Everything else is clean: the remaining `isLoading` sites (`loadDetail`, `loadSurah`, `selectDate`, `navigateToMonth`, …) are one-shot user-initiated loads where a spinner is correct. `QiblaViewModel.setLocation` and `MonthlyPrayerTimesViewModel.calculateMonth` are stream-driven but fire on real input changes, not a timer — same latent shape, not currently a bug. `QuranAudioManager`'s 100ms position loop and `HomeHero`'s 30s clock loop are pure in-memory.

## Tests

- `refreshing over loaded data never re-emits the loading state` — with the worship resolution stubbed to genuinely suspend, which is precisely what made the bug observable.
- `countdown ticks do not re-resolve the worship card every second` — 30s of ticks, zero `nearest()` calls.

## Docs

`SUBSYSTEMS.md` §4 gains the Home refresh-cadence rule (why `nearest()` must never sit on a per-second path, and why the tick must stay suspension-free). The `WidgetsScreen` entry in `CLEAN_ARCHITECTURE_CHECKLIST.md` is corrected to reflect what actually changed — the inline instantiation is mitigated, not resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)