### PR TITLE
Fix worship notifications re-firing on every app open

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationScheduler.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationScheduler.kt
@@ -560,7 +560,12 @@ class PrayerNotificationScheduler @Inject constructor(
                 offsetMinutes = offsetMap[type] ?: type.defaultOffsetMinutes,
                 timesFor = timesFor,
                 hijriFor = hijriFor,
-                witrBeforeFajr = witrBeforeFajr
+                witrBeforeFajr = witrBeforeFajr,
+                // Only arm a strictly-future trigger. An already-active occurrence has
+                // already fired; arming it again at a past instant would make Android
+                // deliver it immediately, re-posting the notification on every app-open
+                // (or reschedule) for the whole window. Roll forward to the next one.
+                requireFutureTrigger = true
             ) ?: return@forEach
             armWorshipReminder(type, occ.triggerAt, occ.eventAt, occ.subKey)
         }

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderCalculator.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderCalculator.kt
@@ -63,7 +63,20 @@ class WorshipReminderCalculator {
         hijriFor: (LocalDate) -> HijriDayInfo?,
         maxSearchDays: Long = forwardSearchDays,
         /** Witr only: fire before Fajr (Fajr − offset) instead of after Isha (Isha + offset). */
-        witrBeforeFajr: Boolean = false
+        witrBeforeFajr: Boolean = false,
+        /**
+         * Scheduler-only gate. When true, only occurrences whose [WorshipReminderOccurrence.triggerAt]
+         * is strictly in the future are accepted — a currently-*active* occurrence (event begun,
+         * window still open, trigger already passed) is skipped and the scan rolls forward to the
+         * next future trigger.
+         *
+         * This is what the alarm scheduler must use. Arming `setExactAndAllowWhileIdle` at a past
+         * instant makes Android fire it *immediately*, so accepting an active-but-past occurrence
+         * (the default, which the Home card wants) re-posts the notification on every reschedule —
+         * i.e. every time the app is opened during the event's window. The Home card resolver keeps
+         * the default so a "happening now" card stays visible.
+         */
+        requireFutureTrigger: Boolean = false
     ): WorshipReminderOccurrence? {
         val startDay = now.toLocalDate().minusDays(1)
         var day = startDay
@@ -80,12 +93,20 @@ class WorshipReminderCalculator {
             // card for the rest of the day. The backward scan already starts at
             // `now.minusDays(1)`, so today's (or last night's) live occurrence is
             // visited — only the acceptance test rejected it.
-            if (occ != null && occ.isLiveAt(now)) {
-                if (best == null || occ.triggerAt.isBefore(best.triggerAt)) best = occ
-                // Daily reminders resolve on the first future day found; keep scanning only for
-                // the sparse eve-of ones where an earlier day might still yield a later-in-window
-                // hit already covered above. Break once we have the earliest daily hit.
-                if (!isEveOf(type)) break
+            //
+            // The scheduler ([requireFutureTrigger]) instead demands a strictly-future
+            // trigger so it never arms a past alarm (which fires immediately, re-posting
+            // the notification on every app-open during the active window).
+            if (occ != null) {
+                val accepted =
+                    if (requireFutureTrigger) occ.triggerAt.isAfter(now) else occ.isLiveAt(now)
+                if (accepted) {
+                    if (best == null || occ.triggerAt.isBefore(best.triggerAt)) best = occ
+                    // Daily reminders resolve on the first future day found; keep scanning only for
+                    // the sparse eve-of ones where an earlier day might still yield a later-in-window
+                    // hit already covered above. Break once we have the earliest daily hit.
+                    if (!isEveOf(type)) break
+                }
             }
             day = day.plusDays(1)
         }

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/WorshipReminderCalculatorTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/WorshipReminderCalculatorTest.kt
@@ -185,6 +185,54 @@ class WorshipReminderCalculatorTest {
         assertThat(occ.triggerAt.toLocalDate()).isEqualTo(LocalDate.of(2026, 3, 8)) // eve of the 9th
     }
 
+    // ── requireFutureTrigger: the scheduler must never re-arm a past trigger ──
+
+    @Test
+    fun `requireFutureTrigger skips an active occurrence and rolls to the next future trigger`() {
+        // 03:00 is inside tonight's Tahajjud window (02:40 → Fajr 05:00). The Home card wants this
+        // active occurrence (default gate); the scheduler must NOT — arming its past 02:40 trigger
+        // would fire immediately. With requireFutureTrigger it rolls to tomorrow night's 02:40.
+        val now = LocalDate.of(2026, 3, 11).atTime(3, 0)
+
+        val forCard = calc.nextOccurrence(
+            WorshipReminderType.TAHAJJUD, now, 0, ::timesForDay, ::nonRamadan
+        )!!
+        assertThat(forCard.triggerAt).isEqualTo(LocalDate.of(2026, 3, 11).atTime(2, 40))
+        assertThat(forCard.isActiveAt(now)).isTrue()
+
+        val forScheduler = calc.nextOccurrence(
+            WorshipReminderType.TAHAJJUD, now, 0, ::timesForDay, ::nonRamadan,
+            requireFutureTrigger = true
+        )!!
+        assertThat(forScheduler.triggerAt).isEqualTo(LocalDate.of(2026, 3, 12).atTime(2, 40))
+        assertThat(forScheduler.triggerAt.isAfter(now)).isTrue()
+    }
+
+    @Test
+    fun `requireFutureTrigger rolls a fired-but-still-open adhkar to tomorrow`() {
+        // 06:00: morning adhkar (Fajr 05:00 + 30m = 05:30) already fired, but its window
+        // (Fajr → Dhuhr 12:30) is still open. The scheduler must arm tomorrow's 05:30, not
+        // re-fire today's past trigger.
+        val now = LocalDate.of(2026, 3, 10).atTime(6, 0)
+
+        val forScheduler = calc.nextOccurrence(
+            WorshipReminderType.ADHKAR_MORNING, now, 30, ::timesForDay, ::nonRamadan,
+            requireFutureTrigger = true
+        )!!
+        assertThat(forScheduler.triggerAt).isEqualTo(LocalDate.of(2026, 3, 11).atTime(5, 30))
+    }
+
+    @Test
+    fun `requireFutureTrigger keeps a genuinely upcoming trigger unchanged`() {
+        // Before the event, both gates agree — the scheduler still arms tonight's occurrence.
+        val now = LocalDate.of(2026, 3, 10).atTime(21, 0)
+        val occ = calc.nextOccurrence(
+            WorshipReminderType.TAHAJJUD, now, 0, ::timesForDay, ::nonRamadan,
+            requireFutureTrigger = true
+        )!!
+        assertThat(occ.triggerAt).isEqualTo(LocalDate.of(2026, 3, 11).atTime(2, 40))
+    }
+
     @Test
     fun `disabled or non-matching types return null`() {
         // A non-Ramadan day yields no Ramadan reminders.

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -222,6 +222,16 @@ Ramadan.
 > (`mutableMapOf<LocalDate, DayWorshipTimes?>`) since each night type now also asks for the next day's
 > Fajr. Covered by `WorshipDayWalkTest` (a zone-independent hour-by-hour walk of a synthetic day).
 
+> **Scheduler must arm a *future* trigger only (`requireFutureTrigger`).** The `isLiveAt(now)`
+> acceptance above is what the Home card wants, but the *scheduler* shares the same `nextOccurrence`
+> — and `AlarmManager.setExactAndAllowWhileIdle` at a **past** instant fires *immediately*. So
+> accepting an already-*active* occurrence (trigger passed, window still open) made
+> `scheduleWorshipReminders` re-post the worship notification on **every** reschedule, i.e. every
+> time the app was opened during the event's window. `nextOccurrence(requireFutureTrigger = true)`
+> (passed only by the scheduler; the resolver keeps the default) demands `triggerAt.isAfter(now)`,
+> skipping an active occurrence and rolling forward to the next future trigger. Regression-covered in
+> `WorshipReminderCalculatorTest`.
+
 > **Home refresh cadence — time is derived, not pushed.** ViewModels publish *facts* (prayer
 > `Instant`s); everything clock-derived is computed in the composable from one shared ticker.
 >


### PR DESCRIPTION
Worship reminders were re-posting each time the app was opened while an
event's window was active. `scheduleWorshipReminders` shares
`WorshipReminderCalculator.nextOccurrence` with the Home "Next Worship"
card resolver, which accepts an occurrence that is `isLiveAt(now)` —
including one whose `triggerAt` has already passed but whose window is
still open. That live-window acceptance is correct for the card, but the
scheduler then armed `AlarmManager.setExactAndAllowWhileIdle` at a past
instant, which Android delivers immediately. Since app startup
(`AppInitializer`) reschedules notifications, every open re-fired the
active worship notification.

Add a scheduler-only `requireFutureTrigger` gate to `nextOccurrence`:
when set it demands `triggerAt.isAfter(now)`, skipping an active-but-past
occurrence and rolling forward to the next future trigger. The scheduler
passes it; the resolver keeps the default so the "happening now" card
stays visible. Mirrors the existing `isAfter(now)` guards on prayer,
Friday, and khatam alarms.

Adds regression tests and documents the split in docs/SUBSYSTEMS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cq47fZUAEMWFSPT2E6BTU3