### PR TITLE
fix(worship): correct night window after midnight + design-system compliance for tappable cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ touches** — this is not optional:
    screen; validate before wiring.)
 7. No hardcoded `Color(0xFF…)` in screens — use `MaterialTheme.colorScheme.*` / `NimazColors.*`
    and reuse `presentation/components` (atoms/molecules/organisms).
+8. **Interactive UI comes from the design system — never hand-rolled.** A button is `NimazButton`
+   (icon-only: `NimazIconButton`), **not** a `Text`/`Box`/`Surface` + `Modifier.clickable`. A
+   whole-card tap target is `NimazCard(onClick = …)` (or `NimazMenuItem` for list rows), **not** a
+   `Modifier.clickable` wrapped around the card — a wrapping `.clickable` paints a **sharp-cornered
+   ripple** that ignores the card radius. `.clickable` on *inner* elements (a `Text`, an icon, a
+   sub-row) is fine. For `EventCard`/`WorshipEventCard`, pass `onClick`/`onClickLabel`. See
+   `docs/ARCHITECTURE.md` §8 (the `NimazButton`/`NimazCard` bullets).
 
 ## Verify before finishing
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -59,12 +58,13 @@ fun HadithOfTheDayCard(
     NimazCard(
         tone = NimazTone.NEUTRAL,
         style = NimazCardStyle.ELEVATED,
+        // Tapping opens this exact hadith in the reader (issue #161). Kept on the whole card so the
+        // large surface is the tap target, not a tiny link — routed through NimazCard's onClick so
+        // the ripple clips to the rounded corners rather than painting a sharp rectangle.
+        onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .then(if (fillHeight) Modifier.fillMaxHeight() else Modifier)
-            // Tapping opens this exact hadith in the reader (issue #161). Kept on
-            // the whole card so the large surface is the tap target, not a tiny link.
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+            .then(if (fillHeight) Modifier.fillMaxHeight() else Modifier),
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/IslamicEventCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/IslamicEventCard.kt
@@ -1,6 +1,5 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -82,9 +81,8 @@ fun IslamicEventCard(
     NimazCard(
         style = NimazCardStyle.ELEVATED,
         tone = NimazTone.NEUTRAL,
-        modifier = modifier
-            .fillMaxWidth()
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp)
     ) {
         Row(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -68,9 +67,8 @@ fun NimazAccordion(
 
     NimazCard(
         style = NimazCardStyle.FILLED,
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { expanded = !expanded },
+        onClick = { expanded = !expanded },
+        modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
         elevation = 1.dp
     ) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazListPicker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazListPicker.kt
@@ -1,7 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -237,9 +236,8 @@ private fun <T> PickerRow(
     // obvious at a glance.
     NimazCard(
         style = if (isSelected) NimazCardStyle.FILLED else NimazCardStyle.OUTLINED,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
         selected = isSelected,
         elevation = 0.dp,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QaidaCellTile.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QaidaCellTile.kt
@@ -3,7 +3,6 @@ package com.arshadshah.nimaz.presentation.components.molecules
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -78,12 +77,12 @@ fun QaidaCellTile(
 
     Box(modifier = modifier) {
         NimazCard(
+            onClick = { onTap(cell) },
             modifier = Modifier
                 .defaultMinSize(minWidth = 72.dp, minHeight = 84.dp)
                 .semantics {
                     contentDescription = cellDescription
-                }
-                .clickable { onTap(cell) },
+                },
             selected = isPlaying,
             shape = RoundedCornerShape(NimazCornerRadius.Large),
             colors = NimazCardDefaults.selectable(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QaidaLetterTile.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QaidaLetterTile.kt
@@ -1,6 +1,5 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -50,11 +49,11 @@ fun QaidaLetterTile(
         stringResource(R.string.qaida_a11y_letter_format, letter.nameTransliteration)
     }
     NimazCard(
+        onClick = { onClick(letter) },
         modifier = modifier
             .fillMaxWidth()
             .aspectRatio(1f)
-            .semantics { contentDescription = desc }
-            .clickable { onClick(letter) },
+            .semantics { contentDescription = desc },
         style = NimazCardStyle.ELEVATED,
         tone = NimazTone.NEUTRAL,
         shape = RoundedCornerShape(NimazCornerRadius.Large),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/EventCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/EventCard.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -62,6 +64,14 @@ data class EventAction(val label: String, val onClick: () -> Unit)
  * accented icon well, English + Arabic headline, an optional proof chip, and up
  * to two CTAs. Accent lives only in the well/chip/border/divider; body copy stays
  * neutral (contrast rule). Reuses existing atoms — no hand-rolled wells or dividers.
+ *
+ * @param onClick when the *whole card* is the tap target (rather than a [primaryAction]
+ *   button), pass it here. It routes through [NimazCard]'s own `onClick`, so the ripple is
+ *   clipped to the card's rounded shape. Do **not** add a `.clickable` to [modifier] for this
+ *   — a `.clickable` on a card's outer modifier paints its tap highlight on the un-rounded
+ *   rectangle, which is the sharp-cornered ripple bug this parameter exists to prevent.
+ * @param onClickLabel accessibility label for [onClick], announced by screen readers in place
+ *   of a bare "button" (e.g. "Read adhkar").
  */
 @Composable
 fun EventCard(
@@ -76,13 +86,25 @@ fun EventCard(
     highlight: (@Composable () -> Unit)? = null,
     ornament: EventOrnament = EventOrnament.None,
     primaryAction: EventAction? = null,
+    onClick: (() -> Unit)? = null,
+    onClickLabel: String? = null,
     onDismiss: (() -> Unit)? = null,
     fillHeight: Boolean = false,
 ) {
+    // Relabel the click action Material's Card(onClick) already installs, so screen readers
+    // announce the destination instead of just "button". Applied only when both are present.
+    val a11yModifier = if (onClick != null && onClickLabel != null) {
+        Modifier.semantics { onClick(label = onClickLabel, action = null) }
+    } else {
+        Modifier
+    }
     NimazCard(
         tone = NimazTone.NEUTRAL,
         style = NimazCardStyle.ELEVATED,
-        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .then(a11yModifier),
     ) {
         EventCardOrnamentScope(ornament) {
             Column(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/WorshipEventCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/WorshipEventCard.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -34,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -181,8 +179,10 @@ fun WorshipEventCard(
     // The whole card is the tap target rather than a CTA button. The card lives in a
     // fixed-height carousel page, so a button would eat scarce vertical space for an
     // affordance the entire surface can carry — and a reminder you can't act on reads as
-    // decoration. `onClickLabel` reuses the per-type action wording ("Read adhkar", "Open
-    // fast tracker") so screen readers announce the destination instead of just "button".
+    // decoration. The click goes through EventCard's `onClick` (→ NimazCard's onClick) so the
+    // tap ripple is clipped to the card's rounded corners; a `.clickable` on the modifier would
+    // paint a sharp-cornered highlight. `onClickLabel` reuses the per-type action wording
+    // ("Read adhkar", "Open fast tracker") so screen readers announce the destination.
     val clickLabel = actionLabelFor(card.type)
     val decorated = if (progress != null) {
         modifier.drawBehind { drawProgressArc(animatedProgress, v.accent) }
@@ -199,13 +199,9 @@ fun WorshipEventCard(
         arabic = card.arabic,
         body = card.body,
         fillHeight = fillHeight,
-        modifier = if (onAction != null) {
-            decorated
-                .testTag(WorshipCardTestTag)
-                .clickable(onClickLabel = clickLabel, role = Role.Button) { onAction(card.type) }
-        } else {
-            decorated
-        },
+        onClick = onAction?.let { action -> { action(card.type) } },
+        onClickLabel = clickLabel,
+        modifier = if (onAction != null) decorated.testTag(WorshipCardTestTag) else decorated,
         trailing = {
             Column(horizontalAlignment = Alignment.End) {
                 NimazClockText(
@@ -248,7 +244,7 @@ fun WorshipEventCard(
                 }
             }
         },
-        // No primaryAction: the surface itself is the affordance (see `clickable` above).
+        // No primaryAction: the surface itself is the affordance (see `onClick` above).
     )
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveMoreScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveMoreScreen.kt
@@ -102,6 +102,7 @@ fun AdaptiveMoreScreen(
                 navController.navigate(Route.TafseerChapters)
             },
             onNavigateToPrayerTracker = { navController.navigate(Route.PrayerTracker()) },
+            onNavigateToNightWorship = { navController.navigate(Route.NightWorship) },
             onNavigateToPrayerTimes = { navController.navigate(Route.PrayerTimes) },
             onNavigateToMonthlyPrayerTimes = { navController.navigate(Route.MonthlyPrayerTimes) },
             onNavigateToKhatam = { navController.navigate(Route.KhatamList) },
@@ -147,6 +148,7 @@ fun AdaptiveMoreScreen(
                             navController.navigate(Route.Tafseer(surahNumber = 1, ayahNumber = 1))
                         },
                         onNavigateToPrayerTracker = { navController.navigate(Route.PrayerTracker()) },
+                        onNavigateToNightWorship = { navController.navigate(Route.NightWorship) },
                         onNavigateToPrayerTimes = { navController.navigate(Route.PrayerTimes) },
                         onNavigateToMonthlyPrayerTimes = { navController.navigate(Route.MonthlyPrayerTimes) },
                         onNavigateToKhatam = { navController.navigate(Route.KhatamList) },

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Abc
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CalendarViewMonth
@@ -61,6 +62,7 @@ fun MoreMenuScreen(
     onNavigateToDuas: () -> Unit,
     onNavigateToTafseer: () -> Unit,
     onNavigateToPrayerTracker: () -> Unit,
+    onNavigateToNightWorship: () -> Unit,
     onNavigateToPrayerTimes: () -> Unit,
     onNavigateToMonthlyPrayerTimes: () -> Unit,
     onNavigateToKhatam: () -> Unit,
@@ -116,6 +118,13 @@ fun MoreMenuScreen(
                         subtitle = stringResource(R.string.fasting_subtitle),
                         icon = Icons.Default.Fastfood,
                         onClick = onNavigateToFasting
+                    )
+                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuItem(
+                        title = stringResource(R.string.night_worship_title),
+                        subtitle = stringResource(R.string.night_worship_subtitle),
+                        icon = Icons.Default.Bedtime,
+                        onClick = onNavigateToNightWorship
                     )
                     NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
                     NimazMenuItem(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
@@ -1,6 +1,5 @@
 package com.arshadshah.nimaz.presentation.screens.worship
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -34,6 +33,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.navigation.DUA_CATEGORY_WITR_AND_NIGHT_PRAYER
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazClockText
@@ -311,23 +313,18 @@ private fun RakahCounterCard(count: Int, onAddPair: () -> Unit, onReset: () -> U
                     modifier = Modifier.testTag(NightWorshipCountTestTag),
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
+                    NimazButton(
                         text = stringResource(R.string.night_worship_reset),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .clickable(onClick = onReset)
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        onClick = onReset,
+                        variant = NimazButtonVariant.TEXT,
+                        size = NimazButtonSize.SMALL,
                     )
-                    Text(
+                    NimazButton(
                         text = stringResource(R.string.night_worship_add_pair),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier
-                            .testTag(NightWorshipAddRakahTestTag)
-                            .clickable(onClick = onAddPair)
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        onClick = onAddPair,
+                        variant = NimazButtonVariant.TONAL,
+                        size = NimazButtonSize.SMALL,
+                        modifier = Modifier.testTag(NightWorshipAddRakahTestTag),
                     )
                 }
             }
@@ -346,8 +343,8 @@ private fun NightWorshipRow(
     NimazCard(
         modifier = Modifier
             .fillMaxWidth()
-            .testTag(testTag)
-            .clickable(onClick = onClick),
+            .testTag(testTag),
+        onClick = onClick,
         style = NimazCardStyle.FILLED,
         shape = RoundedCornerShape(16.dp),
     ) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/NightWorshipViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/NightWorshipViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
+import kotlin.time.Clock
 import kotlin.time.Instant
 
 /**
@@ -28,9 +29,10 @@ import kotlin.time.Instant
  * (`rememberNow`). This is the same rule the Home rework established — a ViewModel that pushes
  * elapsed time as state is what produced the frozen countdowns in the first place.
  *
- * @param lastThirdAt when the last third of the night begins (adhan2 `SunnahTimes`).
- * @param fajrAt tomorrow's Fajr — the instant the night window closes.
- * @param ishaAt tonight's Isha, the earliest sensible start for Witr.
+ * @param lastThirdAt when the last third of the *live* night begins (adhan2 `SunnahTimes`).
+ * @param fajrAt the Fajr that closes the live night — the morning after it began, which is *today's*
+ *   Fajr in the pre-dawn hours and *tomorrow's* once today's Fajr has passed.
+ * @param ishaAt the live night's Isha, the earliest sensible start for Witr.
  * @param rakahCount in-memory tally for the current visit. Not persisted: we have no data on how
  *   people actually use this yet, and inventing a "completed night" model before that would be
  *   guessing. If the count turns out to be worth keeping, that is an easy follow-up.
@@ -73,12 +75,23 @@ class NightWorshipViewModel @Inject constructor(
     }
 
     /**
-     * Resolve tonight's window.
+     * Resolve the night window that is *live right now*.
      *
-     * The last third and Isha come from *today*, but Fajr must come from **tomorrow**: after
-     * midnight the night in progress belongs to the previous calendar day, and taking today's Fajr
-     * would close the window at a time that has already passed and render the hub permanently
-     * "shut". [PrayerTimeCalculator] is Android-free and pure, so this is one astronomical pass.
+     * The last third of the night straddles midnight: [PrayerTimeCalculator.getSunnahTimes] for a
+     * given date measures from that date's Maghrib to the *next* morning's Fajr, so its last-third
+     * instant lands in the small hours of the following calendar day. That makes "which date owns
+     * the current night" depend on the time of day:
+     *
+     *  - **Before today's Fajr** you are still inside the night that began *yesterday*. Its last
+     *    third is happening *this* morning, and it closes at *today's* Fajr. Anchoring on `today`
+     *    here — as the original code did — pointed the whole card at *tomorrow* night, so at 12:47am
+     *    the open window read "opens in 23h". That was the reported time bug.
+     *  - **After today's Fajr** tonight's window is the next one: it begins this evening and its last
+     *    third lands tomorrow morning, closing at tomorrow's Fajr.
+     *
+     * So we pick the night's starting date from where `now` sits relative to today's Fajr, then read
+     * the last third from that date and the closing Fajr from the morning after it.
+     * [PrayerTimeCalculator] is Android-free and pure, so each date is one cheap astronomical pass.
      */
     private fun loadNightTimes() {
         viewModelScope.launch {
@@ -90,15 +103,23 @@ class NightWorshipViewModel @Inject constructor(
                 val highLat = HighLatitudeRule.fromString(settingsRepository.highLatitudeRule.first())
 
                 val today = LocalDate.now()
+                val now = Clock.System.now()
+
+                fun prayerOn(date: LocalDate, type: PrayerType): Instant? = prayerTimeCalculator
+                    .getPrayerTimes(latitude, longitude, date, method, asr, highLat)
+                    .find { it.type == type }?.time
+
+                val fajrToday = prayerOn(today, PrayerType.FAJR)
+                // Pre-dawn (before today's Fajr) → the live night began yesterday; otherwise it is
+                // tonight's, still to come. This is the fix for the after-midnight "opens in 23h" bug.
+                val nightStart = if (fajrToday != null && now < fajrToday) today.minusDays(1) else today
+
                 val sunnah = prayerTimeCalculator.getSunnahTimes(
-                    latitude, longitude, today, method, asr, highLat
+                    latitude, longitude, nightStart, method, asr, highLat
                 )
-                val isha = prayerTimeCalculator
-                    .getPrayerTimes(latitude, longitude, today, method, asr, highLat)
-                    .find { it.type == PrayerType.ISHA }?.time
-                val fajr = prayerTimeCalculator
-                    .getPrayerTimes(latitude, longitude, today.plusDays(1), method, asr, highLat)
-                    .find { it.type == PrayerType.FAJR }?.time
+                // Close the window at the Fajr that *ends* this night — the morning after it starts.
+                val fajr = if (nightStart == today) prayerOn(today.plusDays(1), PrayerType.FAJR) else fajrToday
+                val isha = prayerOn(nightStart, PrayerType.ISHA)
 
                 Triple(sunnah.lastThirdOfTheNight, fajr, isha)
             }.onSuccess { (lastThird, fajr, isha) ->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1611,6 +1611,7 @@
 
     <!-- Nachtgebet-Zentrum (Ziel fuer Tahajjud / Witr) -->
     <string name="night_worship_title">Nachtgebet</string>
+    <string name="night_worship_subtitle">Tahadschud, Witr und das letzte Drittel der Nacht</string>
     <string name="night_worship_last_third">Letztes Drittel der Nacht</string>
     <string name="night_worship_open_now">Jetzt geöffnet</string>
     <string name="night_worship_opens_in">Beginnt in</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1646,6 +1646,7 @@
 
     <!-- Centre de priere nocturne (destination Tahajjud / Witr) -->
     <string name="night_worship_title">Prière de nuit</string>
+    <string name="night_worship_subtitle">Tahajjud, Witr et le dernier tiers de la nuit</string>
     <string name="night_worship_last_third">Dernier tiers de la nuit</string>
     <string name="night_worship_open_now">Ouvert maintenant</string>
     <string name="night_worship_opens_in">Commence dans</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1581,6 +1581,7 @@
 
     <!-- Pusat ibadah malam (tujuan Tahajud / Witir) -->
     <string name="night_worship_title">Ibadah Malam</string>
+    <string name="night_worship_subtitle">Tahajud, Witir dan sepertiga malam terakhir</string>
     <string name="night_worship_last_third">Sepertiga malam terakhir</string>
     <string name="night_worship_open_now">Sedang berlangsung</string>
     <string name="night_worship_opens_in">Dimulai dalam</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1582,6 +1582,7 @@
 
     <!-- Pusat ibadah malam (destinasi Tahajud / Witir) -->
     <string name="night_worship_title">Ibadah Malam</string>
+    <string name="night_worship_subtitle">Tahajud, Witir dan sepertiga malam terakhir</string>
     <string name="night_worship_last_third">Sepertiga malam terakhir</string>
     <string name="night_worship_open_now">Sedang berlangsung</string>
     <string name="night_worship_opens_in">Bermula dalam</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1617,6 +1617,7 @@
 
     <!-- Gece ibadeti merkezi (Teheccud / Vitir hedefi) -->
     <string name="night_worship_title">Gece İbadeti</string>
+    <string name="night_worship_subtitle">Teheccüd, Vitir ve gecenin son üçte biri</string>
     <string name="night_worship_last_third">Gecenin son üçte biri</string>
     <string name="night_worship_open_now">Şu anda açık</string>
     <string name="night_worship_opens_in">Başlamasına</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1774,6 +1774,7 @@
 
     <!-- Night worship hub (Tahajjud / Witr destination) -->
     <string name="night_worship_title">Night Worship</string>
+    <string name="night_worship_subtitle">Tahajjud, Witr and the last third of the night</string>
     <string name="night_worship_last_third">Last third of the night</string>
     <string name="night_worship_open_now">Open now</string>
     <string name="night_worship_opens_in">Opens in</string>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,12 @@ These are the rules most often broken. Keep this checklist in mind for every cha
 7. **No hardcoded colors/typography in screens.** Use `MaterialTheme.colorScheme.*` or
    `NimazColors.*`. Reuse `presentation/components` (atoms/molecules/organisms) instead of
    re-rolling generic UI. Icons are Material glyphs via `NimazIcon` — no emoji.
+   - **Buttons are `NimazButton` (`components/atoms/NimazButton.kt`), never a `Text`/`Box`/
+     `Surface` + `Modifier.clickable`.** Pick the emphasis with `variant` (`FILLED`/`TONAL`/
+     `OUTLINED`/`TEXT`/`DESTRUCTIVE`) and `size`; icon-only actions use `NimazIconButton`.
+   - **A whole card is made tappable with `NimazCard(onClick = …)`, never `Modifier.clickable`
+     wrapped around the card** — the latter paints a sharp-cornered ripple that ignores the card's
+     radius (see §8, the `NimazCard` bullet). `NimazMenuItem` is the ready-made clickable list row.
    > **Exception (Location screen only):** country flags on the Location screen
    > (`LocationScreen`, curated cities in `LocationCatalog.kt`) are rendered as emoji.
    > This is the single sanctioned emoji use in the app; no other emoji are permitted.
@@ -524,6 +530,13 @@ typed route object.
       bordered chevron, `primary` when enabled and dimmed to `outlineVariant` at range ends);
       `direction` is *visual* (which chevron is drawn, auto-mirrored) so RTL surfaces wire the
       left arrow to advance. Default `size` is 48dp; steppers use 44dp. (Issue #227.)
+    - a button is `NimazButton(text, onClick, variant = …, size = …, type = …)`
+      (`components/atoms/NimazButton.kt`), **not** a raw Material `Button`/`OutlinedButton`/
+      `TextButton` and **never** a `Text`/`Box`/`Surface` carrying a `Modifier.clickable`. `variant`
+      is the emphasis (`FILLED`/`TONAL`/`OUTLINED`/`TEXT`/`DESTRUCTIVE`), `size` is
+      `SMALL`/`MEDIUM`/`LARGE`, `type` is `STANDARD` or `PILL`; `leadingIcon`/`trailingIcon`,
+      `loading`, `fullWidth` and an `accent` escape-hatch (for Islamic feature-art colours the
+      Material scheme has no role for) round it out. Icon-only buttons are `NimazIconButton`.
     - a card is `NimazCard(style = NimazCardStyle.FILLED | ELEVATED | OUTLINED | GRADIENT, …)`
       (`components/atoms/NimazCard.kt`), **not** a raw Material 3 `Card`/`ElevatedCard`/
       `OutlinedCard`. It passes through `onClick`/`enabled`/`shape`/`colors`/`elevation`, so
@@ -532,6 +545,17 @@ typed route object.
       the card default stand, picking `tone`/`style` per the separation rule above. Note the
       `OUTLINED` branch renders an `OutlinedCard`, which has no elevation slot — it **silently
       ignores** the `elevation` parameter (see §9 Open).
+      - **A tappable card MUST pass its click through `NimazCard(onClick = …)`, never a
+        `Modifier.clickable(...)` on the card's outer modifier.** A `.clickable` wrapping a card
+        sits *outside* the Material surface, so its ripple/tap-highlight is painted on the
+        un-rounded rectangle and shows **sharp corners** instead of following the card's radius.
+        `NimazCard(onClick)` routes to Material's `Card(onClick=…)`/`ElevatedCard(onClick=…)`, which
+        clips the ripple to the shape and adds `Role.Button`. Reuse `NimazMenuItem` for list rows.
+        For the shared `EventCard`/`WorshipEventCard` organisms, pass `onClick`/`onClickLabel`
+        (they forward to `NimazCard.onClick`); do not re-add a `.clickable`. `.clickable` stays fine
+        on **inner** elements (a `Text`, an icon, a sub-row) — the rule is specifically about making
+        a *whole card* the tap target. (Reported as the "sharp tapped-highlight" bug on the Home
+        worship cards and the Night Worship hub rows.)
     - a minus/value/plus number control is `NimazNumberStepper(value, onValueChange, variant = …,
       size = …, type = …)` (`components/molecules/NimazNumberStepper.kt`), **not** a hand-rolled
       row of `IconButton`s around a `Text`. `variant` is the layout: `INLINE` (a `label` on the

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -90,7 +90,7 @@ flowchart LR
 
     More --> HadithHome & DuaHome & PrayerTimes & FastingHome & ZakatCalculator & IslamicCalendar
     More --> AsmaUlHusnaList & AsmaUnNabiList & ProphetsList & KhatamList & QaidaHome
-    More --> AllBookmarks & GlobalSearch & Settings
+    More --> AllBookmarks & GlobalSearch & Settings & NightWorship
     Qibla --> Qibla
 ```
 
@@ -206,7 +206,8 @@ All routes live in `core/navigation/Routes.kt` and are wired in `core/navigation
 |-------|------|--------|
 | `NightWorship` | — | NightWorshipScreen |
 
-> **Reached only from the Home worship card** (Tahajjud / Witr), not from a menu. The other nine
+> **Reached from the Home worship card** (Tahajjud / Witr) **and from More → Daily Practice →
+> Night Worship**, so the hub is usable outside the reminder window too. The other nine
 > reminder types route to screens that already existed — see the table in
 > `core/navigation/WorshipDestinations.kt`, which is the single source of truth for the mapping and
 > is asserted exhaustively by `WorshipDestinationsTest`.


### PR DESCRIPTION
## Why

Two problems on the Night Worship hub, reported from the screenshot below:

1. **The time was wrong after midnight.** At **12:47 AM** — inside the **12:24 AM – 1:50 AM** last-third window — the card read **"Opens in 23h 37m"**, pointing at *tomorrow* night instead of recognising the window is open *now*.
2. **Hand-rolled controls / sharp tapped-highlight.** The "Reset" / "+2 rakah" controls were `Text` + `.clickable` (not design-system buttons), and the tappable cards (Home worship cards + hub rows) showed a **sharp-cornered tap ripple** instead of the rounded one.

## What changed

### Time fix — `NightWorshipViewModel`
The last third of the night straddles midnight, so *which calendar date owns the current night* depends on the time of day. The old code always anchored on `today`, so `getSunnahTimes(today)` produced *tomorrow* night's window. It now picks the live night from where `now` sits relative to **today's Fajr**:
- **Before today's Fajr** → you're still inside the night that began *yesterday*; its last third is happening this morning and it closes at *today's* Fajr.
- **After today's Fajr** → look ahead to tonight's window, closing at *tomorrow's* Fajr.

### Design-system compliance
The sharp ripple's root cause: a `Modifier.clickable` on a card's **outer** modifier sits *outside* the Material surface, so its highlight is painted on the un-rounded rectangle. The fix is to route clicks through **`NimazCard(onClick = …)`** (→ Material `Card(onClick)`/`ElevatedCard(onClick)`), which clips the ripple to the shape and adds `Role.Button`.

- `EventCard` gains `onClick` / `onClickLabel` params (forwarded to `NimazCard.onClick`, with the a11y label preserved for screen readers); `WorshipEventCard` now uses them instead of a wrapping `.clickable`.
- `NightWorshipScreen`: rows use `NimazCard(onClick=…)`; the rakah "Reset" / "+2 rakah" controls are now `NimazButton`s.
- Same wrapping-`.clickable` bug fixed in **`IslamicEventCard`** and **`HadithOfTheDayCard`**.

### New entry point
Added **More → Daily Practice → Night Worship** (`Route.NightWorship`), wired in both compact and list-detail layouts, so the hub is reachable outside the reminder window.

### Context for future agents
- New non-negotiable rule in **`CLAUDE.md`**.
- Expanded **`docs/ARCHITECTURE.md`** §0 (golden rules) and §8 (`NimazButton` bullet; the "whole-card tap = `NimazCard(onClick)`, never a wrapping `.clickable`" rule with the sharp-ripple rationale).
- **`docs/NAVIGATION.md`** updated for the new entry point.

## Notes
- This environment has JDK 21 but no Android SDK, so `./gradlew :app:compileDebugKotlin` / `testDebugUnitTest` could not be run locally — they need to pass on CI. Existing `NightWorshipContentTest` / `WorshipCardClickTest` (incl. the screen-reader-label assertion) cover the refactored surfaces.
- An app-wide audit for any *remaining* card-level `.clickable` violations is still in progress; further fixes, if any, will follow as commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LueMQ1Vi3X9CDa1mr9DDfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LueMQ1Vi3X9CDa1mr9DDfs)_