### PR TITLE
Order lint after the task that fetches the assets it reads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,8 +163,20 @@ android.sourceSets.getByName("main").assets.srcDir(
     layout.buildDirectory.dir("generated/nimazData/assets").get().asFile
 )
 
-tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
-    .configureEach { dependsOn("fetchNimazData") }
+// Everything that *reads* the generated assets directory has to be ordered after the
+// task that fills it, not just the asset merge. Lint builds a model of every source
+// set — assets included — so `generateReleaseLintVitalReportModel` consumes this
+// directory too, and Gradle fails the build outright rather than racing:
+//
+//   Task ':app:generateReleaseLintVitalReportModel' uses this output of task
+//   ':app:fetchNimazData' without declaring an explicit or implicit dependency.
+//
+// Only release hit it, because lint-vital runs for release and not for debug — so
+// every debug build and both PR check lanes were green while the deploy lane could
+// not build at all.
+tasks.matching {
+    (it.name.startsWith("merge") && it.name.endsWith("Assets")) || it.name.contains("Lint")
+}.configureEach { dependsOn("fetchNimazData") }
 
 kotlin {
     compilerOptions {


### PR DESCRIPTION
The deploy lane has not been able to build since the content artifact moved out of this repo:

```
Task ':app:generateReleaseLintVitalReportModel' uses this output of task
':app:fetchNimazData' without declaring an explicit or implicit dependency.
```

Only `merge*Assets` was ordered after `fetchNimazData`. Lint builds a model of every source set — assets included — so it reads the generated directory too, and Gradle refuses the build rather than racing the two tasks.

Release-only, which is why nothing caught it: lint-vital runs for release and not for debug, so `assembleDebug`, both PR check lanes and the instrumented tests were green while `fastlane android deploy_internal` failed at task configuration every time. It surfaced on the first deploy after #331 merged, but it is not from #331 — it is from the extraction in #328.

Verified locally by running the exact task that failed with `--rerun-tasks`: `:app:fetchNimazData` runs first, `:app:generateReleaseLintVitalReportModel` completes, `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)