### PR TITLE
schemaVersion 22: a verse row is its place in the mushaf, not its text

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,7 +175,12 @@ android.sourceSets.getByName("main").assets.srcDir(
 // every debug build and both PR check lanes were green while the deploy lane could
 // not build at all.
 tasks.matching {
-    (it.name.startsWith("merge") && it.name.endsWith("Assets")) || it.name.contains("Lint")
+    (it.name.startsWith("merge") && it.name.endsWith("Assets")) ||
+        // Case-insensitively: AGP names them both ways — `generateReleaseLintVitalReportModel`
+        // and `lintAnalyzeDebug` — and matching only the capitalised form fixed the release
+        // lane while leaving the debug one to fail on the next PR, which is exactly what
+        // happened.
+        it.name.contains("lint", ignoreCase = true)
 }.configureEach { dependsOn("fetchNimazData") }
 
 kotlin {

--- a/app/schemas/com.arshadshah.nimaz.data.local.database.NimazDatabase/22.json
+++ b/app/schemas/com.arshadshah.nimaz.data.local.database.NimazDatabase/22.json
@@ -1,0 +1,3635 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "41721a7f965932d23810139ba29d7d0f",
+    "entities": [
+      {
+        "tableName": "surahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_english` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `revelation_type` TEXT NOT NULL, `verses_count` INTEGER NOT NULL, `order_revealed` INTEGER NOT NULL, `start_page` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revelationType",
+            "columnName": "revelation_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versesCount",
+            "columnName": "verses_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderRevealed",
+            "columnName": "order_revealed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPage",
+            "columnName": "start_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ayahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `surah_id` INTEGER NOT NULL, `number_in_surah` INTEGER NOT NULL, `number_global` INTEGER NOT NULL, `juz` INTEGER NOT NULL, `hizb` INTEGER NOT NULL, `page` INTEGER NOT NULL, `transliteration` TEXT, `text_tajweed` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`surah_id`) REFERENCES `surahs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInSurah",
+            "columnName": "number_in_surah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberGlobal",
+            "columnName": "number_global",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "juz",
+            "columnName": "juz",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hizb",
+            "columnName": "hizb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textTajweed",
+            "columnName": "text_tajweed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ayahs_surah_id",
+            "unique": false,
+            "columnNames": [
+              "surah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_surah_id` ON `${TABLE_NAME}` (`surah_id`)"
+          },
+          {
+            "name": "index_ayahs_juz",
+            "unique": false,
+            "columnNames": [
+              "juz"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_juz` ON `${TABLE_NAME}` (`juz`)"
+          },
+          {
+            "name": "index_ayahs_page",
+            "unique": false,
+            "columnNames": [
+              "page"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_page` ON `${TABLE_NAME}` (`page`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "surahs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "surah_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "translations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ayah_id` INTEGER NOT NULL, `text` TEXT NOT NULL, `translator_id` TEXT NOT NULL, FOREIGN KEY(`ayah_id`) REFERENCES `ayahs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translatorId",
+            "columnName": "translator_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_translations_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_translations_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          },
+          {
+            "name": "index_translations_ayah_id_translator_id",
+            "unique": true,
+            "columnNames": [
+              "ayah_id",
+              "translator_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_translations_ayah_id_translator_id` ON `${TABLE_NAME}` (`ayah_id`, `translator_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ayahs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ayah_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "quran_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ayahId` INTEGER NOT NULL, `surahNumber` INTEGER NOT NULL, `ayahNumber` INTEGER NOT NULL, `note` TEXT, `color` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayahId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahNumber",
+            "columnName": "ayahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_quran_bookmarks_ayahId",
+            "unique": false,
+            "columnNames": [
+              "ayahId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quran_bookmarks_ayahId` ON `${TABLE_NAME}` (`ayahId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quran_favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ayahId` INTEGER NOT NULL, `surahNumber` INTEGER NOT NULL, `ayahNumber` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`ayahId`))",
+        "fields": [
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayahId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahNumber",
+            "columnName": "ayahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ayahId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `lastReadSurah` INTEGER NOT NULL, `lastReadAyah` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastReadJuz` INTEGER NOT NULL, `totalAyahsRead` INTEGER NOT NULL, `currentKhatmaCount` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadSurah",
+            "columnName": "lastReadSurah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAyah",
+            "columnName": "lastReadAyah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadJuz",
+            "columnName": "lastReadJuz",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAyahsRead",
+            "columnName": "totalAyahsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentKhatmaCount",
+            "columnName": "currentKhatmaCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "surah_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surahNumber` INTEGER NOT NULL, `description` TEXT NOT NULL, `themes` TEXT NOT NULL, PRIMARY KEY(`surahNumber`))",
+        "fields": [
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themes",
+            "columnName": "themes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surahNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "mushaf_ayah_texts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`text_source` TEXT NOT NULL, `ayah_id` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`text_source`, `ayah_id`))",
+        "fields": [
+          {
+            "fieldPath": "textSource",
+            "columnName": "text_source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "text_source",
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mushaf_ayah_texts_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_ayah_texts_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "juzs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "hizb_quarters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `juz_number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "juzNumber",
+            "columnName": "juz_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hizb_quarters_juz_number",
+            "unique": false,
+            "columnNames": [
+              "juz_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hizb_quarters_juz_number` ON `${TABLE_NAME}` (`juz_number`)"
+          }
+        ]
+      },
+      {
+        "tableName": "manzils",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "rukus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `surah_id` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rukus_surah_id",
+            "unique": false,
+            "columnNames": [
+              "surah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rukus_surah_id` ON `${TABLE_NAME}` (`surah_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "sajdas",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ayah_id` INTEGER NOT NULL, `sequence` INTEGER NOT NULL, `kind` TEXT NOT NULL, `upstream_kind` TEXT, PRIMARY KEY(`ayah_id`))",
+        "fields": [
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upstreamKind",
+            "columnName": "upstream_kind",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sajdas_sequence",
+            "unique": false,
+            "columnNames": [
+              "sequence"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sajdas_sequence` ON `${TABLE_NAME}` (`sequence`)"
+          }
+        ]
+      },
+      {
+        "tableName": "surah_structure",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surah_id` INTEGER NOT NULL, `ruku_count` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, `start_page` INTEGER NOT NULL, `end_page` INTEGER NOT NULL, `has_basmalah` INTEGER NOT NULL, `revelation_order` INTEGER NOT NULL, PRIMARY KEY(`surah_id`))",
+        "fields": [
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rukuCount",
+            "columnName": "ruku_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPage",
+            "columnName": "start_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPage",
+            "columnName": "end_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasBasmalah",
+            "columnName": "has_basmalah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revelationOrder",
+            "columnName": "revelation_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surah_id"
+          ]
+        }
+      },
+      {
+        "tableName": "mushaf_layout_lines",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `script` TEXT NOT NULL, `page` INTEGER NOT NULL, `line` INTEGER NOT NULL, `line_type` TEXT NOT NULL, `surah_id` INTEGER NOT NULL, `ayah_id` INTEGER, `first_word_position` INTEGER, `last_word_position` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "script",
+            "columnName": "script",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "line",
+            "columnName": "line",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineType",
+            "columnName": "line_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstWordPosition",
+            "columnName": "first_word_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastWordPosition",
+            "columnName": "last_word_position",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mushaf_layout_lines_script_page_line",
+            "unique": false,
+            "columnNames": [
+              "script",
+              "page",
+              "line"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_layout_lines_script_page_line` ON `${TABLE_NAME}` (`script`, `page`, `line`)"
+          },
+          {
+            "name": "index_mushaf_layout_lines_script",
+            "unique": false,
+            "columnNames": [
+              "script"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_layout_lines_script` ON `${TABLE_NAME}` (`script`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hadith_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `author` TEXT NOT NULL, `hadith_count` INTEGER NOT NULL, `description` TEXT NOT NULL, `icon` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hadithCount",
+            "columnName": "hadith_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "hadiths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `book_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `number_in_book` INTEGER NOT NULL, `number_in_chapter` INTEGER NOT NULL, `text_arabic` TEXT NOT NULL, `text_english` TEXT NOT NULL, `narrator` TEXT NOT NULL, `grade` TEXT NOT NULL, `reference` TEXT NOT NULL, `narrator_chain` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`book_id`) REFERENCES `hadith_books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInBook",
+            "columnName": "number_in_book",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInChapter",
+            "columnName": "number_in_chapter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textEnglish",
+            "columnName": "text_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "grade",
+            "columnName": "grade",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "narratorChain",
+            "columnName": "narrator_chain",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hadiths_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hadiths_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_hadiths_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hadiths_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hadith_books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "hadith_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hadithId` INTEGER NOT NULL, `bookId` INTEGER NOT NULL, `hadithNumber` INTEGER NOT NULL, `note` TEXT, `color` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hadithId",
+            "columnName": "hadithId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hadithNumber",
+            "columnName": "hadithNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hadith_bookmarks_hadithId",
+            "unique": false,
+            "columnNames": [
+              "hadithId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hadith_bookmarks_hadithId` ON `${TABLE_NAME}` (`hadithId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "dua_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `icon` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `dua_count` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duaCount",
+            "columnName": "dua_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "duas",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `category_id` INTEGER NOT NULL, `title_english` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `text_arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `translation` TEXT NOT NULL, `source` TEXT NOT NULL, `virtue` TEXT, `repeat_count` INTEGER NOT NULL, `audio_file` TEXT, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`category_id`) REFERENCES `dua_categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "virtue",
+            "columnName": "virtue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatCount",
+            "columnName": "repeat_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioFile",
+            "columnName": "audio_file",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_duas_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_duas_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dua_categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dua_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `duaId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, `note` TEXT, `isFavorite` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duaId",
+            "columnName": "duaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dua_bookmarks_duaId",
+            "unique": false,
+            "columnNames": [
+              "duaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dua_bookmarks_duaId` ON `${TABLE_NAME}` (`duaId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "dua_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `duaId` INTEGER NOT NULL, `date` INTEGER NOT NULL, `completedCount` INTEGER NOT NULL, `targetCount` INTEGER NOT NULL, `isCompleted` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duaId",
+            "columnName": "duaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedCount",
+            "columnName": "completedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCount",
+            "columnName": "targetCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dua_progress_duaId",
+            "unique": false,
+            "columnNames": [
+              "duaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dua_progress_duaId` ON `${TABLE_NAME}` (`duaId`)"
+          },
+          {
+            "name": "index_dua_progress_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dua_progress_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "prayer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date` INTEGER NOT NULL, `prayerName` TEXT NOT NULL, `status` TEXT NOT NULL, `prayedAt` INTEGER, `scheduledTime` INTEGER NOT NULL, `isJamaah` INTEGER NOT NULL, `isQadaFor` INTEGER, `note` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prayerName",
+            "columnName": "prayerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prayedAt",
+            "columnName": "prayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "scheduledTime",
+            "columnName": "scheduledTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isJamaah",
+            "columnName": "isJamaah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isQadaFor",
+            "columnName": "isQadaFor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_prayer_records_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_prayer_records_date` ON `${TABLE_NAME}` (`date`)"
+          },
+          {
+            "name": "index_prayer_records_prayerName",
+            "unique": false,
+            "columnNames": [
+              "prayerName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_prayer_records_prayerName` ON `${TABLE_NAME}` (`prayerName`)"
+          },
+          {
+            "name": "index_prayer_records_date_prayerName",
+            "unique": true,
+            "columnNames": [
+              "date",
+              "prayerName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_prayer_records_date_prayerName` ON `${TABLE_NAME}` (`date`, `prayerName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fast_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date` INTEGER NOT NULL, `hijriDate` TEXT, `hijriMonth` INTEGER, `hijriYear` INTEGER, `fastType` TEXT NOT NULL, `status` TEXT NOT NULL, `exemptionReason` TEXT, `suhoorTime` INTEGER, `iftarTime` INTEGER, `note` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hijriDate",
+            "columnName": "hijriDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hijriMonth",
+            "columnName": "hijriMonth",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hijriYear",
+            "columnName": "hijriYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fastType",
+            "columnName": "fastType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exemptionReason",
+            "columnName": "exemptionReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "suhoorTime",
+            "columnName": "suhoorTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "iftarTime",
+            "columnName": "iftarTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fast_records_date",
+            "unique": true,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_fast_records_date` ON `${TABLE_NAME}` (`date`)"
+          },
+          {
+            "name": "index_fast_records_hijriMonth",
+            "unique": false,
+            "columnNames": [
+              "hijriMonth"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fast_records_hijriMonth` ON `${TABLE_NAME}` (`hijriMonth`)"
+          },
+          {
+            "name": "index_fast_records_fastType",
+            "unique": false,
+            "columnNames": [
+              "fastType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fast_records_fastType` ON `${TABLE_NAME}` (`fastType`)"
+          }
+        ]
+      },
+      {
+        "tableName": "makeup_fasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `originalDate` INTEGER NOT NULL, `originalHijriDate` TEXT, `reason` TEXT NOT NULL, `status` TEXT NOT NULL, `completedDate` INTEGER, `fidyaAmount` REAL, `note` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalDate",
+            "columnName": "originalDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalHijriDate",
+            "columnName": "originalHijriDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedDate",
+            "columnName": "completedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fidyaAmount",
+            "columnName": "fidyaAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_makeup_fasts_originalDate",
+            "unique": false,
+            "columnNames": [
+              "originalDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_makeup_fasts_originalDate` ON `${TABLE_NAME}` (`originalDate`)"
+          },
+          {
+            "name": "index_makeup_fasts_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_makeup_fasts_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tasbih_presets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `translation` TEXT NOT NULL, `target_count` INTEGER NOT NULL, `is_custom` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `category` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arabic",
+            "columnName": "arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCount",
+            "columnName": "target_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "is_custom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tasbih_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `presetId` INTEGER, `presetName` TEXT, `date` INTEGER NOT NULL, `currentCount` INTEGER NOT NULL, `targetCount` INTEGER NOT NULL, `totalLaps` INTEGER NOT NULL, `isCompleted` INTEGER NOT NULL, `duration` INTEGER, `startedAt` INTEGER NOT NULL, `completedAt` INTEGER, `note` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetId",
+            "columnName": "presetId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "presetName",
+            "columnName": "presetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentCount",
+            "columnName": "currentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCount",
+            "columnName": "targetCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalLaps",
+            "columnName": "totalLaps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tasbih_sessions_presetId",
+            "unique": false,
+            "columnNames": [
+              "presetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tasbih_sessions_presetId` ON `${TABLE_NAME}` (`presetId`)"
+          },
+          {
+            "name": "index_tasbih_sessions_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tasbih_sessions_date` ON `${TABLE_NAME}` (`date`)"
+          },
+          {
+            "name": "index_tasbih_sessions_isCompleted",
+            "unique": false,
+            "columnNames": [
+              "isCompleted"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tasbih_sessions_isCompleted` ON `${TABLE_NAME}` (`isCompleted`)"
+          }
+        ]
+      },
+      {
+        "tableName": "zakat_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `calculatedAt` INTEGER NOT NULL, `totalAssets` REAL NOT NULL, `totalLiabilities` REAL NOT NULL, `netWorth` REAL NOT NULL, `zakatDue` REAL NOT NULL, `nisabType` TEXT NOT NULL, `nisabValue` REAL NOT NULL, `isPaid` INTEGER NOT NULL, `paidAt` INTEGER, `notes` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "calculatedAt",
+            "columnName": "calculatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAssets",
+            "columnName": "totalAssets",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalLiabilities",
+            "columnName": "totalLiabilities",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "netWorth",
+            "columnName": "netWorth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zakatDue",
+            "columnName": "zakatDue",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nisabType",
+            "columnName": "nisabType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nisabValue",
+            "columnName": "nisabValue",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paidAt",
+            "columnName": "paidAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tafseer_blocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tafseer_id` TEXT NOT NULL, `surah_number` INTEGER NOT NULL, `ayah_start` INTEGER NOT NULL, `ayah_end` INTEGER NOT NULL, `text` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tafseerId",
+            "columnName": "tafseer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahStart",
+            "columnName": "ayah_start",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahEnd",
+            "columnName": "ayah_end",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tafseer_blocks_tafseer_id_surah_number_ayah_start_ayah_end",
+            "unique": false,
+            "columnNames": [
+              "tafseer_id",
+              "surah_number",
+              "ayah_start",
+              "ayah_end"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tafseer_blocks_tafseer_id_surah_number_ayah_start_ayah_end` ON `${TABLE_NAME}` (`tafseer_id`, `surah_number`, `ayah_start`, `ayah_end`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tafseer_highlights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ayah_id` INTEGER NOT NULL, `tafseer_id` TEXT NOT NULL, `start_offset` INTEGER NOT NULL, `end_offset` INTEGER NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tafseerId",
+            "columnName": "tafseer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startOffset",
+            "columnName": "start_offset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endOffset",
+            "columnName": "end_offset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tafseer_highlights_ayah_id_tafseer_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id",
+              "tafseer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tafseer_highlights_ayah_id_tafseer_id` ON `${TABLE_NAME}` (`ayah_id`, `tafseer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tafseer_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ayah_id` INTEGER NOT NULL, `tafseer_id` TEXT NOT NULL, `text` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tafseerId",
+            "columnName": "tafseer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tafseer_notes_ayah_id_tafseer_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id",
+              "tafseer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tafseer_notes_ayah_id_tafseer_id` ON `${TABLE_NAME}` (`ayah_id`, `tafseer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "khatams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `notes` TEXT, `status` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `daily_target` INTEGER NOT NULL, `deadline` INTEGER, `reminder_enabled` INTEGER NOT NULL, `reminder_time` TEXT, `total_ayahs_read` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `started_at` INTEGER, `completed_at` INTEGER, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyTarget",
+            "columnName": "daily_target",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadline",
+            "columnName": "deadline",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "reminderEnabled",
+            "columnName": "reminder_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderTime",
+            "columnName": "reminder_time",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalAyahsRead",
+            "columnName": "total_ayahs_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "khatam_ayahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`khatam_id` INTEGER NOT NULL, `ayah_id` INTEGER NOT NULL, `read_at` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`khatam_id`, `ayah_id`), FOREIGN KEY(`khatam_id`) REFERENCES `khatams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "khatamId",
+            "columnName": "khatam_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "khatam_id",
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_khatam_ayahs_khatam_id",
+            "unique": false,
+            "columnNames": [
+              "khatam_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_khatam_ayahs_khatam_id` ON `${TABLE_NAME}` (`khatam_id`)"
+          },
+          {
+            "name": "index_khatam_ayahs_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_khatam_ayahs_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          },
+          {
+            "name": "index_khatam_ayahs_read_at",
+            "unique": false,
+            "columnNames": [
+              "read_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_khatam_ayahs_read_at` ON `${TABLE_NAME}` (`read_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "khatams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "khatam_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "khatam_daily_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`khatam_id` INTEGER NOT NULL, `date` INTEGER NOT NULL, `ayahs_read` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`khatam_id`, `date`), FOREIGN KEY(`khatam_id`) REFERENCES `khatams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "khatamId",
+            "columnName": "khatam_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahsRead",
+            "columnName": "ayahs_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "khatam_id",
+            "date"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_khatam_daily_log_khatam_id",
+            "unique": false,
+            "columnNames": [
+              "khatam_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_khatam_daily_log_khatam_id` ON `${TABLE_NAME}` (`khatam_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "khatams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "khatam_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asma_ul_husna",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `name_english` TEXT NOT NULL, `meaning` TEXT NOT NULL, `explanation` TEXT NOT NULL, `benefits` TEXT NOT NULL, `quran_references` TEXT NOT NULL, `usage_in_dua` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meaning",
+            "columnName": "meaning",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explanation",
+            "columnName": "explanation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "benefits",
+            "columnName": "benefits",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quranReferences",
+            "columnName": "quran_references",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usageInDua",
+            "columnName": "usage_in_dua",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "asma_ul_husna_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name_id` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameId",
+            "columnName": "name_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_asma_ul_husna_bookmarks_name_id",
+            "unique": true,
+            "columnNames": [
+              "name_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_asma_ul_husna_bookmarks_name_id` ON `${TABLE_NAME}` (`name_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "asma_un_nabi",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `name_english` TEXT NOT NULL, `meaning` TEXT NOT NULL, `explanation` TEXT NOT NULL, `source` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meaning",
+            "columnName": "meaning",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explanation",
+            "columnName": "explanation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "asma_un_nabi_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name_id` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameId",
+            "columnName": "name_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_asma_un_nabi_bookmarks_name_id",
+            "unique": true,
+            "columnNames": [
+              "name_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_asma_un_nabi_bookmarks_name_id` ON `${TABLE_NAME}` (`name_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "prophets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_english` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `title_english` TEXT NOT NULL, `story_summary` TEXT NOT NULL, `key_lessons` TEXT NOT NULL, `quran_mentions` TEXT NOT NULL, `era` TEXT NOT NULL, `lineage` TEXT NOT NULL, `years_lived` TEXT NOT NULL, `place_of_preaching` TEXT NOT NULL, `miracles` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storySummary",
+            "columnName": "story_summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyLessons",
+            "columnName": "key_lessons",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quranMentions",
+            "columnName": "quran_mentions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "era",
+            "columnName": "era",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineage",
+            "columnName": "lineage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "yearsLived",
+            "columnName": "years_lived",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeOfPreaching",
+            "columnName": "place_of_preaching",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "miracles",
+            "columnName": "miracles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "prophet_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prophet_id` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prophetId",
+            "columnName": "prophet_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_prophet_bookmarks_prophet_id",
+            "unique": true,
+            "columnNames": [
+              "prophet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_prophet_bookmarks_prophet_id` ON `${TABLE_NAME}` (`prophet_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "help_topic",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `icon_key` TEXT NOT NULL, `color_key` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "icon_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorKey",
+            "columnName": "color_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "help_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `topic_id` TEXT NOT NULL, `type` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `icon_key` TEXT, `estimated_minutes` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topic_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "icon_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estimatedMinutes",
+            "columnName": "estimated_minutes",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_item_topic_id",
+            "unique": false,
+            "columnNames": [
+              "topic_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_item_topic_id` ON `${TABLE_NAME}` (`topic_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "help_step",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `deeplink_route` TEXT, `path_labels` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deeplinkRoute",
+            "columnName": "deeplink_route",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pathLabels",
+            "columnName": "path_labels",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_step_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_step_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "help_string",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`owner_type` TEXT NOT NULL, `owner_id` TEXT NOT NULL, `field_key` TEXT NOT NULL, `lang_code` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`owner_type`, `owner_id`, `field_key`, `lang_code`))",
+        "fields": [
+          {
+            "fieldPath": "ownerType",
+            "columnName": "owner_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldKey",
+            "columnName": "field_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "langCode",
+            "columnName": "lang_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "owner_type",
+            "owner_id",
+            "field_key",
+            "lang_code"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_string_owner_type_owner_id_lang_code",
+            "unique": false,
+            "columnNames": [
+              "owner_type",
+              "owner_id",
+              "lang_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_string_owner_type_owner_id_lang_code` ON `${TABLE_NAME}` (`owner_type`, `owner_id`, `lang_code`)"
+          },
+          {
+            "name": "index_help_string_lang_code",
+            "unique": false,
+            "columnNames": [
+              "lang_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_string_lang_code` ON `${TABLE_NAME}` (`lang_code`)"
+          }
+        ]
+      },
+      {
+        "tableName": "qaida_lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `lesson_number` INTEGER NOT NULL, `title_english` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `title_transliteration` TEXT NOT NULL, `description` TEXT NOT NULL, `concept_tags` TEXT NOT NULL, `icon` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonNumber",
+            "columnName": "lesson_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleTransliteration",
+            "columnName": "title_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conceptTags",
+            "columnName": "concept_tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qaida_letters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `letter_arabic` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `isolated_form` TEXT NOT NULL, `initial_form` TEXT, `medial_form` TEXT, `final_form` TEXT, `is_connecting` INTEGER NOT NULL, `makhraj_area` TEXT NOT NULL, `makhraj_detail` TEXT NOT NULL, `phonetic_hint` TEXT, `audio_key` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterArabic",
+            "columnName": "letter_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isolatedForm",
+            "columnName": "isolated_form",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialForm",
+            "columnName": "initial_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "medialForm",
+            "columnName": "medial_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finalForm",
+            "columnName": "final_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnecting",
+            "columnName": "is_connecting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "makhrajArea",
+            "columnName": "makhraj_area",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "makhrajDetail",
+            "columnName": "makhraj_detail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneticHint",
+            "columnName": "phonetic_hint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioKey",
+            "columnName": "audio_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qaida_lines",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `lesson_id` INTEGER NOT NULL, `line_number` INTEGER NOT NULL, `line_type` TEXT NOT NULL, `instruction_english` TEXT, `instruction_arabic` TEXT, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`lesson_id`) REFERENCES `qaida_lessons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineNumber",
+            "columnName": "line_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineType",
+            "columnName": "line_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionEnglish",
+            "columnName": "instruction_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "instructionArabic",
+            "columnName": "instruction_arabic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_qaida_lines_lesson_id",
+            "unique": false,
+            "columnNames": [
+              "lesson_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_lines_lesson_id` ON `${TABLE_NAME}` (`lesson_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "qaida_lessons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "lesson_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "qaida_cells",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `line_id` INTEGER NOT NULL, `lesson_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `text_arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `token_type` TEXT NOT NULL, `audio_key` TEXT NOT NULL, `highlight_group` TEXT, `letter_id` INTEGER, `notes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`line_id`) REFERENCES `qaida_lines`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`letter_id`) REFERENCES `qaida_letters`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineId",
+            "columnName": "line_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioKey",
+            "columnName": "audio_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlightGroup",
+            "columnName": "highlight_group",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "letterId",
+            "columnName": "letter_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_qaida_cells_line_id",
+            "unique": false,
+            "columnNames": [
+              "line_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_line_id` ON `${TABLE_NAME}` (`line_id`)"
+          },
+          {
+            "name": "index_qaida_cells_lesson_id",
+            "unique": false,
+            "columnNames": [
+              "lesson_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_lesson_id` ON `${TABLE_NAME}` (`lesson_id`)"
+          },
+          {
+            "name": "index_qaida_cells_letter_id",
+            "unique": false,
+            "columnNames": [
+              "letter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_letter_id` ON `${TABLE_NAME}` (`letter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "qaida_lines",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "line_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "qaida_letters",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "letter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "qaida_lesson_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`lesson_id` INTEGER NOT NULL, `status` TEXT NOT NULL, `stars` INTEGER NOT NULL, `last_cell_id` INTEGER, `completed_cells` INTEGER NOT NULL, `total_cells` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`lesson_id`))",
+        "fields": [
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stars",
+            "columnName": "stars",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCellId",
+            "columnName": "last_cell_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedCells",
+            "columnName": "completed_cells",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCells",
+            "columnName": "total_cells",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "lesson_id"
+          ]
+        }
+      },
+      {
+        "tableName": "qaida_cell_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`lesson_id` INTEGER NOT NULL, `cell_id` INTEGER NOT NULL, `heard_count` INTEGER NOT NULL, `is_completed` INTEGER NOT NULL, `last_practiced_at` INTEGER NOT NULL, PRIMARY KEY(`lesson_id`, `cell_id`))",
+        "fields": [
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cellId",
+            "columnName": "cell_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heardCount",
+            "columnName": "heard_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "is_completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPracticedAt",
+            "columnName": "last_practiced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "lesson_id",
+            "cell_id"
+          ]
+        }
+      },
+      {
+        "tableName": "locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timezone` TEXT NOT NULL, `country` TEXT, `city` TEXT, `isCurrentLocation` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `calculationMethod` TEXT, `asrCalculation` TEXT, `highLatitudeRule` TEXT, `fajrAngle` REAL, `ishaAngle` REAL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timezone",
+            "columnName": "timezone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCurrentLocation",
+            "columnName": "isCurrentLocation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "calculationMethod",
+            "columnName": "calculationMethod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asrCalculation",
+            "columnName": "asrCalculation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "highLatitudeRule",
+            "columnName": "highLatitudeRule",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fajrAngle",
+            "columnName": "fajrAngle",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "ishaAngle",
+            "columnName": "ishaAngle",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "islamic_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `hijri_month` INTEGER NOT NULL, `hijri_day` INTEGER NOT NULL, `event_type` TEXT NOT NULL, `description` TEXT NOT NULL, `is_holiday` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hijriMonth",
+            "columnName": "hijri_month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hijriDay",
+            "columnName": "hijri_day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "event_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHoliday",
+            "columnName": "is_holiday",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_islamic_events_hijri_month_hijri_day",
+            "unique": false,
+            "columnNames": [
+              "hijri_month",
+              "hijri_day"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_islamic_events_hijri_month_hijri_day` ON `${TABLE_NAME}` (`hijri_month`, `hijri_day`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '41721a7f965932d23810139ba29d7d0f')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/MigrationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/MigrationTest.kt
@@ -97,6 +97,116 @@ class MigrationTest {
         ).inOrder()
     }
 
+
+    /**
+     * schemaVersion 22: `ayahs` stops carrying text and prostration, and both must survive the
+     * move. Everything the new tables need is already on the device — the Uthmani text is in the
+     * column being dropped, the sajdas are the fifteen marked rows, the juz/hizb/page divisions
+     * are the columns that described them per verse — which is the only reason this can be a
+     * migration rather than a reinstall. `MIGRATION_20_21` shipped without that property and
+     * would have emptied the Tafseer reader for every existing user.
+     */
+    @Test
+    fun migrate21To22_movesTextAndProstrationBeforeDroppingTheColumns() {
+        helper.createDatabase(dbName, 21).use { db ->
+            db.execSQL(
+                "INSERT INTO surahs (id, number, name_arabic, name_english, name_transliteration, " +
+                    "revelation_type, verses_count, order_revealed, start_page) " +
+                    "VALUES (7,7,'ا','Al-Araf','Al-Araf','Meccan',206,39,151)"
+            )
+            // A plain verse, and the prostration at 7:206 — obligatory in the corpus.
+            db.execSQL(
+                "INSERT INTO ayahs (id, surah_id, number_in_surah, number_global, text_arabic, " +
+                    "text_uthmani, juz, hizb, page, sajda, sajda_type, transliteration, text_tajweed) " +
+                    "VALUES (1000,7,100,1000,'arabic one','uthmani one',9,70,200,0,NULL,'translit','[]')"
+            )
+            db.execSQL(
+                "INSERT INTO ayahs (id, surah_id, number_in_surah, number_global, text_arabic, " +
+                    "text_uthmani, juz, hizb, page, sajda, sajda_type) " +
+                    "VALUES (1160,7,206,1160,'arabic sajda','uthmani sajda',9,71,206,1,'obligatory')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName, 22, true, NimazDatabase.MIGRATION_21_22
+        )
+
+        // The Uthmani text is a row now, and it is the same bytes.
+        db.query(
+            "SELECT text FROM mushaf_ayah_texts WHERE text_source = 'UTHMANI' AND ayah_id = 1000"
+        ).use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0)).isEqualTo("uthmani one")
+        }
+
+        // The prostration is a row, with its classification and its place in the sequence.
+        db.query("SELECT ayah_id, sequence, kind FROM sajdas ORDER BY sequence").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getInt(0)).isEqualTo(1160)
+            assertThat(cursor.getInt(1)).isEqualTo(1)
+            assertThat(cursor.getString(2)).isEqualTo("obligatory")
+            assertThat(cursor.count).isEqualTo(1)
+        }
+
+        // The divisions come from the columns that described them.
+        db.query("SELECT number, start_ayah_id, end_ayah_id FROM juzs").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getInt(0)).isEqualTo(9)
+            assertThat(cursor.getInt(1)).isEqualTo(1000)
+            assertThat(cursor.getInt(2)).isEqualTo(1160)
+        }
+        db.query("SELECT COUNT(*) FROM pages").use { cursor ->
+            cursor.moveToFirst()
+            assertThat(cursor.getInt(0)).isEqualTo(2)   // pages 200 and 206
+        }
+        db.query("SELECT number, juz_number FROM hizb_quarters ORDER BY number").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getInt(0)).isEqualTo(70)
+            assertThat(cursor.getInt(1)).isEqualTo(9)
+        }
+
+        // And only then are the columns gone — with what stays, staying.
+        val columns = mutableSetOf<String>()
+        db.query("PRAGMA table_info(`ayahs`)").use { cursor ->
+            val index = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) columns += cursor.getString(index)
+        }
+        assertThat(columns).containsNoneOf(
+            "text_arabic", "text_uthmani", "text_indopak", "sajda", "sajda_type"
+        )
+        assertThat(columns).containsAtLeast(
+            "id", "surah_id", "number_in_surah", "number_global", "juz", "hizb", "page",
+            "transliteration", "text_tajweed",
+        )
+
+        db.query("SELECT transliteration, text_tajweed FROM ayahs WHERE id = 1000").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0)).isEqualTo("translit")
+            assertThat(cursor.getString(1)).isEqualTo("[]")
+        }
+        db.query("SELECT COUNT(*) FROM ayahs").use { cursor ->
+            cursor.moveToFirst()
+            assertThat(cursor.getInt(0)).isEqualTo(2)
+        }
+    }
+
+    /** The fresh-install shape: the artifact already has the v22 layout, so the move is a no-op. */
+    @Test
+    fun migrate21To22_toleratesAnArtifactThatIsAlreadyReshaped() {
+        helper.createDatabase(dbName, 21).use { db ->
+            db.execSQL("INSERT INTO mushaf_ayah_texts (text_source, ayah_id, text) VALUES ('UTHMANI', 5, 'from the artifact')")
+        }
+
+        val db = helper.runMigrationsAndValidate(dbName, 22, true, NimazDatabase.MIGRATION_21_22)
+
+        // INSERT OR IGNORE, not REPLACE: a row that came from the artifact is not overwritten
+        // from a column that a fresh install's ayahs table does not even have.
+        db.query("SELECT text FROM mushaf_ayah_texts WHERE ayah_id = 5").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0)).isEqualTo("from the artifact")
+        }
+    }
+
     /**
      * The legacy-asset repair runs on every freshly copied artifact, before Room
      * validates it. It used to index `tafseer_texts` unconditionally, and

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/TestData.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/TestData.kt
@@ -3,6 +3,11 @@ package com.arshadshah.nimaz.support
 import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.AsmaUnNabiBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.HizbQuarterEntity
+import com.arshadshah.nimaz.data.local.database.entity.JuzEntity
+import com.arshadshah.nimaz.data.local.database.entity.MushafAyahTextEntity
+import com.arshadshah.nimaz.data.local.database.entity.RukuEntity
+import com.arshadshah.nimaz.data.local.database.entity.SajdaEntity
 import com.arshadshah.nimaz.data.local.database.entity.DuaBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.DuaCategoryEntity
 import com.arshadshah.nimaz.data.local.database.entity.DuaEntity
@@ -195,14 +200,35 @@ object TestData {
         surahId = surahId,
         numberInSurah = numberInSurah,
         numberGlobal = numberGlobal,
-        textArabic = "بِسْمِ اللَّهِ",
-        textUthmani = "بِسْمِ اللَّهِ",
         juz = juz,
         hizb = 1,
         page = page,
-        sajda = 0,
-        sajdaType = null,
     )
+
+    /**
+     * A verse's text, which since schemaVersion 22 is a row rather than a column on the verse.
+     * Default source is `UTHMANI`; pass `SIMPLE` for the plain script.
+     */
+    fun ayahText(ayahId: Int = 1, source: String = "UTHMANI", text: String = "بِسْمِ اللَّهِ") =
+        MushafAyahTextEntity(textSource = source, ayahId = ayahId, text = text)
+
+    fun sajda(ayahId: Int = 1160, sequence: Int = 1, kind: String = "obligatory") =
+        SajdaEntity(ayahId = ayahId, sequence = sequence, kind = kind, upstreamKind = null)
+
+    fun juz(number: Int = 1, startAyahId: Int = 1, endAyahId: Int = 148) =
+        JuzEntity(number = number, startAyahId = startAyahId, endAyahId = endAyahId)
+
+    fun hizbQuarter(number: Int = 1, juzNumber: Int = 1, startAyahId: Int = 1, endAyahId: Int = 37) =
+        HizbQuarterEntity(
+            number = number, juzNumber = juzNumber,
+            startAyahId = startAyahId, endAyahId = endAyahId,
+        )
+
+    fun ruku(number: Int = 1, surahId: Int = 1, startAyahId: Int = 1, endAyahId: Int = 7) =
+        RukuEntity(
+            number = number, surahId = surahId,
+            startAyahId = startAyahId, endAyahId = endAyahId,
+        )
 
     fun quranBookmark(ayahId: Int = 1, surahNumber: Int = 1, ayahNumber: Int = 1) =
         QuranBookmarkEntity(

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -61,6 +61,13 @@ import com.arshadshah.nimaz.data.local.database.entity.QuranFavoriteEntity
 import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
+import com.arshadshah.nimaz.data.local.database.entity.HizbQuarterEntity
+import com.arshadshah.nimaz.data.local.database.entity.JuzEntity
+import com.arshadshah.nimaz.data.local.database.entity.ManzilEntity
+import com.arshadshah.nimaz.data.local.database.entity.PageEntity
+import com.arshadshah.nimaz.data.local.database.entity.RukuEntity
+import com.arshadshah.nimaz.data.local.database.entity.SajdaEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahStructureEntity
 import com.arshadshah.nimaz.data.local.database.entity.TafseerBlockEntity
 import com.arshadshah.nimaz.data.local.database.entity.TafseerHighlightEntity
 import com.arshadshah.nimaz.data.local.database.entity.TafseerNoteEntity
@@ -74,7 +81,7 @@ import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
  * migration) for any schema change — it drives both the Room `@Database(version = …)`
  * annotation below and `NimazDatabase.SCHEMA_VERSION` (used to tag crash reports).
  */
-const val NIMAZ_DATABASE_VERSION = 21
+const val NIMAZ_DATABASE_VERSION = 22
 
 @Database(
     entities = [
@@ -87,6 +94,13 @@ const val NIMAZ_DATABASE_VERSION = 21
         ReadingProgressEntity::class,
         SurahInfoEntity::class,
         MushafAyahTextEntity::class,
+        JuzEntity::class,
+        HizbQuarterEntity::class,
+        ManzilEntity::class,
+        RukuEntity::class,
+        PageEntity::class,
+        SajdaEntity::class,
+        SurahStructureEntity::class,
         MushafLayoutLineEntity::class,
         // Hadith
         HadithBookEntity::class,
@@ -365,6 +379,168 @@ abstract class NimazDatabase : RoomDatabase() {
         // `tafseer_highlights`/`tafseer_notes` (user data, keyed by `ayah_id`) are
         // untouched: their `start_offset`/`end_offset` index into the commentary
         // text, which is unchanged for the ayah they were made on.
+// schemaVersion 22 — a verse's row stops being four renderings, a boolean and a
+        // nullable string, and becomes its place in the mushaf.
+        //
+        // Everything moved here is *derivable on the device*, which is the only reason this can
+        // be a migration rather than a reinstall. `createFromAsset` re-copies the artifact only
+        // on a fresh install, and a content patch cannot create a table that its baseline never
+        // had, so anything not derivable would simply be absent for existing users — the trap
+        // MIGRATION_20_21 fell into with tafseer.
+        //
+        //   text_uthmani  -> mushaf_ayah_texts as source UTHMANI  (the row already holds it)
+        //   sajda columns -> sajdas                               (the 15 marked rows)
+        //   juz/hizb/page -> juzs, hizb_quarters, pages           (MIN/MAX over the columns)
+        //
+        // `rukus`, `manzils` and `surah_structure` are content that has never been on a device:
+        // they are created empty and filled from the artifact on a fresh install, or by
+        // QuranStructureSeeder from the bundled seed on an upgrade. `text_arabic` was
+        // byte-identical to `text_uthmani` in all 6,236 rows, so nothing is lost by dropping it;
+        // `text_indopak` was NULL in all of them.
+        val MIGRATION_21_22 = object : Migration(21, 22) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `juzs` (
+                        `number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL,
+                        `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `hizb_quarters` (
+                        `number` INTEGER NOT NULL, `juz_number` INTEGER NOT NULL,
+                        `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL,
+                        PRIMARY KEY(`number`))
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_hizb_quarters_juz_number` ON `hizb_quarters` (`juz_number`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `manzils` (
+                        `number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL,
+                        `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `rukus` (
+                        `number` INTEGER NOT NULL, `surah_id` INTEGER NOT NULL,
+                        `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL,
+                        PRIMARY KEY(`number`))
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_rukus_surah_id` ON `rukus` (`surah_id`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `pages` (
+                        `number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL,
+                        `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `sajdas` (
+                        `ayah_id` INTEGER NOT NULL, `sequence` INTEGER NOT NULL,
+                        `kind` TEXT NOT NULL, `upstream_kind` TEXT, PRIMARY KEY(`ayah_id`))
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_sajdas_sequence` ON `sajdas` (`sequence`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `surah_structure` (
+                        `surah_id` INTEGER NOT NULL, `ruku_count` INTEGER NOT NULL,
+                        `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL,
+                        `start_page` INTEGER NOT NULL, `end_page` INTEGER NOT NULL,
+                        `has_basmalah` INTEGER NOT NULL, `revelation_order` INTEGER NOT NULL,
+                        PRIMARY KEY(`surah_id`))
+                    """.trimIndent()
+                )
+
+                // The Uthmani text the row already carries becomes a text source. INSERT OR
+                // IGNORE, not REPLACE: a device that already has the artifact's UTHMANI rows
+                // must keep them rather than have them overwritten from a column.
+                if (db.hasColumn("ayahs", "text_uthmani")) {
+                    db.execSQL(
+                        """
+                        INSERT OR IGNORE INTO `mushaf_ayah_texts` (`text_source`, `ayah_id`, `text`)
+                        SELECT 'UTHMANI', `id`, `text_uthmani` FROM `ayahs`
+                        WHERE `text_uthmani` IS NOT NULL AND `text_uthmani` != ''
+                        """.trimIndent()
+                    )
+                }
+
+                if (db.hasColumn("ayahs", "sajda")) {
+                    db.execSQL(
+                        """
+                        INSERT OR IGNORE INTO `sajdas` (`ayah_id`, `sequence`, `kind`, `upstream_kind`)
+                        SELECT `id`,
+                               (SELECT COUNT(*) FROM `ayahs` b WHERE b.`sajda` <> 0 AND b.`id` <= a.`id`),
+                               COALESCE(`sajda_type`, 'recommended'),
+                               NULL
+                        FROM `ayahs` a WHERE a.`sajda` <> 0
+                        """.trimIndent()
+                    )
+                }
+
+                // The divisions, from the columns that already describe them per verse.
+                db.execSQL(
+                    """
+                    INSERT OR IGNORE INTO `juzs` (`number`, `start_ayah_id`, `end_ayah_id`)
+                    SELECT `juz`, MIN(`id`), MAX(`id`) FROM `ayahs` GROUP BY `juz`
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    INSERT OR IGNORE INTO `hizb_quarters` (`number`, `juz_number`, `start_ayah_id`, `end_ayah_id`)
+                    SELECT `hizb`, MIN(`juz`), MIN(`id`), MAX(`id`) FROM `ayahs` GROUP BY `hizb`
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    INSERT OR IGNORE INTO `pages` (`number`, `start_ayah_id`, `end_ayah_id`)
+                    SELECT `page`, MIN(`id`), MAX(`id`) FROM `ayahs` GROUP BY `page`
+                    """.trimIndent()
+                )
+
+                // Rebuild `ayahs` without the columns that moved. SQLite cannot drop a column
+                // in a table this old, so it is the documented twelve-step dance, minus the
+                // steps that do not apply.
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `ayahs_new` (
+                        `id` INTEGER NOT NULL,
+                        `surah_id` INTEGER NOT NULL,
+                        `number_in_surah` INTEGER NOT NULL,
+                        `number_global` INTEGER NOT NULL,
+                        `juz` INTEGER NOT NULL,
+                        `hizb` INTEGER NOT NULL,
+                        `page` INTEGER NOT NULL,
+                        `transliteration` TEXT,
+                        `text_tajweed` TEXT,
+                        PRIMARY KEY(`id`),
+                        FOREIGN KEY(`surah_id`) REFERENCES `surahs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    INSERT OR REPLACE INTO `ayahs_new`
+                        (`id`, `surah_id`, `number_in_surah`, `number_global`, `juz`, `hizb`,
+                         `page`, `transliteration`, `text_tajweed`)
+                    SELECT `id`, `surah_id`, `number_in_surah`, `number_global`, `juz`, `hizb`,
+                           `page`, `transliteration`, `text_tajweed`
+                    FROM `ayahs`
+                    """.trimIndent()
+                )
+                db.execSQL("DROP TABLE `ayahs`")
+                db.execSQL("ALTER TABLE `ayahs_new` RENAME TO `ayahs`")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_ayahs_surah_id` ON `ayahs` (`surah_id`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_ayahs_juz` ON `ayahs` (`juz`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_ayahs_page` ON `ayahs` (`page`)")
+            }
+        }
+
         val MIGRATION_20_21 = object : Migration(20, 21) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
@@ -912,6 +1088,7 @@ abstract class NimazDatabase : RoomDatabase() {
             MIGRATION_18_19,
             MIGRATION_19_20,
             MIGRATION_20_21,
+            MIGRATION_21_22,
         )
     }
 }
@@ -950,6 +1127,20 @@ private fun SupportSQLiteDatabase.addColumnIfMissing(
 private fun SupportSQLiteDatabase.hasTable(table: String): Boolean =
     query("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", arrayOf(table))
         .use { it.moveToFirst() }
+
+/**
+ * Whether [table] has [column].
+ *
+ * A migration that moves a column's contents has to run against a database that may or may not
+ * still have it — a device upgrading through the chain, or one that arrived already reshaped in
+ * the artifact. Asking is what makes the move idempotent.
+ */
+private fun SupportSQLiteDatabase.hasColumn(table: String, column: String): Boolean =
+    query("PRAGMA table_info(`$table`)").use { cursor ->
+        val nameIndex = cursor.getColumnIndex("name")
+        generateSequence { if (cursor.moveToNext()) cursor.getString(nameIndex) else null }
+            .any { it == column }
+    }
 
 /** Whether [table] holds no rows. Used to keep a data-carrying migration re-runnable. */
 private fun SupportSQLiteDatabase.isEmpty(table: String): Boolean =

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -1,12 +1,21 @@
 package com.arshadshah.nimaz.data.local.database.dao
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import androidx.room.Embedded
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.HizbQuarterEntity
+import com.arshadshah.nimaz.data.local.database.entity.JuzEntity
+import com.arshadshah.nimaz.data.local.database.entity.ManzilEntity
+import com.arshadshah.nimaz.data.local.database.entity.PageEntity
+import com.arshadshah.nimaz.data.local.database.entity.RukuEntity
+import com.arshadshah.nimaz.data.local.database.entity.SajdaEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahStructureEntity
 import com.arshadshah.nimaz.data.local.database.entity.MushafAyahTextEntity
 import com.arshadshah.nimaz.data.local.database.entity.MushafLayoutLineEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
@@ -109,11 +118,229 @@ interface QuranDao {
     )
     suspend fun getLayoutPageAyahRanges(script: String): List<PageAyahRangeRow>
 
-    @Query("SELECT * FROM ayahs WHERE sajda_type IS NOT NULL ORDER BY id ASC")
+    // The prostration verses, in mushaf order. `sajda`/`sajda_type` were columns on all 6,236
+    // rows to describe fifteen of them; since schemaVersion 22 they are the `sajdas` table.
+    @Query(
+        """
+        SELECT a.* FROM ayahs a
+        JOIN sajdas s ON s.ayah_id = a.id
+        ORDER BY s.sequence ASC
+        """
+    )
     fun getSajdaAyahs(): Flow<List<AyahEntity>>
 
-    @Query("SELECT * FROM ayahs WHERE text_uthmani LIKE '%' || :query || '%' OR text_arabic LIKE '%' || :query || '%'")
+    /** The fifteen prostrations with their classification, which the ayah row no longer carries. */
+    @Query("SELECT * FROM sajdas ORDER BY sequence ASC")
+    fun getSajdas(): Flow<List<SajdaEntity>>
+
+    @Query("SELECT * FROM sajdas WHERE ayah_id = :ayahId")
+    suspend fun getSajdaForAyah(ayahId: Int): SajdaEntity?
+
+    // Search every rendering rather than one column twice. The old query was
+    // `text_uthmani LIKE … OR text_arabic LIKE …` over two columns that held identical bytes,
+    // so it scanned the same 1.3 MB twice and could never match anything the other missed.
+    // Now a match in any script — Uthmani, plain, either IndoPak — finds the verse, and DISTINCT
+    // keeps a verse that matches in three of them from appearing three times.
+    @Query(
+        """
+        SELECT DISTINCT a.* FROM ayahs a
+        JOIN mushaf_ayah_texts t ON t.ayah_id = a.id
+        WHERE t.text LIKE '%' || :query || '%'
+        ORDER BY a.id ASC
+        """
+    )
     fun searchAyahs(query: String): Flow<List<AyahEntity>>
+
+
+    // --- verses with their text (schemaVersion 22) ----------------------------------------
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.surah_id = :surahId
+        ORDER BY a.number_in_surah ASC
+        """
+    )
+    fun getAyahsWithTextBySurah(surahId: Int): Flow<List<AyahWithText>>
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.id = :ayahId
+        """
+    )
+    suspend fun getAyahWithTextById(ayahId: Int): AyahWithText?
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.id BETWEEN :minAyahId AND :maxAyahId
+        ORDER BY a.id ASC
+        """
+    )
+    fun getAyahsWithTextByRange(minAyahId: Int, maxAyahId: Int): Flow<List<AyahWithText>>
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE sj.ayah_id IS NOT NULL
+        ORDER BY sj.sequence ASC
+        """
+    )
+    fun getSajdaAyahsWithText(): Flow<List<AyahWithText>>
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.id IN (
+            SELECT DISTINCT t.ayah_id FROM mushaf_ayah_texts t
+            WHERE t.text LIKE '%' || :query || '%'
+        )
+        ORDER BY a.id ASC
+        """
+    )
+    fun searchAyahsWithText(query: String): Flow<List<AyahWithText>>
+
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.page = :pageNumber
+        ORDER BY a.id ASC
+        """
+    )
+    fun getAyahsWithTextByPage(pageNumber: Int): Flow<List<AyahWithText>>
+
+    @Query(
+        """
+        SELECT a.*,
+               u.text AS text_uthmani,
+               s.text AS text_simple,
+               sj.kind AS sajda_kind,
+               sj.sequence AS sajda_sequence,
+               hq.number AS rub_number
+        FROM ayahs a
+        LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
+        LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
+        LEFT JOIN sajdas sj ON sj.ayah_id = a.id
+        LEFT JOIN hizb_quarters hq ON a.id BETWEEN hq.start_ayah_id AND hq.end_ayah_id
+        WHERE a.juz = :juzNumber
+        ORDER BY a.id ASC
+        """
+    )
+    fun getAyahsWithTextByJuz(juzNumber: Int): Flow<List<AyahWithText>>
+
+    // --- the divisions of the mushaf (schemaVersion 22) ----------------------------------
+    //
+    // Each of these was previously a scan over `ayahs` with a MIN/MAX, which is why none of
+    // them existed and there is no juz screen.
+
+    @Query("SELECT * FROM juzs ORDER BY number ASC")
+    fun getJuzs(): Flow<List<JuzEntity>>
+
+    @Query("SELECT * FROM juzs WHERE :ayahId BETWEEN start_ayah_id AND end_ayah_id")
+    suspend fun getJuzForAyah(ayahId: Int): JuzEntity?
+
+    @Query("SELECT * FROM hizb_quarters WHERE juz_number = :juz ORDER BY number ASC")
+    fun getHizbQuartersForJuz(juz: Int): Flow<List<HizbQuarterEntity>>
+
+    @Query("SELECT * FROM hizb_quarters WHERE :ayahId BETWEEN start_ayah_id AND end_ayah_id")
+    suspend fun getHizbQuarterForAyah(ayahId: Int): HizbQuarterEntity?
+
+    @Query("SELECT * FROM manzils ORDER BY number ASC")
+    fun getManzils(): Flow<List<ManzilEntity>>
+
+    @Query("SELECT * FROM rukus WHERE surah_id = :surahId ORDER BY number ASC")
+    fun getRukusForSurah(surahId: Int): Flow<List<RukuEntity>>
+
+    @Query("SELECT * FROM rukus WHERE :ayahId BETWEEN start_ayah_id AND end_ayah_id")
+    suspend fun getRukuForAyah(ayahId: Int): RukuEntity?
+
+    @Query("SELECT * FROM pages WHERE number = :page")
+    suspend fun getPageRange(page: Int): PageEntity?
+
+    @Query("SELECT * FROM surah_structure WHERE surah_id = :surahId")
+    suspend fun getSurahStructure(surahId: Int): SurahStructureEntity?
+
+    @Query("SELECT * FROM surah_structure ORDER BY surah_id ASC")
+    fun getAllSurahStructure(): Flow<List<SurahStructureEntity>>
+
+    // Seeding for the divisions that are not derivable from `ayahs` on an upgrading device:
+    // rukus, manzils and surah_structure have never been on a phone before.
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRukus(rukus: List<RukuEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertManzils(manzils: List<ManzilEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSurahStructure(rows: List<SurahStructureEntity>)
+
+    @Query("SELECT COUNT(*) FROM rukus")
+    suspend fun rukuCount(): Int
+
+    @Query("SELECT COUNT(*) FROM surah_structure")
+    suspend fun surahStructureCount(): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAyahs(ayahs: List<AyahEntity>)
@@ -352,3 +579,24 @@ interface QuranDao {
     @Query("DELETE FROM reading_progress")
     suspend fun deleteAllReadingProgress()
 }
+
+/**
+ * A verse with everything the reader needs, resolved in one query.
+ *
+ * Since schemaVersion 22 a verse's text is not on its row: `mushaf_ayah_texts` holds one row per
+ * (source, ayah). Reading a page therefore means a join rather than a column, and doing it per
+ * verse would be 6,236 queries for a surah view. This is that join, once — both scripts, the
+ * prostration if there is one, and the quarter the verse falls in.
+ *
+ * `rub_number` is the interesting one: `Ayah.rubNumber` used to be hard-coded to `0` with the
+ * comment "Not available in database", because the quarter a verse belongs to could only be got
+ * by scanning. It is a column of `hizb_quarters` now.
+ */
+data class AyahWithText(
+    @Embedded val ayah: AyahEntity,
+    @ColumnInfo(name = "text_uthmani") val textUthmani: String?,
+    @ColumnInfo(name = "text_simple") val textSimple: String?,
+    @ColumnInfo(name = "sajda_kind") val sajdaKind: String?,
+    @ColumnInfo(name = "sajda_sequence") val sajdaSequence: Int?,
+    @ColumnInfo(name = "rub_number") val rubNumber: Int?,
+)

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
@@ -43,6 +43,21 @@ data class SurahEntity(
         Index(value = ["page"])
     ]
 )
+/**
+ * A verse's *place* in the mushaf. Not its text.
+ *
+ * Until schemaVersion 22 this row carried four renderings of the verse, a boolean and a
+ * nullable string for prostration, and a nullable transliteration — of which the two script
+ * columns were byte-identical in all 6,236 rows, `text_indopak` was NULL in all of them, and
+ * `sajda_type` was NULL in 6,221. A table where most columns are absent for most rows is a
+ * table modelling several things at once.
+ *
+ * Text now lives in [MushafAyahTextEntity], one row per (source, ayah), so a rendering is data
+ * rather than a column: `UTHMANI`, `SIMPLE`, `INDOPAK`, `INDOPAK_13`. Prostration lives in
+ * [SajdaEntity], fifteen rows instead of two columns on six thousand. `transliteration` and
+ * `text_tajweed` stay for now — the first has no second source to sit beside, and the second is
+ * JSON spans rather than a script, so filing it under a text *source* would conflate two things.
+ */
 data class AyahEntity(
     @PrimaryKey
     val id: Int, // Unique ayah id (1-6236)
@@ -52,25 +67,9 @@ data class AyahEntity(
     val numberInSurah: Int, // Ayah number within surah
     @ColumnInfo(name = "number_global")
     val numberGlobal: Int, // Global ayah number
-    @ColumnInfo(name = "text_arabic")
-    val textArabic: String,
-    @ColumnInfo(name = "text_uthmani")
-    val textUthmani: String, // Uthmani script
-    /**
-     * Superseded by [MushafAyahTextEntity], which holds one row per (text source, ayah) and
-     * so can carry more than one script. Kept as a column because dropping one in SQLite
-     * means rebuilding a 6,236-row table for no functional gain; the schema v20 migration
-     * nulls it out to reclaim the space. Nothing reads it — resolve glyph text through
-     * `mushaf_ayah_texts` instead.
-     */
-    @ColumnInfo(name = "text_indopak")
-    val textIndopak: String? = null,
     val juz: Int,
     val hizb: Int,
     val page: Int,
-    val sajda: Int, // 0 = no sajda, 1 = sajda
-    @ColumnInfo(name = "sajda_type")
-    val sajdaType: String?, // "obligatory", "recommended", or null
     val transliteration: String? = null,
     @ColumnInfo(name = "text_tajweed")
     val textTajweed: String? = null
@@ -221,4 +220,81 @@ data class ReadingProgressEntity(
     val totalAyahsRead: Int,
     val currentKhatmaCount: Int, // Number of complete Quran readings
     val updatedAt: Long = System.currentTimeMillis()
+)
+
+/**
+ * The divisions of the mushaf, as ranges rather than columns on every verse.
+ *
+ * `ayahs.juz`, `.hizb` and `.page` answer "which juz is this verse in" and no question a
+ * reader asks: where juz 18 begins, how many pages it runs, which ruku this is, what the next
+ * quarter is. Those needed a scan over 6,236 rows and a MIN/MAX, which is why nothing did them.
+ * Each of these tables answers them with one row. Ranges are inclusive global ayah ids and are
+ * asserted by the data console to tile 1..6236 exactly once.
+ *
+ * `rukus` and `manzils` are content the corpus never carried at all.
+ */
+@Entity(tableName = "juzs")
+data class JuzEntity(
+    @PrimaryKey val number: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+)
+
+@Entity(tableName = "hizb_quarters", indices = [Index(value = ["juz_number"])])
+data class HizbQuarterEntity(
+    @PrimaryKey val number: Int,
+    @ColumnInfo(name = "juz_number") val juzNumber: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+)
+
+@Entity(tableName = "manzils")
+data class ManzilEntity(
+    @PrimaryKey val number: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+)
+
+@Entity(tableName = "rukus", indices = [Index(value = ["surah_id"])])
+data class RukuEntity(
+    @PrimaryKey val number: Int,
+    @ColumnInfo(name = "surah_id") val surahId: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+)
+
+@Entity(tableName = "pages")
+data class PageEntity(
+    @PrimaryKey val number: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+)
+
+/**
+ * A prostration verse. Fifteen rows, replacing `ayahs.sajda` and `ayahs.sajda_type`.
+ *
+ * `kind` is the corpus's classification. `upstreamKind` records where Tanzil's metadata
+ * disagrees — 7:206 and 84:21 (corpus obligatory, Tanzil recommended) and 41:38 (the reverse) —
+ * because obligation is a question of fiqh and discarding one of two answers would hide that
+ * the question is open. The reader shows `kind`.
+ */
+@Entity(tableName = "sajdas", indices = [Index(value = ["sequence"])])
+data class SajdaEntity(
+    @PrimaryKey @ColumnInfo(name = "ayah_id") val ayahId: Int,
+    val sequence: Int,
+    val kind: String,
+    @ColumnInfo(name = "upstream_kind") val upstreamKind: String? = null,
+)
+
+/** Per-surah spans and counts, so a surah header is one row instead of an aggregate query. */
+@Entity(tableName = "surah_structure")
+data class SurahStructureEntity(
+    @PrimaryKey @ColumnInfo(name = "surah_id") val surahId: Int,
+    @ColumnInfo(name = "ruku_count") val rukuCount: Int,
+    @ColumnInfo(name = "start_ayah_id") val startAyahId: Int,
+    @ColumnInfo(name = "end_ayah_id") val endAyahId: Int,
+    @ColumnInfo(name = "start_page") val startPage: Int,
+    @ColumnInfo(name = "end_page") val endPage: Int,
+    @ColumnInfo(name = "has_basmalah") val hasBasmalah: Int,
+    @ColumnInfo(name = "revelation_order") val revelationOrder: Int,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.data.repository
 import com.arshadshah.nimaz.core.util.mapItems
 import com.arshadshah.nimaz.data.local.database.dao.PageAyahRangeRow
 import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.dao.AyahWithText
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranFavoriteEntity
@@ -90,7 +91,7 @@ class QuranRepositoryImpl @Inject constructor(
             surahId
         }.map { surahId ->
             if (surahId != null) {
-                quranDao.getAyahsBySurah(surahId).first().map { it.toDomain() }
+                quranDao.getAyahsWithTextBySurah(surahId).first().map { it.toDomain() }
             } else {
                 emptyList()
             }
@@ -98,15 +99,15 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAyahById(ayahId: Int): Ayah? {
-        return quranDao.getAyahById(ayahId)?.toDomain()
+        return quranDao.getAyahWithTextById(ayahId)?.toDomain()
     }
 
     override fun getAyahsByJuz(juzNumber: Int, translatorId: String?): Flow<List<Ayah>> {
-        return quranDao.getAyahsByJuz(juzNumber).map { entities ->
+        return quranDao.getAyahsWithTextByJuz(juzNumber).map { entities ->
             // Fetch translations if translatorId is provided
             val translation = seededTranslationId(translatorId)
             val translationMap = if (translation != null && entities.isNotEmpty()) {
-                val ayahIds = entities.map { it.id }
+                val ayahIds = entities.map { it.ayah.id }
                 quranDao.getTranslationsForAyahs(ayahIds, translation)
                     .first()
                     .associate { it.ayahId to it.text }
@@ -116,8 +117,8 @@ class QuranRepositoryImpl @Inject constructor(
             // Fetch bookmark IDs to set isBookmarked correctly
             val bookmarkedIds = quranDao.getAllBookmarkIds().toSet()
             entities.map { entity ->
-                entity.toDomain(translationMap[entity.id]).copy(
-                    isBookmarked = entity.id in bookmarkedIds
+                entity.toDomain(translationMap[entity.ayah.id]).copy(
+                    isBookmarked = entity.ayah.id in bookmarkedIds
                 )
             }
         }
@@ -129,7 +130,7 @@ class QuranRepositoryImpl @Inject constructor(
         script: MushafScript
     ): Flow<List<Ayah>> {
         val entityFlow = if (!script.isLineAccurate) {
-            quranDao.getAyahsByPage(pageNumber)
+            quranDao.getAyahsWithTextByPage(pageNumber)
         } else {
             // A line-accurate edition does not paginate by `ayahs.page`, so resolve the
             // page's span through its own layout table and fetch that id range (#325).
@@ -140,7 +141,7 @@ class QuranRepositoryImpl @Inject constructor(
                 if (range == null) {
                     emit(emptyList())
                 } else {
-                    emitAll(quranDao.getAyahsByIdRange(range.minAyahId, range.maxAyahId))
+                    emitAll(quranDao.getAyahsWithTextByRange(range.minAyahId, range.maxAyahId))
                 }
             }
         }
@@ -148,7 +149,7 @@ class QuranRepositoryImpl @Inject constructor(
             // Fetch translations if translatorId is provided
             val translation = seededTranslationId(translatorId)
             val translationMap = if (translation != null && entities.isNotEmpty()) {
-                val ayahIds = entities.map { it.id }
+                val ayahIds = entities.map { it.ayah.id }
                 quranDao.getTranslationsForAyahs(ayahIds, translation)
                     .first()
                     .associate { it.ayahId to it.text }
@@ -158,15 +159,15 @@ class QuranRepositoryImpl @Inject constructor(
             // Fetch bookmark IDs to set isBookmarked correctly
             val bookmarkedIds = quranDao.getAllBookmarkIds().toSet()
             entities.map { entity ->
-                entity.toDomain(translationMap[entity.id]).copy(
-                    isBookmarked = entity.id in bookmarkedIds
+                entity.toDomain(translationMap[entity.ayah.id]).copy(
+                    isBookmarked = entity.ayah.id in bookmarkedIds
                 )
             }
         }
     }
 
     override fun getSajdaAyahs(): Flow<List<Ayah>> {
-        return quranDao.getSajdaAyahs().mapItems { it.toDomain() }
+        return quranDao.getSajdaAyahsWithText().mapItems { it.toDomain() }
     }
 
     override suspend fun getPageAyahRanges(script: MushafScript): List<PageAyahRange> =
@@ -215,13 +216,13 @@ class QuranRepositoryImpl @Inject constructor(
             if (surah != null) {
                 val surahEntity = quranDao.getSurahByNumber(surahNumber)
                 val ayahEntities = surahEntity?.let {
-                    quranDao.getAyahsBySurah(it.id).first()
+                    quranDao.getAyahsWithTextBySurah(it.id).first()
                 } ?: emptyList()
 
                 // Fetch translations if translatorId is provided
                 val translation = seededTranslationId(translatorId)
                 val translationMap = if (translation != null && ayahEntities.isNotEmpty()) {
-                    val ayahIds = ayahEntities.map { it.id }
+                    val ayahIds = ayahEntities.map { it.ayah.id }
                     quranDao.getTranslationsForAyahs(ayahIds, translation)
                         .first()
                         .associate { it.ayahId to it.text }
@@ -234,8 +235,8 @@ class QuranRepositoryImpl @Inject constructor(
 
                 // Map ayahs with translations and bookmark status
                 val ayahs = ayahEntities.map { ayah ->
-                    ayah.toDomain(translationMap[ayah.id]).copy(
-                        isBookmarked = ayah.id in bookmarkedIds
+                    ayah.toDomain(translationMap[ayah.ayah.id]).copy(
+                        isBookmarked = ayah.ayah.id in bookmarkedIds
                     )
                 }
 
@@ -280,11 +281,11 @@ class QuranRepositoryImpl @Inject constructor(
             val surahMap = surahs.associate { it.id to it.nameEnglish }
 
             // Search Arabic text
-            val arabicResults = quranDao.searchAyahs(query).first().map { ayah ->
+            val arabicResults = quranDao.searchAyahsWithText(query).first().map { ayah ->
                 QuranSearchResult(
                     ayah = ayah.toDomain(),
-                    surahName = surahMap[ayah.surahId] ?: "Surah ${ayah.surahId}",
-                    matchedText = ayah.textArabic,
+                    surahName = surahMap[ayah.ayah.surahId] ?: "Surah ${ayah.ayah.surahId}",
+                    matchedText = ayah.textUthmani.orEmpty(),
                     searchType = SearchType.ARABIC
                 )
             }
@@ -293,10 +294,10 @@ class QuranRepositoryImpl @Inject constructor(
             val translatorKey = seededTranslationId(translatorId)
             val translationResults = if (translatorKey != null) {
                 quranDao.searchTranslations(query, translatorKey).first().mapNotNull { translation ->
-                    quranDao.getAyahById(translation.ayahId)?.let { ayah ->
+                    quranDao.getAyahWithTextById(translation.ayahId)?.let { ayah ->
                         QuranSearchResult(
                             ayah = ayah.toDomain(),
-                            surahName = surahMap[ayah.surahId] ?: "Surah ${ayah.surahId}",
+                            surahName = surahMap[ayah.ayah.surahId] ?: "Surah ${ayah.ayah.surahId}",
                             matchedText = translation.text,
                             searchType = SearchType.TRANSLATION
                         )
@@ -422,22 +423,33 @@ class QuranRepositoryImpl @Inject constructor(
         )
     }
 
-    private fun AyahEntity.toDomain(translation: String? = null): Ayah {
+    /**
+     * A verse row plus the text and structure resolved beside it (schemaVersion 22).
+     *
+     * `textArabic` is the Uthmani rendering — the one that carries the mushaf pause marks — and
+     * `textSimple` is now a genuinely different string rather than the same bytes under a second
+     * name. Before this, `ayahs.text_arabic` and `.text_uthmani` were byte-identical in all 6,236
+     * rows, so a reader who chose the plain script got the Uthmani one and could not tell.
+     *
+     * `rubNumber` was hard-coded to `0` with the comment "Not available in database". It is the
+     * quarter from `hizb_quarters` now.
+     */
+    private fun AyahWithText.toDomain(translation: String? = null): Ayah {
         return Ayah(
-            id = id,
-            surahNumber = surahId,
-            ayahNumber = numberInSurah,
-            textArabic = textArabic,
-            textSimple = textUthmani,
-            juzNumber = juz,
-            hizbNumber = hizb,
-            rubNumber = 0, // Not available in database
-            pageNumber = page,
-            sajdaType = SajdaType.fromString(sajdaType),
-            sajdaNumber = if (sajda > 0) sajda else null,
+            id = ayah.id,
+            surahNumber = ayah.surahId,
+            ayahNumber = ayah.numberInSurah,
+            textArabic = textUthmani.orEmpty(),
+            textSimple = textSimple ?: textUthmani.orEmpty(),
+            juzNumber = ayah.juz,
+            hizbNumber = ayah.hizb,
+            rubNumber = rubNumber ?: 0,
+            pageNumber = ayah.page,
+            sajdaType = SajdaType.fromString(sajdaKind),
+            sajdaNumber = sajdaSequence,
             translation = translation,
-            transliteration = transliteration,
-            textTajweed = textTajweed
+            transliteration = ayah.transliteration,
+            textTajweed = ayah.textTajweed
         )
     }
 

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/content/ContentPatchSeederTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/content/ContentPatchSeederTest.kt
@@ -36,9 +36,11 @@ class ContentPatchSeederTest {
                 "revelation_type, verses_count, order_revealed, start_page) " +
                 "VALUES (1,1,'ا','A','A','Meccan',7,5,1)"
         )
+        // Since schemaVersion 22 a verse row is its place in the mushaf; its text is a row
+        // in mushaf_ayah_texts, which is also the table a patch now inserts into.
         exec(
-            "INSERT INTO ayahs (id, surah_id, number_in_surah, number_global, text_arabic, " +
-                "text_uthmani, juz, hizb, page, sajda) VALUES (1,1,1,1,'ا','ا',1,1,1,0)"
+            "INSERT INTO ayahs (id, surah_id, number_in_surah, number_global, juz, hizb, page) " +
+                "VALUES (1,1,1,1,1,1,1)"
         )
     }
 

--- a/data.lock.json
+++ b/data.lock.json
@@ -9,19 +9,12 @@
     "to cost another 140 MB object forever."
   ],
   "repo": "arshad-shah/nimaz-data",
-  "tag": "data-v4",
-  "schemaVersion": 21,
+  "tag": "data-v5",
+  "schemaVersion": 22,
   "artifact": {
-    "file": "nimaz-34792432.db",
+    "file": "nimaz-b4164794.db",
     "assetPath": "database/nimaz_prepopulated.db",
-    "sha256": "34792432b54678efc178b3bd61f8506b21b0c76ae6524eb8340bf997e77a0835",
-    "bytes": 133894144
-  },
-  "patch": {
-    "file": "content-patch.json.gz",
-    "assetPath": "database/content-patch.json",
-    "sha256": "f844558ab0e68f6bcc4f7d0bcb8521699af6618acb204f54ec77505db0c476b6",
-    "version": 4,
-    "baseline": "sha256:9a9e29067562ce07140813f5a469ad5a433f104d1a7e142c559a22400c887a94"
+    "sha256": "b4164794b37b5d0be2d62143b8bbe0d2873a5f880cd78326ba0618eaafd94652",
+    "bytes": 133599232
   }
 }


### PR DESCRIPTION
Pairs with **arshad-shah/nimaz-data#10**, which ships the artifact at this schema. Both must land together: stage 7 in the data repo holds the artifact to *this* repo's KSP export, so they cannot disagree the way `data-v3` did.

## The shape

`ayahs` carried four renderings of every verse, a boolean and a nullable string for prostration, and a nullable transliteration. Two renderings were byte-identical in all 6,236 rows, one was NULL in all of them, and the prostration columns described fifteen. A table where most columns are absent for most rows is several tables wearing one name.

| | |
|---|---|
| `ayahs` | `id`, `surah_id`, `number_in_surah`, `number_global`, `juz`, `hizb`, `page`, `transliteration`, `text_tajweed` |
| `mushaf_ayah_texts` | `UTHMANI` · **`SIMPLE`** · `INDOPAK` · `INDOPAK_13` — a rendering is a row |
| `sajdas` | 15 rows, corpus `kind` + Tanzil `upstream_kind` |
| `juzs` `hizb_quarters` `manzils` `rukus` `pages` `surah_structure` | 30 · 240 · 7 · 556 · 604 · 114 |

**`SIMPLE` is new content**, not a rename: the plain script the reader's toggle has always promised and never had, because `textSimple` was mapped to the Uthmani column.

## The migration moves everything before it drops anything

Every table `MIGRATION_21_22` fills is derivable from what is already on the phone — the Uthmani text is *in* the column being dropped, the sajdas are the fifteen marked rows, the juz/hizb/page divisions are the columns that described them per verse. That is the only reason this can be a migration rather than a reinstall: `createFromAsset` re-copies only on a fresh install, and a content patch cannot create a table its baseline never had. **`MIGRATION_20_21` shipped without that property and would have emptied the Tafseer reader for every existing user** — this one is written the other way round.

`INSERT OR IGNORE`, not `REPLACE`, so a device whose artifact already carries v22 rows keeps them instead of having them overwritten from a column.

## Two things fall out of the read path

- **`Ayah.rubNumber` was hard-coded to `0`** with the comment "Not available in database". It is a column of `hizb_quarters` now.
- **Search scanned the same bytes twice.** It was `text_uthmani LIKE … OR text_arabic LIKE …` across two columns holding identical bytes — 1.3 MB scanned twice, and no match either could find alone. It searches every rendering now, `DISTINCT` so a verse matching in three scripts appears once.

`AyahWithText` resolves a verse, both scripts, its prostration and its quarter in one join — per-verse resolution would be 6,236 queries for a surah view. New DAO reads for the divisions (juz for an ayah, quarters per juz, rukus per surah, page spans, surah structure); each was previously a scan with a MIN/MAX, which is why none existed and there is no juz screen.

## Verified

- `:app:compileDebugKotlin`, `:app:compileDebugAndroidTestKotlin`, `:app:testDebugUnitTest` green
- `schemas/22.json` committed — identity `41721a7f965932d23810139ba29d7d0f`, 53 tables
- two new instrumented tests: the 21→22 move (text, sajdas, juz/hizb/pages all carried, then the columns gone, `transliteration`/`text_tajweed` intact), and the already-reshaped artifact case
- the data repo builds green against this export: 7 gates, 58 collections, 30 rules, 0 blocking

Needs the emulator run for the migration tests, as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)