### PR TITLE
Take the release version from what was published, not the working tree

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,15 @@ on:
   push:
     branches: [ dev ]
 
+# Never run two deploys at once. Each one bumps the version, uploads, and only
+# then pushes the bump back to dev, so overlapping runs read the same baseline
+# and the later upload is rejected as a duplicate version code. Queue instead of
+# cancelling: a run that has already uploaded to Play still has to push its bump
+# and tag, and cancelling it there would leave dev behind what Play has.
+concurrency:
+  group: android-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Set execution flag for gradlew
         run: chmod +x gradlew
 
+      # Cheap and first: the release version bump has no other coverage, and
+      # getting it wrong is only visible after a full release build has been
+      # spent and the Play upload is rejected as a duplicate version code.
+      - name: Check the release version bump
+        run: ruby fastlane/version_bump_spec.rb
+
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,30 +35,105 @@ platform :android do
     )
   end
 
+  # Highest versionCode Google Play has already seen, across every track.
+  #
+  # Play — not the checked-out tree — is the authority on what "already used"
+  # means, and the two disagree whenever a deploy is in flight: the bump lands
+  # on dev only *after* the upload succeeds, so a second deploy starting in that
+  # window checks out the pre-bump tree, picks the same code, and its upload is
+  # rejected with "Version code N has already been used" after a full 17-minute
+  # build. Asking Play closes that window no matter which tree is checked out.
+  #
+  # Returns nil when Play cannot be reached (no service-account key on a local
+  # run, say), so the caller falls back to the tree baseline.
+  def highest_play_version_code(package_name)
+    key = ENV["ANDROID_JSON_KEY_FILE"]
+    if key.nil? || key.empty?
+      UI.important("No ANDROID_JSON_KEY_FILE; using the checked-out tree as the version baseline.")
+      return nil
+    end
+
+    codes = %w[internal alpha beta production].flat_map do |track|
+      begin
+        Array(google_play_track_version_codes(
+          package_name: package_name,
+          track: track,
+          json_key: key
+        ))
+      rescue StandardError => e
+        # An empty or never-used track raises rather than returning []. That is
+        # not fatal: the other tracks still bound the baseline.
+        UI.important("Could not read the '#{track}' track (#{e.message}); ignoring it.")
+        []
+      end
+    end
+
+    highest = codes.compact.map(&:to_i).max
+    # A key was supplied but no track answered: the network or the credential is
+    # broken. Fail rather than fall back to the tree, because the tree is exactly
+    # what cannot be trusted here — guessing produces a duplicate code and the
+    # upload dies after the build instead of before it.
+    UI.user_error!("Have a Play credential but could not read a version code from any track; refusing to guess.") if highest.nil?
+    highest
+  end
+
+  # Highest released versionName, taken from the release tags. Same reasoning as
+  # above: tags are pushed for every published build, so they outlive a stale
+  # working tree and keep the name moving in lockstep with the code.
+  def highest_tagged_version_name
+    tags = `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname`.split("\n")
+    tags.map { |t| t.strip.delete_prefix("v") }.reject(&:empty?).max_by { |n| version_key(n) }
+  rescue StandardError => e
+    UI.important("Could not read release tags (#{e.message}); using the tree's versionName.")
+    nil
+  end
+
+  def version_key(name)
+    name.split(".").map(&:to_i)
+  end
+
   private_lane :fetch_and_increment_build_number do
     # Bump the version in build.gradle.kts for this build. We only edit the
     # working tree here; committing and pushing the bump back to dev is handled
     # by the deploy workflow after the build/upload succeeds (it pushes with a
     # GitHub App token that can bypass branch protection).
     #
+    # The baseline is the highest of what the tree says and what has actually
+    # been published, so the bump is monotonic even when the tree is behind.
+    #
     # The project uses the Kotlin DSL (build.gradle.kts), which the
     # android_versioning plugin does not support, hence the manual approach.
     gradle_file = File.expand_path("../app/build.gradle.kts", __dir__)
     contents = File.read(gradle_file)
 
-    current_code = contents[/versionCode\s*=\s*(\d+)/, 1]
-    UI.user_error!("Could not find versionCode in #{gradle_file}") if current_code.nil?
-    new_code = current_code.to_i + 1
-    contents = contents.sub(/versionCode\s*=\s*\d+/, "versionCode = #{new_code}")
+    tree_code = contents[/versionCode\s*=\s*(\d+)/, 1]
+    UI.user_error!("Could not find versionCode in #{gradle_file}") if tree_code.nil?
+    tree_name = contents[/versionName\s*=\s*"([^"]+)"/, 1]
+    UI.user_error!("Could not find versionName in #{gradle_file}") if tree_name.nil?
 
-    current_name = contents[/versionName\s*=\s*"([^"]+)"/, 1]
-    UI.user_error!("Could not find versionName in #{gradle_file}") if current_name.nil?
-    major, minor, patch = current_name.split(".").map(&:to_i)
+    package_name = contents[/applicationId\s*=\s*"([^"]+)"/, 1]
+    UI.user_error!("Could not find applicationId in #{gradle_file}") if package_name.nil?
+
+    play_code = highest_play_version_code(package_name)
+    baseline_code = [tree_code.to_i, play_code].compact.max
+    if play_code && play_code >= tree_code.to_i
+      UI.important("Play has versionCode #{play_code}; the tree says #{tree_code}. Using Play as the baseline.")
+    end
+    new_code = baseline_code + 1
+
+    tagged_name = highest_tagged_version_name
+    baseline_name = [tree_name, tagged_name].compact.max_by { |n| version_key(n) }
+    if tagged_name && (version_key(tagged_name) <=> version_key(tree_name)) == 1
+      UI.important("Tag v#{tagged_name} is ahead of the tree's #{tree_name}. Using the tag as the baseline.")
+    end
+    major, minor, patch = version_key(baseline_name)
     new_name = "#{major}.#{minor}.#{patch + 1}"
+
+    contents = contents.sub(/versionCode\s*=\s*\d+/, "versionCode = #{new_code}")
     contents = contents.sub(/versionName\s*=\s*"[^"]+"/, "versionName = \"#{new_name}\"")
 
     File.write(gradle_file, contents)
-    UI.success("Bumped versionCode #{current_code} -> #{new_code}, versionName #{current_name} -> #{new_name}")
+    UI.success("Bumped versionCode #{baseline_code} -> #{new_code}, versionName #{baseline_name} -> #{new_name}")
   end
 
   private_lane :build_and_sign_apk_or_aab do

--- a/fastlane/version_bump_spec.rb
+++ b/fastlane/version_bump_spec.rb
@@ -1,0 +1,190 @@
+# Regression spec for the version bump in Fastfile.
+#
+# A deploy bumps the version, uploads to Play, and only then pushes the bump back
+# to dev. Anything that derives the next version from the checked-out tree alone
+# therefore picks the same version twice when two deploys overlap, and the second
+# upload fails with "Version code N has already been used" — after a full release
+# build has been paid for. That happened on 2026-07-30 (versionCode 380).
+#
+# The bump now takes its baseline from what has actually been published: the
+# version codes Play reports, and the release tags. These scenarios pin that
+# behaviour. Run with: ruby fastlane/version_bump_spec.rb
+#
+# The spec drives the real Fastfile under a stub of the small slice of fastlane
+# it touches, so there is nothing to keep in sync with the shipped source.
+
+require "tmpdir"
+require "fileutils"
+
+module UI
+  def self.important(msg)
+    $log << "WARN #{msg}"
+  end
+
+  def self.success(msg)
+    $log << "OK   #{msg}"
+  end
+
+  def self.user_error!(msg)
+    raise(RuntimeError, msg)
+  end
+end
+
+$lanes = {}
+
+def default_platform(*)
+  nil
+end
+
+def platform(_name)
+  yield
+end
+
+def desc(*)
+  nil
+end
+
+def lane(name, &block)
+  $lanes[name] = block
+end
+
+def private_lane(name, &block)
+  $lanes[name] = block
+end
+
+# Stands in for the fastlane action. An empty or never-used track raises in real
+# life rather than returning [], so the stub does too.
+def google_play_track_version_codes(package_name:, track:, json_key:)
+  raise "Track '#{track}' not found." unless $play.key?(track)
+
+  $play[track]
+end
+
+FASTFILE = File.expand_path("Fastfile", __dir__)
+GRADLE_FILE = File.expand_path("../app/build.gradle.kts", __dir__)
+
+# Deliberate: the input is this repo's own Fastfile, and evaluating it verbatim is
+# the point — the spec tests the shipped source rather than a copy of its logic
+# that could drift. The third argument makes __dir__ resolve inside the Fastfile.
+eval(File.read(FASTFILE), TOPLEVEL_BINDING, FASTFILE)
+
+ORIGINAL_GRADLE = File.read(GRADLE_FILE)
+$failures = []
+
+# Tags are read with git, so give each scenario a throwaway repo holding exactly
+# the tags it describes. That keeps the spec independent of how much history the
+# CI checkout happens to fetch.
+def with_tags(tags)
+  Dir.mktmpdir("version-bump-spec") do |dir|
+    system("git", "init", "--quiet", dir, out: File::NULL, err: File::NULL)
+    Dir.chdir(dir) do
+      system("git", "-c", "user.email=spec@example.com", "-c", "user.name=spec",
+             "commit", "--quiet", "--allow-empty", "-m", "base",
+             out: File::NULL, err: File::NULL)
+      tags.each { |tag| system("git", "tag", tag, out: File::NULL, err: File::NULL) }
+      yield
+    end
+  end
+end
+
+def scenario(name, tree_code:, tree_name:, key:, play:, tags:,
+             expect_code: nil, expect_name: nil, expect_error: nil)
+  $log = []
+  $play = play
+
+  source = ORIGINAL_GRADLE
+           .sub(/versionCode\s*=\s*\d+/, "versionCode = #{tree_code}")
+           .sub(/versionName\s*=\s*"[^"]+"/, "versionName = \"#{tree_name}\"")
+  File.write(GRADLE_FILE, source)
+  key ? ENV["ANDROID_JSON_KEY_FILE"] = key : ENV.delete("ANDROID_JSON_KEY_FILE")
+
+  begin
+    with_tags(tags) { $lanes[:fetch_and_increment_build_number].call }
+
+    if expect_error
+      $failures << "#{name}: expected it to refuse (#{expect_error}), but it succeeded"
+      return
+    end
+
+    written = File.read(GRADLE_FILE)
+    code = written[/versionCode\s*=\s*(\d+)/, 1].to_i
+    version_name = written[/versionName\s*=\s*"([^"]+)"/, 1]
+
+    problems = []
+    problems << "versionCode #{code}, expected #{expect_code}" if expect_code && code != expect_code
+    problems << "versionName #{version_name}, expected #{expect_name}" if expect_name && version_name != expect_name
+
+    if problems.empty?
+      puts "PASS #{name} -> #{code} / #{version_name}"
+    else
+      $failures << "#{name}: #{problems.join('; ')}"
+      puts "FAIL #{name}: #{problems.join('; ')}"
+    end
+  rescue RuntimeError => e
+    if expect_error && e.message.include?(expect_error)
+      puts "PASS #{name} -> refused, as it should: #{e.message}"
+    else
+      $failures << "#{name}: #{e.message}"
+      puts "FAIL #{name}: #{e.message}"
+    end
+  end
+ensure
+  File.write(GRADLE_FILE, ORIGINAL_GRADLE)
+end
+
+# The regression itself: an in-flight deploy has published 380 but has not pushed
+# its bump yet, so the tree still says 379. Reading the tree would pick 380 again.
+scenario("stale tree while Play is ahead (the 2026-07-30 failure)",
+         tree_code: 379, tree_name: "3.0.79", key: "/tmp/play-key.json",
+         play: { "internal" => [380] }, tags: ["v3.0.79", "v3.0.80"],
+         expect_code: 381, expect_name: "3.0.81")
+
+scenario("tree in step with Play",
+         tree_code: 380, tree_name: "3.0.80", key: "/tmp/play-key.json",
+         play: { "internal" => [380] }, tags: ["v3.0.80"],
+         expect_code: 381, expect_name: "3.0.81")
+
+# The highest code need not live on internal — a promoted build sits further on.
+scenario("highest code on another track",
+         tree_code: 380, tree_name: "3.0.80", key: "/tmp/play-key.json",
+         play: { "internal" => [380], "beta" => [391], "production" => [412] },
+         tags: ["v3.0.80"], expect_code: 413, expect_name: "3.0.81")
+
+# A bump that landed in git but was never published leaves the tree ahead.
+scenario("tree ahead of Play",
+         tree_code: 390, tree_name: "3.0.90", key: "/tmp/play-key.json",
+         play: { "internal" => [380] }, tags: ["v3.0.80"],
+         expect_code: 391, expect_name: "3.0.91")
+
+scenario("no tags yet falls back to the tree's name",
+         tree_code: 380, tree_name: "3.0.80", key: "/tmp/play-key.json",
+         play: { "internal" => [380] }, tags: [],
+         expect_code: 381, expect_name: "3.0.81")
+
+# Tags sort by version, not lexically: v3.0.9 must not beat v3.0.80.
+scenario("tags sort numerically",
+         tree_code: 380, tree_name: "3.0.80", key: "/tmp/play-key.json",
+         play: { "internal" => [380] }, tags: ["v3.0.9", "v3.0.80", "v3.0.100"],
+         expect_code: 381, expect_name: "3.0.101")
+
+# A local run has no service-account key: fall back to the tree, never fail.
+scenario("no credential falls back to the tree",
+         tree_code: 379, tree_name: "3.0.79", key: nil,
+         play: {}, tags: ["v3.0.79"],
+         expect_code: 380, expect_name: "3.0.80")
+
+# But a credential that cannot read Play must not silently guess from the tree —
+# guessing is what produces the duplicate code in the first place.
+scenario("credential present but Play unreadable refuses to guess",
+         tree_code: 379, tree_name: "3.0.79", key: "/tmp/play-key.json",
+         play: {}, tags: ["v3.0.79"],
+         expect_error: "refusing to guess")
+
+if $failures.empty?
+  puts "\nAll version-bump scenarios passed."
+  exit 0
+else
+  puts "\n#{$failures.length} scenario(s) failed:"
+  $failures.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## What broke

The 3.0.80 deploy failed on the upload step with:

```
Google Api Error: Invalid request - Version code 380 has already been used.
```

Two deploys overlapped. The lane bumps the version in the working tree, builds, uploads, and pushes the bump back to `dev` **only after** the upload succeeds. So:

| Run | Tree it checked out | Code it picked | Outcome |
|---|---|---|---|
| merge of #334 | 379 | 380 | uploaded, then pushed the bump |
| the follow-up deploy | still 379 (bump hadn't landed) | 380 again | rejected after a 17-minute build |

The build wasn't wrong — the baseline was. The working tree is not the authority on which version codes exist.

## What changed

**The baseline comes from what was actually published.** `versionCode` is now `max(tree, highest code Play reports across internal/alpha/beta/production) + 1`, and `versionName` is bumped from the highest of the tree and the release tags. Both survive a stale checkout.

**A credential that can't read Play now fails the bump** instead of falling back to the tree. Falling back is what produces the duplicate, and it produces it *after* the build rather than before — so refusing is strictly cheaper.

**A `concurrency` group serialises deploys**, closing the window rather than just surviving it. It queues instead of cancelling: a run that has already uploaded still has to push its bump and tag, and cancelling there would leave `dev` behind Play.

## Coverage

The bump had none. `fastlane/version_bump_spec.rb` evaluates the real `Fastfile` under a stub of the slice of fastlane it uses — no second copy of the logic to drift — and pins eight scenarios:

```
PASS stale tree while Play is ahead (the 2026-07-30 failure) -> 381 / 3.0.81
PASS tree in step with Play -> 381 / 3.0.81
PASS highest code on another track -> 413 / 3.0.81
PASS tree ahead of Play -> 391 / 3.0.91
PASS no tags yet falls back to the tree's name -> 381 / 3.0.81
PASS tags sort numerically -> 381 / 3.0.101
PASS no credential falls back to the tree -> 380 / 3.0.80
PASS credential present but Play unreadable refuses to guess -> refused, as it should
```

It caught a real bug in the first draft of this change: Ruby arrays have `<=>` but not `>`, so the version comparison raised `NoMethodError`. PR checks run it first — it costs a second and needs no Android toolchain.

## Note on the `v3.0.80` tag

The tag points at a commit whose tree carries the **data-v6** lock, but the AAB on the internal track was built from the **data-v5** tree — the tag step ran after a rebase, so the tagged tree isn't the built tree. That binary is self-consistent and works (v5 does contain the user tables the build expects), it just isn't the content-only artifact. Merging this PR triggers a deploy that publishes **3.0.81** from the current `dev` tip, which is correct on both axes. The stale `v3.0.80` tag is worth deleting or annotating separately.