### PR TITLE
fix(design-system): size NimazButton labels off the label type scale

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazButton.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazButton.kt
@@ -245,11 +245,23 @@ private fun outlinedBorder(enabled: Boolean): BorderStroke {
     return BorderStroke(1.dp, if (enabled) color else color.copy(alpha = 0.12f))
 }
 
+/**
+ * Label style per [NimazButtonSize].
+ *
+ * Button labels live on the **label** scale (`Type.kt`: "For buttons, tabs, and small
+ * labels"), not the **title** scale used for card headings. Sizing them off `title*`
+ * made a [NimazButtonSize.LARGE] button render its label at `titleLarge` (22.sp) —
+ * heading-sized text inside a 56.dp button, which crowded the icon and truncated
+ * two-word labels ("Start Reading") on narrow screens.
+ *
+ * [NimazButtonSize.LARGE] keeps `titleMedium` (16.sp) so it still steps up visibly
+ * from the other two; that matches Material 3's own 56.dp button label size.
+ */
 @Composable
 private fun textStyleFor(size: NimazButtonSize): TextStyle = when (size) {
-    NimazButtonSize.SMALL -> MaterialTheme.typography.titleSmall
-    NimazButtonSize.MEDIUM -> MaterialTheme.typography.titleMedium
-    NimazButtonSize.LARGE -> MaterialTheme.typography.titleLarge
+    NimazButtonSize.SMALL -> MaterialTheme.typography.labelLarge
+    NimazButtonSize.MEDIUM -> MaterialTheme.typography.labelLarge
+    NimazButtonSize.LARGE -> MaterialTheme.typography.titleMedium
 }
 
 @Composable

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -537,6 +537,14 @@ typed route object.
       `SMALL`/`MEDIUM`/`LARGE`, `type` is `STANDARD` or `PILL`; `leadingIcon`/`trailingIcon`,
       `loading`, `fullWidth` and an `accent` escape-hatch (for Islamic feature-art colours the
       Material scheme has no role for) round it out. Icon-only buttons are `NimazIconButton`.
+      - **Label size comes from `size`, off the `label*` type scale — never `title*`.**
+        `SMALL`/`MEDIUM` render `labelLarge` (14.sp) and `LARGE` renders `titleMedium` (16.sp).
+        `Type.kt` designates `label*` as the button/tab scale and `title*` as the card-heading
+        scale; sizing labels off `title*` had `LARGE` drawing its text at `titleLarge` (22.sp) —
+        heading-sized text inside a 56.dp button, which crowded the leading icon and ellipsised
+        two-word labels ("Start Reading" on the Surah info screen) on narrow screens. `LARGE`
+        stays one step up at 16.sp, which is Material 3's own label size for a 56.dp button.
+        Call sites don't pass a style — pick the `size`.
     - a card is `NimazCard(style = NimazCardStyle.FILLED | ELEVATED | OUTLINED | GRADIENT, …)`
       (`components/atoms/NimazCard.kt`), **not** a raw Material 3 `Card`/`ElevatedCard`/
       `OutlinedCard`. It passes through `onClick`/`enabled`/`shape`/`colors`/`elevation`, so


### PR DESCRIPTION
NimazButton mapped its size presets onto the *title* type scale, so a
LARGE button drew its label at titleLarge (22.sp) — heading-sized text
inside a 56.dp button. On the Surah info screen this crowded the leading
icons and ellipsised the "Listen" / "Start Reading" labels on narrow
screens.

Type.kt designates label* as the "buttons, tabs, and small labels" scale
and title* as the card-heading scale, so move button labels there:

  SMALL  titleSmall  (14.sp) -> labelLarge  (14.sp)  — identical metrics,
                                                       now on the right scale
  MEDIUM titleMedium (16.sp) -> labelLarge  (14.sp)
  LARGE  titleLarge  (22.sp) -> titleMedium (16.sp)

LARGE keeps a visible step up at 16.sp, matching Material 3's own label
size for a 56.dp button.

Swept the rest of the design system for the same symptom: chips, pills,
menu items, reader/audio bottom bars and GlassPill already sit on the
label scale, and no screen hand-rolls a Material Button. The remaining
title*/headline* call sites are card headings and numeric value displays
(NimazNumberStepper's value, tasbih/fasting counters), not button labels,
so they are left as-is.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vac2RZj74im4P5ZfNxVHmn