### PR TITLE
never ATTACH on a connection Room owns

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/local/user/NimazUserDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/user/NimazUserDatabase.kt
@@ -1,8 +1,8 @@
 package com.arshadshah.nimaz.data.local.user
 
+import android.database.sqlite.SQLiteDatabase
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import androidx.sqlite.db.SupportSQLiteDatabase
 import com.arshadshah.nimaz.data.local.database.entity.FastRecordEntity
 import com.arshadshah.nimaz.data.local.database.entity.KhatamAyahEntity
 import com.arshadshah.nimaz.data.local.database.entity.KhatamDailyLogEntity
@@ -137,53 +137,96 @@ abstract class NimazUserDatabase : RoomDatabase() {
  * opened, mapping the seven bookmark tables and three progress tables into the two that
  * replace them.
  *
- * Written as one transaction over an `ATTACH`ed legacy file rather than as a Kotlin loop,
- * so an interrupted copy leaves nothing half-written and a second attempt is a no-op:
- * every statement is `INSERT OR IGNORE` keyed on what the new tables key on.
+ * Written as one transaction over two `ATTACH`ed files rather than as a Kotlin loop, so an
+ * interrupted copy leaves nothing half-written and a second attempt is a no-op: every
+ * statement is `INSERT OR IGNORE` keyed on what the new tables key on.
  *
  * The legacy tables are never modified. Dropping them would be the tidy thing and the
  * wrong thing — a bug here must be survivable, and it is only survivable while the
  * original rows are still on disk.
+ *
+ * ## Why this opens a connection of its own
+ *
+ * Neither database is opened as `main`: both are attached to a throwaway in-memory database
+ * that this object owns and closes. That is not tidiness, it is the fix for a crash.
+ *
+ * `SQLiteDatabase.execSQL` inspects every statement, and on the first `ATTACH` a connection
+ * ever sees it clears `ENABLE_WRITE_AHEAD_LOGGING` and reconfigures the pool. Changing the
+ * open flags that way makes the framework **close the primary connection and open a new
+ * one**. Room keeps its entire invalidation tracker in that connection's temporary schema —
+ * `room_table_modification_log` is a `CREATE TEMP TABLE` and the per-table triggers are
+ * `CREATE TEMP TRIGGER` — and it only builds them when *it* opens a connection. After the
+ * swap they are gone for the life of the process, and the next Flow to start observing a
+ * table dies in `syncTriggers` with
+ *
+ *     android.database.sqlite.SQLiteException: no such table: room_table_modification_log,
+ *     while compiling: INSERT OR IGNORE INTO room_table_modification_log VALUES(4, 0)
+ *
+ * which is a crash on launch for anyone the copy runs for. So the `ATTACH` has to happen
+ * somewhere Room is not looking. An in-memory `main` is the one place that costs nothing:
+ * it has no journal mode to be taken out of and its pool is capped at a single connection
+ * either way, so the reconfigure is a no-op and both real files keep the journal mode Room
+ * gave them.
+ *
+ * The flip side is that Room does not see these writes — the triggers that would have
+ * noticed them belong to a different connection — so this must finish before anything
+ * starts observing. `AppInitializer` awaits it and the splash screen holds until it does.
  */
 object LegacyUserDataImport {
 
-    /** True when the legacy file exists and has at least one of the tables we read. */
-    fun isNeeded(db: SupportSQLiteDatabase, legacyPath: String): Boolean {
-        if (!java.io.File(legacyPath).exists()) return false
-        return db.query("SELECT COUNT(*) FROM bookmarks").use { cursor ->
-            cursor.moveToFirst() && cursor.getInt(0) == 0
-        } && db.query("SELECT COUNT(*) FROM reading_progress").use { cursor ->
-            cursor.moveToFirst() && cursor.getInt(0) == 0
+    /**
+     * Copies [legacyPath]'s user rows into [userPath], and returns how many statements
+     * moved anything.
+     *
+     * Both are file paths rather than an open database on purpose — see the note above on
+     * why this cannot borrow Room's connection. [userPath] must already hold the schema;
+     * Room creates it when it opens the database, which [UserDataMigrator] does first.
+     */
+    fun run(userPath: String, legacyPath: String): Int {
+        if (!java.io.File(legacyPath).exists()) return 0
+        val db = SQLiteDatabase.create(null)
+        return try {
+            db.execSQL("ATTACH DATABASE ? AS user", arrayOf<Any?>(userPath))
+            db.execSQL("ATTACH DATABASE ? AS legacy", arrayOf<Any?>(legacyPath))
+            if (isNeeded(db)) copy(db) else 0
+        } finally {
+            // Closing detaches both; the in-memory database itself never held anything.
+            db.close()
         }
     }
 
-    fun run(db: SupportSQLiteDatabase, legacyPath: String): Int {
-        db.execSQL("ATTACH DATABASE ? AS legacy", arrayOf(legacyPath))
+    /** Nothing to do once the user database has rows of its own. */
+    private fun isNeeded(db: SQLiteDatabase): Boolean =
+        isEmpty(db, "bookmarks") && isEmpty(db, "reading_progress")
+
+    private fun isEmpty(db: SQLiteDatabase, table: String): Boolean =
+        db.rawQuery("SELECT 1 FROM user.`$table` LIMIT 1", null).use { !it.moveToFirst() }
+
+    private fun copy(db: SQLiteDatabase): Int {
         var copied = 0
+        // Non-exclusive (`BEGIN IMMEDIATE`): both attached files are open in WAL on Room's own
+        // connections at this point, and an exclusive transaction would take locks that lock
+        // Room's readers out for the length of the copy.
+        db.beginTransactionNonExclusive()
         try {
-            db.beginTransaction()
-            try {
-                copied += bookmarks(db)
-                copied += progress(db)
-                copied += customPresets(db)
-                copied += straightCopies(db)
-                db.setTransactionSuccessful()
-            } finally {
-                db.endTransaction()
-            }
+            copied += bookmarks(db)
+            copied += progress(db)
+            copied += customPresets(db)
+            copied += straightCopies(db)
+            db.setTransactionSuccessful()
         } finally {
-            db.execSQL("DETACH DATABASE legacy")
+            db.endTransaction()
         }
         return copied
     }
 
-    private fun has(db: SupportSQLiteDatabase, table: String): Boolean =
-        db.query(
+    private fun has(db: SQLiteDatabase, table: String): Boolean =
+        db.rawQuery(
             "SELECT 1 FROM legacy.sqlite_master WHERE type='table' AND name=?",
             arrayOf(table),
         ).use { it.moveToFirst() }
 
-    private fun exec(db: SupportSQLiteDatabase, table: String, sql: String): Int {
+    private fun exec(db: SQLiteDatabase, table: String, sql: String): Int {
         if (!has(db, table)) return 0
         db.execSQL(sql)
         return 1
@@ -196,12 +239,12 @@ object LegacyUserDataImport {
      * as one row with both flags — hence the favourites pass is an `UPDATE` of anything the
      * bookmark pass already inserted, then an `INSERT` for the rest.
      */
-    private fun bookmarks(db: SupportSQLiteDatabase): Int {
+    private fun bookmarks(db: SQLiteDatabase): Int {
         var n = 0
         n += exec(
             db, "quran_bookmarks",
             """
-            INSERT OR IGNORE INTO bookmarks
+            INSERT OR IGNORE INTO user.bookmarks
                 (kind, target_id, bookmarked, favourite, note, colour, context_id, ordinal,
                  created_at, updated_at)
             SELECT '${BookmarkKind.AYAH}', ayahId, 1, 0, note, color, surahNumber, ayahNumber,
@@ -212,14 +255,14 @@ object LegacyUserDataImport {
         if (has(db, "quran_favorites")) {
             db.execSQL(
                 """
-                UPDATE bookmarks SET favourite = 1
+                UPDATE user.bookmarks SET favourite = 1
                 WHERE kind = '${BookmarkKind.AYAH}'
                   AND target_id IN (SELECT ayahId FROM legacy.quran_favorites)
                 """.trimIndent()
             )
             db.execSQL(
                 """
-                INSERT OR IGNORE INTO bookmarks
+                INSERT OR IGNORE INTO user.bookmarks
                     (kind, target_id, bookmarked, favourite, note, colour, context_id, ordinal,
                      created_at, updated_at)
                 SELECT '${BookmarkKind.AYAH}', ayahId, 0, 1, NULL, NULL, surahNumber, ayahNumber,
@@ -232,7 +275,7 @@ object LegacyUserDataImport {
         n += exec(
             db, "hadith_bookmarks",
             """
-            INSERT OR IGNORE INTO bookmarks
+            INSERT OR IGNORE INTO user.bookmarks
                 (kind, target_id, bookmarked, favourite, note, colour, context_id, ordinal,
                  created_at, updated_at)
             SELECT '${BookmarkKind.HADITH}', hadithId, 1, 0, note, color, bookId, hadithNumber,
@@ -243,7 +286,7 @@ object LegacyUserDataImport {
         n += exec(
             db, "dua_bookmarks",
             """
-            INSERT OR IGNORE INTO bookmarks
+            INSERT OR IGNORE INTO user.bookmarks
                 (kind, target_id, bookmarked, favourite, note, colour, context_id, ordinal,
                  created_at, updated_at)
             SELECT '${BookmarkKind.DUA}', duaId, 1, isFavorite, note, NULL, categoryId, NULL,
@@ -259,7 +302,7 @@ object LegacyUserDataImport {
             n += exec(
                 db, table,
                 """
-                INSERT OR IGNORE INTO bookmarks
+                INSERT OR IGNORE INTO user.bookmarks
                     (kind, target_id, bookmarked, favourite, note, colour, context_id, ordinal,
                      created_at, updated_at)
                 SELECT '$kind', $column, 1, is_favorite, NULL, NULL, NULL, NULL,
@@ -284,10 +327,10 @@ object LegacyUserDataImport {
      * the user database is first opened. The instrumented suite caught it; the unit test had
      * built its own fixture and did not include this table, so it could not.
      */
-    private fun customPresets(db: SupportSQLiteDatabase): Int = exec(
+    private fun customPresets(db: SQLiteDatabase): Int = exec(
         db, "tasbih_presets",
         """
-        INSERT OR IGNORE INTO custom_tasbih_presets
+        INSERT OR IGNORE INTO user.custom_tasbih_presets
             (id, name, arabic, transliteration, translation, target_count, display_order,
              category, created_at, updated_at)
         SELECT id, name, arabic, transliteration, translation, target_count, display_order,
@@ -297,12 +340,12 @@ object LegacyUserDataImport {
     )
 
     /** Three progress tables into one. `reading_progress` copies across unchanged. */
-    private fun progress(db: SupportSQLiteDatabase): Int {
+    private fun progress(db: SQLiteDatabase): Int {
         var n = 0
         n += exec(
             db, "dua_progress",
             """
-            INSERT OR IGNORE INTO progress
+            INSERT OR IGNORE INTO user.progress
                 (kind, target_id, date, context_id, completed, total, is_completed, state,
                  score, resume_id, created_at, updated_at)
             SELECT '${ProgressKind.DUA}', duaId, date, NULL, completedCount, targetCount,
@@ -313,7 +356,7 @@ object LegacyUserDataImport {
         n += exec(
             db, "qaida_lesson_progress",
             """
-            INSERT OR IGNORE INTO progress
+            INSERT OR IGNORE INTO user.progress
                 (kind, target_id, date, context_id, completed, total, is_completed, state,
                  score, resume_id, created_at, updated_at)
             SELECT '${ProgressKind.QAIDA_LESSON}', lesson_id, 0, NULL, completed_cells,
@@ -325,7 +368,7 @@ object LegacyUserDataImport {
         n += exec(
             db, "qaida_cell_progress",
             """
-            INSERT OR IGNORE INTO progress
+            INSERT OR IGNORE INTO user.progress
                 (kind, target_id, date, context_id, completed, total, is_completed, state,
                  score, resume_id, created_at, updated_at)
             SELECT '${ProgressKind.QAIDA_CELL}', cell_id, 0, lesson_id, heard_count, NULL,
@@ -341,7 +384,7 @@ object LegacyUserDataImport {
      * `SELECT *`: a `SELECT *` copy silently depends on column order matching, which is
      * exactly the kind of assumption that survives review and fails on one device.
      */
-    private fun straightCopies(db: SupportSQLiteDatabase): Int {
+    private fun straightCopies(db: SQLiteDatabase): Int {
         val copies = listOf(
             "reading_progress" to
                 "id, lastReadSurah, lastReadAyah, lastReadPage, lastReadJuz, totalAyahsRead, " +
@@ -363,15 +406,22 @@ object LegacyUserDataImport {
             if (!has(db, table)) continue
             val list = columns ?: columnsOf(db, table).joinToString(", ") { "`$it`" }
             if (list.isBlank()) continue
-            db.execSQL("INSERT OR IGNORE INTO `$table` ($list) SELECT $list FROM legacy.`$table`")
+            db.execSQL(
+                "INSERT OR IGNORE INTO user.`$table` ($list) SELECT $list FROM legacy.`$table`"
+            )
             n++
         }
         return n
     }
 
-    /** The columns the *new* database declares, so a legacy extra column is left behind. */
-    private fun columnsOf(db: SupportSQLiteDatabase, table: String): List<String> =
-        db.query("PRAGMA table_info(`$table`)").use { cursor ->
+    /**
+     * The columns the *new* database declares, so a legacy extra column is left behind.
+     *
+     * Also the guard for a table the new database does not have at all: `PRAGMA table_info`
+     * on a missing table returns no rows, which [straightCopies] reads as "skip".
+     */
+    private fun columnsOf(db: SQLiteDatabase, table: String): List<String> =
+        db.rawQuery("PRAGMA user.table_info(`$table`)", null).use { cursor ->
             val index = cursor.getColumnIndex("name")
             buildList { while (cursor.moveToNext()) add(cursor.getString(index)) }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/user/UserDataMigrator.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/user/UserDataMigrator.kt
@@ -21,6 +21,12 @@ import javax.inject.Singleton
  * database. Idempotent, so running it on a launch where it has already happened costs two
  * counts; and it never throws — a person whose data cannot be copied should still get an app,
  * with the original rows still sitting untouched in the old file for a later attempt.
+ *
+ * What it does *not* do any more is hand Room's own connection to the copy. That looked like
+ * the frugal thing — the database is already open, why open another? — and it brought the same
+ * crash back through a different door, because the copy's `ATTACH` makes the framework swap
+ * the connection out from under Room and take the tracker's temporary tables with it. The
+ * copy owns its connection now; see [LegacyUserDataImport].
  */
 @Singleton
 class UserDataMigrator @Inject constructor(
@@ -32,9 +38,11 @@ class UserDataMigrator @Inject constructor(
         val legacy = File(context.getDatabasePath(NimazDatabase.DATABASE_NAME).absolutePath)
         if (!legacy.exists()) return 0
         return try {
-            val db = userDatabase.openHelper.writableDatabase
-            if (!LegacyUserDataImport.isNeeded(db, legacy.absolutePath)) 0
-            else LegacyUserDataImport.run(db, legacy.absolutePath)
+            // Touched only to make Room create and migrate the schema — the copy needs the
+            // tables to exist before it can write to them. Nothing is read or written here.
+            userDatabase.openHelper.writableDatabase
+            val user = context.getDatabasePath(NimazUserDatabase.DATABASE_NAME)
+            LegacyUserDataImport.run(user.absolutePath, legacy.absolutePath)
         } catch (e: Exception) {
             // Reported, not rethrown, and nothing is left half-written: the copy is one
             // transaction. The legacy rows are untouched either way.

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/user/LegacyUserDataImportTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/user/LegacyUserDataImportTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -25,14 +26,21 @@ import java.io.File
 class LegacyUserDataImportTest {
 
     private lateinit var db: NimazUserDatabase
+    private lateinit var user: File
     private lateinit var legacy: File
 
     @Before
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        db = Room.inMemoryDatabaseBuilder(context, NimazUserDatabase::class.java)
+        // On disk rather than in memory, because the copy runs on a connection of its own and
+        // attaches this file by path — it deliberately never borrows Room's. An in-memory
+        // database has no path to attach, and would not exercise the thing being tested.
+        user = File.createTempFile("nimaz-user", ".db").also { it.delete() }
+        db = Room.databaseBuilder(context, NimazUserDatabase::class.java, user.absolutePath)
             .allowMainThreadQueries()
             .build()
+        // Force the schema into existence: the copy writes into tables Room creates.
+        db.openHelper.writableDatabase
         legacy = File.createTempFile("legacy-content", ".db")
         buildLegacy(legacy)
     }
@@ -40,6 +48,7 @@ class LegacyUserDataImportTest {
     @After
     fun tearDown() {
         db.close()
+        user.delete()
         legacy.delete()
     }
 
@@ -90,6 +99,24 @@ class LegacyUserDataImportTest {
                 "arabic TEXT NOT NULL, transliteration TEXT NOT NULL, translation TEXT NOT NULL, " +
                 "target_count INTEGER NOT NULL, is_custom INTEGER NOT NULL, " +
                 "display_order INTEGER NOT NULL, updatedAt INTEGER NOT NULL DEFAULT 0, category TEXT)"
+        )
+        // A straight copy, and the one that carries a column the new database does not have.
+        // The column list for these is read back off the *new* schema rather than spelled out,
+        // so this is what pins that lookup — and that `legacyOnly` is left where it is.
+        helper.execSQL(
+            "CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, " +
+                "latitude REAL NOT NULL, longitude REAL NOT NULL, timezone TEXT NOT NULL, " +
+                "country TEXT, city TEXT, isCurrentLocation INTEGER NOT NULL, " +
+                "isFavorite INTEGER NOT NULL, calculationMethod TEXT, asrCalculation TEXT, " +
+                "highLatitudeRule TEXT, fajrAngle REAL, ishaAngle REAL, createdAt INTEGER NOT NULL, " +
+                "updatedAt INTEGER NOT NULL, legacyOnly TEXT)"
+        )
+        helper.execSQL(
+            "INSERT INTO locations (name, latitude, longitude, timezone, country, city, " +
+                "isCurrentLocation, isFavorite, calculationMethod, asrCalculation, highLatitudeRule, " +
+                "fajrAngle, ishaAngle, createdAt, updatedAt, legacyOnly) " +
+                "VALUES ('Dublin', 53.35, -6.26, 'Europe/Dublin', 'Ireland', 'Dublin', " +
+                "1, 0, 'MWL', 'standard', NULL, NULL, NULL, 1100, 1100, 'dropped')"
         )
         helper.execSQL(
             "CREATE TABLE reading_progress (id INTEGER PRIMARY KEY, lastReadSurah INTEGER NOT NULL, " +
@@ -153,7 +180,7 @@ class LegacyUserDataImportTest {
     }
 
     private fun import() =
-        LegacyUserDataImport.run(db.openHelper.writableDatabase, legacy.absolutePath)
+        LegacyUserDataImport.run(user.absolutePath, legacy.absolutePath)
 
     @Test
     fun `a verse that was bookmarked and favourited becomes one row with both flags`() = runTest {
@@ -237,6 +264,23 @@ class LegacyUserDataImportTest {
         }
     }
 
+    /**
+     * The straight copies name their columns off the *new* schema when the caller does not
+     * spell them out, which is what lets a legacy-only column stay behind instead of failing
+     * the insert. That lookup reads the user database across an attachment, so it is only
+     * right if it asks the right schema.
+     */
+    @Test
+    fun `a straight copy takes the columns the new database declares and no others`() = runTest {
+        import()
+
+        val saved = db.locationDao().getAllLocations().first()
+        assertThat(saved).hasSize(1)
+        assertThat(saved.single().name).isEqualTo("Dublin")
+        assertThat(saved.single().timezone).isEqualTo("Europe/Dublin")
+        assertThat(saved.single().isCurrentLocation).isTrue()
+    }
+
     @Test
     fun `running twice changes nothing`() = runTest {
         import()
@@ -260,17 +304,16 @@ class LegacyUserDataImportTest {
             helper.execSQL("INSERT INTO prophet_bookmarks (prophet_id, is_favorite, created_at) VALUES (1, 1, 5)")
         }
 
-        LegacyUserDataImport.run(db.openHelper.writableDatabase, sparse.absolutePath)
+        LegacyUserDataImport.run(user.absolutePath, sparse.absolutePath)
 
         assertThat(db.bookmarkDao().all()).hasSize(1)
         sparse.delete()
     }
 
     @Test
-    fun `an absent legacy file is not needed and not an error`() {
+    fun `an absent legacy file is not an error`() {
         val gone = File(legacy.parentFile, "does-not-exist.db")
-        assertThat(LegacyUserDataImport.isNeeded(db.openHelper.writableDatabase, gone.absolutePath))
-            .isFalse()
+        assertThat(LegacyUserDataImport.run(user.absolutePath, gone.absolutePath)).isEqualTo(0)
     }
 
     @Test
@@ -280,8 +323,37 @@ class LegacyUserDataImportTest {
                 kind = BookmarkKind.AYAH, targetId = 999, createdAt = 1, updatedAt = 1,
             )
         )
-        assertThat(LegacyUserDataImport.isNeeded(db.openHelper.writableDatabase, legacy.absolutePath))
-            .isFalse()
+
+        assertThat(import()).isEqualTo(0)
+
+        val kept = db.bookmarkDao().all()
+        assertThat(kept).hasSize(1)
+        assertThat(kept.single().targetId).isEqualTo(999)
+    }
+
+    /**
+     * The regression this whole shape exists for.
+     *
+     * The copy used to run on Room's own connection, and its `ATTACH` made the framework
+     * close that connection and open a new one — taking `room_table_modification_log` and
+     * every invalidation trigger with it, because Room creates both as `TEMP` and only when
+     * it opens a connection itself. The next Flow to start observing a table then died with
+     * "no such table: room_table_modification_log". Starting to observe *after* an import is
+     * exactly that path.
+     */
+    @Test
+    fun `the invalidation tracker still works after an import`() = runTest {
+        import()
+
+        // Starts tracking the table, which is what wrote to room_table_modification_log and
+        // threw. Collecting it at all is the assertion.
+        assertThat(db.bookmarkDao().bookmarks(BookmarkKind.AYAH).first()).isNotEmpty()
+
+        // And a write through Room still goes through, triggers and all.
+        db.bookmarkDao().upsert(
+            BookmarkEntity(kind = BookmarkKind.AYAH, targetId = 4242, createdAt = 1, updatedAt = 1)
+        )
+        assertThat(db.bookmarkDao().find(BookmarkKind.AYAH, 4242)).isNotNull()
     }
 
     @Test

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -302,8 +302,40 @@ Ramadan.
 
 ## 5. Database & migrations
 
-`data/local/database/NimazDatabase.kt` — a single Room `@Database` (`version = 18`), provided
-in `core/di/DatabaseModule.kt`.
+Two Room `@Database`es, both provided in `core/di/DatabaseModule.kt`:
+
+- `data/local/database/NimazDatabase.kt` (`nimaz_database`, `NIMAZ_DATABASE_VERSION`) — shipped
+  content. Read-only in practice and disposable: it arrives as a fetched artifact (§7) and is
+  replaced wholesale by a release.
+- `data/local/user/NimazUserDatabase.kt` (`nimaz_user_database`, `NIMAZ_USER_DATABASE_VERSION`) —
+  everything the user made. Created by Room on the device, never shipped. Split out at content
+  `schemaVersion 23`; `MIGRATION_22_23` is deliberately empty, because the old tables are **left
+  in place** rather than dropped so the original rows stay recoverable.
+
+**Legacy user-data import.** `LegacyUserDataImport` copies an existing install's rows out of the
+content database into the user database the first time it is opened, driven by `UserDataMigrator`
+from `AppInitializer` (§9) and awaited before the splash screen lifts. It is one transaction of
+`INSERT OR IGNORE`s over two `ATTACH`ed files, so an interrupted copy leaves nothing half-written
+and a second attempt is a no-op.
+
+> **Never `ATTACH` on a connection Room owns.** This has now caused the same crash twice, by two
+> different routes, and both are worth knowing:
+>
+> 1. Writing from a Room `Callback.onOpen` fires invalidation triggers before Room has created
+>    `room_table_modification_log`. This is why `provideNimazUserDatabase` has no `addCallback`.
+> 2. `SQLiteDatabase.execSQL` inspects every statement, and on the first `ATTACH` a connection
+>    ever sees it clears `ENABLE_WRITE_AHEAD_LOGGING` and reconfigures the pool — which **closes
+>    the primary connection and opens a new one**. Room builds its whole tracker in that
+>    connection's temporary schema (`room_table_modification_log` is a `CREATE TEMP TABLE`, the
+>    per-table triggers are `CREATE TEMP TRIGGER`) and only does so when *it* opens a connection,
+>    so after the swap they are gone for the life of the process.
+>
+> Either way the next Flow to start observing a table dies in `syncTriggers` with
+> `no such table: room_table_modification_log`. The import therefore attaches **both** files to a
+> throwaway in-memory database it owns and closes: an in-memory `main` has no journal mode to be
+> taken out of and is capped at one connection anyway, so the reconfigure is a no-op and both
+> real files keep the journal mode Room gave them. The cost of the separate connection is that
+> Room does not observe the copy — hence the ordering guarantee above.
 
 **Prepopulated DB.** The app ships a prebuilt DB in `app/src/main/assets/database/nimaz_prepopulated.db`, wired via `.createFromAsset("database/nimaz_prepopulated.db", NimazDatabase.PREPACKAGED_CALLBACK)`. **Room copies this asset only on a fresh install** — it is *not* re-copied on app update. That single fact drives both the migration discipline here and the entire content-seeding subsystem (§7).
 


### PR DESCRIPTION
Fatal on launch for anyone the legacy user-data copy runs for:

    android.database.sqlite.SQLiteException: no such table:
    room_table_modification_log, while compiling:
    INSERT OR IGNORE INTO room_table_modification_log VALUES(4, 0)
      at androidx.room.TriggerBasedInvalidationTracker.startTrackingTable

The copy ran on Room's own connection, and its `ATTACH` is what broke it.
`SQLiteDatabase.execSQL` inspects every statement, and on the first ATTACH a
connection ever sees it clears ENABLE_WRITE_AHEAD_LOGGING and reconfigures the
pool — which closes the primary connection and opens a new one. Room builds its
whole invalidation tracker in that connection's temporary schema
(`room_table_modification_log` is a CREATE TEMP TABLE, the per-table triggers
are CREATE TEMP TRIGGER) and only does so when it opens a connection itself, so
after the swap they are gone for the life of the process. The next Flow to
start observing a table then dies in syncTriggers.

`isNeeded` gates on the new tables being empty, so this fired on every launch
for anyone who had not yet made a bookmark or opened the reader.

So the copy owns its connection now: both files are attached to a throwaway
in-memory database rather than either being opened as `main`. An in-memory main
has no journal mode to be taken out of and its pool is capped at one connection
anyway, so the reconfigure is a no-op and both real files keep the journal mode
Room gave them. The transaction is BEGIN IMMEDIATE rather than EXCLUSIVE, since
Room is holding both files open while this runs.

The unit test moves to a file-backed user database — an in-memory one has no
path to attach and could not exercise this — and gains a case that observes a
Flow after an import, which is the path that threw. Verified against the real
framework connection pool under Robolectric: a probe doing the old thing
reproduces the crash message exactly, table id and all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012CezuyptXYe25xDLHHKAon