### PR TITLE
Give the Qur'an a thematic layer: background, passages and 2,512 subjects

### DIFF
--- a/app/schemas/com.arshadshah.nimaz.data.local.database.NimazDatabase/24.json
+++ b/app/schemas/com.arshadshah.nimaz.data.local.database.NimazDatabase/24.json
@@ -1,0 +1,2324 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "6fc2866b5cbad8ec79472580e8002515",
+    "entities": [
+      {
+        "tableName": "surahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_english` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `revelation_type` TEXT NOT NULL, `verses_count` INTEGER NOT NULL, `order_revealed` INTEGER NOT NULL, `start_page` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revelationType",
+            "columnName": "revelation_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versesCount",
+            "columnName": "verses_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderRevealed",
+            "columnName": "order_revealed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPage",
+            "columnName": "start_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ayahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `surah_id` INTEGER NOT NULL, `number_in_surah` INTEGER NOT NULL, `number_global` INTEGER NOT NULL, `juz` INTEGER NOT NULL, `hizb` INTEGER NOT NULL, `page` INTEGER NOT NULL, `transliteration` TEXT, `text_tajweed` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`surah_id`) REFERENCES `surahs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInSurah",
+            "columnName": "number_in_surah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberGlobal",
+            "columnName": "number_global",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "juz",
+            "columnName": "juz",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hizb",
+            "columnName": "hizb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textTajweed",
+            "columnName": "text_tajweed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ayahs_surah_id",
+            "unique": false,
+            "columnNames": [
+              "surah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_surah_id` ON `${TABLE_NAME}` (`surah_id`)"
+          },
+          {
+            "name": "index_ayahs_juz",
+            "unique": false,
+            "columnNames": [
+              "juz"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_juz` ON `${TABLE_NAME}` (`juz`)"
+          },
+          {
+            "name": "index_ayahs_page",
+            "unique": false,
+            "columnNames": [
+              "page"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ayahs_page` ON `${TABLE_NAME}` (`page`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "surahs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "surah_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "translations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ayah_id` INTEGER NOT NULL, `text` TEXT NOT NULL, `translator_id` TEXT NOT NULL, FOREIGN KEY(`ayah_id`) REFERENCES `ayahs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translatorId",
+            "columnName": "translator_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_translations_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_translations_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          },
+          {
+            "name": "index_translations_ayah_id_translator_id",
+            "unique": true,
+            "columnNames": [
+              "ayah_id",
+              "translator_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_translations_ayah_id_translator_id` ON `${TABLE_NAME}` (`ayah_id`, `translator_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ayahs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ayah_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surah_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surahNumber` INTEGER NOT NULL, `description` TEXT NOT NULL, `themes` TEXT NOT NULL, PRIMARY KEY(`surahNumber`))",
+        "fields": [
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surahNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themes",
+            "columnName": "themes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surahNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "mushaf_ayah_texts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`text_source` TEXT NOT NULL, `ayah_id` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`text_source`, `ayah_id`))",
+        "fields": [
+          {
+            "fieldPath": "textSource",
+            "columnName": "text_source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "text_source",
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mushaf_ayah_texts_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_ayah_texts_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "juzs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "hizb_quarters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `juz_number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "juzNumber",
+            "columnName": "juz_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hizb_quarters_juz_number",
+            "unique": false,
+            "columnNames": [
+              "juz_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hizb_quarters_juz_number` ON `${TABLE_NAME}` (`juz_number`)"
+          }
+        ]
+      },
+      {
+        "tableName": "manzils",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "rukus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `surah_id` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rukus_surah_id",
+            "unique": false,
+            "columnNames": [
+              "surah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rukus_surah_id` ON `${TABLE_NAME}` (`surah_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`number` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, PRIMARY KEY(`number`))",
+        "fields": [
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "number"
+          ]
+        }
+      },
+      {
+        "tableName": "sajdas",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ayah_id` INTEGER NOT NULL, `sequence` INTEGER NOT NULL, `kind` TEXT NOT NULL, `upstream_kind` TEXT, PRIMARY KEY(`ayah_id`))",
+        "fields": [
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upstreamKind",
+            "columnName": "upstream_kind",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sajdas_sequence",
+            "unique": false,
+            "columnNames": [
+              "sequence"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sajdas_sequence` ON `${TABLE_NAME}` (`sequence`)"
+          }
+        ]
+      },
+      {
+        "tableName": "surah_structure",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surah_id` INTEGER NOT NULL, `ruku_count` INTEGER NOT NULL, `start_ayah_id` INTEGER NOT NULL, `end_ayah_id` INTEGER NOT NULL, `start_page` INTEGER NOT NULL, `end_page` INTEGER NOT NULL, `has_basmalah` INTEGER NOT NULL, `revelation_order` INTEGER NOT NULL, PRIMARY KEY(`surah_id`))",
+        "fields": [
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rukuCount",
+            "columnName": "ruku_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAyahId",
+            "columnName": "start_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAyahId",
+            "columnName": "end_ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPage",
+            "columnName": "start_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPage",
+            "columnName": "end_page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasBasmalah",
+            "columnName": "has_basmalah",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revelationOrder",
+            "columnName": "revelation_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surah_id"
+          ]
+        }
+      },
+      {
+        "tableName": "mushaf_layout_lines",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `script` TEXT NOT NULL, `page` INTEGER NOT NULL, `line` INTEGER NOT NULL, `line_type` TEXT NOT NULL, `surah_id` INTEGER NOT NULL, `ayah_id` INTEGER, `first_word_position` INTEGER, `last_word_position` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "script",
+            "columnName": "script",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "line",
+            "columnName": "line",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineType",
+            "columnName": "line_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahId",
+            "columnName": "surah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstWordPosition",
+            "columnName": "first_word_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastWordPosition",
+            "columnName": "last_word_position",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mushaf_layout_lines_script_page_line",
+            "unique": false,
+            "columnNames": [
+              "script",
+              "page",
+              "line"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_layout_lines_script_page_line` ON `${TABLE_NAME}` (`script`, `page`, `line`)"
+          },
+          {
+            "name": "index_mushaf_layout_lines_script",
+            "unique": false,
+            "columnNames": [
+              "script"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mushaf_layout_lines_script` ON `${TABLE_NAME}` (`script`)"
+          }
+        ]
+      },
+      {
+        "tableName": "surah_overviews",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surah_number` INTEGER NOT NULL, `summary` TEXT NOT NULL, PRIMARY KEY(`surah_number`))",
+        "fields": [
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surah_number"
+          ]
+        }
+      },
+      {
+        "tableName": "surah_overview_sections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surah_number` INTEGER NOT NULL, `position` INTEGER NOT NULL, `heading` TEXT NOT NULL, `section_group` TEXT NOT NULL, `body` TEXT NOT NULL, PRIMARY KEY(`surah_number`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heading",
+            "columnName": "heading",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "group",
+            "columnName": "section_group",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surah_number",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "ayah_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surah_number` INTEGER NOT NULL, `ayah_from` INTEGER NOT NULL, `ayah_to` INTEGER NOT NULL, `theme` TEXT NOT NULL, `keywords` TEXT NOT NULL, `ayah_count` INTEGER NOT NULL, PRIMARY KEY(`surah_number`, `ayah_from`))",
+        "fields": [
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahFrom",
+            "columnName": "ayah_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahTo",
+            "columnName": "ayah_to",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keywords",
+            "columnName": "keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahCount",
+            "columnName": "ayah_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surah_number",
+            "ayah_from"
+          ]
+        }
+      },
+      {
+        "tableName": "quran_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`topic_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `arabic_name` TEXT NOT NULL, `parent_id` INTEGER, `thematic_parent_id` INTEGER, `ontology_parent_id` INTEGER, `description` TEXT NOT NULL, `wiki_link` TEXT NOT NULL, `is_thematic` INTEGER NOT NULL, `is_ontology` INTEGER NOT NULL, `ayah_count` INTEGER NOT NULL, `related_topic_ids` TEXT NOT NULL, PRIMARY KEY(`topic_id`))",
+        "fields": [
+          {
+            "fieldPath": "topicId",
+            "columnName": "topic_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arabicName",
+            "columnName": "arabic_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parent_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thematicParentId",
+            "columnName": "thematic_parent_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ontologyParentId",
+            "columnName": "ontology_parent_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wikiLink",
+            "columnName": "wiki_link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isThematic",
+            "columnName": "is_thematic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOntology",
+            "columnName": "is_ontology",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahCount",
+            "columnName": "ayah_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedTopicIds",
+            "columnName": "related_topic_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "topic_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_quran_topics_parent_id",
+            "unique": false,
+            "columnNames": [
+              "parent_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quran_topics_parent_id` ON `${TABLE_NAME}` (`parent_id`)"
+          },
+          {
+            "name": "index_quran_topics_thematic_parent_id",
+            "unique": false,
+            "columnNames": [
+              "thematic_parent_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quran_topics_thematic_parent_id` ON `${TABLE_NAME}` (`thematic_parent_id`)"
+          },
+          {
+            "name": "index_quran_topics_ontology_parent_id",
+            "unique": false,
+            "columnNames": [
+              "ontology_parent_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quran_topics_ontology_parent_id` ON `${TABLE_NAME}` (`ontology_parent_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quran_topic_ayahs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`topic_id` INTEGER NOT NULL, `ayah_id` INTEGER NOT NULL, `surah_number` INTEGER NOT NULL, `ayah_number` INTEGER NOT NULL, PRIMARY KEY(`topic_id`, `ayah_id`))",
+        "fields": [
+          {
+            "fieldPath": "topicId",
+            "columnName": "topic_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahId",
+            "columnName": "ayah_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahNumber",
+            "columnName": "ayah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "topic_id",
+            "ayah_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_quran_topic_ayahs_ayah_id",
+            "unique": false,
+            "columnNames": [
+              "ayah_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quran_topic_ayahs_ayah_id` ON `${TABLE_NAME}` (`ayah_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hadith_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `author` TEXT NOT NULL, `hadith_count` INTEGER NOT NULL, `description` TEXT NOT NULL, `icon` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hadithCount",
+            "columnName": "hadith_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "hadiths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `book_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `number_in_book` INTEGER NOT NULL, `number_in_chapter` INTEGER NOT NULL, `text_arabic` TEXT NOT NULL, `text_english` TEXT NOT NULL, `narrator` TEXT NOT NULL, `grade` TEXT NOT NULL, `reference` TEXT NOT NULL, `narrator_chain` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`book_id`) REFERENCES `hadith_books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInBook",
+            "columnName": "number_in_book",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInChapter",
+            "columnName": "number_in_chapter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textEnglish",
+            "columnName": "text_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "grade",
+            "columnName": "grade",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "narratorChain",
+            "columnName": "narrator_chain",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hadiths_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hadiths_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_hadiths_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hadiths_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hadith_books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dua_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `icon` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `dua_count` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duaCount",
+            "columnName": "dua_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "duas",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `category_id` INTEGER NOT NULL, `title_english` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `text_arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `translation` TEXT NOT NULL, `source` TEXT NOT NULL, `virtue` TEXT, `repeat_count` INTEGER NOT NULL, `audio_file` TEXT, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`category_id`) REFERENCES `dua_categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "virtue",
+            "columnName": "virtue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatCount",
+            "columnName": "repeat_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioFile",
+            "columnName": "audio_file",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_duas_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_duas_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dua_categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tasbih_presets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `translation` TEXT NOT NULL, `target_count` INTEGER NOT NULL, `is_custom` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `category` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arabic",
+            "columnName": "arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCount",
+            "columnName": "target_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "is_custom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tafseer_blocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tafseer_id` TEXT NOT NULL, `surah_number` INTEGER NOT NULL, `ayah_start` INTEGER NOT NULL, `ayah_end` INTEGER NOT NULL, `text` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tafseerId",
+            "columnName": "tafseer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surahNumber",
+            "columnName": "surah_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahStart",
+            "columnName": "ayah_start",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ayahEnd",
+            "columnName": "ayah_end",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tafseer_blocks_tafseer_id_surah_number_ayah_start_ayah_end",
+            "unique": false,
+            "columnNames": [
+              "tafseer_id",
+              "surah_number",
+              "ayah_start",
+              "ayah_end"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tafseer_blocks_tafseer_id_surah_number_ayah_start_ayah_end` ON `${TABLE_NAME}` (`tafseer_id`, `surah_number`, `ayah_start`, `ayah_end`)"
+          }
+        ]
+      },
+      {
+        "tableName": "asma_ul_husna",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `name_english` TEXT NOT NULL, `meaning` TEXT NOT NULL, `explanation` TEXT NOT NULL, `benefits` TEXT NOT NULL, `quran_references` TEXT NOT NULL, `usage_in_dua` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meaning",
+            "columnName": "meaning",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explanation",
+            "columnName": "explanation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "benefits",
+            "columnName": "benefits",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quranReferences",
+            "columnName": "quran_references",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usageInDua",
+            "columnName": "usage_in_dua",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "asma_un_nabi",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `name_english` TEXT NOT NULL, `meaning` TEXT NOT NULL, `explanation` TEXT NOT NULL, `source` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meaning",
+            "columnName": "meaning",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explanation",
+            "columnName": "explanation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "prophets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `number` INTEGER NOT NULL, `name_arabic` TEXT NOT NULL, `name_english` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `title_english` TEXT NOT NULL, `story_summary` TEXT NOT NULL, `key_lessons` TEXT NOT NULL, `quran_mentions` TEXT NOT NULL, `era` TEXT NOT NULL, `lineage` TEXT NOT NULL, `years_lived` TEXT NOT NULL, `place_of_preaching` TEXT NOT NULL, `miracles` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storySummary",
+            "columnName": "story_summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyLessons",
+            "columnName": "key_lessons",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quranMentions",
+            "columnName": "quran_mentions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "era",
+            "columnName": "era",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineage",
+            "columnName": "lineage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "yearsLived",
+            "columnName": "years_lived",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeOfPreaching",
+            "columnName": "place_of_preaching",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "miracles",
+            "columnName": "miracles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "help_topic",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `icon_key` TEXT NOT NULL, `color_key` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "icon_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorKey",
+            "columnName": "color_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "help_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `topic_id` TEXT NOT NULL, `type` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `icon_key` TEXT, `estimated_minutes` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topic_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "icon_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estimatedMinutes",
+            "columnName": "estimated_minutes",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_item_topic_id",
+            "unique": false,
+            "columnNames": [
+              "topic_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_item_topic_id` ON `${TABLE_NAME}` (`topic_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "help_step",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `deeplink_route` TEXT, `path_labels` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deeplinkRoute",
+            "columnName": "deeplink_route",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pathLabels",
+            "columnName": "path_labels",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_step_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_step_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "help_string",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`owner_type` TEXT NOT NULL, `owner_id` TEXT NOT NULL, `field_key` TEXT NOT NULL, `lang_code` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`owner_type`, `owner_id`, `field_key`, `lang_code`))",
+        "fields": [
+          {
+            "fieldPath": "ownerType",
+            "columnName": "owner_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldKey",
+            "columnName": "field_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "langCode",
+            "columnName": "lang_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "owner_type",
+            "owner_id",
+            "field_key",
+            "lang_code"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_help_string_owner_type_owner_id_lang_code",
+            "unique": false,
+            "columnNames": [
+              "owner_type",
+              "owner_id",
+              "lang_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_string_owner_type_owner_id_lang_code` ON `${TABLE_NAME}` (`owner_type`, `owner_id`, `lang_code`)"
+          },
+          {
+            "name": "index_help_string_lang_code",
+            "unique": false,
+            "columnNames": [
+              "lang_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_help_string_lang_code` ON `${TABLE_NAME}` (`lang_code`)"
+          }
+        ]
+      },
+      {
+        "tableName": "qaida_lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `lesson_number` INTEGER NOT NULL, `title_english` TEXT NOT NULL, `title_arabic` TEXT NOT NULL, `title_transliteration` TEXT NOT NULL, `description` TEXT NOT NULL, `concept_tags` TEXT NOT NULL, `icon` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonNumber",
+            "columnName": "lesson_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleArabic",
+            "columnName": "title_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleTransliteration",
+            "columnName": "title_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conceptTags",
+            "columnName": "concept_tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qaida_letters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `letter_arabic` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `name_transliteration` TEXT NOT NULL, `isolated_form` TEXT NOT NULL, `initial_form` TEXT, `medial_form` TEXT, `final_form` TEXT, `is_connecting` INTEGER NOT NULL, `makhraj_area` TEXT NOT NULL, `makhraj_detail` TEXT NOT NULL, `phonetic_hint` TEXT, `audio_key` TEXT NOT NULL, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterArabic",
+            "columnName": "letter_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameTransliteration",
+            "columnName": "name_transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isolatedForm",
+            "columnName": "isolated_form",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialForm",
+            "columnName": "initial_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "medialForm",
+            "columnName": "medial_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finalForm",
+            "columnName": "final_form",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnecting",
+            "columnName": "is_connecting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "makhrajArea",
+            "columnName": "makhraj_area",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "makhrajDetail",
+            "columnName": "makhraj_detail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneticHint",
+            "columnName": "phonetic_hint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioKey",
+            "columnName": "audio_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qaida_lines",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `lesson_id` INTEGER NOT NULL, `line_number` INTEGER NOT NULL, `line_type` TEXT NOT NULL, `instruction_english` TEXT, `instruction_arabic` TEXT, `display_order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`lesson_id`) REFERENCES `qaida_lessons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineNumber",
+            "columnName": "line_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineType",
+            "columnName": "line_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionEnglish",
+            "columnName": "instruction_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "instructionArabic",
+            "columnName": "instruction_arabic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_qaida_lines_lesson_id",
+            "unique": false,
+            "columnNames": [
+              "lesson_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_lines_lesson_id` ON `${TABLE_NAME}` (`lesson_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "qaida_lessons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "lesson_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "qaida_cells",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `line_id` INTEGER NOT NULL, `lesson_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `text_arabic` TEXT NOT NULL, `transliteration` TEXT NOT NULL, `token_type` TEXT NOT NULL, `audio_key` TEXT NOT NULL, `highlight_group` TEXT, `letter_id` INTEGER, `notes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`line_id`) REFERENCES `qaida_lines`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`letter_id`) REFERENCES `qaida_letters`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineId",
+            "columnName": "line_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lesson_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textArabic",
+            "columnName": "text_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transliteration",
+            "columnName": "transliteration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioKey",
+            "columnName": "audio_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlightGroup",
+            "columnName": "highlight_group",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "letterId",
+            "columnName": "letter_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_qaida_cells_line_id",
+            "unique": false,
+            "columnNames": [
+              "line_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_line_id` ON `${TABLE_NAME}` (`line_id`)"
+          },
+          {
+            "name": "index_qaida_cells_lesson_id",
+            "unique": false,
+            "columnNames": [
+              "lesson_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_lesson_id` ON `${TABLE_NAME}` (`lesson_id`)"
+          },
+          {
+            "name": "index_qaida_cells_letter_id",
+            "unique": false,
+            "columnNames": [
+              "letter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_qaida_cells_letter_id` ON `${TABLE_NAME}` (`letter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "qaida_lines",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "line_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "qaida_letters",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "letter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "islamic_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name_english` TEXT NOT NULL, `name_arabic` TEXT NOT NULL, `hijri_month` INTEGER NOT NULL, `hijri_day` INTEGER NOT NULL, `event_type` TEXT NOT NULL, `description` TEXT NOT NULL, `is_holiday` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameEnglish",
+            "columnName": "name_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameArabic",
+            "columnName": "name_arabic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hijriMonth",
+            "columnName": "hijri_month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hijriDay",
+            "columnName": "hijri_day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "event_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHoliday",
+            "columnName": "is_holiday",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_islamic_events_hijri_month_hijri_day",
+            "unique": false,
+            "columnNames": [
+              "hijri_month",
+              "hijri_day"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_islamic_events_hijri_month_hijri_day` ON `${TABLE_NAME}` (`hijri_month`, `hijri_day`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6fc2866b5cbad8ec79472580e8002515')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/arshadshah/nimaz/MigrationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/MigrationTest.kt
@@ -190,6 +190,69 @@ class MigrationTest {
         }
     }
 
+    /**
+     * schemaVersion 24: the thematic layer's five tables are *created*, and nothing else.
+     *
+     * They hold content, so their rows arrive the way every other content row does — with the
+     * artifact on a fresh install, or on a patch. What this asserts is the shape a device is
+     * left in between the two: the tables exist, they are empty, and Room validates them
+     * against the exported v24 schema. Every read path in the app is built for exactly that
+     * state, so it has to be a state the migration actually produces.
+     */
+    @Test
+    fun migrate23To24_createsTheThematicTablesEmpty() {
+        helper.createDatabase(dbName, 23).close()
+
+        val db = helper.runMigrationsAndValidate(
+            dbName, 24, true, NimazDatabase.MIGRATION_23_24
+        )
+
+        listOf(
+            "surah_overviews",
+            "surah_overview_sections",
+            "ayah_themes",
+            "quran_topics",
+            "quran_topic_ayahs",
+        ).forEach { table ->
+            db.query("SELECT COUNT(*) FROM $table").use { cursor ->
+                assertThat(cursor.moveToFirst()).isTrue()
+                assertThat(cursor.getInt(0)).isEqualTo(0)
+            }
+        }
+    }
+
+    /**
+     * The fresh-install shape: the artifact already carries the thematic tables *and their
+     * rows*, and the migration still runs over them. Every statement is `IF NOT EXISTS`, so it
+     * has to be a no-op rather than a crash — and, more to the point, it must not take the rows
+     * away.
+     */
+    @Test
+    fun migrate23To24_toleratesAnArtifactThatAlreadyHasTheTables() {
+        helper.createDatabase(dbName, 23).use { db ->
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `ayah_themes` (`surah_number` INTEGER NOT NULL, " +
+                    "`ayah_from` INTEGER NOT NULL, `ayah_to` INTEGER NOT NULL, `theme` TEXT NOT NULL, " +
+                    "`keywords` TEXT NOT NULL, `ayah_count` INTEGER NOT NULL, " +
+                    "PRIMARY KEY(`surah_number`, `ayah_from`))"
+            )
+            db.execSQL(
+                "INSERT INTO ayah_themes (surah_number, ayah_from, ayah_to, theme, keywords, ayah_count) " +
+                    "VALUES (2, 8, 16, 'Hypocrites and the consequences of hypocrisy', '', 9)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName, 24, true, NimazDatabase.MIGRATION_23_24
+        )
+
+        db.query("SELECT theme FROM ayah_themes WHERE surah_number = 2 AND ayah_from = 8").use { cursor ->
+            assertThat(cursor.moveToFirst()).isTrue()
+            assertThat(cursor.getString(0))
+                .isEqualTo("Hypocrites and the consequences of hypocrisy")
+        }
+    }
+
     /** The fresh-install shape: the artifact already has the v22 layout, so the move is a no-op. */
     @Test
     fun migrate21To22_toleratesAnArtifactThatIsAlreadyReshaped() {

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -141,6 +141,14 @@ import com.arshadshah.nimaz.domain.usecase.GetSessionsForDateUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSessionsInRangeUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahByNumberUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahInfoUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSurahOverviewUseCase
+import com.arshadshah.nimaz.domain.usecase.GetSurahThemesUseCase
+import com.arshadshah.nimaz.domain.usecase.GetThemeForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicDetailUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicTreeRootsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicsForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.HasThematicContentUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchTopicsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahListUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahWithAyahsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetTafseerForAyahUseCase
@@ -390,6 +398,14 @@ object UseCaseModule {
             updateReadingPosition = UpdateReadingPositionUseCase(repository),
             incrementAyahsRead = IncrementAyahsReadUseCase(repository),
             getSurahInfo = GetSurahInfoUseCase(repository),
+            getSurahOverview = GetSurahOverviewUseCase(repository),
+            getSurahThemes = GetSurahThemesUseCase(repository),
+            getThemeForAyah = GetThemeForAyahUseCase(repository),
+            getTopicTreeRoots = GetTopicTreeRootsUseCase(repository),
+            getTopicDetail = GetTopicDetailUseCase(repository),
+            getTopicsForAyah = GetTopicsForAyahUseCase(repository),
+            searchTopics = SearchTopicsUseCase(repository),
+            hasThematicContent = HasThematicContentUseCase(repository),
             getPageAyahRanges = GetPageAyahRangesUseCase(repository),
             getMushafPagination = GetMushafPaginationUseCase(repository),
             getMushafPageLayout = GetMushafPageLayoutUseCase(repository),

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -91,6 +91,9 @@ import com.arshadshah.nimaz.presentation.screens.qibla.QiblaScreen
 import com.arshadshah.nimaz.presentation.screens.quran.QuranReaderScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SelectReciterScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SelectTranslationScreen
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.presentation.screens.quran.QuranTopicDetailScreen
+import com.arshadshah.nimaz.presentation.screens.quran.QuranTopicsScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SurahInfoScreen
 import com.arshadshah.nimaz.presentation.screens.quran.TafseerChaptersScreen
 import com.arshadshah.nimaz.presentation.screens.quran.TafseerScreen
@@ -348,6 +351,7 @@ fun NavGraph(
                 AdaptiveQuranScreen(
                     navController = navController,
                     onNavigateToSearch = { navController.navigate(Route.GlobalSearch) },
+                    onNavigateToTopics = { navController.navigate(Route.QuranTopics) },
                     onNavigateToBookmarks = { navController.navigate(Route.QuranBookmarks) },
                     onNavigateToSettings = { navController.navigate(Route.SettingsQuran) },
                     onNavigateToSurahInfo = { surahNumber ->
@@ -444,7 +448,10 @@ fun NavGraph(
                 TafseerScreen(
                     surahNumber = args.surahNumber,
                     ayahNumber = args.ayahNumber,
-                    onNavigateBack = { navController.popBackStack() }
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToTopic = { topicId ->
+                        navController.navigate(Route.QuranTopicDetail(topicId))
+                    }
                 )
             }
 
@@ -455,6 +462,36 @@ fun NavGraph(
                     onNavigateBack = { navController.popBackStack() },
                     onStartReading = {
                         navController.navigate(Route.QuranReader(args.surahNumber))
+                    },
+                    onOpenAyah = { surah, ayah ->
+                        navController.navigate(Route.QuranReader(surah, ayah))
+                    },
+                    onOpenTopic = { topicId ->
+                        navController.navigate(Route.QuranTopicDetail(topicId))
+                    }
+                )
+            }
+
+            taggedComposable<Route.QuranTopics>(ScreenTags.QuranTopics) {
+                QuranTopicsScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onOpenTopic = { topicId, tree ->
+                        navController.navigate(Route.QuranTopicDetail(topicId, tree.wire))
+                    }
+                )
+            }
+
+            taggedComposable<Route.QuranTopicDetail>(ScreenTags.QuranTopicDetail) { backStackEntry ->
+                val args = backStackEntry.toRoute<Route.QuranTopicDetail>()
+                QuranTopicDetailScreen(
+                    topicId = args.topicId,
+                    tree = TopicTree.fromWire(args.tree),
+                    onNavigateBack = { navController.popBackStack() },
+                    onOpenAyah = { surah, ayah ->
+                        navController.navigate(Route.QuranReader(surah, ayah))
+                    },
+                    onOpenTopic = { topicId, tree ->
+                        navController.navigate(Route.QuranTopicDetail(topicId, tree.wire))
                     }
                 )
             }

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
@@ -243,6 +243,25 @@ sealed interface Route {
     @Serializable
     data class SurahInfo(val surahNumber: Int) : Route
 
+    /**
+     * The Qur'an's subject browser. One route for the whole descent, not one per level —
+     * the ontology goes five deep, and a route per level would mean five back-stack entries
+     * for one act of browsing. `QuranTopicsViewModel` holds the path.
+     */
+    @Serializable
+    data object QuranTopics : Route
+
+    /**
+     * One subject, with its citations.
+     *
+     * [tree] is a [com.arshadshah.nimaz.domain.model.TopicTree] `wire` value rather than the
+     * enum, because a route argument has to have a `NavType` and a String always does. It is
+     * only used to pick which hierarchy the breadcrumb and the child list are drawn from; an
+     * unrecognised value falls back to the thematic tree rather than failing to open.
+     */
+    @Serializable
+    data class QuranTopicDetail(val topicId: Int, val tree: String = "thematic") : Route
+
     // Select Reciter
     @Serializable
     data object SelectReciter : Route

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -30,6 +30,8 @@ object ScreenTags {
     const val TafseerChapters = "screen_tafseer_chapters"
     const val Tafseer = "screen_tafseer"
     const val SurahInfo = "screen_surah_info"
+    const val QuranTopics = "screen_quran_topics"
+    const val QuranTopicDetail = "screen_quran_topic_detail"
     const val QuranPage = "screen_quran_page"
     const val QuranJuz = "screen_quran_juz"
     const val QuranSearch = "screen_quran_search"

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/ThematicMarkup.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/ThematicMarkup.kt
@@ -1,0 +1,167 @@
+package com.arshadshah.nimaz.core.util
+
+/**
+ * The four-tag markup the thematic layer arrives in, parsed into something Compose can draw.
+ *
+ * The content artifact normalises three very different upstream dialects onto one small one
+ * (arshad-shah/nimaz-data, `data/importers/quran_thematic.py`), and a build-time rule
+ * (`thematic.sections-dialect`) refuses to ship anything outside it:
+ *
+ * ```
+ * <p>…</p>   <strong>…</strong>   <em>…</em>
+ * <a href="quran:2:153-251">…</a>   <a href="topic:61">…</a>
+ * ```
+ *
+ * That is the whole grammar, which is why this is a hand-written scanner rather than an HTML
+ * parser. It is also why the scanner is *lenient*: an unknown tag is dropped and its text kept,
+ * so the worst a fifth tag can do on a device is lose its styling. Nothing here throws — the
+ * alternative to a mis-styled paragraph must never be a screen that will not open.
+ *
+ * The links are the point. 446 of them are cross-references the source writes as prose ("see
+ * 2:153-251") and 509 are cross-links between topics; both address screens this app has, so
+ * they resolve to [ThematicLink] and become taps rather than dead text.
+ */
+object ThematicMarkup {
+
+    /**
+     * *Any* tag, not only the four. A tag outside the dialect has to be consumed here so its
+     * markup is dropped and its text kept — matching only the known ones would leave
+     * `<span class="ar">` printed literally in the middle of a sentence.
+     */
+    private val TAG = Regex("<[^>]*>")
+    private val KNOWN = Regex("^<(/?)(p|strong|em|a)(\\s[^>]*)?>$", RegexOption.IGNORE_CASE)
+    private val HREF = Regex("href\\s*=\\s*\"([^\"]*)\"", RegexOption.IGNORE_CASE)
+
+    /**
+     * Split into paragraphs, each a list of styled runs.
+     *
+     * Text outside any `<p>` is not dropped: the dialect says paragraphs are the only block
+     * element, but a source that forgot one should still be readable, so loose text becomes a
+     * paragraph of its own.
+     */
+    fun parse(html: String): List<ThematicParagraph> {
+        if (html.isBlank()) return emptyList()
+
+        val paragraphs = mutableListOf<ThematicParagraph>()
+        val spans = mutableListOf<ThematicSpan>()
+        var bold = 0
+        var italic = 0
+        var link: ThematicLink? = null
+        var cursor = 0
+
+        fun flushText(upTo: Int) {
+            if (upTo <= cursor) return
+            val text = unescape(html.substring(cursor, upTo))
+            if (text.isEmpty()) return
+            spans += ThematicSpan(
+                text = text,
+                bold = bold > 0,
+                italic = italic > 0,
+                link = link,
+            )
+        }
+
+        fun flushParagraph() {
+            val text = spans.joinToString("") { it.text }
+            if (text.isNotBlank()) paragraphs += ThematicParagraph(spans.toList())
+            spans.clear()
+        }
+
+        for (match in TAG.findAll(html)) {
+            flushText(match.range.first)
+            cursor = match.range.last + 1
+
+            val known = KNOWN.find(match.value) ?: continue
+            val closing = known.groupValues[1] == "/"
+            when (known.groupValues[2].lowercase()) {
+                "p" -> flushParagraph()
+                "strong" -> if (closing) bold = (bold - 1).coerceAtLeast(0) else bold++
+                "em" -> if (closing) italic = (italic - 1).coerceAtLeast(0) else italic++
+                "a" -> link = if (closing) {
+                    null
+                } else {
+                    HREF.find(known.groupValues[3])?.groupValues?.get(1)?.let(::linkOf)
+                }
+            }
+        }
+        flushText(html.length)
+        flushParagraph()
+        return paragraphs
+    }
+
+    /** Plain text — for a preview line, a content description, or anything measuring length. */
+    fun plain(html: String): String =
+        parse(html).joinToString("\n\n") { paragraph ->
+            paragraph.spans.joinToString("") { it.text }.trim()
+        }
+
+    /**
+     * `quran:2`, `quran:2:255`, `quran:2:153-251`, `topic:61` — and null for anything else.
+     *
+     * Malformed hrefs cannot reach a device (`thematic.links-resolve` blocks the build on one),
+     * so returning null here is about a *future* corpus rather than this one: an unrecognised
+     * scheme becomes unstyled text instead of a tap that goes nowhere.
+     */
+    fun linkOf(href: String): ThematicLink? = when {
+        href.startsWith(TOPIC_SCHEME) ->
+            href.removePrefix(TOPIC_SCHEME).toIntOrNull()?.let(ThematicLink::Topic)
+
+        href.startsWith(QURAN_SCHEME) -> {
+            val parts = href.removePrefix(QURAN_SCHEME).split(':')
+            val surah = parts.getOrNull(0)?.toIntOrNull()
+            when {
+                surah == null || surah !in 1..114 -> null
+                parts.size == 1 -> ThematicLink.Verses(surah, null, null)
+                else -> {
+                    val start = parts[1].substringBefore('-').toIntOrNull()
+                    val end = parts[1].substringAfter('-', "").toIntOrNull()
+                    if (start == null) null else ThematicLink.Verses(surah, start, end ?: start)
+                }
+            }
+        }
+
+        else -> null
+    }
+
+    /**
+     * The five XML entities, and nothing more.
+     *
+     * The corpus is NFC-normalised text with entities already decoded on import; these survive
+     * only where the source escaped a literal `&` or angle bracket, which it does in a handful
+     * of places. A general entity table would be code for a case that does not occur.
+     */
+    private fun unescape(raw: String): String =
+        if ('&' !in raw) raw else raw
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&amp;", "&")
+
+    private const val QURAN_SCHEME = "quran:"
+    private const val TOPIC_SCHEME = "topic:"
+}
+
+/** One paragraph of thematic prose. */
+data class ThematicParagraph(val spans: List<ThematicSpan>) {
+    val text: String get() = spans.joinToString("") { it.text }
+}
+
+/** A run of text with uniform styling, and at most one link. */
+data class ThematicSpan(
+    val text: String,
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val link: ThematicLink? = null,
+)
+
+/** A destination inside the app that a run of prose points at. */
+sealed interface ThematicLink {
+    /**
+     * A verse or a range of them. [from] is null for a whole-surah reference; [to] equals
+     * [from] for a single verse, so a caller never has to special-case a one-verse range.
+     */
+    data class Verses(val surah: Int, val from: Int?, val to: Int?) : ThematicLink
+
+    data class Topic(val id: Int) : ThematicLink
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/NimazDatabase.kt
@@ -21,6 +21,7 @@ import com.arshadshah.nimaz.data.local.search.SearchIndexDao
 import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaEntity
 import com.arshadshah.nimaz.data.local.database.entity.AsmaUnNabiEntity
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.AyahThemeEntity
 import com.arshadshah.nimaz.data.local.database.entity.DuaCategoryEntity
 import com.arshadshah.nimaz.data.local.database.entity.DuaEntity
 import com.arshadshah.nimaz.data.local.database.entity.HadithBookEntity
@@ -37,8 +38,12 @@ import com.arshadshah.nimaz.data.local.database.entity.QaidaCellEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLessonEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLetterEntity
 import com.arshadshah.nimaz.data.local.database.entity.QaidaLineEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewSectionEntity
 import com.arshadshah.nimaz.data.local.database.entity.HizbQuarterEntity
 import com.arshadshah.nimaz.data.local.database.entity.JuzEntity
 import com.arshadshah.nimaz.data.local.database.entity.ManzilEntity
@@ -55,7 +60,7 @@ import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
  * migration) for any schema change — it drives both the Room `@Database(version = …)`
  * annotation below and `NimazDatabase.SCHEMA_VERSION` (used to tag crash reports).
  */
-const val NIMAZ_DATABASE_VERSION = 23
+const val NIMAZ_DATABASE_VERSION = 24
 
 @Database(
     entities = [
@@ -73,6 +78,11 @@ const val NIMAZ_DATABASE_VERSION = 23
         SajdaEntity::class,
         SurahStructureEntity::class,
         MushafLayoutLineEntity::class,
+        SurahOverviewEntity::class,
+        SurahOverviewSectionEntity::class,
+        AyahThemeEntity::class,
+        QuranTopicEntity::class,
+        QuranTopicAyahEntity::class,
         // Hadith
         HadithBookEntity::class,
         HadithEntity::class,
@@ -378,6 +388,74 @@ abstract class NimazDatabase : RoomDatabase() {
         // can drop them once there is nothing left to recover.
         val MIGRATION_22_23 = object : Migration(22, 23) {
             override fun migrate(db: SupportSQLiteDatabase) = Unit
+        }
+
+        /**
+         * schemaVersion 24 — the Qur'an gains its thematic layer: the long-form background to
+         * each surah, the passages the mushaf's own outline divides it into, and the subject
+         * hierarchies that say which verses speak about what.
+         *
+         * All five tables are **content**, so this migration only creates them empty. The rows
+         * arrive the way every other content row does (§7): with the artifact on a fresh
+         * install, or via `ContentPatchSeeder` on an upgrade. A device that upgrades before the
+         * matching artifact ships therefore has the tables and no rows, and every read path is
+         * built to treat that as "nothing to show" rather than as an error.
+         *
+         * Every statement is `IF NOT EXISTS`, so running this against a database that already
+         * arrived with the tables — a fresh install off a schemaVersion 24 artifact — is a
+         * no-op rather than a crash.
+         */
+        val MIGRATION_23_24 = object : Migration(23, 24) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `surah_overviews` (
+                        `surah_number` INTEGER NOT NULL, `summary` TEXT NOT NULL,
+                        PRIMARY KEY(`surah_number`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `surah_overview_sections` (
+                        `surah_number` INTEGER NOT NULL, `position` INTEGER NOT NULL,
+                        `heading` TEXT NOT NULL, `section_group` TEXT NOT NULL, `body` TEXT NOT NULL,
+                        PRIMARY KEY(`surah_number`, `position`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `ayah_themes` (
+                        `surah_number` INTEGER NOT NULL, `ayah_from` INTEGER NOT NULL,
+                        `ayah_to` INTEGER NOT NULL, `theme` TEXT NOT NULL,
+                        `keywords` TEXT NOT NULL, `ayah_count` INTEGER NOT NULL,
+                        PRIMARY KEY(`surah_number`, `ayah_from`))
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `quran_topics` (
+                        `topic_id` INTEGER NOT NULL, `name` TEXT NOT NULL,
+                        `arabic_name` TEXT NOT NULL, `parent_id` INTEGER,
+                        `thematic_parent_id` INTEGER, `ontology_parent_id` INTEGER,
+                        `description` TEXT NOT NULL, `wiki_link` TEXT NOT NULL,
+                        `is_thematic` INTEGER NOT NULL, `is_ontology` INTEGER NOT NULL,
+                        `ayah_count` INTEGER NOT NULL, `related_topic_ids` TEXT NOT NULL,
+                        PRIMARY KEY(`topic_id`))
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_quran_topics_parent_id` ON `quran_topics` (`parent_id`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_quran_topics_thematic_parent_id` ON `quran_topics` (`thematic_parent_id`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_quran_topics_ontology_parent_id` ON `quran_topics` (`ontology_parent_id`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `quran_topic_ayahs` (
+                        `topic_id` INTEGER NOT NULL, `ayah_id` INTEGER NOT NULL,
+                        `surah_number` INTEGER NOT NULL, `ayah_number` INTEGER NOT NULL,
+                        PRIMARY KEY(`topic_id`, `ayah_id`))
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_quran_topic_ayahs_ayah_id` ON `quran_topic_ayahs` (`ayah_id`)")
+            }
         }
 
         val MIGRATION_21_22 = object : Migration(21, 22) {
@@ -1074,6 +1152,7 @@ abstract class NimazDatabase : RoomDatabase() {
             MIGRATION_20_21,
             MIGRATION_21_22,
             MIGRATION_22_23,
+            MIGRATION_23_24,
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -9,6 +9,7 @@ import androidx.room.Transaction
 import androidx.room.Update
 import androidx.room.Embedded
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.AyahThemeEntity
 import com.arshadshah.nimaz.data.local.database.entity.HizbQuarterEntity
 import com.arshadshah.nimaz.data.local.database.entity.JuzEntity
 import com.arshadshah.nimaz.data.local.database.entity.ManzilEntity
@@ -20,9 +21,13 @@ import com.arshadshah.nimaz.data.local.database.entity.MushafAyahTextEntity
 import com.arshadshah.nimaz.data.local.database.entity.MushafLayoutLineEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranFavoriteEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicEntity
 import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewSectionEntity
 import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -494,6 +499,97 @@ interface QuranDao {
 
     @Query("SELECT * FROM surah_info WHERE surahNumber = :surahNumber")
     suspend fun getSurahInfo(surahNumber: Int): SurahInfoEntity?
+
+    // ---- Surah overview (long-form background) ----
+
+    @Query("SELECT * FROM surah_overviews WHERE surah_number = :surahNumber")
+    suspend fun getSurahOverview(surahNumber: Int): SurahOverviewEntity?
+
+    @Query(
+        "SELECT * FROM surah_overview_sections WHERE surah_number = :surahNumber " +
+            "ORDER BY position ASC"
+    )
+    suspend fun getSurahOverviewSections(surahNumber: Int): List<SurahOverviewSectionEntity>
+
+    // ---- Thematic passages ----
+
+    @Query(
+        "SELECT * FROM ayah_themes WHERE surah_number = :surahNumber " +
+            "ORDER BY ayah_from ASC"
+    )
+    suspend fun getThemesForSurah(surahNumber: Int): List<AyahThemeEntity>
+
+    /**
+     * The passage an ayah falls in. Containment rides the `(surah_number, ayah_from)` primary
+     * key, and the ranges never overlap, so at most one row can match — `LIMIT 1` states that
+     * rather than relying on it.
+     */
+    @Query(
+        "SELECT * FROM ayah_themes WHERE surah_number = :surahNumber " +
+            "AND ayah_from <= :ayahNumber AND ayah_to >= :ayahNumber LIMIT 1"
+    )
+    suspend fun getThemeForAyah(surahNumber: Int, ayahNumber: Int): AyahThemeEntity?
+
+    @Query("SELECT COUNT(*) FROM ayah_themes")
+    suspend fun countThemes(): Int
+
+    // ---- Topics ----
+
+    @Query("SELECT * FROM quran_topics WHERE topic_id = :topicId")
+    suspend fun getTopic(topicId: Int): QuranTopicEntity?
+
+    @Query("SELECT * FROM quran_topics WHERE topic_id IN (:topicIds)")
+    suspend fun getTopics(topicIds: List<Int>): List<QuranTopicEntity>
+
+    /**
+     * The roots of one of the three hierarchies. `parent` is the subject index (a root is a
+     * topic with no `parent_id`); `thematic` and `ontology` are the two curated trees, whose
+     * roots are members with a null parent of that kind — which is why membership is a column
+     * and not inferred from the parent being null.
+     */
+    @Query(
+        "SELECT * FROM quran_topics WHERE " +
+            "(:tree = 'thematic' AND is_thematic = 1 AND thematic_parent_id IS NULL) OR " +
+            "(:tree = 'ontology' AND is_ontology = 1 AND ontology_parent_id IS NULL) OR " +
+            "(:tree = 'index' AND parent_id IS NULL) " +
+            "ORDER BY ayah_count DESC, name ASC"
+    )
+    suspend fun getRootTopics(tree: String): List<QuranTopicEntity>
+
+    @Query(
+        "SELECT * FROM quran_topics WHERE " +
+            "(:tree = 'thematic' AND thematic_parent_id = :parentId) OR " +
+            "(:tree = 'ontology' AND ontology_parent_id = :parentId) OR " +
+            "(:tree = 'index' AND parent_id = :parentId) " +
+            "ORDER BY ayah_count DESC, name ASC"
+    )
+    suspend fun getChildTopics(tree: String, parentId: Int): List<QuranTopicEntity>
+
+    @Query(
+        "SELECT * FROM quran_topic_ayahs WHERE topic_id = :topicId " +
+            "ORDER BY ayah_id ASC"
+    )
+    suspend fun getTopicAyahs(topicId: Int): List<QuranTopicAyahEntity>
+
+    /**
+     * Every topic that cites this verse, busiest first. The index on `ayah_id` is what keeps
+     * this off a scan of all 30,687 citations.
+     */
+    @Query(
+        "SELECT t.* FROM quran_topics t " +
+            "JOIN quran_topic_ayahs ta ON ta.topic_id = t.topic_id " +
+            "WHERE ta.ayah_id = :ayahId ORDER BY t.ayah_count DESC, t.name ASC"
+    )
+    suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopicEntity>
+
+    @Query(
+        "SELECT * FROM quran_topics WHERE name LIKE '%' || :query || '%' " +
+            "ORDER BY ayah_count DESC, name ASC LIMIT :limit"
+    )
+    suspend fun searchTopicsByName(query: String, limit: Int): List<QuranTopicEntity>
+
+    @Query("SELECT COUNT(*) FROM quran_topics")
+    suspend fun countTopics(): Int
 
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
@@ -298,3 +298,124 @@ data class SurahStructureEntity(
     @ColumnInfo(name = "has_basmalah") val hasBasmalah: Int,
     @ColumnInfo(name = "revelation_order") val revelationOrder: Int,
 )
+
+/**
+ * The long-form background to a surah — its name, when it was revealed, its theme and the
+ * subjects it moves through — split into the sections the source writes it in.
+ *
+ * This is deliberately *not* [SurahInfoEntity]. That row is one sentence and a comma-separated
+ * theme list, written for a list cell; this is several pages of prose per surah. Keeping them
+ * apart keeps the cheap query cheap: the surah list reads `surah_info` for 114 short rows and
+ * never touches the ~900 KB of overview text, which only the info screen opens.
+ *
+ * [summary] is the source's own one-paragraph opening, used where a card needs a lede.
+ */
+@Entity(tableName = "surah_overviews")
+data class SurahOverviewEntity(
+    @PrimaryKey @ColumnInfo(name = "surah_number") val surahNumber: Int,
+    val summary: String,
+)
+
+/**
+ * One `<h2>` section of a surah's overview, in the order the source prints them.
+ *
+ * The split happens at import (arshad-shah/nimaz-data), not here. The source writes the same
+ * section under thirty different headings — "Theme and Subject Matter", "Subject Matter and
+ * Theme", "Theme and Subject matter" — so the normalisation is data work, and doing it on the
+ * device would mean parsing 47 KB of HTML per surah on the way to a screen.
+ *
+ * [body] is the section's inner HTML, limited to the inline set the source uses
+ * (`p`, `em`, `strong`, `ol`, `li`, `a`, `h3`). [heading] is the source heading, verbatim;
+ * [group] is that heading folded onto one of a handful of stable buckets so the screen can
+ * order and icon sections without matching on prose.
+ */
+@Entity(tableName = "surah_overview_sections", primaryKeys = ["surah_number", "position"])
+data class SurahOverviewSectionEntity(
+    @ColumnInfo(name = "surah_number") val surahNumber: Int,
+    val position: Int,
+    val heading: String,
+    @ColumnInfo(name = "section_group") val group: String,
+    val body: String,
+)
+
+/**
+ * A run of consecutive ayahs that the mushaf's own thematic outline treats as one passage.
+ *
+ * 1,049 rows tiling all 114 surahs: every ayah but two (2:134 and 40:61, absent upstream) falls
+ * inside exactly one theme, so "what is this passage about" is a single lookup rather than a
+ * guess. The key is `(surah_number, ayah_from)` and the containment query
+ * (`ayah_from <= ? AND ayah_to >= ?`) rides its index, so no second index is declared —
+ * Room compares index *sets*, and an unused one here fails validation like a missing one.
+ *
+ * [keywords] are the source's stemmed tokens ("Stori", "Believ"). They are indexed for search
+ * and deliberately never rendered.
+ */
+@Entity(tableName = "ayah_themes", primaryKeys = ["surah_number", "ayah_from"])
+data class AyahThemeEntity(
+    @ColumnInfo(name = "surah_number") val surahNumber: Int,
+    @ColumnInfo(name = "ayah_from") val ayahFrom: Int,
+    @ColumnInfo(name = "ayah_to") val ayahTo: Int,
+    val theme: String,
+    val keywords: String,
+    @ColumnInfo(name = "ayah_count") val ayahCount: Int,
+)
+
+/**
+ * A subject the Qur'an speaks about, in three overlapping hierarchies.
+ *
+ * The source carries a topic under up to three parents and they are not the same tree:
+ *  - [parentId] — the subject *index*, the shape a printed concordance has ("Musa" > "parting
+ *    of the Red Sea"). 732 topics sit under one.
+ *  - [thematicParentId] — the thematic outline, rooted at Doctrine, Stories and The Unseen.
+ *  - [ontologyParentId] — the ontology, rooted at kinds of thing (Location, Living Creation,
+ *    Event, …).
+ *
+ * A topic can be in all three, or in none but the index. [isThematic] and [isOntology] mark
+ * membership so a browser can walk one tree without inferring it from null parents — a root of
+ * the thematic tree and a topic that is simply not in it both have a null thematic parent.
+ *
+ * [description] is HTML carrying `<topic data-id="N">` cross-links; resolving those into
+ * navigation is the renderer's job.
+ */
+@Entity(
+    tableName = "quran_topics",
+    indices = [
+        Index(value = ["parent_id"]),
+        Index(value = ["thematic_parent_id"]),
+        Index(value = ["ontology_parent_id"]),
+    ]
+)
+data class QuranTopicEntity(
+    @PrimaryKey @ColumnInfo(name = "topic_id") val topicId: Int,
+    val name: String,
+    @ColumnInfo(name = "arabic_name") val arabicName: String,
+    @ColumnInfo(name = "parent_id") val parentId: Int?,
+    @ColumnInfo(name = "thematic_parent_id") val thematicParentId: Int?,
+    @ColumnInfo(name = "ontology_parent_id") val ontologyParentId: Int?,
+    val description: String,
+    @ColumnInfo(name = "wiki_link") val wikiLink: String,
+    @ColumnInfo(name = "is_thematic") val isThematic: Int,
+    @ColumnInfo(name = "is_ontology") val isOntology: Int,
+    @ColumnInfo(name = "ayah_count") val ayahCount: Int,
+    @ColumnInfo(name = "related_topic_ids") val relatedTopicIds: String,
+)
+
+/**
+ * One verse cited under one topic — 30,687 rows over 2,330 topics.
+ *
+ * The global [ayahId] is the join key the rest of the Qur'an schema uses; `surah_number` and
+ * `ayah_number` ride along so a citation list can be labelled "2:255" without a join. The index
+ * on [ayahId] is what makes the reverse question — *which topics does this verse belong to* —
+ * a lookup rather than a scan of the whole table.
+ */
+@Entity(
+    tableName = "quran_topic_ayahs",
+    primaryKeys = ["topic_id", "ayah_id"],
+    indices = [Index(value = ["ayah_id"])]
+)
+data class QuranTopicAyahEntity(
+    @ColumnInfo(name = "topic_id") val topicId: Int,
+    @ColumnInfo(name = "ayah_id") val ayahId: Int,
+    @ColumnInfo(name = "surah_number") val surahNumber: Int,
+    @ColumnInfo(name = "ayah_number") val ayahNumber: Int,
+)

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/search/ContentSearchIndex.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/search/ContentSearchIndex.kt
@@ -178,6 +178,13 @@ enum class SearchKind(val wire: String) {
     DUA("dua"),
     DUA_CATEGORY("dua-category"),
     TAFSEER("tafseer"),
+
+    /**
+     * The Qur'an's thematic layer (nimaz-data schemaVersion 24). A `theme` ref is
+     * `surah:ayah_from` — the passage's key — and a `topic` ref is the topic id.
+     */
+    THEME("theme"),
+    TOPIC("topic"),
     ASMA_UL_HUSNA("asma-ul-husna"),
     ASMA_UN_NABI("asma-un-nabi"),
     PROPHET("prophet"),

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -9,19 +9,23 @@ import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
 import com.arshadshah.nimaz.data.local.database.dao.QuranDao
 import com.arshadshah.nimaz.data.local.database.dao.AyahWithText
 import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.AyahThemeEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranBookmarkEntity
 import com.arshadshah.nimaz.data.local.database.entity.QuranFavoriteEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicEntity
 import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
 import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
 import com.arshadshah.nimaz.data.local.search.SearchKind
 import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.AyahTheme
 import com.arshadshah.nimaz.domain.model.MushafPageLayout
 import com.arshadshah.nimaz.domain.model.MushafScript
 import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.domain.model.QuranBookmark
 import com.arshadshah.nimaz.domain.model.QuranFavorite
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
+import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.QuranTranslation
 import com.arshadshah.nimaz.domain.model.ReadingProgress
 import com.arshadshah.nimaz.domain.model.RevelationType
@@ -29,7 +33,13 @@ import com.arshadshah.nimaz.domain.model.SajdaType
 import com.arshadshah.nimaz.domain.model.SearchType
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.SurahInfo
+import com.arshadshah.nimaz.domain.model.SurahOverview
+import com.arshadshah.nimaz.domain.model.SurahOverviewGroup
+import com.arshadshah.nimaz.domain.model.SurahOverviewSection
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
+import com.arshadshah.nimaz.domain.model.TopicCitation
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
 import com.arshadshah.nimaz.domain.model.Translator
 import com.arshadshah.nimaz.domain.repository.QuranRepository
 import kotlinx.coroutines.flow.Flow
@@ -67,6 +77,16 @@ class QuranRepositoryImpl @Inject constructor(
         if (translatorId == null) return null
         return QuranTranslation.fromId(translatorId).id
     }
+
+    /**
+     * Whether this install's artifact carries the thematic layer, resolved once.
+     *
+     * It cannot change while the process lives: the content database is replaced wholesale by
+     * a release, never written to at runtime. Two `COUNT(*)`s on every screen that wants to
+     * know would be two queries to learn a constant.
+     */
+    @Volatile
+    private var thematicContent: Boolean? = null
 
     override fun getAllSurahs(): Flow<List<Surah>> {
         return quranDao.getAllSurahs().mapItems { it.toDomain() }
@@ -522,6 +542,108 @@ class QuranRepositoryImpl @Inject constructor(
         }
     }
 
+    // ---- The thematic layer (schemaVersion 24) ----
+
+    override suspend fun getSurahOverview(surahNumber: Int): SurahOverview? {
+        val overview = quranDao.getSurahOverview(surahNumber) ?: return null
+        return SurahOverview(
+            surahNumber = overview.surahNumber,
+            summary = overview.summary,
+            sections = quranDao.getSurahOverviewSections(surahNumber).map { section ->
+                SurahOverviewSection(
+                    position = section.position,
+                    heading = section.heading,
+                    group = SurahOverviewGroup.fromWire(section.group),
+                    body = section.body,
+                )
+            },
+        )
+    }
+
+    override suspend fun getThemesForSurah(surahNumber: Int): List<AyahTheme> =
+        quranDao.getThemesForSurah(surahNumber).map { it.toDomain() }
+
+    override suspend fun getThemeForAyah(surahNumber: Int, ayahNumber: Int): AyahTheme? =
+        quranDao.getThemeForAyah(surahNumber, ayahNumber)?.toDomain()
+
+    override suspend fun getTopicTreeRoots(tree: TopicTree): List<QuranTopic> =
+        quranDao.getRootTopics(tree.wire).map { it.toDomain() }
+
+    /**
+     * A topic, its place in [tree], and everything reachable from it in one call.
+     *
+     * The breadcrumb is walked upwards with a visited set. The corpus's parents are validated
+     * acyclic at import, so the guard is not for the data that ships — it is for the next
+     * corpus, and the cost of being wrong is a screen that hangs.
+     */
+    override suspend fun getTopicDetail(topicId: Int, tree: TopicTree): TopicDetail? {
+        val topic = quranDao.getTopic(topicId)?.toDomain() ?: return null
+
+        val breadcrumb = ArrayDeque<QuranTopic>()
+        val seen = mutableSetOf(topic.id)
+        var parentId = topic.parentIn(tree)
+        while (parentId != null && seen.add(parentId)) {
+            val parent = quranDao.getTopic(parentId)?.toDomain() ?: break
+            breadcrumb.addFirst(parent)
+            parentId = parent.parentIn(tree)
+        }
+
+        val related = topic.relatedTopicIds
+            .takeIf { it.isNotEmpty() }
+            ?.let { ids -> quranDao.getTopics(ids).map { it.toDomain() } }
+            .orEmpty()
+
+        return TopicDetail(
+            topic = topic,
+            tree = tree,
+            breadcrumb = breadcrumb.toList(),
+            children = quranDao.getChildTopics(tree.wire, topicId).map { it.toDomain() },
+            related = related,
+            citations = quranDao.getTopicAyahs(topicId).map {
+                TopicCitation(
+                    ayahId = it.ayahId,
+                    surahNumber = it.surahNumber,
+                    ayahNumber = it.ayahNumber,
+                )
+            },
+        )
+    }
+
+    override suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopic> =
+        quranDao.getTopicsForAyah(ayahId).map { it.toDomain() }
+
+    /**
+     * Topic search, through the shipped FTS index where there is one.
+     *
+     * The index carries each topic's Arabic name and description as well as its name, folded,
+     * so "الله" and "resurrection" both reach rows the `LIKE` fallback cannot: the fallback
+     * matches the English name and nothing else. Index order is relevance order, and
+     * `getTopics` does not preserve it, so the ids are re-sorted back into it here.
+     */
+    override suspend fun searchTopics(query: String, limit: Int): List<QuranTopic> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return emptyList()
+        if (!searchIndex.isAvailable()) {
+            return quranDao.searchTopicsByName(trimmed, limit).map { it.toDomain() }
+        }
+        val ids = searchIndex.refs(trimmed, SearchKind.TOPIC)
+            .mapNotNull(String::toIntOrNull)
+            .distinct()
+            .take(limit)
+        if (ids.isEmpty()) return emptyList()
+        val rank = ids.withIndex().associate { (index, id) -> id to index }
+        return quranDao.getTopics(ids)
+            .map { it.toDomain() }
+            .sortedBy { rank[it.id] ?: Int.MAX_VALUE }
+    }
+
+    override suspend fun hasThematicContent(): Boolean {
+        thematicContent?.let { return it }
+        val present = quranDao.countThemes() > 0 && quranDao.countTopics() > 0
+        thematicContent = present
+        return present
+    }
+
     override suspend fun initializeQuranData() {
         // Data is pre-populated in the database
     }
@@ -531,6 +653,34 @@ class QuranRepositoryImpl @Inject constructor(
     }
 
     // Extension functions for mapping
+    private fun AyahThemeEntity.toDomain(): AyahTheme = AyahTheme(
+        surahNumber = surahNumber,
+        ayahFrom = ayahFrom,
+        ayahTo = ayahTo,
+        theme = theme,
+        ayahCount = ayahCount,
+    )
+
+    /**
+     * `related_topic_ids` is a comma-separated list, which is the shape the corpus stores it
+     * in for the seventeen topics that have one. A table for seventeen rows would be a table
+     * nothing ever joins.
+     */
+    private fun QuranTopicEntity.toDomain(): QuranTopic = QuranTopic(
+        id = topicId,
+        name = name,
+        arabicName = arabicName,
+        description = description,
+        wikiLink = wikiLink,
+        ayahCount = ayahCount,
+        parentId = parentId,
+        thematicParentId = thematicParentId,
+        ontologyParentId = ontologyParentId,
+        isThematic = isThematic == 1,
+        isOntology = isOntology == 1,
+        relatedTopicIds = relatedTopicIds.split(',').mapNotNull { it.trim().toIntOrNull() },
+    )
+
     private fun SurahEntity.toDomain(): Surah {
         return Surah(
             number = number,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranThematic.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranThematic.kt
@@ -1,0 +1,179 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * The Qur'an's thematic layer — what a surah is about, what a passage is about, and which
+ * verses speak to a subject.
+ *
+ * None of it is scripture. It is the apparatus a printed mushaf carries in its margins and an
+ * introduction, and it arrives with the content artifact like everything else
+ * (arshad-shah/nimaz-data, schemaVersion 24). A device that has not yet been handed a
+ * schemaVersion 24 artifact has the tables and no rows, so every model here is reached through
+ * a nullable or a possibly-empty list and no screen treats absence as an error.
+ *
+ * ## The HTML dialect
+ *
+ * [SurahOverviewSection.body] and [QuranTopic.description] carry markup, and it is deliberately
+ * a *tiny* dialect, normalised at import so nothing has to be parsed generously here:
+ *
+ * ```
+ * <p>…</p>  <strong>…</strong>  <em>…</em>
+ * <a href="quran:2:153-251">…</a>   <a href="topic:61">…</a>
+ * ```
+ *
+ * Four tags, and the two link schemes address screens this app has. `ThematicHtml` in the
+ * presentation layer is the only thing that reads them.
+ */
+
+/** A surah's long-form background, and the sections the source divides it into. */
+data class SurahOverview(
+    val surahNumber: Int,
+    val summary: String,
+    val sections: List<SurahOverviewSection>,
+)
+
+/**
+ * One section of that background.
+ *
+ * [heading] is the source's own wording — 65 spellings across 114 surahs — and is what the
+ * reader sees. [group] is that heading folded onto a handful of stable buckets at import, and
+ * is what the screen orders and icons by, so a new spelling of "Theme and Subject Matter" is
+ * still a section that lands in the right place.
+ */
+data class SurahOverviewSection(
+    val position: Int,
+    val heading: String,
+    val group: SurahOverviewGroup,
+    val body: String,
+)
+
+enum class SurahOverviewGroup(val wire: String) {
+    /** Why the surah is called what it is called. */
+    NAME("name"),
+
+    /** When it was revealed, and into what. */
+    REVELATION("revelation"),
+
+    /** What it is about — the longest section, and usually the one worth opening first. */
+    THEME("theme"),
+
+    /** The events around it. */
+    BACKGROUND("background"),
+
+    /** An editorial note that precedes the first heading. Two surahs have one: 113 and 114. */
+    NOTE("note"),
+
+    OTHER("other");
+
+    companion object {
+        fun fromWire(wire: String): SurahOverviewGroup =
+            entries.firstOrNull { it.wire == wire } ?: OTHER
+    }
+}
+
+/**
+ * A run of consecutive ayahs the mushaf's own outline treats as one passage.
+ *
+ * 1,049 of them tile all 114 surahs — every verse but 2:134 and 40:61 falls inside exactly one,
+ * which is what lets the reader answer "what is this passage about" for wherever it happens to
+ * be, rather than only at a surah boundary.
+ */
+data class AyahTheme(
+    val surahNumber: Int,
+    val ayahFrom: Int,
+    val ayahTo: Int,
+    val theme: String,
+    val ayahCount: Int,
+) {
+    val isSingleAyah: Boolean get() = ayahFrom == ayahTo
+
+    /** "2:8–16", or "2:25" when the passage is one verse. */
+    val reference: String
+        get() = if (isSingleAyah) "$surahNumber:$ayahFrom" else "$surahNumber:$ayahFrom–$ayahTo"
+
+    fun contains(ayahNumber: Int): Boolean = ayahNumber in ayahFrom..ayahTo
+}
+
+/**
+ * A subject the Qur'an speaks about.
+ *
+ * The three parent ids are three *different* hierarchies, not one with fallbacks — see
+ * [TopicTree]. A topic can sit in all three under three different parents, and collapsing them
+ * would be choosing which of three editors was right.
+ */
+data class QuranTopic(
+    val id: Int,
+    val name: String,
+    val arabicName: String,
+    val description: String,
+    val wikiLink: String,
+    val ayahCount: Int,
+    val parentId: Int?,
+    val thematicParentId: Int?,
+    val ontologyParentId: Int?,
+    val isThematic: Boolean,
+    val isOntology: Boolean,
+    val relatedTopicIds: List<Int>,
+) {
+    val hasArabicName: Boolean get() = arabicName.isNotBlank()
+    val hasDescription: Boolean get() = description.isNotBlank()
+
+    fun parentIn(tree: TopicTree): Int? = when (tree) {
+        TopicTree.THEMATIC -> thematicParentId
+        TopicTree.ONTOLOGY -> ontologyParentId
+        TopicTree.INDEX -> parentId
+    }
+
+    fun belongsTo(tree: TopicTree): Boolean = when (tree) {
+        TopicTree.THEMATIC -> isThematic
+        TopicTree.ONTOLOGY -> isOntology
+        TopicTree.INDEX -> true
+    }
+}
+
+/**
+ * Which of the three hierarchies a topic browser is walking.
+ *
+ * [wire] is matched in SQL, so these strings are a contract with `QuranDao` and must not drift.
+ */
+enum class TopicTree(val wire: String) {
+    /** Doctrine, Stories, The Unseen — the curated thematic outline. 695 topics. */
+    THEMATIC("thematic"),
+
+    /** Location, Living Creation, Event, … — kinds of thing. 284 topics. */
+    ONTOLOGY("ontology"),
+
+    /** The shape a printed concordance has: "Musa" > "parting of the Red Sea". */
+    INDEX("index");
+
+    companion object {
+        val DEFAULT = THEMATIC
+
+        /** Resolves a route argument. An unknown value opens the default tree, never nothing. */
+        fun fromWire(wire: String?): TopicTree =
+            entries.firstOrNull { it.wire == wire } ?: DEFAULT
+    }
+}
+
+/** One verse cited under a topic. */
+data class TopicCitation(
+    val ayahId: Int,
+    val surahNumber: Int,
+    val ayahNumber: Int,
+) {
+    val reference: String get() = "$surahNumber:$ayahNumber"
+}
+
+/**
+ * A topic with its citations resolved, and the neighbours a reader can move to from it.
+ *
+ * [breadcrumb] is the path from the tree's root down to (but not including) the topic itself,
+ * so a topic five levels into the ontology says where it sits instead of appearing free-floating.
+ */
+data class TopicDetail(
+    val topic: QuranTopic,
+    val tree: TopicTree,
+    val breadcrumb: List<QuranTopic>,
+    val children: List<QuranTopic>,
+    val related: List<QuranTopic>,
+    val citations: List<TopicCitation>,
+)

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
@@ -1,17 +1,22 @@
 package com.arshadshah.nimaz.domain.repository
 
 import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.AyahTheme
 import com.arshadshah.nimaz.domain.model.MushafPageLayout
 import com.arshadshah.nimaz.domain.model.MushafScript
 import com.arshadshah.nimaz.domain.model.PageAyahRange
 import com.arshadshah.nimaz.domain.model.QuranBookmark
 import com.arshadshah.nimaz.domain.model.QuranFavorite
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
+import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.ReadingProgress
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.SurahInfo
+import com.arshadshah.nimaz.domain.model.SurahOverview
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
 import com.arshadshah.nimaz.domain.model.Translator
 import kotlinx.coroutines.flow.Flow
 
@@ -92,6 +97,22 @@ interface QuranRepository {
 
     // Surah info
     suspend fun getSurahInfo(surahNumber: Int): SurahInfo?
+
+    /**
+     * The thematic layer (schemaVersion 24). Every method here answers "nothing" rather than
+     * throwing on a device whose artifact predates it — the tables exist from the migration,
+     * the rows arrive with the artifact, and the gap between the two is a normal state.
+     */
+    suspend fun getSurahOverview(surahNumber: Int): SurahOverview?
+    suspend fun getThemesForSurah(surahNumber: Int): List<AyahTheme>
+    suspend fun getThemeForAyah(surahNumber: Int, ayahNumber: Int): AyahTheme?
+    suspend fun getTopicTreeRoots(tree: TopicTree): List<QuranTopic>
+    suspend fun getTopicDetail(topicId: Int, tree: TopicTree): TopicDetail?
+    suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopic>
+    suspend fun searchTopics(query: String, limit: Int = 60): List<QuranTopic>
+
+    /** Whether this install's artifact actually carries the thematic layer at all. */
+    suspend fun hasThematicContent(): Boolean
 
     // Data initialization
     suspend fun initializeQuranData()

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
@@ -11,7 +11,12 @@ import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.ReadingProgress
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.AyahTheme
+import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.SurahInfo
+import com.arshadshah.nimaz.domain.model.SurahOverview
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
 import com.arshadshah.nimaz.domain.model.Translator
 import com.arshadshah.nimaz.domain.repository.QuranRepository
@@ -180,6 +185,75 @@ class GetSurahInfoUseCase @Inject constructor(
     suspend operator fun invoke(surahNumber: Int): SurahInfo? = repository.getSurahInfo(surahNumber)
 }
 
+/**
+ * The thematic layer (schemaVersion 24). Every one of these returns nothing rather than
+ * failing on an install whose artifact predates it — see [HasThematicContentUseCase], which
+ * is what a screen asks before it offers an entry point into any of them.
+ */
+class GetSurahOverviewUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(surahNumber: Int): SurahOverview? =
+        repository.getSurahOverview(surahNumber)
+}
+
+class GetSurahThemesUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(surahNumber: Int): List<AyahTheme> =
+        repository.getThemesForSurah(surahNumber)
+}
+
+/** The passage a verse falls in — at most one, since the ranges never overlap. */
+class GetThemeForAyahUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(surahNumber: Int, ayahNumber: Int): AyahTheme? =
+        repository.getThemeForAyah(surahNumber, ayahNumber)
+}
+
+class GetTopicTreeRootsUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(tree: TopicTree): List<QuranTopic> =
+        repository.getTopicTreeRoots(tree)
+}
+
+class GetTopicDetailUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(topicId: Int, tree: TopicTree): TopicDetail? =
+        repository.getTopicDetail(topicId, tree)
+}
+
+/** Which subjects cite this verse — busiest first. */
+class GetTopicsForAyahUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(ayahId: Int): List<QuranTopic> =
+        repository.getTopicsForAyah(ayahId)
+}
+
+class SearchTopicsUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(query: String, limit: Int = 60): List<QuranTopic> =
+        repository.searchTopics(query, limit)
+}
+
+/**
+ * Whether this install's artifact carries the thematic layer at all.
+ *
+ * `MIGRATION_23_24` creates the tables on every device; the rows only arrive with a
+ * schemaVersion 24 artifact. Screens ask this before showing an entry point, so an install
+ * in between shows one fewer affordance rather than an empty screen behind a promising tab.
+ */
+class HasThematicContentUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(): Boolean = repository.hasThematicContent()
+}
+
 class GetPageAyahRangesUseCase @Inject constructor(
     private val repository: QuranRepository
 ) {
@@ -290,6 +364,14 @@ data class QuranUseCases(
     val updateReadingPosition: UpdateReadingPositionUseCase,
     val incrementAyahsRead: IncrementAyahsReadUseCase,
     val getSurahInfo: GetSurahInfoUseCase,
+    val getSurahOverview: GetSurahOverviewUseCase,
+    val getSurahThemes: GetSurahThemesUseCase,
+    val getThemeForAyah: GetThemeForAyahUseCase,
+    val getTopicTreeRoots: GetTopicTreeRootsUseCase,
+    val getTopicDetail: GetTopicDetailUseCase,
+    val getTopicsForAyah: GetTopicsForAyahUseCase,
+    val searchTopics: SearchTopicsUseCase,
+    val hasThematicContent: HasThematicContentUseCase,
     val getPageAyahRanges: GetPageAyahRangesUseCase,
     val getMushafPagination: GetMushafPaginationUseCase,
     val getMushafPageLayout: GetMushafPageLayoutUseCase,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ThematicText.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ThematicText.kt
@@ -1,0 +1,135 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arshadshah.nimaz.core.util.ThematicLink
+import com.arshadshah.nimaz.core.util.ThematicMarkup
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+
+/**
+ * Renders the thematic layer's four-tag markup — the only place in the app that reads it.
+ *
+ * One `Text` per paragraph rather than one with embedded newlines, so paragraph spacing is
+ * layout instead of blank lines, and a long section is a column of independently measured
+ * blocks rather than a single 40 KB string.
+ *
+ * The links are the reason this is a component and not a `Text` with `AnnotatedString.fromHtml`.
+ * A `quran:` reference is a *destination in this app*, not a URL: it opens the reader at the
+ * verses the sentence is talking about, and a `topic:` reference opens that subject. Both are
+ * delivered as [ThematicLink] so the caller decides navigation and this stays presentation.
+ *
+ * Parsing is `remember`ed on the raw markup. Without it, every recomposition of an expanded
+ * section re-scans its text — and the longest of these is most of a printed page.
+ */
+@Composable
+fun ThematicText(
+    html: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    onLinkClick: ((ThematicLink) -> Unit)? = null,
+) {
+    val linkStyles = TextLinkStyles(
+        style = SpanStyle(
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Medium,
+        ),
+        pressedStyle = SpanStyle(
+            color = MaterialTheme.colorScheme.primary,
+            textDecoration = TextDecoration.Underline,
+        ),
+    )
+
+    val paragraphs = remember(html, onLinkClick, linkStyles) {
+        ThematicMarkup.parse(html).map { paragraph ->
+            buildAnnotatedString {
+                paragraph.spans.forEach { span ->
+                    val link = span.link
+                    if (link != null && onLinkClick != null) {
+                        withLink(
+                            LinkAnnotation.Clickable(
+                                tag = link.tag,
+                                styles = linkStyles,
+                                linkInteractionListener = { onLinkClick(link) },
+                            )
+                        ) { appendStyled(span.text, span.bold, span.italic) }
+                    } else {
+                        appendStyled(span.text, span.bold, span.italic)
+                    }
+                }
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        paragraphs.forEach { paragraph ->
+            Text(
+                text = paragraph,
+                style = style,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineHeight = 24.sp,
+            )
+        }
+    }
+}
+
+private fun AnnotatedString.Builder.appendStyled(text: String, bold: Boolean, italic: Boolean) {
+    if (!bold && !italic) {
+        append(text)
+        return
+    }
+    withStyle(
+        SpanStyle(
+            fontWeight = if (bold) FontWeight.SemiBold else null,
+            fontStyle = if (italic) FontStyle.Italic else null,
+        )
+    ) { append(text) }
+}
+
+/**
+ * A stable identifier for the destination, used as the annotation tag.
+ *
+ * `LinkAnnotation.Clickable` compares by tag as well as by listener, so two links to different
+ * verses in the same paragraph must not share one.
+ */
+private val ThematicLink.tag: String
+    get() = when (this) {
+        is ThematicLink.Verses -> "quran:$surah:${from ?: 0}-${to ?: 0}"
+        is ThematicLink.Topic -> "topic:$id"
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun ThematicTextPreview() {
+    NimazTheme {
+        ThematicText(
+            html = "<p>This Surah is named <strong>Al-Fatihah</strong> because of its " +
+                "subject matter — see <a href=\"quran:1:1-7\">the opening verses</a>.</p>" +
+                "<p>It is <em>a prayer</em> that Allah has taught to all those who want to " +
+                "make a study of His book.</p>",
+            onLinkClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SurahThematicSections.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SurahThematicSections.kt
@@ -1,0 +1,229 @@
+package com.arshadshah.nimaz.presentation.components.organisms
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Badge
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.util.ThematicLink
+import com.arshadshah.nimaz.domain.model.AyahTheme
+import com.arshadshah.nimaz.domain.model.SurahOverview
+import com.arshadshah.nimaz.domain.model.SurahOverviewGroup
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionTitle
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
+import com.arshadshah.nimaz.presentation.components.molecules.ThematicText
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * A surah's long-form background, as the source's own sections.
+ *
+ * Collapsed by default, and that is not a stylistic choice: the longest of these runs to 47 KB
+ * of prose for one surah, and rendering every section expanded would measure most of a book
+ * chapter to draw a screen whose first fold is three stat cards. The first section opens so the
+ * block never reads as inert.
+ *
+ * The `quran:` links inside the prose are the reason this is worth building at all — the source
+ * says "see 2:153-251" and here that is a tap into the reader, not a reference to copy out.
+ */
+@Composable
+fun SurahBackgroundSections(
+    overview: SurahOverview?,
+    onOpenAyah: (surah: Int, ayah: Int) -> Unit,
+    onOpenTopic: (topicId: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (overview == null || overview.sections.isEmpty()) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        NimazSectionTitle(
+            text = stringResource(R.string.surah_info_background),
+            uppercase = false,
+        )
+        overview.sections.forEachIndexed { index, section ->
+            NimazAccordion(
+                title = section.heading.ifBlank { stringResource(section.group.labelRes) },
+                leadingIcon = section.group.icon,
+                initiallyExpanded = index == 0,
+            ) {
+                ThematicText(
+                    html = section.body,
+                    onLinkClick = { link ->
+                        when (link) {
+                            is ThematicLink.Verses -> onOpenAyah(link.surah, link.from ?: 1)
+                            is ThematicLink.Topic -> onOpenTopic(link.id)
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The surah's passage outline — the mushaf's own division of it into subjects.
+ *
+ * Al-Baqarah has 282 of these, so this is a plain `Column` inside the screen's scroll rather
+ * than a nested `LazyColumn`: a lazy list inside a scrolling parent has unbounded height and
+ * Compose throws on it. The rows are cheap (two `Text`s), and the screen already carries the
+ * overview prose above them.
+ */
+@Composable
+fun SurahPassageOutline(
+    passages: List<AyahTheme>,
+    onOpenAyah: (ayah: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (passages.isEmpty()) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        NimazSectionTitle(
+            text = stringResource(R.string.surah_info_passages),
+            uppercase = false,
+        )
+        Text(
+            text = stringResource(R.string.surah_info_passages_subtitle, passages.size),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        passages.forEach { passage ->
+            PassageRow(passage = passage, onClick = { onOpenAyah(passage.ayahFrom) })
+        }
+    }
+}
+
+@Composable
+private fun PassageRow(passage: AyahTheme, onClick: () -> Unit) {
+    NimazCard(
+        style = NimazCardStyle.FILLED,
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.width(72.dp)) {
+                Text(
+                    text = passage.reference.substringAfter(':'),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = if (passage.isSingleAyah) {
+                        stringResource(R.string.surah_info_passage_verse)
+                    } else {
+                        stringResource(R.string.surah_info_passage_verses, passage.ayahCount)
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = passage.theme,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/**
+ * The icon and fallback label for a section group.
+ *
+ * The fallback matters for exactly two rows in the corpus — the shared note on surahs 113 and
+ * 114, which the source prints with no heading at all — and for any future section whose
+ * heading is blank.
+ */
+private val SurahOverviewGroup.icon: ImageVector
+    get() = when (this) {
+        SurahOverviewGroup.NAME -> Icons.Default.Badge
+        SurahOverviewGroup.REVELATION -> Icons.Default.CalendarMonth
+        SurahOverviewGroup.THEME -> Icons.Default.Lightbulb
+        SurahOverviewGroup.BACKGROUND -> Icons.Default.History
+        SurahOverviewGroup.NOTE -> Icons.Default.Info
+        SurahOverviewGroup.OTHER -> Icons.AutoMirrored.Filled.MenuBook
+    }
+
+private val SurahOverviewGroup.labelRes: Int
+    get() = when (this) {
+        SurahOverviewGroup.NAME -> R.string.surah_info_section_name
+        SurahOverviewGroup.REVELATION -> R.string.surah_info_section_revelation
+        SurahOverviewGroup.THEME -> R.string.surah_info_section_theme
+        SurahOverviewGroup.BACKGROUND -> R.string.surah_info_section_background
+        SurahOverviewGroup.NOTE -> R.string.surah_info_section_note
+        SurahOverviewGroup.OTHER -> R.string.surah_info_about
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun SurahPassageOutlinePreview() {
+    NimazTheme {
+        SurahPassageOutline(
+            passages = listOf(
+                AyahTheme(2, 1, 5, "The Qur'an is guidance for the God-fearing", 5),
+                AyahTheme(2, 8, 16, "Hypocrites and the consequences of hypocrisy", 9),
+            ),
+            onOpenAyah = {},
+        )
+    }
+}
+
+/**
+ * The heading the reader prints where a new passage opens.
+ *
+ * Deliberately quiet — a label and a line of prose, no card and no chevron. It sits between two
+ * verses of scripture, and anything with a container would read as content of the same weight
+ * as what it is annotating.
+ */
+@Composable
+fun PassageHeading(passage: AyahTheme, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = passage.reference,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = passage.theme,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SurahThematicSections.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/SurahThematicSections.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Badge
@@ -38,47 +42,46 @@ import androidx.compose.ui.tooling.preview.Preview
 /**
  * A surah's long-form background, as the source's own sections.
  *
- * Collapsed by default, and that is not a stylistic choice: the longest of these runs to 47 KB
- * of prose for one surah, and rendering every section expanded would measure most of a book
- * chapter to draw a screen whose first fold is three stat cards. The first section opens so the
- * block never reads as inert.
+ * A `LazyListScope` extension rather than a composable, so the caller's list owns the scroll and
+ * each section composes when it scrolls into view. That matters twice over here: the longest
+ * background runs to 47 KB of prose for one surah, and it is followed by an outline of up to 282
+ * rows in the same list.
  *
- * The `quran:` links inside the prose are the reason this is worth building at all — the source
- * says "see 2:153-251" and here that is a tap into the reader, not a reference to copy out.
+ * Collapsed by default for the same reason, with the first section open so the block never reads
+ * as inert. The `quran:` links inside the prose are what make it worth building at all — the
+ * source says "see 2:153-251" and here that is a tap into the reader, not a reference to copy out.
  */
-@Composable
-fun SurahBackgroundSections(
+fun LazyListScope.surahBackgroundSections(
     overview: SurahOverview?,
     onOpenAyah: (surah: Int, ayah: Int) -> Unit,
     onOpenTopic: (topicId: Int) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     if (overview == null || overview.sections.isEmpty()) return
 
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
+    item(key = "background-title") {
         NimazSectionTitle(
             text = stringResource(R.string.surah_info_background),
             uppercase = false,
         )
-        overview.sections.forEachIndexed { index, section ->
-            NimazAccordion(
-                title = section.heading.ifBlank { stringResource(section.group.labelRes) },
-                leadingIcon = section.group.icon,
-                initiallyExpanded = index == 0,
-            ) {
-                ThematicText(
-                    html = section.body,
-                    onLinkClick = { link ->
-                        when (link) {
-                            is ThematicLink.Verses -> onOpenAyah(link.surah, link.from ?: 1)
-                            is ThematicLink.Topic -> onOpenTopic(link.id)
-                        }
-                    },
-                )
-            }
+    }
+    itemsIndexed(
+        items = overview.sections,
+        key = { _, section -> "background-${section.position}" },
+    ) { index, section ->
+        NimazAccordion(
+            title = section.heading.ifBlank { stringResource(section.group.labelRes) },
+            leadingIcon = section.group.icon,
+            initiallyExpanded = index == 0,
+        ) {
+            ThematicText(
+                html = section.body,
+                onLinkClick = { link ->
+                    when (link) {
+                        is ThematicLink.Verses -> onOpenAyah(link.surah, link.from ?: 1)
+                        is ThematicLink.Topic -> onOpenTopic(link.id)
+                    }
+                },
+            )
         }
     }
 }
@@ -86,35 +89,36 @@ fun SurahBackgroundSections(
 /**
  * The surah's passage outline — the mushaf's own division of it into subjects.
  *
- * Al-Baqarah has 282 of these, so this is a plain `Column` inside the screen's scroll rather
- * than a nested `LazyColumn`: a lazy list inside a scrolling parent has unbounded height and
- * Compose throws on it. The rows are cheap (two `Text`s), and the screen already carries the
- * overview prose above them.
+ * Al-Baqarah has 282 of these. As items in the caller's list they compose as they scroll into
+ * view; as a `Column` they would all compose and measure to draw a screen whose first fold is
+ * three stat cards, and a nested `LazyColumn` is not the alternative — a lazy list inside a
+ * scrolling parent has unbounded height and Compose throws on it. Hence a `LazyListScope`
+ * extension: one list, lazily.
  */
-@Composable
-fun SurahPassageOutline(
+fun LazyListScope.surahPassageOutline(
     passages: List<AyahTheme>,
     onOpenAyah: (ayah: Int) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     if (passages.isEmpty()) return
 
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        NimazSectionTitle(
-            text = stringResource(R.string.surah_info_passages),
-            uppercase = false,
-        )
-        Text(
-            text = stringResource(R.string.surah_info_passages_subtitle, passages.size),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        passages.forEach { passage ->
-            PassageRow(passage = passage, onClick = { onOpenAyah(passage.ayahFrom) })
+    item(key = "passages-title") {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            NimazSectionTitle(
+                text = stringResource(R.string.surah_info_passages),
+                uppercase = false,
+            )
+            Text(
+                text = stringResource(R.string.surah_info_passages_subtitle, passages.size),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
+    }
+    items(
+        items = passages,
+        key = { passage -> "passage-${passage.ayahFrom}" },
+    ) { passage ->
+        PassageRow(passage = passage, onClick = { onOpenAyah(passage.ayahFrom) })
     }
 }
 
@@ -189,13 +193,15 @@ private val SurahOverviewGroup.labelRes: Int
 @Composable
 private fun SurahPassageOutlinePreview() {
     NimazTheme {
-        SurahPassageOutline(
-            passages = listOf(
-                AyahTheme(2, 1, 5, "The Qur'an is guidance for the God-fearing", 5),
-                AyahTheme(2, 8, 16, "Hypocrites and the consequences of hypocrisy", 9),
-            ),
-            onOpenAyah = {},
-        )
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            surahPassageOutline(
+                passages = listOf(
+                    AyahTheme(2, 1, 5, "The Qur'an is guidance for the God-fearing", 5),
+                    AyahTheme(2, 8, 16, "Hypocrites and the consequences of hypocrisy", 9),
+                ),
+                onOpenAyah = {},
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContent.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -56,6 +58,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.presentation.components.atoms.NimazChip
+import com.arshadshah.nimaz.presentation.components.atoms.NimazChipVariant
 import com.arshadshah.nimaz.domain.model.TafseerHighlight
 import com.arshadshah.nimaz.domain.model.TafseerSource
 import com.arshadshah.nimaz.domain.model.TafseerText
@@ -184,6 +189,13 @@ fun TafseerPageContent(
     onHighlightUpdated: (highlightId: Long, color: String, note: String?) -> Unit,
     onHighlightDeleted: (highlightId: Long) -> Unit,
     onShare: () -> Unit,
+    /**
+     * The subjects the corpus files this verse under (schemaVersion 24). Shown as chips under
+     * the verse, on the first content page only — they belong to the *verse*, and a block can
+     * span nine of them.
+     */
+    topics: List<QuranTopic> = emptyList(),
+    onTopicClick: (topicId: Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showNotesSheet by remember { mutableStateOf(false) }
@@ -274,6 +286,14 @@ fun TafseerPageContent(
                                         .padding(vertical = 8.dp)
                                 )
                                 QuranOrnamentalDivider()
+                            }
+
+                            if (topics.isNotEmpty()) {
+                                AyahTopicChips(
+                                    topics = topics,
+                                    onTopicClick = onTopicClick,
+                                    modifier = Modifier.padding(bottom = 8.dp)
+                                )
                             }
                         }
 
@@ -913,3 +933,39 @@ private fun TafseerPageContentDarkPreview() {
         TafseerPageContentShowcase()
     }
 }
+
+/**
+ * The subjects a verse is filed under, as chips.
+ *
+ * Capped at six. "Allah" and "Quran" are cited by hundreds of verses each, so a busy verse can
+ * carry a dozen topics and the row would push the commentary itself off the first screen — the
+ * chips are a doorway out of this verse, not the reason to be on it. They are ordered by how
+ * many verses the subject covers, so the six shown are the substantial ones.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AyahTopicChips(
+    topics: List<QuranTopic>,
+    onTopicClick: (topicId: Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.quran_ayah_topics),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 6.dp)
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            topics.take(MAX_AYAH_TOPICS).forEach { topic ->
+                NimazChip(
+                    text = topic.name,
+                    onClick = { onTopicClick(topic.id) },
+                    variant = NimazChipVariant.SUGGESTION
+                )
+            }
+        }
+    }
+}
+
+private const val MAX_AYAH_TOPICS = 6

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveQuranScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveQuranScreen.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 fun AdaptiveQuranScreen(
     navController: NavController,
     onNavigateToSearch: () -> Unit,
+    onNavigateToTopics: () -> Unit,
     onNavigateToBookmarks: () -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToSurahInfo: (Int) -> Unit,
@@ -46,6 +47,7 @@ fun AdaptiveQuranScreen(
         // Phone: Unchanged behavior — delegate to QuranHomeScreen directly
         QuranHomeScreen(
             onNavigateToSearch = onNavigateToSearch,
+            onNavigateToTopics = onNavigateToTopics,
             onNavigateToSurah = { surahNumber ->
                 navController.navigate(Route.QuranReader(surahNumber))
             },
@@ -99,6 +101,7 @@ fun AdaptiveQuranScreen(
                 AnimatedPane {
                     QuranHomeScreen(
                         onNavigateToSearch = onNavigateToSearch,
+                        onNavigateToTopics = onNavigateToTopics,
                         onNavigateToSurah = { surahNumber ->
                             scope.launch {
                                 navigator.navigateTo(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
@@ -122,6 +123,7 @@ fun QuranHomeScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToSurahInfo: (Int) -> Unit = {},
     onNavigateToSearch: () -> Unit = {},
+    onNavigateToTopics: () -> Unit = {},
     onNavigateToQuranAyah: (Int, Int) -> Unit = { surah, ayah -> onNavigateToSurah(surah) },
     onNavigateToKhatam: () -> Unit = {},
     onNavigateToKhatamDetail: (Long) -> Unit = {},
@@ -163,6 +165,15 @@ fun QuranHomeScreen(
                 title = stringResource(R.string.quran_home_title),
                 scrollBehavior = scrollBehavior,
                 actions = {
+                    // Topics — the Qur'an's subject index (schemaVersion 24). It sits beside
+                    // search because it answers the same question from the other end: search
+                    // needs the words a verse uses, this needs only the subject.
+                    IconButton(onClick = onNavigateToTopics) {
+                        NimazIcon(
+                            imageVector = Icons.Default.Category,
+                            contentDescription = stringResource(R.string.quran_topics_title)
+                        )
+                    }
                     // Search icon
                     IconButton(onClick = onNavigateToSearch) {
                         NimazIcon(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
@@ -74,6 +74,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownMenu
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownRow
 import com.arshadshah.nimaz.presentation.components.molecules.SurahHeaderCartouche
 import com.arshadshah.nimaz.presentation.components.organisms.AyahItem
+import com.arshadshah.nimaz.presentation.components.organisms.PassageHeading
 import com.arshadshah.nimaz.presentation.components.organisms.MushafLinePage
 import com.arshadshah.nimaz.presentation.components.organisms.MushafPage
 import com.arshadshah.nimaz.presentation.components.organisms.TajweedLegendSheet
@@ -802,6 +803,13 @@ fun QuranReaderScreen(
                         items = displayAyahs,
                         key = { it.id }
                     ) { ayah ->
+                        // The mushaf's own outline starts a new subject here (schemaVersion 24).
+                        // Printed above the verse it opens on, so reading down the list reads as
+                        // passages rather than as 286 undifferentiated verses.
+                        state.passageStarts[ayah.numberInSurah]?.let { passage ->
+                            PassageHeading(passage = passage)
+                        }
+
                         if (state.readingMode == ReadingMode.JUZ && ayah.id in surahStartIds) {
                             val surah = surahByNumber[ayah.surahNumber]
                             PageSurahSeparator(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicDetailScreen.kt
@@ -1,0 +1,206 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.util.ThematicLink
+import com.arshadshah.nimaz.domain.model.TopicCitation
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionTitle
+import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
+import com.arshadshah.nimaz.presentation.components.molecules.ThematicText
+import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsViewModel
+
+/**
+ * One subject: what it is, where it sits, and every verse that speaks to it.
+ *
+ * The citation list is the whole point — "Allah" cites 153 verses, "Patience" a dozen — so it
+ * is the body of the screen rather than a section buried under prose, and every row opens the
+ * reader at that verse. The description's own `topic:` cross-links navigate here too, which is
+ * what turns 2,512 rows into something you can actually wander through.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuranTopicDetailScreen(
+    topicId: Int,
+    tree: TopicTree,
+    onNavigateBack: () -> Unit,
+    onOpenAyah: (surah: Int, ayah: Int) -> Unit,
+    onOpenTopic: (topicId: Int, tree: TopicTree) -> Unit,
+    viewModel: QuranTopicsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.detailState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(topicId, tree) {
+        viewModel.onEvent(QuranTopicsEvent.LoadDetail(topicId, tree))
+    }
+
+    val detail = state.detail
+
+    NimazScreenScaffold(
+        topBar = {
+            NimazTopAppBar(
+                title = detail?.topic?.name ?: stringResource(R.string.quran_topics_title),
+                subtitle = detail?.breadcrumb
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.joinToString(" › ") { it.name }
+                    ?: detail?.topic?.arabicName?.takeIf { it.isNotBlank() },
+                navigationIcon = {
+                    NimazIconButton(
+                        icon = Icons.AutoMirrored.Filled.ArrowBack,
+                        onClick = onNavigateBack,
+                        contentDescription = stringResource(R.string.cd_back),
+                    )
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.isLoading -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { CircularProgressIndicator() }
+
+            detail == null -> NimazEmptyState(
+                title = stringResource(R.string.quran_topics_no_results_title),
+                message = stringResource(R.string.quran_topic_not_found),
+                icon = Icons.Default.Category,
+                modifier = Modifier
+                    .padding(padding)
+                    .padding(20.dp),
+            )
+
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (detail.topic.hasDescription) {
+                    item(key = "description") {
+                        NimazCard(
+                            style = NimazCardStyle.FILLED,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            ThematicText(
+                                html = detail.topic.description,
+                                modifier = Modifier.padding(16.dp),
+                                onLinkClick = { link ->
+                                    when (link) {
+                                        is ThematicLink.Topic ->
+                                            onOpenTopic(link.id, detail.tree)
+
+                                        is ThematicLink.Verses ->
+                                            onOpenAyah(link.surah, link.from ?: 1)
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+
+                if (detail.children.isNotEmpty()) {
+                    item(key = "subtopics-title") {
+                        NimazSectionTitle(
+                            text = stringResource(R.string.quran_topic_subtopics),
+                            uppercase = false,
+                        )
+                    }
+                    items(detail.children, key = { "child-${it.id}" }) { child ->
+                        NimazMenuItem(
+                            title = child.name,
+                            subtitle = topicVerseCountLabel(child),
+                            icon = Icons.Default.AccountTree,
+                            onClick = { onOpenTopic(child.id, detail.tree) },
+                        )
+                    }
+                }
+
+                if (detail.related.isNotEmpty()) {
+                    item(key = "related-title") {
+                        NimazSectionTitle(
+                            text = stringResource(R.string.quran_topic_related),
+                            uppercase = false,
+                        )
+                    }
+                    items(detail.related, key = { "related-${it.id}" }) { related ->
+                        NimazMenuItem(
+                            title = related.name,
+                            subtitle = topicVerseCountLabel(related),
+                            icon = Icons.Default.Link,
+                            onClick = { onOpenTopic(related.id, detail.tree) },
+                        )
+                    }
+                }
+
+                if (detail.citations.isNotEmpty()) {
+                    item(key = "citations-title") {
+                        Column {
+                            NimazSectionTitle(
+                                text = stringResource(R.string.quran_topic_verses_section),
+                                uppercase = false,
+                            )
+                            Text(
+                                text = topicVerseCountLabel(detail.topic),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    items(detail.citations, key = { "ayah-${it.ayahId}" }) { citation ->
+                        CitationRow(
+                            citation = citation,
+                            onClick = { onOpenAyah(citation.surahNumber, citation.ayahNumber) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CitationRow(citation: TopicCitation, onClick: () -> Unit) {
+    NimazMenuItem(
+        title = citation.reference,
+        subtitle = stringResource(R.string.quran_topic_open_reader),
+        icon = Icons.AutoMirrored.Filled.MenuBook,
+        onClick = onClick,
+    )
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,6 +64,8 @@ fun QuranTopicsScreen(
     viewModel: QuranTopicsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.browseState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) { viewModel.onEvent(QuranTopicsEvent.OpenBrowser) }
 
     BackHandler(enabled = !state.isBrowsingRoots) {
         viewModel.onEvent(QuranTopicsEvent.Ascend)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicsScreen.kt
@@ -1,0 +1,258 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.ListAlt
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
+import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
+import com.arshadshah.nimaz.presentation.components.organisms.NimazPillTabs
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
+import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsViewModel
+
+/**
+ * Browsing the Qur'an's 2,512 subjects — three hierarchies, one screen.
+ *
+ * The tree tabs are not filters over one list; they are three different editors' answers to
+ * "how is the Qur'an organised", and the app keeps all three rather than picking one. Themes
+ * is the curated outline (Doctrine, Stories, The Unseen), Kinds is the ontology (Location,
+ * Living Creation, …), Index is the shape a printed concordance has.
+ *
+ * Descent happens *in place*: the list becomes the children and the top bar grows a breadcrumb.
+ * The system back gesture pops one level before it leaves the screen, which is the behaviour a
+ * list that redraws itself has to have — otherwise back from five levels down exits entirely.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuranTopicsScreen(
+    onNavigateBack: () -> Unit,
+    onOpenTopic: (topicId: Int, tree: TopicTree) -> Unit,
+    viewModel: QuranTopicsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.browseState.collectAsStateWithLifecycle()
+
+    BackHandler(enabled = !state.isBrowsingRoots) {
+        viewModel.onEvent(QuranTopicsEvent.Ascend)
+    }
+
+    NimazScreenScaffold(
+        topBar = {
+            NimazTopAppBar(
+                title = state.current?.name ?: stringResource(R.string.quran_topics_title),
+                subtitle = state.current?.let { topic ->
+                    state.path.dropLast(1).joinToString(" › ") { it.name }
+                        .ifBlank { topic.arabicName.ifBlank { null } }
+                } ?: stringResource(R.string.quran_topics_subtitle),
+                navigationIcon = {
+                    NimazIconButton(
+                        icon = Icons.AutoMirrored.Filled.ArrowBack,
+                        onClick = {
+                            if (state.isBrowsingRoots) {
+                                onNavigateBack()
+                            } else {
+                                viewModel.onEvent(QuranTopicsEvent.Ascend)
+                            }
+                        },
+                        contentDescription = if (state.isBrowsingRoots) {
+                            stringResource(R.string.cd_back)
+                        } else {
+                            stringResource(R.string.cd_topic_up)
+                        },
+                    )
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (!state.isAvailable) {
+                NimazEmptyState(
+                    title = stringResource(R.string.quran_topics_unavailable_title),
+                    message = stringResource(R.string.quran_topics_unavailable),
+                    icon = Icons.Default.Category,
+                    modifier = Modifier.padding(20.dp),
+                )
+                return@Column
+            }
+
+            NimazSearchBar(
+                query = state.searchQuery,
+                onQueryChange = { viewModel.onEvent(QuranTopicsEvent.Search(it)) },
+                onClear = { viewModel.onEvent(QuranTopicsEvent.ClearSearch) },
+                placeholder = stringResource(R.string.quran_topics_search_hint),
+                isLoading = state.isSearching,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            // Searching spans all three hierarchies, so which one is selected stops meaning
+            // anything while a query is live — and a tab row that no longer filters the list
+            // below it is a control that lies.
+            if (state.searchQuery.isBlank()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    NimazPillTabs(
+                        tabs = TREES.map { stringResource(it.second) },
+                        selectedIndex = TREES.indexOfFirst { it.first == state.tree },
+                        onTabSelect = { index ->
+                            viewModel.onEvent(QuranTopicsEvent.SelectTree(TREES[index].first))
+                        },
+                    )
+                }
+            }
+
+            val topics = state.visibleTopics
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+
+                topics.isEmpty() && state.searchQuery.isNotBlank() && !state.isSearching ->
+                    NimazEmptyState(
+                        title = stringResource(R.string.quran_topics_no_results_title),
+                        message = stringResource(
+                            R.string.quran_topics_no_results,
+                            state.searchQuery,
+                        ),
+                        icon = Icons.Default.SearchOff,
+                        modifier = Modifier.padding(20.dp),
+                    )
+
+                else -> LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        horizontal = 16.dp,
+                        vertical = 8.dp,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    items(topics, key = { it.id }) { topic ->
+                        TopicRow(
+                            topic = topic,
+                            tree = state.tree,
+                            searching = state.searchQuery.isNotBlank(),
+                            onOpen = { onOpenTopic(topic.id, state.tree) },
+                            onDescend = { viewModel.onEvent(QuranTopicsEvent.Descend(topic)) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One subject in the list.
+ *
+ * Whether a tap descends or opens is decided by the *data*, not by a chevron the user has to
+ * interpret: a topic with children is a level, a leaf is a destination. A search result always
+ * opens, because a result is an answer and descending from it would discard the search.
+ */
+@Composable
+private fun TopicRow(
+    topic: QuranTopic,
+    tree: TopicTree,
+    searching: Boolean,
+    onOpen: () -> Unit,
+    onDescend: () -> Unit,
+) {
+    val verses = if (topic.ayahCount == 1) {
+        stringResource(R.string.quran_topics_verse)
+    } else {
+        stringResource(R.string.quran_topics_verses, topic.ayahCount)
+    }
+    val subtitle = listOfNotNull(
+        topic.arabicName.takeIf { it.isNotBlank() },
+        verses.takeIf { topic.ayahCount > 0 },
+    ).joinToString(" · ")
+
+    NimazMenuItem(
+        title = topic.name,
+        subtitle = subtitle.ifBlank { null },
+        onClick = if (searching) onOpen else onDescend,
+        trailingIcon = Icons.AutoMirrored.Filled.ArrowForward,
+        icon = when (tree) {
+            TopicTree.THEMATIC -> Icons.Default.AccountTree
+            TopicTree.ONTOLOGY -> Icons.Default.Category
+            TopicTree.INDEX -> Icons.Default.ListAlt
+        },
+    )
+}
+
+/** Tab order, and the label each tree is shown under. */
+private val TREES = listOf(
+    TopicTree.THEMATIC to R.string.quran_topics_tree_thematic,
+    TopicTree.ONTOLOGY to R.string.quran_topics_tree_ontology,
+    TopicTree.INDEX to R.string.quran_topics_tree_index,
+)
+
+/**
+ * A one-line label for a topic, shared by the browser and the ayah sheet.
+ *
+ * Kept here rather than on the model because "3 verses" is a localised string and the domain
+ * layer has no resources.
+ */
+@Composable
+fun topicVerseCountLabel(topic: QuranTopic): String =
+    if (topic.ayahCount == 1) {
+        stringResource(R.string.quran_topics_verse)
+    } else {
+        stringResource(R.string.quran_topics_verses, topic.ayahCount)
+    }
+
+@Composable
+internal fun TopicNameWithCount(topic: QuranTopic, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Text(
+            text = topic.name,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = topicVerseCountLabel(topic),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
@@ -3,11 +3,11 @@ package com.arshadshah.nimaz.presentation.screens.quran
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.MenuBook
@@ -33,8 +33,8 @@ import com.arshadshah.nimaz.presentation.components.molecules.DetailCard
 import com.arshadshah.nimaz.presentation.components.molecules.SurahHeaderCartouche
 import com.arshadshah.nimaz.presentation.components.organisms.BottomActions
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
-import com.arshadshah.nimaz.presentation.components.organisms.SurahBackgroundSections
-import com.arshadshah.nimaz.presentation.components.organisms.SurahPassageOutline
+import com.arshadshah.nimaz.presentation.components.organisms.surahBackgroundSections
+import com.arshadshah.nimaz.presentation.components.organisms.surahPassageOutline
 import com.arshadshah.nimaz.presentation.components.organisms.ThemesList
 import com.arshadshah.nimaz.presentation.viewmodel.QuranEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QuranViewModel
@@ -103,84 +103,94 @@ fun SurahInfoScreen(
         }
     ) { paddingValues ->
         if (surah != null) {
-            Column(
+            // A LazyColumn, not a scrolling Column. Al-Baqarah's passage outline is 282 rows
+            // and its background is 47 KB of prose; a Column composes and measures every one of
+            // them to draw a first fold that is three stat cards.
+            LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 20.dp, vertical = 20.dp),
+                    .padding(paddingValues),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
                 // Surah identity — the same cartouche the reader and list use
-                SurahHeaderCartouche(
-                    surah = surah,
-                    showBismillah = false
-                )
+                item(key = "cartouche") {
+                    SurahHeaderCartouche(
+                        surah = surah,
+                        showBismillah = false
+                    )
+                }
 
                 // Stats row: Verses / Juz / Page
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    DetailCard(
-                        icon = Icons.Default.FormatListNumbered,
-                        label = stringResource(R.string.quran_verses_label),
-                        value = surah.ayahCount.toString(),
-                        modifier = Modifier.weight(1f)
-                    )
-                    DetailCard(
-                        icon = Icons.Default.Layers,
-                        label = stringResource(R.string.quran_juz_label),
-                        value = surah.juzStart.toString(),
-                        modifier = Modifier.weight(1f)
-                    )
-                    DetailCard(
-                        icon = Icons.AutoMirrored.Filled.MenuBook,
-                        label = stringResource(R.string.quran_page_label),
-                        value = surah.startPage.toString(),
-                        modifier = Modifier.weight(1f)
-                    )
+                item(key = "stats") {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        DetailCard(
+                            icon = Icons.Default.FormatListNumbered,
+                            label = stringResource(R.string.quran_verses_label),
+                            value = surah.ayahCount.toString(),
+                            modifier = Modifier.weight(1f)
+                        )
+                        DetailCard(
+                            icon = Icons.Default.Layers,
+                            label = stringResource(R.string.quran_juz_label),
+                            value = surah.juzStart.toString(),
+                            modifier = Modifier.weight(1f)
+                        )
+                        DetailCard(
+                            icon = Icons.AutoMirrored.Filled.MenuBook,
+                            label = stringResource(R.string.quran_page_label),
+                            value = surah.startPage.toString(),
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                 }
 
                 // About This Surah
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    NimazSectionTitle(
-                        text = stringResource(R.string.surah_info_about),
-                        uppercase = false
-                    )
-                    InfoCard(
-                        text = surahInfo?.description
-                            ?: stringResource(R.string.surah_info_description_fallback)
-                    )
+                item(key = "about") {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        NimazSectionTitle(
+                            text = stringResource(R.string.surah_info_about),
+                            uppercase = false
+                        )
+                        InfoCard(
+                            text = surahInfo?.description
+                                ?: stringResource(R.string.surah_info_description_fallback)
+                        )
+                    }
                 }
 
                 // Main Themes
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    NimazSectionTitle(
-                        text = stringResource(R.string.surah_info_main_themes),
-                        uppercase = false
-                    )
-                    ThemesList(
-                        themes = surahInfo?.themes
-                            ?: listOf(
-                                stringResource(R.string.surah_info_theme_guidance),
-                                stringResource(R.string.surah_info_theme_worship),
-                                stringResource(R.string.surah_info_theme_morality),
-                                stringResource(R.string.surah_info_theme_remembrance)
-                            )
-                    )
+                item(key = "themes") {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        NimazSectionTitle(
+                            text = stringResource(R.string.surah_info_main_themes),
+                            uppercase = false
+                        )
+                        ThemesList(
+                            themes = surahInfo?.themes
+                                ?: listOf(
+                                    stringResource(R.string.surah_info_theme_guidance),
+                                    stringResource(R.string.surah_info_theme_worship),
+                                    stringResource(R.string.surah_info_theme_morality),
+                                    stringResource(R.string.surah_info_theme_remembrance)
+                                )
+                        )
+                    }
                 }
 
                 // The long-form background and the passage outline (schemaVersion 24). Both are
-                // absent on an install whose artifact predates them, and both simply do not
-                // render — there is no empty state, because the sections above already answer
+                // absent on an install whose artifact predates them, and both simply contribute
+                // no items — there is no empty state, because the sections above already answer
                 // the screen's question and a placeholder would only advertise a gap.
-                SurahBackgroundSections(
+                surahBackgroundSections(
                     overview = thematic.overview,
                     onOpenAyah = onOpenAyah,
                     onOpenTopic = onOpenTopic
                 )
 
-                SurahPassageOutline(
+                surahPassageOutline(
                     passages = thematic.passages,
                     onOpenAyah = { ayah -> onOpenAyah(surahNumber, ayah) }
                 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
@@ -33,6 +33,8 @@ import com.arshadshah.nimaz.presentation.components.molecules.DetailCard
 import com.arshadshah.nimaz.presentation.components.molecules.SurahHeaderCartouche
 import com.arshadshah.nimaz.presentation.components.organisms.BottomActions
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
+import com.arshadshah.nimaz.presentation.components.organisms.SurahBackgroundSections
+import com.arshadshah.nimaz.presentation.components.organisms.SurahPassageOutline
 import com.arshadshah.nimaz.presentation.components.organisms.ThemesList
 import com.arshadshah.nimaz.presentation.viewmodel.QuranEvent
 import com.arshadshah.nimaz.presentation.viewmodel.QuranViewModel
@@ -43,10 +45,13 @@ fun SurahInfoScreen(
     surahNumber: Int,
     onNavigateBack: () -> Unit,
     onStartReading: () -> Unit,
+    onOpenAyah: (surah: Int, ayah: Int) -> Unit = { _, _ -> },
+    onOpenTopic: (topicId: Int) -> Unit = {},
     viewModel: QuranViewModel = hiltViewModel()
 ) {
     val homeState by viewModel.homeState.collectAsStateWithLifecycle()
     val surahInfo by viewModel.surahInfo.collectAsStateWithLifecycle()
+    val thematic by viewModel.surahThematic.collectAsStateWithLifecycle()
     val audioState by viewModel.audioState.collectAsStateWithLifecycle()
     val surah = homeState.surahs.find { it.number == surahNumber }
 
@@ -164,6 +169,21 @@ fun SurahInfoScreen(
                             )
                     )
                 }
+
+                // The long-form background and the passage outline (schemaVersion 24). Both are
+                // absent on an install whose artifact predates them, and both simply do not
+                // render — there is no empty state, because the sections above already answer
+                // the screen's question and a placeholder would only advertise a gap.
+                SurahBackgroundSections(
+                    overview = thematic.overview,
+                    onOpenAyah = onOpenAyah,
+                    onOpenTopic = onOpenTopic
+                )
+
+                SurahPassageOutline(
+                    passages = thematic.passages,
+                    onOpenAyah = { ayah -> onOpenAyah(surahNumber, ayah) }
+                )
             }
         } else {
             // Loading or surah not found

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
@@ -48,6 +48,7 @@ fun TafseerScreen(
     surahNumber: Int,
     ayahNumber: Int = 1,
     onNavigateBack: () -> Unit,
+    onNavigateToTopic: (topicId: Int) -> Unit = {},
     viewModel: TafseerViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -191,7 +192,9 @@ fun TafseerScreen(
                         onHighlightDeleted = { id ->
                             viewModel.onEvent(TafseerEvent.DeleteHighlight(id))
                         },
-                        onShare = { shareTafseerPdf() }
+                        onShare = { shareTafseerPdf() },
+                        topics = if (isCurrentPage) state.topics else emptyList(),
+                        onTopicClick = onNavigateToTopic
                     )
                 }
             } else {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
@@ -1,0 +1,231 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Browsing and searching the Qur'an's subject hierarchies.
+ *
+ * The browser is a *stack*, not a screen per level. Walking from "Stories" to "Musa" to
+ * "parting of the Red Sea" is three levels of the same list, and the ontology goes five deep —
+ * a route per level would mean five back-stack entries for one act of browsing, and a tree
+ * switch would strand the user halfway down a tree that no longer exists. [TopicBrowseState.path]
+ * holds the descent, [QuranTopicsEvent.Ascend] pops it.
+ *
+ * Search is a separate mode over the same list rather than a separate screen, because a query
+ * that matches nothing should fall back to *where you were*, not to an empty screen.
+ */
+data class TopicBrowseState(
+    val tree: TopicTree = TopicTree.THEMATIC,
+
+    /** The descent from the tree's root. Empty means the roots are showing. */
+    val path: List<QuranTopic> = emptyList(),
+
+    /** What the current level lists — roots, or the children of `path.last()`. */
+    val topics: List<QuranTopic> = emptyList(),
+
+    val searchQuery: String = "",
+    val searchResults: List<QuranTopic> = emptyList(),
+    val isSearching: Boolean = false,
+    val isLoading: Boolean = true,
+
+    /**
+     * Whether this install's artifact carries the thematic layer at all. False means the
+     * migration ran but a schemaVersion 24 artifact has not arrived yet — an explainable
+     * state, not an error.
+     */
+    val isAvailable: Boolean = true,
+) {
+    val current: QuranTopic? get() = path.lastOrNull()
+    val isBrowsingRoots: Boolean get() = path.isEmpty()
+
+    /** What the list should show: search results while a query is live, else the level. */
+    val visibleTopics: List<QuranTopic>
+        get() = if (searchQuery.isBlank()) topics else searchResults
+}
+
+data class TopicDetailState(
+    val detail: TopicDetail? = null,
+    val isLoading: Boolean = true,
+)
+
+sealed interface QuranTopicsEvent {
+    data class SelectTree(val tree: TopicTree) : QuranTopicsEvent
+
+    /** Descend into a topic that has children. */
+    data class Descend(val topic: QuranTopic) : QuranTopicsEvent
+
+    /** Back up one level. Returns false-ish (a no-op) at the roots; the screen pops instead. */
+    data object Ascend : QuranTopicsEvent
+
+    data class Search(val query: String) : QuranTopicsEvent
+    data object ClearSearch : QuranTopicsEvent
+
+    data class LoadDetail(val topicId: Int, val tree: TopicTree) : QuranTopicsEvent
+}
+
+@HiltViewModel
+class QuranTopicsViewModel @Inject constructor(
+    private val quranUseCases: QuranUseCases
+) : ViewModel() {
+
+    private val _browseState = MutableStateFlow(TopicBrowseState())
+    val browseState: StateFlow<TopicBrowseState> = _browseState.asStateFlow()
+
+    private val _detailState = MutableStateFlow(TopicDetailState())
+    val detailState: StateFlow<TopicDetailState> = _detailState.asStateFlow()
+
+    private val queries = MutableStateFlow("")
+
+    init {
+        observeQueries()
+        loadRoots(TopicTree.THEMATIC)
+    }
+
+    fun onEvent(event: QuranTopicsEvent) {
+        when (event) {
+            is QuranTopicsEvent.SelectTree -> {
+                AppAnalytics.logFeatureUsed("quran_topics", "select_tree")
+                selectTree(event.tree)
+            }
+
+            is QuranTopicsEvent.Descend -> {
+                AppAnalytics.logFeatureUsed("quran_topics", "descend")
+                descend(event.topic)
+            }
+
+            QuranTopicsEvent.Ascend -> ascend()
+
+            is QuranTopicsEvent.Search -> {
+                _browseState.update { it.copy(searchQuery = event.query) }
+                queries.value = event.query
+            }
+
+            QuranTopicsEvent.ClearSearch -> {
+                _browseState.update {
+                    it.copy(searchQuery = "", searchResults = emptyList(), isSearching = false)
+                }
+                queries.value = ""
+            }
+
+            is QuranTopicsEvent.LoadDetail -> {
+                AppAnalytics.logFeatureUsed("quran_topics", "open_detail")
+                loadDetail(event.topicId, event.tree)
+            }
+        }
+    }
+
+    /**
+     * Debounced so a query is run once the typing settles, not once per keystroke. Each search
+     * is an FTS walk plus an `IN (…)` over up to 60 ids; at one per character a fast typist
+     * would queue a dozen of them to display the last.
+     */
+    @OptIn(FlowPreview::class)
+    private fun observeQueries() {
+        viewModelScope.launch {
+            queries
+                .debounce(SEARCH_DEBOUNCE_MS)
+                .distinctUntilChanged()
+                .collect { query ->
+                    if (query.isBlank()) {
+                        _browseState.update {
+                            it.copy(searchResults = emptyList(), isSearching = false)
+                        }
+                        return@collect
+                    }
+                    _browseState.update { it.copy(isSearching = true) }
+                    val results = quranUseCases.searchTopics(query)
+                    _browseState.update { state ->
+                        // The query may have been cleared while this was in flight; dropping the
+                        // stale result is what keeps a cleared box from repopulating itself.
+                        if (state.searchQuery.isBlank()) state
+                        else state.copy(searchResults = results, isSearching = false)
+                    }
+                }
+        }
+    }
+
+    private fun selectTree(tree: TopicTree) {
+        if (tree == _browseState.value.tree) return
+        _browseState.update { it.copy(tree = tree, path = emptyList(), isLoading = true) }
+        loadRoots(tree)
+    }
+
+    private fun loadRoots(tree: TopicTree) {
+        viewModelScope.launch {
+            val available = quranUseCases.hasThematicContent()
+            val roots = if (available) quranUseCases.getTopicTreeRoots(tree) else emptyList()
+            _browseState.update {
+                it.copy(topics = roots, isLoading = false, isAvailable = available)
+            }
+        }
+    }
+
+    /**
+     * Descend, but only where there is somewhere to go.
+     *
+     * A topic's children are not known until they are fetched, so this loads first and pushes
+     * the path only when the level is non-empty — otherwise a leaf would push a level that
+     * renders as an empty list with a back button.
+     */
+    private fun descend(topic: QuranTopic) {
+        viewModelScope.launch {
+            _browseState.update { it.copy(isLoading = true) }
+            val tree = _browseState.value.tree
+            val children = quranUseCases.getTopicDetail(topic.id, tree)?.children.orEmpty()
+            _browseState.update { state ->
+                if (children.isEmpty()) {
+                    state.copy(isLoading = false)
+                } else {
+                    state.copy(
+                        path = state.path + topic,
+                        topics = children,
+                        isLoading = false,
+                        searchQuery = "",
+                        searchResults = emptyList(),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun ascend() {
+        val state = _browseState.value
+        if (state.path.isEmpty()) return
+        val path = state.path.dropLast(1)
+        _browseState.update { it.copy(path = path, isLoading = true) }
+        viewModelScope.launch {
+            val level = path.lastOrNull()
+                ?.let { quranUseCases.getTopicDetail(it.id, state.tree)?.children.orEmpty() }
+                ?: quranUseCases.getTopicTreeRoots(state.tree)
+            _browseState.update { it.copy(topics = level, isLoading = false) }
+        }
+    }
+
+    private fun loadDetail(topicId: Int, tree: TopicTree) {
+        viewModelScope.launch {
+            _detailState.update { it.copy(isLoading = true) }
+            val detail = quranUseCases.getTopicDetail(topicId, tree)
+            _detailState.update { TopicDetailState(detail = detail, isLoading = false) }
+        }
+    }
+
+    private companion object {
+        const val SEARCH_DEBOUNCE_MS = 250L
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
@@ -65,6 +65,9 @@ data class TopicDetailState(
 )
 
 sealed interface QuranTopicsEvent {
+    /** The browser is on screen and wants its current level. Idempotent — safe to re-send. */
+    data object OpenBrowser : QuranTopicsEvent
+
     data class SelectTree(val tree: TopicTree) : QuranTopicsEvent
 
     /** Descend into a topic that has children. */
@@ -92,13 +95,24 @@ class QuranTopicsViewModel @Inject constructor(
 
     private val queries = MutableStateFlow("")
 
+    /**
+     * Only the query pipeline. The roots are *not* loaded here.
+     *
+     * Both screens resolve this ViewModel per back-stack entry, and topic detail is reachable
+     * from a topic description's cross-links — so a reader wandering five topics deep would
+     * fire five root queries for a list none of those screens shows. The browser asks for its
+     * own level with [QuranTopicsEvent.OpenBrowser].
+     */
     init {
         observeQueries()
-        loadRoots(TopicTree.THEMATIC)
     }
 
     fun onEvent(event: QuranTopicsEvent) {
         when (event) {
+            QuranTopicsEvent.OpenBrowser -> {
+                if (_browseState.value.topics.isEmpty()) loadRoots(_browseState.value.tree)
+            }
+
             is QuranTopicsEvent.SelectTree -> {
                 AppAnalytics.logFeatureUsed("quran_topics", "select_tree")
                 selectTree(event.tree)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -23,7 +23,9 @@ import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.QuranTranslation
 import com.arshadshah.nimaz.domain.model.ReadingProgress
 import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.AyahTheme
 import com.arshadshah.nimaz.domain.model.SurahInfo
+import com.arshadshah.nimaz.domain.model.SurahOverview
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
 import com.arshadshah.nimaz.domain.model.TranslationLanguage
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -71,6 +73,22 @@ data class FavoriteAyahUi(
     val arabicText: String?,
     val createdAt: Long,
 )
+
+/**
+ * The Qur'an's thematic layer for one surah: its long-form background and its passage outline.
+ *
+ * [isAvailable] separates "this install has no thematic content" from "this surah has none".
+ * Only the first is possible in practice — every surah has an overview and at least one passage
+ * — but an install that upgraded before the schemaVersion 24 artifact arrived has neither, and
+ * the screen says so instead of showing two empty sections.
+ */
+data class SurahThematicUiState(
+    val overview: SurahOverview? = null,
+    val passages: List<AyahTheme> = emptyList(),
+    val isLoading: Boolean = true,
+) {
+    val isAvailable: Boolean get() = overview != null || passages.isNotEmpty()
+}
 
 data class QuranHomeUiState(
     val surahs: List<Surah> = emptyList(),
@@ -137,10 +155,22 @@ data class QuranReaderUiState(
      * pager's bounds come from the edition's real page ranges rather than the count declared
      * on the enum.
      */
-    val pagination: MushafPagination = MushafPagination.fallback(MushafScript.DEFAULT)
+    val pagination: MushafPagination = MushafPagination.fallback(MushafScript.DEFAULT),
+    /**
+     * The passage outline of the surah being read (schemaVersion 24), used to print a heading
+     * where the mushaf's own outline starts a new subject. Empty in juz and page mode, and on
+     * an install whose artifact predates the thematic layer.
+     */
+    val passages: List<AyahTheme> = emptyList()
 ) {
     /** Whether to render stored line-accurate pages instead of flowing ayahs into a page. */
     val useLineAccurateLayout: Boolean get() = mushafScript.isLineAccurate
+
+    /**
+     * Passage headings by the verse number each one opens on, so the list can ask "does a
+     * passage start here" per row instead of scanning 282 ranges for every one of them.
+     */
+    val passageStarts: Map<Int, AyahTheme> by lazy { passages.associateBy { it.ayahFrom } }
 
     /**
      * Language of the active translation — what its prose must be *drawn* in (face, direction
@@ -243,7 +273,50 @@ class QuranViewModel @Inject constructor(
     private val _surahInfo = MutableStateFlow<SurahInfo?>(null)
     val surahInfo: StateFlow<SurahInfo?> = _surahInfo.asStateFlow()
 
+    /**
+     * The surah's long-form background and its passage outline (schemaVersion 24).
+     *
+     * Kept beside [surahInfo] rather than folded into it: they are different content with
+     * different provenance and different sizes — one row of one sentence against ~8 KB of prose
+     * per surah — and the surah *list* reads the first for 114 rows and must never touch the
+     * second.
+     */
+    private val _surahThematic = MutableStateFlow(SurahThematicUiState())
+    val surahThematic: StateFlow<SurahThematicUiState> = _surahThematic.asStateFlow()
+
     val audioState: StateFlow<AudioState> = audioManager.audioState
+
+    /**
+     * The passage outline for the surah the reader is on, so the verse list can print a heading
+     * where the mushaf's own outline starts a new subject.
+     *
+     * Surah mode only, and deliberately: a juz spans up to a dozen surahs and a page can span
+     * two, so covering them would mean a query per surah on every page turn to label a boundary
+     * that mode rarely crosses. Surah mode is where a reader is reading *through* something,
+     * which is the case a passage heading is for.
+     */
+    private fun loadReaderPassages(surahNumber: Int) {
+        passagesJob?.cancel()
+        passagesJob = viewModelScope.launch {
+            val passages = quranUseCases.getSurahThemes(surahNumber)
+            _readerState.update { state ->
+                // A slower load for a surah the reader has since left must not repaint headings
+                // over a different surah's verses.
+                if (readerTarget != ReaderTarget.Surah(surahNumber)) state
+                else state.copy(passages = passages)
+            }
+        }
+    }
+
+    private var passagesJob: Job? = null
+
+    /**
+     * One job for the info screen's thematic load, cancelled when a different surah asks.
+     *
+     * The screen is reachable from the surah list, from a deep link and from the reader, so two
+     * surahs can be requested in quick succession — without this, the slower of the two wins.
+     */
+    private var surahThematicJob: Job? = null
 
     // Debounced search support
     private val searchQueryFlow = MutableStateFlow("")
@@ -587,6 +660,28 @@ class QuranViewModel @Inject constructor(
         viewModelScope.launch {
             _surahInfo.value = quranUseCases.getSurahInfo(surahNumber)
         }
+        loadSurahThematic(surahNumber)
+    }
+
+    /**
+     * The background and passage outline, in one job.
+     *
+     * Both come from the same artifact and are shown on the same screen, so loading them
+     * separately would only buy two spinners that finish at the same time. A surah whose
+     * overview is absent is not an error — see [SurahThematicUiState.isAvailable].
+     */
+    private fun loadSurahThematic(surahNumber: Int) {
+        surahThematicJob?.cancel()
+        surahThematicJob = viewModelScope.launch {
+            _surahThematic.value = SurahThematicUiState(isLoading = true)
+            val overview = quranUseCases.getSurahOverview(surahNumber)
+            val themes = quranUseCases.getSurahThemes(surahNumber)
+            _surahThematic.value = SurahThematicUiState(
+                overview = overview,
+                passages = themes,
+                isLoading = false,
+            )
+        }
     }
 
     private fun playSurahFromInfo(surahNumber: Int) {
@@ -729,9 +824,11 @@ class QuranViewModel @Inject constructor(
                 surahWithAyahs = null,
                 ayahs = emptyList(),
                 title = "",
-                subtitle = ""
+                subtitle = "",
+                passages = emptyList()
             )
         }
+        loadReaderPassages(surahNumber)
         contentJob?.cancel()
         cancelPageJobs()
         contentJob = viewModelScope.launch {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.TafseerHighlight
 import com.arshadshah.nimaz.domain.model.TafseerNote
 import com.arshadshah.nimaz.domain.model.TafseerSource
@@ -36,7 +37,15 @@ data class TafseerUiState(
     val isLoading: Boolean = true,
     // Sources whose seed data actually has non-empty text for the current ayah.
     // Used to recommend an alternate source when the selected one has no content.
-    val availableSources: Set<TafseerSource> = emptySet()
+    val availableSources: Set<TafseerSource> = emptySet(),
+    /**
+     * The subjects the corpus files this verse under (schemaVersion 24) — busiest first.
+     *
+     * The commentary screen is where a reader is studying one verse, which is exactly where
+     * "what else does the Qur'an say about this" is the next question. Empty for a verse no
+     * topic cites, and on an install whose artifact predates the topic index.
+     */
+    val topics: List<QuranTopic> = emptyList()
 )
 
 sealed interface TafseerEvent {
@@ -190,7 +199,10 @@ class TafseerViewModel @Inject constructor(
             _state.value = _state.value.copy(
                 currentTafseer = tafseer,
                 currentTafseerPage = if (sameBlock) _state.value.currentTafseerPage else 0,
-                availableSources = available
+                availableSources = available,
+                // Keyed on the verse, not the block: a block can span nine verses and the
+                // subjects the corpus files 43:81 under are not the ones it files 43:89 under.
+                topics = quranUseCases.getTopicsForAyah(ayah.id)
             )
 
             if (tafseer != null) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -994,6 +994,38 @@
     <string name="surah_info_theme_worship">Anbetung</string>
     <string name="surah_info_theme_morality">Moral</string>
     <string name="surah_info_theme_remembrance">Gedenken</string>
+    <!-- Surah-Info-Bildschirm — die thematische Ebene (schemaVersion 24) -->
+    <string name="surah_info_background">Hintergrund</string>
+    <string name="surah_info_passages">Abschnitte</string>
+    <string name="surah_info_passages_subtitle">%1$d Abschnitte in dieser Surah</string>
+    <string name="surah_info_section_name">Name</string>
+    <string name="surah_info_section_revelation">Offenbarungszeit</string>
+    <string name="surah_info_section_theme">Thema und Inhalt</string>
+    <string name="surah_info_section_background">Historischer Hintergrund</string>
+    <string name="surah_info_section_note">Hinweis</string>
+    <string name="surah_info_passage_verses">%1$d Verse</string>
+    <string name="surah_info_passage_verse">1 Vers</string>
+
+    <!-- Quran-Themen -->
+    <string name="quran_topics_title">Themen</string>
+    <string name="quran_topics_subtitle">Wovon der Koran spricht</string>
+    <string name="quran_topics_search_hint">Themen suchen…</string>
+    <string name="quran_topics_tree_thematic">Themen</string>
+    <string name="quran_topics_tree_ontology">Arten</string>
+    <string name="quran_topics_tree_index">Register</string>
+    <string name="quran_topics_verses">%1$d Verse</string>
+    <string name="quran_topics_verse">1 Vers</string>
+    <string name="quran_topics_no_results_title">Keine Treffer</string>
+    <string name="quran_topics_no_results">Kein Thema passt zu „%1$s“. Versuchen Sie ein kürzeres Wort — das Register findet ganze Wörter, keine Wortteile.</string>
+    <string name="quran_topics_unavailable_title">Themen sind noch nicht verfügbar</string>
+    <string name="quran_topics_unavailable">Die Koran-Inhalte dieser Installation sind älter als das Themenregister. Es kommt mit der nächsten Inhaltsaktualisierung — Sie müssen nichts tun.</string>
+    <string name="quran_topic_verses_section">Verse zu diesem Thema</string>
+    <string name="quran_topic_subtopics">Unterthemen</string>
+    <string name="quran_topic_related">Verwandte Themen</string>
+    <string name="quran_topic_not_found">Dieses Thema steht nicht im Register.</string>
+    <string name="quran_topic_open_reader">Im Leser öffnen</string>
+    <string name="cd_topic_up">Eine Ebene höher</string>
+    <string name="quran_ayah_topics">Themen</string>
     <string name="cd_switch_to_list_view">Zur Listenansicht wechseln</string>
     <string name="cd_switch_to_page_view">Zur Seitenansicht wechseln</string>
     <string name="quran_continue_next_surah">Zur nächsten Surah fortfahren</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1016,6 +1016,38 @@
     <string name="surah_info_theme_worship">Adoration</string>
     <string name="surah_info_theme_morality">Moralité</string>
     <string name="surah_info_theme_remembrance">Rappel</string>
+    <!-- Écran d\'information sur la sourate — la couche thématique (schemaVersion 24) -->
+    <string name="surah_info_background">Contexte</string>
+    <string name="surah_info_passages">Passages</string>
+    <string name="surah_info_passages_subtitle">%1$d passages dans cette sourate</string>
+    <string name="surah_info_section_name">Nom</string>
+    <string name="surah_info_section_revelation">Période de révélation</string>
+    <string name="surah_info_section_theme">Thème et contenu</string>
+    <string name="surah_info_section_background">Contexte historique</string>
+    <string name="surah_info_section_note">Note</string>
+    <string name="surah_info_passage_verses">%1$d versets</string>
+    <string name="surah_info_passage_verse">1 verset</string>
+
+    <!-- Thèmes du Coran -->
+    <string name="quran_topics_title">Thèmes</string>
+    <string name="quran_topics_subtitle">Ce dont parle le Coran</string>
+    <string name="quran_topics_search_hint">Rechercher un sujet…</string>
+    <string name="quran_topics_tree_thematic">Thèmes</string>
+    <string name="quran_topics_tree_ontology">Catégories</string>
+    <string name="quran_topics_tree_index">Index</string>
+    <string name="quran_topics_verses">%1$d versets</string>
+    <string name="quran_topics_verse">1 verset</string>
+    <string name="quran_topics_no_results_title">Aucun résultat</string>
+    <string name="quran_topics_no_results">Aucun sujet ne correspond à «\u00A0%1$s\u00A0». Essayez un mot plus court — l\'index cherche des mots entiers, pas des fragments.</string>
+    <string name="quran_topics_unavailable_title">Les thèmes ne sont pas encore là</string>
+    <string name="quran_topics_unavailable">Le contenu coranique de cette installation est antérieur à l\'index thématique. Il arrivera avec la prochaine mise à jour du contenu — rien à faire.</string>
+    <string name="quran_topic_verses_section">Versets sur ce sujet</string>
+    <string name="quran_topic_subtopics">Sous-thèmes</string>
+    <string name="quran_topic_related">Sujets liés</string>
+    <string name="quran_topic_not_found">Ce sujet ne figure pas dans l\'index.</string>
+    <string name="quran_topic_open_reader">Ouvrir dans le lecteur</string>
+    <string name="cd_topic_up">Remonter d\'un niveau</string>
+    <string name="quran_ayah_topics">Thèmes</string>
     <string name="cd_switch_to_list_view">Passer à la vue liste</string>
     <string name="cd_switch_to_page_view">Passer à la vue page</string>
     <string name="quran_continue_next_surah">Continuer vers la sourate suivante</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -977,6 +977,38 @@
     <string name="surah_info_theme_worship">Ibadah</string>
     <string name="surah_info_theme_morality">Akhlak</string>
     <string name="surah_info_theme_remembrance">Zikir</string>
+    <!-- Layar Info Surah — lapisan tematik (schemaVersion 24) -->
+    <string name="surah_info_background">Latar Belakang</string>
+    <string name="surah_info_passages">Bagian</string>
+    <string name="surah_info_passages_subtitle">%1$d bagian dalam surah ini</string>
+    <string name="surah_info_section_name">Nama</string>
+    <string name="surah_info_section_revelation">Masa Pewahyuan</string>
+    <string name="surah_info_section_theme">Tema dan Pokok Bahasan</string>
+    <string name="surah_info_section_background">Latar Belakang Sejarah</string>
+    <string name="surah_info_section_note">Catatan</string>
+    <string name="surah_info_passage_verses">%1$d ayat</string>
+    <string name="surah_info_passage_verse">1 ayat</string>
+
+    <!-- Topik Al-Quran -->
+    <string name="quran_topics_title">Topik</string>
+    <string name="quran_topics_subtitle">Apa yang dibicarakan Al-Quran</string>
+    <string name="quran_topics_search_hint">Cari topik…</string>
+    <string name="quran_topics_tree_thematic">Tema</string>
+    <string name="quran_topics_tree_ontology">Jenis</string>
+    <string name="quran_topics_tree_index">Indeks</string>
+    <string name="quran_topics_verses">%1$d ayat</string>
+    <string name="quran_topics_verse">1 ayat</string>
+    <string name="quran_topics_no_results_title">Tidak ada yang cocok</string>
+    <string name="quran_topics_no_results">Tidak ada topik yang cocok dengan “%1$s”. Coba kata yang lebih pendek — indeks mencocokkan kata utuh, bukan potongan.</string>
+    <string name="quran_topics_unavailable_title">Topik belum tersedia</string>
+    <string name="quran_topics_unavailable">Konten Al-Quran pada pemasangan ini lebih lama daripada indeks topik. Indeks akan hadir pada pembaruan konten berikutnya — tidak ada yang perlu dilakukan.</string>
+    <string name="quran_topic_verses_section">Ayat tentang topik ini</string>
+    <string name="quran_topic_subtopics">Subtopik</string>
+    <string name="quran_topic_related">Topik terkait</string>
+    <string name="quran_topic_not_found">Topik ini tidak ada dalam indeks.</string>
+    <string name="quran_topic_open_reader">Buka di pembaca</string>
+    <string name="cd_topic_up">Naik satu tingkat</string>
+    <string name="quran_ayah_topics">Topik</string>
     <string name="cd_switch_to_list_view">Beralih ke tampilan daftar</string>
     <string name="cd_switch_to_page_view">Beralih ke tampilan halaman</string>
     <string name="quran_continue_next_surah">Lanjutkan ke surah berikutnya</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -978,6 +978,38 @@
     <string name="surah_info_theme_worship">Ibadah</string>
     <string name="surah_info_theme_morality">Akhlak</string>
     <string name="surah_info_theme_remembrance">Zikir</string>
+    <!-- Skrin Maklumat Surah — lapisan tematik (schemaVersion 24) -->
+    <string name="surah_info_background">Latar Belakang</string>
+    <string name="surah_info_passages">Bahagian</string>
+    <string name="surah_info_passages_subtitle">%1$d bahagian dalam surah ini</string>
+    <string name="surah_info_section_name">Nama</string>
+    <string name="surah_info_section_revelation">Tempoh Penurunan</string>
+    <string name="surah_info_section_theme">Tema dan Perkara Utama</string>
+    <string name="surah_info_section_background">Latar Belakang Sejarah</string>
+    <string name="surah_info_section_note">Nota</string>
+    <string name="surah_info_passage_verses">%1$d ayat</string>
+    <string name="surah_info_passage_verse">1 ayat</string>
+
+    <!-- Topik Al-Quran -->
+    <string name="quran_topics_title">Topik</string>
+    <string name="quran_topics_subtitle">Apa yang diperkatakan Al-Quran</string>
+    <string name="quran_topics_search_hint">Cari topik…</string>
+    <string name="quran_topics_tree_thematic">Tema</string>
+    <string name="quran_topics_tree_ontology">Jenis</string>
+    <string name="quran_topics_tree_index">Indeks</string>
+    <string name="quran_topics_verses">%1$d ayat</string>
+    <string name="quran_topics_verse">1 ayat</string>
+    <string name="quran_topics_no_results_title">Tiada padanan</string>
+    <string name="quran_topics_no_results">Tiada topik sepadan dengan “%1$s”. Cuba perkataan yang lebih pendek — indeks memadankan perkataan penuh, bukan cebisan.</string>
+    <string name="quran_topics_unavailable_title">Topik belum tersedia</string>
+    <string name="quran_topics_unavailable">Kandungan Al-Quran pemasangan ini lebih awal daripada indeks topik. Ia akan tiba dengan kemas kini kandungan seterusnya — tiada apa perlu dilakukan.</string>
+    <string name="quran_topic_verses_section">Ayat tentang topik ini</string>
+    <string name="quran_topic_subtopics">Subtopik</string>
+    <string name="quran_topic_related">Topik berkaitan</string>
+    <string name="quran_topic_not_found">Topik ini tiada dalam indeks.</string>
+    <string name="quran_topic_open_reader">Buka dalam pembaca</string>
+    <string name="cd_topic_up">Naik satu peringkat</string>
+    <string name="quran_ayah_topics">Topik</string>
     <string name="cd_switch_to_list_view">Tukar ke paparan senarai</string>
     <string name="cd_switch_to_page_view">Tukar ke paparan halaman</string>
     <string name="quran_continue_next_surah">Teruskan ke surah seterusnya</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1000,6 +1000,38 @@
     <string name="surah_info_theme_worship">İbadet</string>
     <string name="surah_info_theme_morality">Ahlak</string>
     <string name="surah_info_theme_remembrance">Zikir</string>
+    <!-- Sure Bilgisi ekranı — tematik katman (schemaVersion 24) -->
+    <string name="surah_info_background">Arka Plan</string>
+    <string name="surah_info_passages">Bölümler</string>
+    <string name="surah_info_passages_subtitle">Bu surede %1$d bölüm</string>
+    <string name="surah_info_section_name">Adı</string>
+    <string name="surah_info_section_revelation">İniş Dönemi</string>
+    <string name="surah_info_section_theme">Konu ve İçerik</string>
+    <string name="surah_info_section_background">Tarihsel Arka Plan</string>
+    <string name="surah_info_section_note">Not</string>
+    <string name="surah_info_passage_verses">%1$d ayet</string>
+    <string name="surah_info_passage_verse">1 ayet</string>
+
+    <!-- Kur\'an konuları -->
+    <string name="quran_topics_title">Konular</string>
+    <string name="quran_topics_subtitle">Kur\'an neden söz ediyor</string>
+    <string name="quran_topics_search_hint">Konu ara…</string>
+    <string name="quran_topics_tree_thematic">Temalar</string>
+    <string name="quran_topics_tree_ontology">Türler</string>
+    <string name="quran_topics_tree_index">Dizin</string>
+    <string name="quran_topics_verses">%1$d ayet</string>
+    <string name="quran_topics_verse">1 ayet</string>
+    <string name="quran_topics_no_results_title">Eşleşme yok</string>
+    <string name="quran_topics_no_results">“%1$s” ile eşleşen konu yok. Daha kısa bir sözcük deneyin — dizin sözcük parçalarını değil, tam sözcükleri eşleştirir.</string>
+    <string name="quran_topics_unavailable_title">Konular henüz burada değil</string>
+    <string name="quran_topics_unavailable">Bu kurulumun Kur\'an içeriği konu dizininden eski. Dizin bir sonraki içerik güncellemesiyle gelecek — yapmanız gereken bir şey yok.</string>
+    <string name="quran_topic_verses_section">Bu konudaki ayetler</string>
+    <string name="quran_topic_subtopics">Alt konular</string>
+    <string name="quran_topic_related">İlgili konular</string>
+    <string name="quran_topic_not_found">Bu konu dizinde yok.</string>
+    <string name="quran_topic_open_reader">Okuyucuda aç</string>
+    <string name="cd_topic_up">Bir üst düzeye</string>
+    <string name="quran_ayah_topics">Konular</string>
     <string name="cd_switch_to_list_view">Liste görünümüne geç</string>
     <string name="cd_switch_to_page_view">Sayfa görünümüne geç</string>
     <string name="quran_continue_next_surah">Sonraki sureye geç</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1249,6 +1249,39 @@
     <string name="surah_info_theme_morality">Morality</string>
     <string name="surah_info_theme_remembrance">Remembrance</string>
 
+    <!-- Surah Info Screen — the thematic layer (schemaVersion 24) -->
+    <string name="surah_info_background">Background</string>
+    <string name="surah_info_passages">Passages</string>
+    <string name="surah_info_passages_subtitle">%1$d passages in this surah</string>
+    <string name="surah_info_section_name">Name</string>
+    <string name="surah_info_section_revelation">Period of Revelation</string>
+    <string name="surah_info_section_theme">Theme and Subject Matter</string>
+    <string name="surah_info_section_background">Historical Background</string>
+    <string name="surah_info_section_note">Note</string>
+    <string name="surah_info_passage_verses">%1$d verses</string>
+    <string name="surah_info_passage_verse">1 verse</string>
+
+    <!-- Quran topics -->
+    <string name="quran_topics_title">Topics</string>
+    <string name="quran_topics_subtitle">What the Qur\'an speaks about</string>
+    <string name="quran_topics_search_hint">Search subjects…</string>
+    <string name="quran_topics_tree_thematic">Themes</string>
+    <string name="quran_topics_tree_ontology">Kinds</string>
+    <string name="quran_topics_tree_index">Index</string>
+    <string name="quran_topics_verses">%1$d verses</string>
+    <string name="quran_topics_verse">1 verse</string>
+    <string name="quran_topics_no_results_title">Nothing matched</string>
+    <string name="quran_topics_no_results">No subject matches “%1$s”. Try a shorter word — the index matches whole words, not fragments.</string>
+    <string name="quran_topics_unavailable_title">Topics aren\'t here yet</string>
+    <string name="quran_topics_unavailable">This install\'s Qur\'an content predates the topic index. It arrives with the next content update — nothing to do.</string>
+    <string name="quran_topic_verses_section">Verses on this subject</string>
+    <string name="quran_topic_subtopics">Subtopics</string>
+    <string name="quran_topic_related">Related subjects</string>
+    <string name="quran_topic_not_found">This subject isn\'t in the index.</string>
+    <string name="quran_topic_open_reader">Open in reader</string>
+    <string name="cd_topic_up">Up one level</string>
+    <string name="quran_ayah_topics">Topics</string>
+
     <!-- Quran Reader Screen -->
     <string name="cd_switch_to_list_view">Switch to list view</string>
     <string name="cd_switch_to_page_view">Switch to page view</string>

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/ThematicMarkupTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/ThematicMarkupTest.kt
@@ -1,0 +1,152 @@
+package com.arshadshah.nimaz.core.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The scanner over the thematic layer's four-tag dialect.
+ *
+ * The cases that matter are the ones a device can actually be handed: the dialect as the corpus
+ * emits it, and everything the scanner has to survive *outside* it — because a mis-parsed
+ * paragraph must degrade to plain text, never to a screen that will not open.
+ */
+class ThematicMarkupTest {
+
+    @Test
+    fun `splits on paragraphs`() {
+        val paragraphs = ThematicMarkup.parse("<p>One.</p><p>Two.</p>")
+
+        assertEquals(2, paragraphs.size)
+        assertEquals("One.", paragraphs[0].text)
+        assertEquals("Two.", paragraphs[1].text)
+    }
+
+    @Test
+    fun `carries bold and italic through as spans`() {
+        val spans = ThematicMarkup
+            .parse("<p>A <strong>bold</strong> and <em>italic</em> word.</p>")
+            .single()
+            .spans
+
+        assertEquals("bold", spans.single { it.bold }.text)
+        assertEquals("italic", spans.single { it.italic }.text)
+    }
+
+    @Test
+    fun `resolves a verse range link`() {
+        val span = ThematicMarkup
+            .parse("""<p>See <a href="quran:2:153-251">these verses</a>.</p>""")
+            .single()
+            .spans
+            .single { it.link != null }
+
+        assertEquals("these verses", span.text)
+        assertEquals(ThematicLink.Verses(2, 153, 251), span.link)
+    }
+
+    @Test
+    fun `a single-verse link reports the same start and end`() {
+        assertEquals(ThematicLink.Verses(2, 255, 255), ThematicMarkup.linkOf("quran:2:255"))
+    }
+
+    @Test
+    fun `a whole-surah link has no verses`() {
+        assertEquals(ThematicLink.Verses(2, null, null), ThematicMarkup.linkOf("quran:2"))
+    }
+
+    @Test
+    fun `resolves a topic link`() {
+        assertEquals(ThematicLink.Topic(61), ThematicMarkup.linkOf("topic:61"))
+    }
+
+    @Test
+    fun `refuses a surah that does not exist`() {
+        assertNull(ThematicMarkup.linkOf("quran:115"))
+        assertNull(ThematicMarkup.linkOf("quran:0"))
+    }
+
+    @Test
+    fun `refuses a scheme the app has no screen for`() {
+        assertNull(ThematicMarkup.linkOf("https://example.com"))
+        assertNull(ThematicMarkup.linkOf("hadith:1:2"))
+    }
+
+    /**
+     * The corpus cannot contain one — `thematic.sections-dialect` blocks the build — but a
+     * future corpus could, and the failure mode has to be a missing style rather than markup
+     * printed in the middle of a sentence.
+     */
+    @Test
+    fun `an unknown tag loses its markup and keeps its text`() {
+        val paragraph = ThematicMarkup.parse("<p>A <span class=\"ar\">word</span> here.</p>").single()
+
+        assertEquals("A word here.", paragraph.text)
+        assertTrue(paragraph.spans.none { it.bold || it.italic })
+    }
+
+    @Test
+    fun `an anchor with no resolvable target keeps its text and loses its link`() {
+        val paragraph = ThematicMarkup
+            .parse("""<p>See <a href="quran:900">nothing</a>.</p>""")
+            .single()
+
+        assertEquals("See nothing.", paragraph.text)
+        assertTrue(paragraph.spans.all { it.link == null })
+    }
+
+    @Test
+    fun `unclosed tags do not run off the end`() {
+        val paragraph = ThematicMarkup.parse("<p>Still <strong>readable").single()
+
+        assertEquals("Still readable", paragraph.text)
+    }
+
+    @Test
+    fun `text outside a paragraph is still a paragraph`() {
+        assertEquals("Loose text.", ThematicMarkup.parse("Loose text.").single().text)
+    }
+
+    @Test
+    fun `blank and whitespace-only input produce nothing`() {
+        assertTrue(ThematicMarkup.parse("").isEmpty())
+        assertTrue(ThematicMarkup.parse("   ").isEmpty())
+        assertTrue(ThematicMarkup.parse("<p></p><p>  </p>").isEmpty())
+    }
+
+    @Test
+    fun `decodes the entities the source escapes`() {
+        assertEquals("Ibrahim &amp; Musa", ThematicMarkup.parse("<p>Ibrahim &amp;amp; Musa</p>").single().text)
+        assertEquals("a < b", ThematicMarkup.parse("<p>a &lt; b</p>").single().text)
+    }
+
+    @Test
+    fun `plain flattens paragraphs for a preview line`() {
+        assertEquals(
+            "One.\n\nTwo.",
+            ThematicMarkup.plain("<p>One.</p><p><strong>Two.</strong></p>"),
+        )
+    }
+
+    /**
+     * Two links in one paragraph must stay two destinations. They are rendered with a tag
+     * derived from the link, and a shared tag would make the second open the first.
+     */
+    @Test
+    fun `two links in one paragraph resolve independently`() {
+        val links = ThematicMarkup
+            .parse(
+                """<p>Compare <a href="quran:2:1-5">these</a> with """ +
+                    """<a href="quran:9:1">those</a>.</p>"""
+            )
+            .single()
+            .spans
+            .mapNotNull { it.link }
+
+        assertEquals(
+            listOf(ThematicLink.Verses(2, 1, 5), ThematicLink.Verses(9, 1, 1)),
+            links,
+        )
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/corpus/DeviceStateCorpusTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/corpus/DeviceStateCorpusTest.kt
@@ -96,6 +96,8 @@ class DeviceStateCorpusTest {
 
                 assertThat(userVersion(db)).isEqualTo(NIMAZ_DATABASE_VERSION)
 
+                assertThematicLayerIsWholeOrAbsent(db)
+
                 // Absent or blank means "just assert" — the harness role is opt-in, so the
                 // suite stays a fast regression check on CI and only writes 147 MB on demand.
                 System.getProperty(OUT_PROPERTY)
@@ -119,6 +121,46 @@ class DeviceStateCorpusTest {
             .allowMainThreadQueries()
             .build()
             .also { it.openHelper.writableDatabase }
+    }
+
+    /**
+     * The thematic layer arrives whole or not at all.
+     *
+     * It cannot be in [CONTENT_TABLES]: `MIGRATION_23_24` creates its five tables on every
+     * device and the rows only arrive with a schemaVersion 24 artifact, so between the app
+     * bumping and the content release landing they are legitimately empty — and asserting
+     * non-empty would make the app's own PR red on a fact about a file in another repository.
+     *
+     * What is *not* legitimate is a partial one. The five tables are one release: a citation
+     * list with no topics to name, or an outline with no overviews beside it, is an artifact
+     * built from a half-imported corpus. So the assertion is conditional on the layer being
+     * present at all, and engages by itself the moment `data.lock.json` points at an artifact
+     * that carries it.
+     */
+    private fun assertThematicLayerIsWholeOrAbsent(db: NimazDatabase) {
+        val counts = THEMATIC_TABLES.associateWith { rowCount(db, it) }
+        if (counts.values.all { it == 0 }) return
+        for ((table, rows) in counts) {
+            assertThat("$table=$rows").isNotEqualTo("$table=0")
+        }
+        // Every verse a topic cites has to be a verse the corpus has, or the topic screen
+        // opens the reader on nothing.
+        assertThat(
+            scalar(
+                db,
+                "SELECT COUNT(*) FROM quran_topic_ayahs ta " +
+                    "LEFT JOIN ayahs a ON a.id = ta.ayah_id WHERE a.id IS NULL"
+            )
+        ).isEqualTo(0)
+        // And every overview section belongs to an overview.
+        assertThat(
+            scalar(
+                db,
+                "SELECT COUNT(*) FROM surah_overview_sections s " +
+                    "LEFT JOIN surah_overviews o ON o.surah_number = s.surah_number " +
+                    "WHERE o.surah_number IS NULL"
+            )
+        ).isEqualTo(0)
     }
 
     private fun contentRowCounts(db: NimazDatabase): Map<String, Int> =
@@ -197,6 +239,19 @@ class DeviceStateCorpusTest {
             "qaida_letters",
             "qaida_cells",
             "qaida_lines",
+        )
+
+        /**
+         * The Qur'an's thematic layer (schemaVersion 24) — apparatus, not scripture. Held apart
+         * from [CONTENT_TABLES] because "empty" is a valid state for it until the matching
+         * content release lands; see `assertThematicLayerIsWholeOrAbsent`.
+         */
+        val THEMATIC_TABLES = listOf(
+            "surah_overviews",
+            "surah_overview_sections",
+            "ayah_themes",
+            "quran_topics",
+            "quran_topic_ayahs",
         )
 
         /**

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -30,7 +30,12 @@ flowchart LR
 
     subgraph Q["Quran"]
         QuranHub --> QuranReader & QuranPage & QuranJuz & QuranSearch & QuranBookmarks
+        QuranHub --> QuranTopics
         QuranReader --> SurahInfo & Tafseer
+        QuranTopics --> QuranTopicDetail
+        SurahInfo --> QuranTopicDetail
+        Tafseer --> QuranTopicDetail
+        QuranTopicDetail --> QuranTopicDetail
         SettingsQuran --> SelectReciter & SelectTranslation
     end
 
@@ -163,6 +168,8 @@ All routes live in `core/navigation/Routes.kt` and are wired in `core/navigation
 | `QuranBookmarks` | — | QuranBookmarksScreen |
 | `SurahInfo` | `surahNumber: Int` | SurahInfoScreen |
 | `Tafseer` | `surahNumber: Int, ayahNumber: Int = 1` | TafseerScreen |
+| `QuranTopics` | — | QuranTopicsScreen — the subject browser. **One route for the whole descent:** the ontology goes five levels deep and `QuranTopicsViewModel` holds the path, so browsing down and back is one back-stack entry, not five |
+| `QuranTopicDetail` | `topicId: Int, tree: String = "thematic"` | QuranTopicDetailScreen. `tree` is a `TopicTree.wire` value rather than the enum, because a route argument needs a `NavType`; an unrecognised value falls back to the thematic tree. Reachable from the browser, from a `topic:` link in a surah's background, from the Tafseer screen's topic chips, and **from itself** (a description's cross-links) |
 | `SelectReciter` | — | SelectReciterScreen |
 | `SelectTranslation` | — | SelectTranslationScreen |
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -355,7 +355,48 @@ and a second attempt is a no-op.
 
 **Tajweed data verification (issue #292).** The artifact's `ayahs.text_tajweed` column is built by the tajweed pipeline in **arshad-shah/nimaz-data** (`upstream/scripts/generate_database.py`), and verified there rather than here — `upstream/scripts/verify_tajweed.py` runs as a fail-the-build post-step, and the corpus rules engine (`data/rules/`) re-checks it on every `nz build`. The app-side `tajweed_data_checks.yml` was deleted at versionCode 385 (`docs/retirement.yaml`): it triggered on a `nimaz-pro-data/**` path that can no longer change in this repo. It asserts coverage, well-formedness (no leaked markup), the round-trip against `text_arabic`, the v3 code whitelist, character-coverage conservation, cross-source drift vs cpfair, and a golden-ayah fixture.
 
-**Migration chain** (registered in `DatabaseModule.provideNimazDatabase`): `MIGRATION_7_8` (khatam) → `8_9` (asma/prophets) → `9_10` (a *missing* migration restored after the original release bumped the version without registering it) → `10_11` (`updatedAt` columns) → `11_12` (surah start_page fix) → `12_13` (legacy asset repair) → `13_14` (Help tables) → `14_15` (Qaida tables) → `15_16` (tasbih `category`) → `16_17` (hadith `narrator_chain`) → `17_18` (16-line IndoPak: `ayahs.text_indopak` column + `mushaf_layout_indopak16` table) → `18_19` (translations: dedupe + unique index on `(ayah_id, translator_id)`) → `19_20` (generalised mushaf storage: `mushaf_ayah_texts` + `mushaf_layout_lines`, drops `mushaf_layout_indopak16`) → `20_21` (tafseer range blocks: drops `tafseer_texts`, creates `tafseer_blocks`).
+**Migration chain** (registered in `DatabaseModule.provideNimazDatabase`): `MIGRATION_7_8` (khatam) → `8_9` (asma/prophets) → `9_10` (a *missing* migration restored after the original release bumped the version without registering it) → `10_11` (`updatedAt` columns) → `11_12` (surah start_page fix) → `12_13` (legacy asset repair) → `13_14` (Help tables) → `14_15` (Qaida tables) → `15_16` (tasbih `category`) → `16_17` (hadith `narrator_chain`) → `17_18` (16-line IndoPak: `ayahs.text_indopak` column + `mushaf_layout_indopak16` table) → `18_19` (translations: dedupe + unique index on `(ayah_id, translator_id)`) → `19_20` (generalised mushaf storage: `mushaf_ayah_texts` + `mushaf_layout_lines`, drops `mushaf_layout_indopak16`) → `20_21` (tafseer range blocks: drops `tafseer_texts`, creates `tafseer_blocks`) → `21_22` (mushaf divisions as tables) → `22_23` (user data moves to `NimazUserDatabase`; deliberately empty) → `23_24` (the Qur'an's thematic layer: five content tables, created empty).
+
+**The Qur'an's thematic layer (`v24`).** Five content tables of *apparatus* — the kind of thing
+a printed mushaf carries in its margins and a reader app usually cannot answer at all:
+
+- `surah_overviews(surah_number, summary)` and
+  `surah_overview_sections(surah_number, position, heading, section_group, body)` — the long-form
+  background to each surah, split at the source's own `<h2>` boundaries **at import**, because the
+  source writes the same section under 65 different headings and folding those onto a handful of
+  `section_group` buckets is data work rather than something to redo on a device per screen.
+  Deliberately *not* `surah_info`, whose one-sentence `description` is first-party text written
+  for a list cell: the surah list reads 114 short rows and must never touch the ~900 KB of prose.
+- `ayah_themes(surah_number, ayah_from, ayah_to, theme, keywords, ayah_count)` — 1,049
+  non-overlapping passages tiling all 114 surahs, so "what is this passage about" is one lookup
+  wherever the reader happens to be. No second index: containment (`ayah_from <= ? AND ayah_to >= ?`)
+  rides the primary key, and Room compares index *sets*.
+- `quran_topics` and `quran_topic_ayahs(topic_id, ayah_id, surah_number, ayah_number)` — 2,512
+  subjects in **three** hierarchies that do not agree (the subject index, the thematic outline, the
+  ontology), and 30,687 citations. The citations are rows rather than the comma-separated string
+  upstream keeps them in, because the question the app asks most is the reverse one — *which topics
+  is this verse under* — which is an index lookup here and 2,512 `LIKE` scans there.
+
+`MIGRATION_23_24` creates all five **empty**: they are content, so the rows arrive the way every
+other content row does (§7). A device that upgrades before the schemaVersion 24 artifact lands
+therefore has the tables and no rows, and every read path treats that as "nothing to show" —
+`QuranRepository.hasThematicContent()` is what a screen asks before offering an entry point, and
+`DeviceStateCorpusTest.assertThematicLayerIsWholeOrAbsent` asserts the layer is whole *or* absent
+rather than requiring it, so the app's own PR is not red on a fact about another repository.
+
+**One HTML dialect.** `surah_overview_sections.body` and `quran_topics.description` carry markup,
+normalised at import onto four tags — `<p>`, `<strong>`, `<em>`, and `<a href="quran:2:153-251">` /
+`<a href="topic:61">`. A build rule (`thematic.sections-dialect`) refuses to ship a fifth, so
+`core/util/ThematicMarkup` is a 130-line scanner rather than an HTML parser, and the two link
+schemes address screens this app has: 446 cross-references the source writes as prose ("see
+2:153-251") are taps into the reader, and 509 `topic:` links are taps into the subject browser.
+
+**Where it surfaces.** The surah info screen grows a collapsible background (first section open —
+the longest runs to 47 KB of prose for one surah) and the surah's passage outline; the reader
+prints a passage heading where the outline starts a new subject (surah mode only — a juz spans a
+dozen surahs and would cost a query per surah per page turn); the Tafseer screen shows the verse's
+subjects as chips, capped at six; and `Route.QuranTopics` browses all three hierarchies. Two new
+search kinds — `theme` and `topic` — ride the shipped FTS index.
 
 **Tafseer range blocks (`v21`, #329).** Tafseer is range-based, not ayah-based — a single commentary passage (e.g. Ibn Kathir discussing 43:81-89) is one block, not nine identical rows. `tafseer_texts` (one row per ayah, `ayah_id`/`surah_number`/`ayah_number`) is replaced by `tafseer_blocks` (`tafseer_id`, `surah_number`, `ayah_start`, `ayah_end`, `text`), indexed on `(tafseer_id, surah_number, ayah_start, ayah_end)`. `MIGRATION_20_21` drops the old table outright — it is shipped content, not user data, replaced wholesale by the schemaVersion 21 artifact (`nimaz-data` issue #1) — and creates the new one empty; the block rows arrive with that artifact. `TafseerDao.getTafseerForAyah(surahNumber, ayahNumber, tafseerId)` now matches by containment (`ayah_start <= ? AND ayah_end >= ?`) instead of equality. `tafseer_highlights`/`tafseer_notes` (user data) are untouched: they stay keyed by the single `ayah_id` they were made on — the offsets they store index into the block text, which is unchanged for that ayah — but the reader now gathers every highlight/note whose ayah falls inside the *displayed block's* range (`TafseerDao.getHighlightsForRange`/`getNotesForRange`, joined against `ayahs`) so an annotation shows whenever its block is on screen, not only on the exact ayah it was created on. `TafseerPageContent` renders a "Commentary on 43:81-89" header from the block's own range, and `TafseerViewModel` hoists the reader's content-page index into `TafseerUiState.currentTafseerPage` so swiping to the next ayah of the same block holds reading position instead of reopening the block from page 1.
 


### PR DESCRIPTION
The reader could tell you what a verse says and nothing about what it is *about*. schemaVersion 24 adds the apparatus a printed mushaf carries in its margins.

Pairs with **arshad-shah/nimaz-data#12**, which ships the content.

## What's new on screen

| Where | What |
|---|---|
| **Surah info** | A collapsible long-form background — Name, Period of Revelation, Theme and Subject Matter — plus the surah's own passage outline, every row opening the reader at that passage |
| **Reader** | A passage heading printed where the mushaf's outline starts a new subject, so reading down Al-Baqarah reads as 282 passages rather than 286 undifferentiated verses |
| **Tafseer** | The verse's subjects as chips, each one a door into everything else the Qur'an says on it |
| **Topics** (new) | 2,512 subjects in three hierarchies, searchable, every subject listing the verses that speak to it |

Prose links are live: the source says "see 2:153-251" and that is now a tap into the reader; a topic description's cross-links are taps into the browser.

## The data

Five content tables, created empty by `MIGRATION_23_24`:

- `surah_overviews` / `surah_overview_sections` — the background, split at the source's own `<h2>` boundaries **at import**, because the source writes the same section under 65 different headings. Deliberately *not* `surah_info`, whose one-sentence description is first-party text for a list cell: the surah list reads 114 short rows and must never touch the ~900 KB of prose.
- `ayah_themes` — 1,049 non-overlapping passages. No second index: containment rides the primary key, and Room compares index *sets*.
- `quran_topics` / `quran_topic_ayahs` — three hierarchies that do not agree, kept as three, and 30,687 citations as rows so "which topics is this verse under" is an index lookup.

## Design notes

**Empty is a normal state, not an error.** The rows are content, so they arrive with the artifact (§7) — a device that upgrades before the schemaVersion 24 artifact lands has the tables and nothing in them. `hasThematicContent()` is what a screen asks before offering an entry point, and every read path treats absence as "nothing to show".

**One route for the whole topic descent.** The ontology goes five levels deep; a route per level would mean five back-stack entries for one act of browsing, and a tree switch would strand the user halfway down a tree that no longer exists. `QuranTopicsViewModel` holds the path; the back gesture pops one level before leaving the screen.

**`ThematicMarkup` is a scanner, not an HTML parser.** The artifact normalises three upstream dialects onto four tags and refuses at build time to ship a fifth, so 130 lines suffice. It is lenient on purpose: an unknown tag loses its styling, never the screen.

**Reader passage headings are surah-mode only.** A juz spans a dozen surahs; covering it would cost a query per surah on every page turn to label a boundary that mode rarely crosses. Surah mode is where a reader is reading *through* something, which is what a heading is for.

**Collapsed sections are not styling.** The longest surah background runs to 47 KB of prose; expanding all of it would measure most of a book chapter to draw a screen whose first fold is three stat cards.

## Tests

- `ThematicMarkupTest` — 15 cases over the dialect and, more to the point, everything outside it: unknown tags, unclosed tags, unresolvable links, loose text, entities.
- `MigrationTest.migrate23To24_*` — the tables are created empty *and* the migration is a no-op against an artifact that already carries them with rows.
- `MigrationChainTest` covers 7 → 24 already; it reads `ALL_MIGRATIONS`, so nothing needed adding.
- `DeviceStateCorpusTest.assertThematicLayerIsWholeOrAbsent` — the five tables are one release, so a *partial* layer is a corpus half-imported. Asserting them non-empty outright would make this PR red on a fact about a file in another repository, so the assertion is conditional and engages by itself the moment `data.lock.json` moves.

```
./gradlew :app:compileDebugKotlin    BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest     BUILD SUCCESSFUL
```

## ⚠️ Not mergeable on its own — two things first

1. **nimaz-data#12 has to merge and be released.** `data.lock.json` still pins `data-v7` (schemaVersion 23). The app runs correctly against it — the migration creates the tables and the UI shows one fewer affordance — but the feature is inert until a schemaVersion 24 artifact ships. That needs `nz release` from nimaz-data and then `nz app sync`, which needs the publishing credential. **I could not do this step**; it is the one thing left.
2. **`LICENSES_THEMATIC.md` says SIGN-OFF PENDING.** The three source databases were supplied already built, and which published work the surah prose is — and which Qur'anic ontology `topics.db` is, since several share that shape and not all share a licence — still has to be established. The app is built to survive the answer being "no": drop the collections and every screen here degrades to what it does on a pre-24 artifact.

Docs updated: `docs/SUBSYSTEMS.md` §5 (the layer, the dialect, where it surfaces) and `docs/NAVIGATION.md` (two routes, and the diagram).

---
_Generated by [Claude Code](https://claude.ai/code/session_019uUerpA88QUJJboLYsoVVm)_