### PR TITLE
Pin data-v8 — the artifact that actually has the thematic layer in it

### DIFF
--- a/data.lock.json
+++ b/data.lock.json
@@ -12,17 +12,17 @@
     "stays the hash of the *decompressed* file, which is what gets verified."
   ],
   "repo": "arshad-shah/nimaz-data",
-  "tag": "data-v7",
-  "schemaVersion": 23,
+  "tag": "data-v8",
+  "schemaVersion": 24,
   "artifact": {
-    "file": "nimaz-d7af8364.db",
+    "file": "nimaz-7dc5ac01.db",
     "assetPath": "database/nimaz_prepopulated.db",
-    "sha256": "d7af8364b095552b846c0d5d36832f6231fd8df5edcd147f3df83a019f196b37",
-    "bytes": 176562176,
+    "sha256": "7dc5ac018b38c99425acb66847f2781456f8c93ed029510f6c13439d2eae438d",
+    "bytes": 180035584,
     "compressed": {
-      "file": "nimaz-d7af8364.db.gz",
-      "sha256": "0c84cf0096d6b48cffa8d699732d3f348df2ddf64166e0140a7e3db662b021fb",
-      "bytes": 54415049
+      "file": "nimaz-7dc5ac01.db.gz",
+      "sha256": "27b3ee8a2c24642f363bf28cc3cbd919a49e3ba703c7443f508b8bb7a0e5b157",
+      "bytes": 55734451
     }
   }
 }

--- a/gradle/nimaz-data.gradle.kts
+++ b/gradle/nimaz-data.gradle.kts
@@ -1,5 +1,6 @@
 import groovy.json.JsonSlurper
 import java.io.File
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
 import java.security.MessageDigest
@@ -64,7 +65,43 @@ fun resolveDataToken(): String {
     )
 }
 
-fun githubApi(url: String, token: String): String {
+/**
+ * Runs [block], retrying the failures that are GitHub having a moment rather than this build
+ * being wrong.
+ *
+ * Every fetch here is a cold one on CI, and a release asset that exists and a credential that
+ * works still produce the occasional `HTTP response code: 500` — twice on `dev`, each time
+ * reddening a deploy that had nothing wrong with it and each time green on a plain re-run. An
+ * `IOException` from `HttpURLConnection` covers that case (the 500 surfaces as one when the
+ * stream is opened) along with resets and read timeouts.
+ *
+ * Deliberately narrow: [GradleException] passes straight through, so the 401/403/404 diagnoses
+ * below — which are all *permanent* — still fail on the first attempt with their explanation
+ * intact. Retrying those would turn a clear message into a slow one.
+ */
+fun <T> retrying(what: String, block: () -> T): T {
+    var wait = 2_000L
+    var last: IOException? = null
+    repeat(4) { attempt ->
+        try {
+            return block()
+        } catch (e: IOException) {
+            last = e
+            if (attempt == 3) return@repeat
+            project.logger.lifecycle(
+                "nimaz-data: $what failed (${e.message}); retrying in ${wait / 1000}s"
+            )
+            Thread.sleep(wait)
+            wait *= 2
+        }
+    }
+    throw GradleException(
+        "nimaz-data: $what failed on all 4 attempts. Last error: ${last?.message}",
+        last,
+    )
+}
+
+fun githubApi(url: String, token: String): String = retrying("resolving $url") {
     val conn = URI(url).toURL().openConnection() as HttpURLConnection
     conn.setRequestProperty("Authorization", "Bearer $token")
     conn.setRequestProperty("Accept", "application/vnd.github+json")
@@ -92,7 +129,7 @@ fun githubApi(url: String, token: String): String {
                 "  See docs/CONTENT_REPO_AUTH.md."
         )
     }
-    return conn.inputStream.bufferedReader().use { it.readText() }
+    conn.inputStream.bufferedReader().use { it.readText() }
 }
 
 tasks.register("fetchNimazData") {
@@ -149,20 +186,27 @@ tasks.register("fetchNimazData") {
 
                 logger.lifecycle("nimaz-data: fetching $fetchedName from $repo@$tag")
                 cached.parentFile.mkdirs()
-                val conn = URI(asset["url"] as String).toURL()
-                    .openConnection() as HttpURLConnection
-                conn.setRequestProperty("Authorization", "Bearer ${token!!}")
-                // The API serves metadata for this URL unless octet-stream is asked for.
-                conn.setRequestProperty("Accept", "application/octet-stream")
-                conn.instanceFollowRedirects = true
-                conn.inputStream.use { input ->
-                    // Decompressed on the way in, so what lands in the cache is always
-                    // the artifact itself and the sha256 below always means the same
-                    // thing. The lockfile pins the *decompressed* bytes — verifying the
-                    // wrapper instead would let a re-compression change what the pin
-                    // asserts without the hash moving.
-                    val source = if (compressed) GZIPInputStream(input, 1 shl 16) else input
-                    cached.outputStream().use { source.copyTo(it) }
+                // Retried like the metadata call, and for a stronger reason: this is a 54 MB
+                // transfer, so it has far more time in which to be interrupted. Restarting from
+                // zero rather than resuming is the right trade for a file this size — a resumed
+                // download that silently misjoins is exactly the corruption the sha256 below is
+                // there to catch, and re-fetching costs a minute.
+                retrying("downloading $fetchedName") {
+                    val conn = URI(asset["url"] as String).toURL()
+                        .openConnection() as HttpURLConnection
+                    conn.setRequestProperty("Authorization", "Bearer ${token!!}")
+                    // The API serves metadata for this URL unless octet-stream is asked for.
+                    conn.setRequestProperty("Accept", "application/octet-stream")
+                    conn.instanceFollowRedirects = true
+                    conn.inputStream.use { input ->
+                        // Decompressed on the way in, so what lands in the cache is always
+                        // the artifact itself and the sha256 below always means the same
+                        // thing. The lockfile pins the *decompressed* bytes — verifying the
+                        // wrapper instead would let a re-compression change what the pin
+                        // asserts without the hash moving.
+                        val source = if (compressed) GZIPInputStream(input, 1 shl 16) else input
+                        cached.outputStream().use { source.copyTo(it) }
+                    }
                 }
 
                 val actual = sha256Of(cached)


### PR DESCRIPTION
## Why the topic screen was empty

Not a bug in the code that reads the data. `data.lock.json` still pinned **data-v7**, cut on 31 July at schemaVersion 23 — three days before the thematic collections existed. Room created the five tables from the v24 migration, found no rows to copy, and the screen correctly reported it had nothing.

[`data-v8`](https://github.com/arshad-shah/nimaz-data/releases/tag/data-v8) is now published and this pins it.

| | |
|---|---|
| artifact | `nimaz-7dc5ac01.db`, 180,035,584 bytes |
| sha256 | `7dc5ac018b38c99425acb66847f2781456f8c93ed029510f6c13439d2eae438d` |
| schemaVersion | 24 |
| contents | 114 surah overviews · 398 background sections · 1,049 passages · 2,512 topics · 30,687 citations |
| search index | 1,049 `theme` + 2,512 `topic` documents |

The CI build reproduced the local one byte for byte — same hash, same size — which is what nimaz-data's "Full rebuild, twice" job exists to assert.

## It reaches existing installs, not only fresh ones

`CONTENT_ARTIFACT_SHA256` is read from this file at build time, so moving the pin moves what `ContentArtifactInstaller` compares against. First launch after the update: the stored artifact differs, the content database is deleted, Room copies the new one from assets. Installs predating schemaVersion 23 wait exactly one launch while `LegacyUserDataImport` copies their rows out first — the deferral that `once the legacy import has run, the replace proceeds despite the rows remaining` covers.

## Also here: the fetch stops reddening builds over a transient 5xx

`fetchNimazData` had no retry anywhere, so one bad response from GitHub failed the build. It happened twice on `dev`, most recently [run 30808873906](https://github.com/arshad-shah/Nimaz/actions/runs/30808873906):

```
fetchNimazData FAILED ... HTTP response code: 500
```

— for an asset that existed, with a credential that worked, green on a plain re-run. Both network calls now go through a `retrying` helper: 4 attempts, 2/4/8s backoff, catching `IOException` (how `HttpURLConnection` surfaces a 5xx). `GradleException` passes straight through, so the 401/403/404 diagnoses still fail immediately with their instructions intact.

## Verification

The script plugin compiles and `:app` configures with it. The fetch itself can't run outside CI — it needs the private-repo credential — so this PR's build is the first end-to-end check that the new pin resolves and verifies.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uUerpA88QUJJboLYsoVVm)_