### PR TITLE
Make a surah's subjects know which surah they came from

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -144,6 +144,7 @@ import com.arshadshah.nimaz.domain.usecase.GetTopicChildrenUseCase
 import com.arshadshah.nimaz.domain.usecase.GetTopicDetailUseCase
 import com.arshadshah.nimaz.domain.usecase.GetTopicTreeRootsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetTopicsForAyahUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicsForSurahUseCase
 import com.arshadshah.nimaz.domain.usecase.HasThematicContentUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchTopicsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetSurahListUseCase
@@ -387,6 +388,7 @@ object UseCaseModule {
             getTopicChildren = GetTopicChildrenUseCase(repository),
             getTopicDetail = GetTopicDetailUseCase(repository),
             getTopicsForAyah = GetTopicsForAyahUseCase(repository),
+            getTopicsForSurah = GetTopicsForSurahUseCase(repository),
             searchTopics = SearchTopicsUseCase(repository),
             hasThematicContent = HasThematicContentUseCase(repository),
             getPageAyahRanges = GetPageAyahRangesUseCase(repository),

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -97,6 +97,7 @@ import com.arshadshah.nimaz.presentation.screens.quran.QuranTopicsScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SurahBackgroundScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SurahInfoScreen
 import com.arshadshah.nimaz.presentation.screens.quran.SurahPassagesScreen
+import com.arshadshah.nimaz.presentation.screens.quran.SurahSubjectsScreen
 import com.arshadshah.nimaz.presentation.screens.quran.TafseerChaptersScreen
 import com.arshadshah.nimaz.presentation.screens.quran.TafseerScreen
 import com.arshadshah.nimaz.presentation.screens.search.SearchScreen
@@ -426,7 +427,11 @@ fun NavGraph(
                     onNavigateToPassages = { surah, ayah ->
                         navController.navigate(Route.SurahPassages(surah, ayah))
                     },
-                    onNavigateToSubjects = { navController.navigate(Route.QuranTopics) },
+                    onNavigateToSubjects = { surah ->
+                        navController.navigate(
+                            if (surah != null) Route.SurahSubjects(surah) else Route.QuranTopics
+                        )
+                    },
                     onNavigateToNextSurah = { nextSurah ->
                         navController.navigate(Route.QuranReader(nextSurah)) {
                             popUpTo<Route.QuranReader> { inclusive = true }
@@ -475,7 +480,9 @@ fun NavGraph(
                     onOpenPassages = {
                         navController.navigate(Route.SurahPassages(args.surahNumber))
                     },
-                    onOpenSubjects = { navController.navigate(Route.QuranTopics) }
+                    onOpenSubjects = {
+                        navController.navigate(Route.SurahSubjects(args.surahNumber))
+                    }
                 )
             }
 
@@ -505,6 +512,20 @@ fun NavGraph(
                 )
             }
 
+            taggedComposable<Route.SurahSubjects>(ScreenTags.SurahSubjects) { backStackEntry ->
+                val args = backStackEntry.toRoute<Route.SurahSubjects>()
+                SurahSubjectsScreen(
+                    surahNumber = args.surahNumber,
+                    onNavigateBack = { navController.popBackStack() },
+                    onOpenTopic = { topicId, tree ->
+                        navController.navigate(
+                            Route.QuranTopicDetail(topicId, tree.wire, args.surahNumber)
+                        )
+                    },
+                    onBrowseAllSubjects = { navController.navigate(Route.QuranTopics) }
+                )
+            }
+
             taggedComposable<Route.QuranTopics>(ScreenTags.QuranTopics) {
                 QuranTopicsScreen(
                     onNavigateBack = { navController.popBackStack() },
@@ -519,12 +540,18 @@ fun NavGraph(
                 QuranTopicDetailScreen(
                     topicId = args.topicId,
                     tree = TopicTree.fromWire(args.tree),
+                    fromSurah = args.fromSurah,
                     onNavigateBack = { navController.popBackStack() },
                     onOpenAyah = { surah, ayah ->
                         navController.navigate(Route.QuranReader(surah, ayah))
                     },
+                    // The surah travels with every lateral move — a subtopic, a related
+                    // subject, a cross-link in the prose. Dropping it one hop in would put the
+                    // reader back where this whole change started, one screen later.
                     onOpenTopic = { topicId, tree ->
-                        navController.navigate(Route.QuranTopicDetail(topicId, tree.wire))
+                        navController.navigate(
+                            Route.QuranTopicDetail(topicId, tree.wire, args.fromSurah)
+                        )
                     }
                 )
             }
@@ -541,7 +568,11 @@ fun NavGraph(
                     onNavigateToPassages = { surah, ayah ->
                         navController.navigate(Route.SurahPassages(surah, ayah))
                     },
-                    onNavigateToSubjects = { navController.navigate(Route.QuranTopics) }
+                    onNavigateToSubjects = { surah ->
+                        navController.navigate(
+                            if (surah != null) Route.SurahSubjects(surah) else Route.QuranTopics
+                        )
+                    }
                 )
             }
 
@@ -557,7 +588,11 @@ fun NavGraph(
                     onNavigateToPassages = { surah, ayah ->
                         navController.navigate(Route.SurahPassages(surah, ayah))
                     },
-                    onNavigateToSubjects = { navController.navigate(Route.QuranTopics) }
+                    onNavigateToSubjects = { surah ->
+                        navController.navigate(
+                            if (surah != null) Route.SurahSubjects(surah) else Route.QuranTopics
+                        )
+                    }
                 )
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
@@ -272,15 +272,36 @@ sealed interface Route {
     data object QuranTopics : Route
 
     /**
+     * The subjects one surah speaks about, weightiest here first.
+     *
+     * Its own destination rather than [QuranTopics] opened with an argument, because it is a
+     * different question. [QuranTopics] browses a hierarchy from its roots down; this is a flat
+     * list of what *these* verses are cited under, and it exists because "Subjects in this
+     * surah" used to open the global tree at the top — the same twenty roots whichever surah
+     * you came from, with nothing carrying the surah you were holding.
+     */
+    @Serializable
+    data class SurahSubjects(val surahNumber: Int) : Route
+
+    /**
      * One subject, with its citations.
      *
      * [tree] is a [com.arshadshah.nimaz.domain.model.TopicTree] `wire` value rather than the
      * enum, because a route argument has to have a `NavType` and a String always does. It is
      * only used to pick which hierarchy the breadcrumb and the child list are drawn from; an
      * unrecognised value falls back to the thematic tree rather than failing to open.
+     *
+     * [fromSurah] is the surah the reader arrived from, when they arrived from one. It does not
+     * filter anything — a subject's citations are the whole of it — but that surah's verses are
+     * pinned to the top of the list and named, so opening "Patience" from Al-Baqarah does not
+     * land on Al-Fatiha's citation with Al-Baqarah's forty somewhere below the fold.
      */
     @Serializable
-    data class QuranTopicDetail(val topicId: Int, val tree: String = "thematic") : Route
+    data class QuranTopicDetail(
+        val topicId: Int,
+        val tree: String = "thematic",
+        val fromSurah: Int? = null,
+    ) : Route
 
     // Select Reciter
     @Serializable

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -32,6 +32,7 @@ object ScreenTags {
     const val SurahInfo = "screen_surah_info"
     const val SurahBackground = "screen_surah_background"
     const val SurahPassages = "screen_surah_passages"
+    const val SurahSubjects = "screen_surah_subjects"
     const val QuranTopics = "screen_quran_topics"
     const val QuranTopicDetail = "screen_quran_topic_detail"
     const val QuranPage = "screen_quran_page"

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -28,6 +28,7 @@ import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewEntity
 import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewSectionEntity
+import com.arshadshah.nimaz.data.local.database.entity.TopicWithSurahCount
 import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -600,6 +601,41 @@ interface QuranDao {
             "WHERE ta.ayah_id = :ayahId ORDER BY t.ayah_count DESC, t.name ASC"
     )
     suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopicEntity>
+
+    /**
+     * Every subject this surah's verses are cited under, weightiest *here* first.
+     *
+     * `verses_here` counts only the citations that fall inside this surah, and it is what the
+     * list is ordered by: a reader on Al-Fatiha wants the seven verses' own subjects, not the
+     * busiest subjects in the Qur'an that happen to touch it once. Ties fall back to the
+     * global count, so between two subjects with one verse here the broader one leads.
+     *
+     * `surah_number` is not indexed — the table's index is on `ayah_id`, for the reverse
+     * question — so this walks 30,687 rows. Once per surah, off the main thread, against a
+     * table small enough that an index of its own would cost more in artifact size than it
+     * saves here.
+     */
+    @Query(
+        "SELECT t.*, COUNT(ta.ayah_id) AS verses_here FROM quran_topics t " +
+            "JOIN quran_topic_ayahs ta ON ta.topic_id = t.topic_id " +
+            "WHERE ta.surah_number = :surahNumber " +
+            "GROUP BY t.topic_id " +
+            "ORDER BY verses_here DESC, t.ayah_count DESC, t.name ASC"
+    )
+    suspend fun getTopicsForSurah(surahNumber: Int): List<TopicWithSurahCount>
+
+    /**
+     * How many subjects this surah touches.
+     *
+     * Asked by the surah-info screen, which needs the number to label a row and not the rows
+     * themselves — loading a few hundred topics to display one integer is the query this
+     * exists to avoid.
+     */
+    @Query(
+        "SELECT COUNT(DISTINCT topic_id) FROM quran_topic_ayahs " +
+            "WHERE surah_number = :surahNumber"
+    )
+    suspend fun countTopicsForSurah(surahNumber: Int): Int
 
     @Query(
         "SELECT * FROM quran_topics WHERE name LIKE '%' || :query || '%' " +

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/entity/QuranEntities.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.data.local.database.entity
 
 import androidx.room.ColumnInfo
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
@@ -418,4 +419,16 @@ data class QuranTopicAyahEntity(
     @ColumnInfo(name = "ayah_id") val ayahId: Int,
     @ColumnInfo(name = "surah_number") val surahNumber: Int,
     @ColumnInfo(name = "ayah_number") val ayahNumber: Int,
+)
+
+/**
+ * A topic, with how many verses of *one particular surah* are cited under it.
+ *
+ * The count is the whole point of the projection. [QuranTopicEntity.ayahCount] is the subject's
+ * reach across the entire Qur'an, so ordering a surah's subjects by it would put "Allah" — 153
+ * verses, two of which are here — above the subject the surah is actually about.
+ */
+data class TopicWithSurahCount(
+    @Embedded val topic: QuranTopicEntity,
+    @ColumnInfo(name = "verses_here") val versesHere: Int,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -36,6 +36,7 @@ import com.arshadshah.nimaz.domain.model.SurahInfo
 import com.arshadshah.nimaz.domain.model.SurahOverview
 import com.arshadshah.nimaz.domain.model.SurahOverviewGroup
 import com.arshadshah.nimaz.domain.model.SurahOverviewSection
+import com.arshadshah.nimaz.domain.model.SurahTopic
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
 import com.arshadshah.nimaz.domain.model.TopicCitation
 import com.arshadshah.nimaz.domain.model.TopicDetail
@@ -655,6 +656,14 @@ class QuranRepositoryImpl @Inject constructor(
 
     override suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopic> =
         quranDao.getTopicsForAyah(ayahId).map { it.toDomain() }
+
+    override suspend fun getTopicsForSurah(surahNumber: Int): List<SurahTopic> =
+        quranDao.getTopicsForSurah(surahNumber).map {
+            SurahTopic(topic = it.topic.toDomain(), versesInSurah = it.versesHere)
+        }
+
+    override suspend fun countTopicsForSurah(surahNumber: Int): Int =
+        quranDao.countTopicsForSurah(surahNumber)
 
     /**
      * Topic search, through the shipped FTS index where there is one.

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranThematic.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranThematic.kt
@@ -128,7 +128,35 @@ data class QuranTopic(
         TopicTree.ONTOLOGY -> isOntology
         TopicTree.INDEX -> true
     }
+
+    /**
+     * The hierarchy to open this topic *in* when nothing else says which.
+     *
+     * A subject reached from a surah — or from a search, or a cross-link — arrives without a
+     * tree, and defaulting to [TopicTree.THEMATIC] for all of them is what produces a detail
+     * screen with no breadcrumb and no subtopics for the 1,817 subjects the thematic outline
+     * does not place. Preference order is the curated outline, then the ontology, then the
+     * index, which every topic belongs to.
+     */
+    val homeTree: TopicTree
+        get() = when {
+            isThematic -> TopicTree.THEMATIC
+            isOntology -> TopicTree.ONTOLOGY
+            else -> TopicTree.INDEX
+        }
 }
+
+/**
+ * A subject, and how much of one surah is cited under it.
+ *
+ * [versesInSurah] is the local weight and [QuranTopic.ayahCount] is the global one; a row that
+ * shows both is what separates "this surah is about this" from "this subject is everywhere and
+ * touches here once".
+ */
+data class SurahTopic(
+    val topic: QuranTopic,
+    val versesInSurah: Int,
+)
 
 /**
  * Which of the three hierarchies a topic browser is walking.

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
@@ -14,6 +14,7 @@ import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.SurahInfo
 import com.arshadshah.nimaz.domain.model.SurahOverview
+import com.arshadshah.nimaz.domain.model.SurahTopic
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
 import com.arshadshah.nimaz.domain.model.TopicDetail
 import com.arshadshah.nimaz.domain.model.TopicTree
@@ -139,6 +140,19 @@ interface QuranRepository {
 
     suspend fun getTopicDetail(topicId: Int, tree: TopicTree): TopicDetail?
     suspend fun getTopicsForAyah(ayahId: Int): List<QuranTopic>
+
+    /**
+     * Which subjects this surah speaks about, and how many of its verses each one takes.
+     *
+     * The surah-scoped counterpart to [getTopicTreeRoots]: a reader who arrived from a surah is
+     * asking what *this* surah is about, and the three hierarchies' roots — the same 20-odd
+     * nouns for all 114 surahs — cannot answer that. Ordered by weight inside the surah.
+     */
+    suspend fun getTopicsForSurah(surahNumber: Int): List<SurahTopic>
+
+    /** How many subjects [getTopicsForSurah] would return, without returning them. */
+    suspend fun countTopicsForSurah(surahNumber: Int): Int
+
     suspend fun searchTopics(query: String, limit: Int = 60): List<QuranTopic>
 
     /** Whether this install's artifact actually carries the thematic layer at all. */

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
@@ -15,6 +15,7 @@ import com.arshadshah.nimaz.domain.model.AyahTheme
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.SurahInfo
 import com.arshadshah.nimaz.domain.model.SurahOverview
+import com.arshadshah.nimaz.domain.model.SurahTopic
 import com.arshadshah.nimaz.domain.model.TopicDetail
 import com.arshadshah.nimaz.domain.model.TopicTree
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
@@ -252,6 +253,23 @@ class GetTopicsForAyahUseCase @Inject constructor(
         repository.getTopicsForAyah(ayahId)
 }
 
+/**
+ * Which subjects this surah speaks about, weightiest here first.
+ *
+ * What "Subjects in this surah" has to be answered with. The global browser's roots are the
+ * same twenty nouns whichever surah you came from, so opening it from a surah drops the one
+ * thing the reader was holding.
+ */
+class GetTopicsForSurahUseCase @Inject constructor(
+    private val repository: QuranRepository
+) {
+    suspend operator fun invoke(surahNumber: Int): List<SurahTopic> =
+        repository.getTopicsForSurah(surahNumber)
+
+    /** Just the number of them — what a menu row needs to say how much is behind it. */
+    suspend fun count(surahNumber: Int): Int = repository.countTopicsForSurah(surahNumber)
+}
+
 class SearchTopicsUseCase @Inject constructor(
     private val repository: QuranRepository
 ) {
@@ -412,6 +430,7 @@ data class QuranUseCases(
     val getTopicChildren: GetTopicChildrenUseCase,
     val getTopicDetail: GetTopicDetailUseCase,
     val getTopicsForAyah: GetTopicsForAyahUseCase,
+    val getTopicsForSurah: GetTopicsForSurahUseCase,
     val searchTopics: SearchTopicsUseCase,
     val hasThematicContent: HasThematicContentUseCase,
     val getPageAyahRanges: GetPageAyahRangesUseCase,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveQuranScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveQuranScreen.kt
@@ -168,7 +168,15 @@ fun AdaptiveQuranScreen(
                             onNavigateToPassages = { surah, ayah ->
                                 navController.navigate(Route.SurahPassages(surah, ayah))
                             },
-                            onNavigateToSubjects = { navController.navigate(Route.QuranTopics) },
+                            onNavigateToSubjects = { surah ->
+                                navController.navigate(
+                                    if (surah != null) {
+                                        Route.SurahSubjects(surah)
+                                    } else {
+                                        Route.QuranTopics
+                                    }
+                                )
+                            },
                             onNavigateToNextSurah = { nextSurah ->
                                 scope.launch {
                                     navigator.navigateTo(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
@@ -97,7 +97,12 @@ fun QuranReaderScreen(
     onNavigateToQuranSettings: () -> Unit = {},
     onNavigateToTafseer: (surahNumber: Int, ayahNumber: Int) -> Unit = { _, _ -> },
     onNavigateToPassages: (surahNumber: Int, currentAyah: Int) -> Unit = { _, _ -> },
-    onNavigateToSubjects: () -> Unit = {},
+    /**
+     * The subject index. [surahNumber] is the surah on screen when there is one, and the
+     * destination is that surah's own subjects; null in page and juz mode before the layout
+     * has resolved a surah, where the only honest answer is the whole index.
+     */
+    onNavigateToSubjects: (surahNumber: Int?) -> Unit = {},
     onNavigateToNextSurah: (Int) -> Unit = {},
     onPageModeChanged: (Boolean) -> Unit = {},
     viewModel: QuranViewModel = hiltViewModel()
@@ -456,12 +461,21 @@ fun QuranReaderScreen(
                                 )
                             }
                         }
+                        // Scoped to the surah on screen where there is one, and labelled as
+                        // such. "Topics" opening the whole index from inside a surah was the
+                        // reader asking a question about these verses and being handed the
+                        // table of contents for all 114.
+                        val subjectsSurah = state.surahWithAyahs?.surah?.number
                         NimazDropdownRow(
-                            text = stringResource(R.string.quran_topics_title),
+                            text = if (subjectsSurah != null) {
+                                stringResource(R.string.surah_info_subjects)
+                            } else {
+                                stringResource(R.string.quran_topics_title)
+                            },
                             leadingIcon = Icons.Default.AccountTree,
                             onClick = {
                                 menuExpanded = false
-                                onNavigateToSubjects()
+                                onNavigateToSubjects(subjectsSurah)
                             },
                         )
                         if (state.showTajweed) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranTopicDetailScreen.kt
@@ -72,12 +72,13 @@ fun QuranTopicDetailScreen(
     onNavigateBack: () -> Unit,
     onOpenAyah: (surah: Int, ayah: Int) -> Unit,
     onOpenTopic: (topicId: Int, tree: TopicTree) -> Unit,
+    fromSurah: Int? = null,
     viewModel: QuranTopicsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.detailState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(topicId, tree) {
-        viewModel.onEvent(QuranTopicsEvent.LoadDetail(topicId, tree))
+    LaunchedEffect(topicId, tree, fromSurah) {
+        viewModel.onEvent(QuranTopicsEvent.LoadDetail(topicId, tree, fromSurah))
     }
 
     val detail = state.detail
@@ -138,11 +139,27 @@ fun QuranTopicDetailScreen(
                     contentPadding = PaddingValues(bottom = 32.dp),
                 ) {
                     item(key = "count") {
-                        Row(modifier = Modifier.padding(start = 20.dp, top = 16.dp)) {
+                        Row(
+                            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
                             NimazBadge(
                                 text = topicVerseCountLabel(detail.topic),
                                 tone = NimazTone.ACCENT,
                             )
+                            // How much of this subject is in the surah the reader came from.
+                            // Beside the total rather than instead of it: the point of the pair
+                            // is the ratio — 12 of 153 is a passing mention, 12 of 14 is not.
+                            state.surahContext?.let { context ->
+                                NimazBadge(
+                                    text = stringResource(
+                                        R.string.quran_topic_in_surah,
+                                        context.verseCount,
+                                        context.surahName,
+                                    ),
+                                    tone = NimazTone.PROMINENT,
+                                )
+                            }
                         }
                     }
 
@@ -218,6 +235,7 @@ fun QuranTopicDetailScreen(
                                 CitationGroupHeader(
                                     surahName = group.surahName,
                                     verseCount = group.citations.size,
+                                    isFromSurah = group.isFromSurah,
                                 )
                             }
                             items(
@@ -246,15 +264,24 @@ fun QuranTopicDetailScreen(
  *
  * Sticky, and opaque rather than translucent: it sits over scrolling verse text, and a header
  * you can read the list through is a header that stops answering the question it is there for.
+ *
+ * [isFromSurah] marks the one group that was lifted out of Qur'anic order — the surah the
+ * reader arrived from. Lifting it silently would be the worse half of the change: a list that
+ * looks like it is in the mushaf's sequence and is not.
  */
 @Composable
-private fun CitationGroupHeader(surahName: String, verseCount: Int) {
+private fun CitationGroupHeader(
+    surahName: String,
+    verseCount: Int,
+    isFromSurah: Boolean = false,
+) {
     Surface(color = MaterialTheme.colorScheme.background) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 6.dp),
             verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
                 text = surahName,
@@ -263,6 +290,12 @@ private fun CitationGroupHeader(surahName: String, verseCount: Int) {
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.weight(1f),
             )
+            if (isFromSurah) {
+                NimazBadge(
+                    text = stringResource(R.string.quran_topic_surah_you_came_from),
+                    tone = NimazTone.PROMINENT,
+                )
+            }
             Text(
                 text = if (verseCount == 1) {
                     stringResource(R.string.quran_topics_verse)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
@@ -188,7 +188,7 @@ fun SurahInfoScreen(
                         sectionCount = thematic.overview?.sections?.size ?: 0,
                         passageCount = thematic.passages.size,
                         ayahCount = surah.ayahCount,
-                        hasSubjects = thematic.isAvailable,
+                        subjectCount = thematic.subjectCount,
                         onOpenBackground = onOpenBackground,
                         onOpenPassages = onOpenPassages,
                         onOpenSubjects = onOpenSubjects
@@ -260,12 +260,12 @@ private fun GoDeeper(
     sectionCount: Int,
     passageCount: Int,
     ayahCount: Int,
-    hasSubjects: Boolean,
+    subjectCount: Int,
     onOpenBackground: () -> Unit,
     onOpenPassages: () -> Unit,
     onOpenSubjects: () -> Unit
 ) {
-    if (sectionCount == 0 && passageCount == 0 && !hasSubjects) return
+    if (sectionCount == 0 && passageCount == 0 && subjectCount == 0) return
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         NimazSectionHeader(title = stringResource(R.string.surah_info_go_deeper))
@@ -293,10 +293,16 @@ private fun GoDeeper(
                     onClick = onOpenPassages
                 )
             }
-            if (hasSubjects) {
+            // Counted like the other two, and for the same reason: the row used to promise
+            // "Browse what the Qur'an speaks about" and then open the global index at its
+            // roots, which is a row whose subtitle was true and whose destination was wrong.
+            if (subjectCount > 0) {
                 NimazMenuItem(
                     title = stringResource(R.string.surah_info_subjects),
-                    subtitle = stringResource(R.string.surah_info_subjects_subtitle),
+                    subtitle = stringResource(
+                        R.string.surah_info_subjects_subtitle,
+                        subjectCount
+                    ),
                     icon = Icons.Default.AccountTree,
                     onClick = onOpenSubjects
                 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahSubjectsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahSubjectsScreen.kt
@@ -1,0 +1,235 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.domain.model.SurahTopic
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTreeRow
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
+import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.QuranTopicsViewModel
+
+/**
+ * What one surah speaks about — its own subjects, weightiest here first.
+ *
+ * "Subjects in this surah" used to open the global browser at the top of the thematic tree: the
+ * same twenty roots — Doctrine, Stories, The Unseen — whichever surah you had just been reading,
+ * with nothing carrying the surah across. The reader was holding a specific question and the
+ * screen answered a general one.
+ *
+ * This is the specific answer. A flat list, not a tree, because the hierarchies place a subject
+ * relative to *other subjects*, and that is not the question here; the ordering is by how many
+ * of this surah's verses the subject actually takes, so Al-Baqarah leads with what it is about
+ * rather than with whichever subject is busiest Qur'an-wide. Each row says how far the subject
+ * reaches beyond these verses, which is what separates a subject this surah owns from one that
+ * is everywhere and touches here once. The whole index is still one tap away, at the bottom,
+ * where a reader who wanted the general question can go and ask it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SurahSubjectsScreen(
+    surahNumber: Int,
+    onNavigateBack: () -> Unit,
+    onOpenTopic: (topicId: Int, tree: TopicTree) -> Unit,
+    onBrowseAllSubjects: () -> Unit,
+    viewModel: QuranTopicsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.surahSubjects.collectAsStateWithLifecycle()
+
+    LaunchedEffect(surahNumber) {
+        viewModel.onEvent(QuranTopicsEvent.LoadSurahSubjects(surahNumber))
+    }
+
+    NimazScreenScaffold(
+        topBar = {
+            NimazTopAppBar(
+                title = state.surahName.takeIf { it.isNotBlank() }
+                    ?: stringResource(R.string.surah_subjects_title),
+                subtitle = stringResource(R.string.surah_subjects_subtitle),
+                navigationIcon = {
+                    NimazIconButton(
+                        icon = Icons.AutoMirrored.Filled.ArrowBack,
+                        onClick = onNavigateBack,
+                        contentDescription = stringResource(R.string.cd_back),
+                    )
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+
+                // No rows at all is not an empty search. Almost always it is an install whose
+                // artifact predates the thematic layer, which is a sentence about the install
+                // and not about the surah — so the two cases say different things.
+                state.subjects.isEmpty() -> NimazEmptyState(
+                    title = if (state.isAvailable) {
+                        stringResource(R.string.surah_subjects_none_title)
+                    } else {
+                        stringResource(R.string.quran_topics_unavailable_title)
+                    },
+                    message = if (state.isAvailable) {
+                        stringResource(R.string.surah_subjects_none)
+                    } else {
+                        stringResource(R.string.quran_topics_unavailable)
+                    },
+                    icon = Icons.Default.Category,
+                    // The way out, offered where the list would have been. Only where there is
+                    // an index to browse — on an install without one it is a button onto the
+                    // same sentence.
+                    actionLabel = stringResource(R.string.surah_subjects_browse_all)
+                        .takeIf { state.isAvailable },
+                    onAction = onBrowseAllSubjects.takeIf { state.isAvailable },
+                    modifier = Modifier.padding(20.dp),
+                )
+
+                else -> {
+                    // Filtering only where there is enough to lose something in. Under a
+                    // screenful, a filter box is a control that costs more room than it saves.
+                    if (state.subjects.size >= FILTER_THRESHOLD) {
+                        NimazSearchBar(
+                            query = state.query,
+                            onQueryChange = {
+                                viewModel.onEvent(QuranTopicsEvent.FilterSurahSubjects(it))
+                            },
+                            onClear = {
+                                viewModel.onEvent(QuranTopicsEvent.ClearSurahSubjectsFilter)
+                            },
+                            placeholder = stringResource(R.string.surah_subjects_filter_hint),
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+
+                    SubjectList(
+                        subjects = state.visible,
+                        totalCount = state.subjects.size,
+                        citations = state.citations,
+                        query = state.query,
+                        onOpenTopic = onOpenTopic,
+                        onBrowseAllSubjects = onBrowseAllSubjects,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubjectList(
+    subjects: List<SurahTopic>,
+    totalCount: Int,
+    citations: Int,
+    query: String,
+    onOpenTopic: (topicId: Int, tree: TopicTree) -> Unit,
+    onBrowseAllSubjects: () -> Unit,
+) {
+    if (subjects.isEmpty()) {
+        NimazEmptyState(
+            title = stringResource(R.string.quran_topics_no_results_title),
+            message = stringResource(R.string.surah_subjects_no_match, query, totalCount),
+            icon = Icons.Default.SearchOff,
+            modifier = Modifier.padding(20.dp),
+        )
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 24.dp),
+    ) {
+        item(key = "count") {
+            NimazSectionHeader(
+                title = stringResource(R.string.surah_subjects_count, totalCount),
+                trailingText = stringResource(
+                    R.string.surah_subjects_citations,
+                    citations,
+                ),
+                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp),
+            )
+        }
+
+        items(subjects, key = { it.topic.id }) { subject ->
+            NimazTreeRow(
+                label = subject.topic.name,
+                secondaryLabel = subject.topic.arabicName.takeIf { it.isNotBlank() },
+                supportingText = reachLabel(subject),
+                badgeText = subject.versesInSurah.toString(),
+                // The tree the subject actually sits in, not the tab that happened to be
+                // selected somewhere else — otherwise the 1,817 subjects the thematic outline
+                // does not place open with no breadcrumb and no subtopics.
+                onClick = { onOpenTopic(subject.topic.id, subject.topic.homeTree) },
+            )
+        }
+
+        // The general question, kept reachable. Below the specific answer rather than instead
+        // of it, which is the whole of what this screen changes.
+        item(key = "browse-all") {
+            NimazMenuGroup(modifier = Modifier.padding(horizontal = 8.dp, vertical = 16.dp)) {
+                NimazMenuItem(
+                    title = stringResource(R.string.surah_subjects_browse_all),
+                    subtitle = stringResource(R.string.surah_subjects_browse_all_subtitle),
+                    icon = Icons.Default.AccountTree,
+                    onClick = onBrowseAllSubjects,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * How far the subject reaches past these verses.
+ *
+ * The number that makes the list readable: "Patience — 12 here, 91 elsewhere" is a subject the
+ * Qur'an returns to, and "The cow — 7 here, none elsewhere" is what this surah is named for.
+ * The subtraction is clamped because a subject's stored `ayahCount` and its citation rows are
+ * two fields in the artifact, and a negative remainder would be a number about a disagreement.
+ */
+@Composable
+private fun reachLabel(subject: SurahTopic): String {
+    val elsewhere = (subject.topic.ayahCount - subject.versesInSurah).coerceAtLeast(0)
+    return if (elsewhere == 0) {
+        stringResource(R.string.surah_subjects_only_here)
+    } else {
+        stringResource(R.string.surah_subjects_elsewhere, elsewhere)
+    }
+}
+
+/** Below this many subjects the whole list fits in a scroll or two, and a filter is clutter. */
+private const val FILTER_THRESHOLD = 12

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.domain.model.SurahTopic
 import com.arshadshah.nimaz.domain.model.TopicCitation
 import com.arshadshah.nimaz.domain.model.TopicDetail
 import com.arshadshah.nimaz.domain.model.TopicTree
@@ -130,11 +131,71 @@ data class TopicBrowseState(
     }
 }
 
-/** One surah's worth of a topic's citations, under the surah's own name. */
+/**
+ * The subjects one surah speaks about.
+ *
+ * A flat, weighted list and not a tree: the three hierarchies place a subject relative to other
+ * subjects, which is a question about the index. "What is this surah about" is a question about
+ * these verses, and its answer is the subjects they are actually cited under, most-cited first.
+ *
+ * [query] filters what is already loaded rather than re-querying. The list is at most a few
+ * hundred rows and already in memory, so a debounce and an FTS walk would buy latency and a
+ * result set that no longer means "in this surah".
+ */
+data class SurahSubjectsState(
+    val surahNumber: Int = 0,
+    val surahName: String = "",
+    val subjects: List<SurahTopic> = emptyList(),
+    val query: String = "",
+
+    /**
+     * Whether this install's artifact carries the thematic layer at all.
+     *
+     * The same distinction [TopicBrowseState.isAvailable] draws, and for the same reason: an
+     * empty list means "your content predates the subject index" far more often than it means
+     * "this surah has no subjects", and those are two different sentences.
+     */
+    val isAvailable: Boolean = true,
+
+    val isLoading: Boolean = true,
+) {
+    val visible: List<SurahTopic> by lazy {
+        val needle = query.trim()
+        if (needle.isEmpty()) subjects
+        else subjects.filter {
+            it.topic.name.contains(needle, ignoreCase = true) ||
+                it.topic.arabicName.contains(needle)
+        }
+    }
+
+    /**
+     * How many subject-to-verse citations land in this surah.
+     *
+     * Citations and not distinct verses: a verse indexed under three subjects is three of
+     * these, and de-duplicating would need the ayah ids, which is the citation list this
+     * screen deliberately does not load.
+     */
+    val citations: Int by lazy { subjects.sumOf { it.versesInSurah } }
+}
+
+/**
+ * One surah's worth of a topic's citations, under the surah's own name.
+ *
+ * [isFromSurah] marks the group the reader arrived from, which is drawn first and named as
+ * theirs — see [TopicDetailState.surahContext].
+ */
 data class CitationGroup(
     val surahNumber: Int,
     val surahName: String,
     val citations: List<TopicCitation>,
+    val isFromSurah: Boolean = false,
+)
+
+/** The surah a subject was opened from, and how much of this subject sits in it. */
+data class TopicSurahContext(
+    val surahNumber: Int,
+    val surahName: String,
+    val verseCount: Int,
 )
 
 data class TopicDetailState(
@@ -157,6 +218,14 @@ data class TopicDetailState(
      * than a gap where a sentence should be.
      */
     val previews: Map<Int, String> = emptyMap(),
+
+    /**
+     * The surah this subject was opened from, when it was opened from one.
+     *
+     * Null everywhere else, and the screen then shows exactly what it showed before: the
+     * citations in Qur'anic order with no group singled out.
+     */
+    val surahContext: TopicSurahContext? = null,
 
     val isLoading: Boolean = true,
 )
@@ -192,7 +261,23 @@ sealed interface QuranTopicsEvent {
     data class Search(val query: String) : QuranTopicsEvent
     data object ClearSearch : QuranTopicsEvent
 
-    data class LoadDetail(val topicId: Int, val tree: TopicTree) : QuranTopicsEvent
+    /** The subjects one surah speaks about. Idempotent — safe to re-send for the same surah. */
+    data class LoadSurahSubjects(val surahNumber: Int) : QuranTopicsEvent
+
+    /** Filter the loaded surah subjects. In memory; no query is run. */
+    data class FilterSurahSubjects(val query: String) : QuranTopicsEvent
+
+    data object ClearSurahSubjectsFilter : QuranTopicsEvent
+
+    /**
+     * One subject's detail. [fromSurah] is the surah the reader came from, whose citations are
+     * pinned to the top — null when they came from somewhere with no surah in hand.
+     */
+    data class LoadDetail(
+        val topicId: Int,
+        val tree: TopicTree,
+        val fromSurah: Int? = null,
+    ) : QuranTopicsEvent
 }
 
 @HiltViewModel
@@ -206,6 +291,9 @@ class QuranTopicsViewModel @Inject constructor(
 
     private val _detailState = MutableStateFlow(TopicDetailState())
     val detailState: StateFlow<TopicDetailState> = _detailState.asStateFlow()
+
+    private val _surahSubjects = MutableStateFlow(SurahSubjectsState())
+    val surahSubjects: StateFlow<SurahSubjectsState> = _surahSubjects.asStateFlow()
 
     private val queries = MutableStateFlow("")
 
@@ -260,9 +348,22 @@ class QuranTopicsViewModel @Inject constructor(
                 queries.value = ""
             }
 
+            is QuranTopicsEvent.LoadSurahSubjects -> {
+                if (_surahSubjects.value.surahNumber != event.surahNumber) {
+                    AppAnalytics.logFeatureUsed("quran_topics", "open_surah_subjects")
+                    loadSurahSubjects(event.surahNumber)
+                }
+            }
+
+            is QuranTopicsEvent.FilterSurahSubjects ->
+                _surahSubjects.update { it.copy(query = event.query) }
+
+            QuranTopicsEvent.ClearSurahSubjectsFilter ->
+                _surahSubjects.update { it.copy(query = "") }
+
             is QuranTopicsEvent.LoadDetail -> {
                 AppAnalytics.logFeatureUsed("quran_topics", "open_detail")
-                loadDetail(event.topicId, event.tree)
+                loadDetail(event.topicId, event.tree, event.fromSurah)
             }
         }
     }
@@ -450,13 +551,53 @@ class QuranTopicsViewModel @Inject constructor(
     }
 
     /**
+     * The subjects one surah is cited under, and the surah's own name for the top bar.
+     *
+     * One query for the list; the name comes from the surah list, which the home screen has
+     * already warmed. A surah whose artifact predates the thematic layer simply has no rows,
+     * which the screen says in words rather than treating as a failure.
+     */
+    private fun loadSurahSubjects(surahNumber: Int) {
+        viewModelScope.launch {
+            _surahSubjects.value = SurahSubjectsState(
+                surahNumber = surahNumber,
+                isLoading = true,
+            )
+            val subjects = quranUseCases.getTopicsForSurah(surahNumber)
+            // Only asked when there is nothing to show, because that is the only time the
+            // answer changes what is said. It is a cached count either way.
+            val available = subjects.isNotEmpty() || quranUseCases.hasThematicContent()
+            val name = quranUseCases.getSurahList().first()
+                .firstOrNull { it.number == surahNumber }
+                ?.nameEnglish
+                .orEmpty()
+            _surahSubjects.update { state ->
+                // A second surah may have been asked for while this was in flight — the pane
+                // layouts can swap the detail surah without leaving the screen.
+                if (state.surahNumber != surahNumber) state
+                else state.copy(
+                    surahName = name,
+                    subjects = subjects,
+                    isAvailable = available,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    /**
      * A topic, its citations grouped under the surahs they fall in, and a line of each verse.
      *
      * The previews are one query for the whole list — `getTranslationsForAyahs` takes the ids
      * as an `IN (…)` — so "Allah" costs two reads rather than 153. A translation the device
      * does not have simply yields nothing, and the rows fall back to bare references.
+     *
+     * The groups stay in the corpus's order — which is Qur'anic order — with exactly one
+     * exception: the surah the reader came from is lifted to the front. Ordering by relevance
+     * would be replacing the mushaf's sequence with one of our own; lifting the surah they are
+     * holding is answering the question they opened the subject with.
      */
-    private fun loadDetail(topicId: Int, tree: TopicTree) {
+    private fun loadDetail(topicId: Int, tree: TopicTree, fromSurah: Int? = null) {
         viewModelScope.launch {
             _detailState.update { it.copy(isLoading = true) }
             val detail = quranUseCases.getTopicDetail(topicId, tree)
@@ -475,12 +616,23 @@ class QuranTopicsViewModel @Inject constructor(
                         surahNumber = surah,
                         surahName = names[surah].orEmpty(),
                         citations = citations,
+                        isFromSurah = surah == fromSurah,
                     )
                 }
+                .sortedByDescending { it.isFromSurah }
 
             _detailState.value = TopicDetailState(
                 detail = detail,
                 citationGroups = groups,
+                // Only where the subject actually reaches that surah. A context line reading
+                // "0 verses in Al-Fatiha" is a label for something that is not there.
+                surahContext = groups.firstOrNull { it.isFromSurah }?.let { group ->
+                    TopicSurahContext(
+                        surahNumber = group.surahNumber,
+                        surahName = group.surahName,
+                        verseCount = group.citations.size,
+                    )
+                },
                 isLoading = false,
             )
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -85,9 +85,19 @@ data class FavoriteAyahUi(
 data class SurahThematicUiState(
     val overview: SurahOverview? = null,
     val passages: List<AyahTheme> = emptyList(),
+
+    /**
+     * How many subjects this surah's verses are cited under.
+     *
+     * A count and not the list: the info screen labels one row with it, and loading a few
+     * hundred topics to render a single integer is what the counting query exists to avoid.
+     */
+    val subjectCount: Int = 0,
+
     val isLoading: Boolean = true,
 ) {
-    val isAvailable: Boolean get() = overview != null || passages.isNotEmpty()
+    val isAvailable: Boolean
+        get() = overview != null || passages.isNotEmpty() || subjectCount > 0
 }
 
 data class QuranHomeUiState(
@@ -682,9 +692,11 @@ class QuranViewModel @Inject constructor(
             _surahThematic.value = SurahThematicUiState(isLoading = true)
             val overview = quranUseCases.getSurahOverview(surahNumber)
             val themes = quranUseCases.getSurahThemes(surahNumber)
+            val subjects = quranUseCases.getTopicsForSurah.count(surahNumber)
             _surahThematic.value = SurahThematicUiState(
                 overview = overview,
                 passages = themes,
+                subjectCount = subjects,
                 isLoading = false,
             )
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1004,13 +1004,27 @@
     <string name="surah_info_background_subtitle">%1$d Abschnitte</string>
     <string name="surah_info_passages_row_subtitle">%1$d Abschnitte über %2$d Verse</string>
     <string name="surah_info_subjects">Themen in dieser Sure</string>
-    <string name="surah_info_subjects_subtitle">Durchsuchen, wovon der Koran spricht</string>
+    <string name="surah_info_subjects_subtitle">%1$d Themen, meistgenannte zuerst</string>
     <string name="surah_info_section_other">Sonstiges</string>
     <string name="surah_passages_filter_hint">Abschnitte filtern</string>
     <string name="surah_passages_reading">Aktuell</string>
     <string name="surah_passages_none_title">Nichts gefunden</string>
     <string name="surah_passages_none">Kein Abschnitt passt dazu. Filter löschen, um alle %1$d zu sehen.</string>
     <string name="cd_passage_open">%1$s im Leser öffnen</string>
+
+    <!-- Themen einer Sure -->
+    <string name="surah_subjects_title">Themen</string>
+    <string name="surah_subjects_subtitle">Themen in dieser Sure</string>
+    <string name="surah_subjects_filter_hint">Diese Themen filtern…</string>
+    <string name="surah_subjects_count">%1$d Themen</string>
+    <string name="surah_subjects_citations">%1$d Fundstellen</string>
+    <string name="surah_subjects_only_here">Jeder Vers zu diesem Thema steht in dieser Sure</string>
+    <string name="surah_subjects_elsewhere">%1$d weitere Verse anderswo im Koran</string>
+    <string name="surah_subjects_no_match">Kein Thema hier passt zu „%1$s“. Filter löschen, um alle %2$d zu sehen.</string>
+    <string name="surah_subjects_none_title">Hier ist nichts erfasst</string>
+    <string name="surah_subjects_none">Das Themenregister führt keinen Vers dieser Sure. Der Rest des Registers ist weiterhin da.</string>
+    <string name="surah_subjects_browse_all">Alle Themen</string>
+    <string name="surah_subjects_browse_all_subtitle">Das ganze Register durchsuchen, über alle 114 Suren</string>
 
     <!-- Quran-Themen -->
     <string name="quran_home_browse_subjects">Themen im Koran</string>
@@ -1032,6 +1046,8 @@
     <string name="quran_topic_related">Verwandte Themen</string>
     <string name="quran_topic_not_found">Dieses Thema steht nicht im Register.</string>
     <string name="quran_topic_verses_across">%1$d in %2$d Suren</string>
+    <string name="quran_topic_surah_you_came_from">Diese Sure</string>
+    <string name="quran_topic_in_surah">%1$d in %2$s</string>
     <string name="quran_topics_crumb_home">Alle Themen</string>
     <string name="quran_topics_scope_search">Durchsucht alle drei Gliederungen</string>
     <string name="quran_topics_scope_thematic">Eine kuratierte Gliederung — Glaube, Gottesdienst, Geschichten</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1026,13 +1026,27 @@
     <string name="surah_info_background_subtitle">%1$d sections</string>
     <string name="surah_info_passages_row_subtitle">%1$d passages sur %2$d versets</string>
     <string name="surah_info_subjects">Sujets de cette sourate</string>
-    <string name="surah_info_subjects_subtitle">Parcourir ce dont parle le Coran</string>
+    <string name="surah_info_subjects_subtitle">%1$d sujets, les plus cités d\'abord</string>
     <string name="surah_info_section_other">Autre</string>
     <string name="surah_passages_filter_hint">Filtrer les passages</string>
     <string name="surah_passages_reading">En cours</string>
     <string name="surah_passages_none_title">Aucun résultat</string>
     <string name="surah_passages_none">Aucun passage ne correspond. Effacez le filtre pour voir les %1$d.</string>
     <string name="cd_passage_open">Ouvrir %1$s dans le lecteur</string>
+
+    <!-- Sujets d\'une sourate -->
+    <string name="surah_subjects_title">Sujets</string>
+    <string name="surah_subjects_subtitle">Sujets de cette sourate</string>
+    <string name="surah_subjects_filter_hint">Filtrer ces sujets…</string>
+    <string name="surah_subjects_count">%1$d sujets</string>
+    <string name="surah_subjects_citations">%1$d références</string>
+    <string name="surah_subjects_only_here">Tous les versets sur ce sujet sont dans cette sourate</string>
+    <string name="surah_subjects_elsewhere">%1$d autres versets ailleurs dans le Coran</string>
+    <string name="surah_subjects_no_match">Aucun sujet ici ne correspond à «\u00A0%1$s\u00A0». Effacez le filtre pour voir les %2$d.</string>
+    <string name="surah_subjects_none_title">Rien d\'indexé ici</string>
+    <string name="surah_subjects_none">L\'index thématique ne cite aucun verset de cette sourate. Le reste de l\'index est toujours là.</string>
+    <string name="surah_subjects_browse_all">Tous les sujets</string>
+    <string name="surah_subjects_browse_all_subtitle">Parcourir tout l\'index, sur les 114 sourates</string>
 
     <!-- Thèmes du Coran -->
     <string name="quran_home_browse_subjects">Sujets du Coran</string>
@@ -1054,6 +1068,8 @@
     <string name="quran_topic_related">Sujets liés</string>
     <string name="quran_topic_not_found">Ce sujet ne figure pas dans l\'index.</string>
     <string name="quran_topic_verses_across">%1$d dans %2$d sourates</string>
+    <string name="quran_topic_surah_you_came_from">Cette sourate</string>
+    <string name="quran_topic_in_surah">%1$d dans %2$s</string>
     <string name="quran_topics_crumb_home">Tous les sujets</string>
     <string name="quran_topics_scope_search">Recherche dans les trois hiérarchies</string>
     <string name="quran_topics_scope_thematic">Un plan raisonné — doctrine, adoration, récits</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -987,13 +987,27 @@
     <string name="surah_info_background_subtitle">%1$d bagian</string>
     <string name="surah_info_passages_row_subtitle">%1$d bagian mencakup %2$d ayat</string>
     <string name="surah_info_subjects">Topik dalam surah ini</string>
-    <string name="surah_info_subjects_subtitle">Jelajahi apa yang dibicarakan Al-Quran</string>
+    <string name="surah_info_subjects_subtitle">%1$d topik, paling banyak dirujuk lebih dahulu</string>
     <string name="surah_info_section_other">Lainnya</string>
     <string name="surah_passages_filter_hint">Saring bagian</string>
     <string name="surah_passages_reading">Sedang dibaca</string>
     <string name="surah_passages_none_title">Tidak ada yang cocok</string>
     <string name="surah_passages_none">Tidak ada bagian yang cocok. Hapus filter untuk melihat semua %1$d.</string>
     <string name="cd_passage_open">Buka %1$s di pembaca</string>
+
+    <!-- Topik dalam satu surah -->
+    <string name="surah_subjects_title">Topik</string>
+    <string name="surah_subjects_subtitle">Topik dalam surah ini</string>
+    <string name="surah_subjects_filter_hint">Saring topik ini…</string>
+    <string name="surah_subjects_count">%1$d topik</string>
+    <string name="surah_subjects_citations">%1$d rujukan</string>
+    <string name="surah_subjects_only_here">Setiap ayat tentang topik ini ada di surah ini</string>
+    <string name="surah_subjects_elsewhere">%1$d ayat lain di bagian lain Al-Quran</string>
+    <string name="surah_subjects_no_match">Tidak ada topik di sini yang cocok dengan “%1$s”. Hapus filter untuk melihat semua %2$d.</string>
+    <string name="surah_subjects_none_title">Tidak ada yang terindeks di sini</string>
+    <string name="surah_subjects_none">Indeks topik tidak merujuk satu pun ayat surah ini. Sisa indeksnya tetap ada.</string>
+    <string name="surah_subjects_browse_all">Semua topik</string>
+    <string name="surah_subjects_browse_all_subtitle">Jelajahi seluruh indeks, mencakup semua 114 surah</string>
 
     <!-- Topik Al-Quran -->
     <string name="quran_home_browse_subjects">Topik dalam Al-Quran</string>
@@ -1015,6 +1029,8 @@
     <string name="quran_topic_related">Topik terkait</string>
     <string name="quran_topic_not_found">Topik ini tidak ada dalam indeks.</string>
     <string name="quran_topic_verses_across">%1$d di %2$d surah</string>
+    <string name="quran_topic_surah_you_came_from">Surah ini</string>
+    <string name="quran_topic_in_surah">%1$d di %2$s</string>
     <string name="quran_topics_crumb_home">Semua topik</string>
     <string name="quran_topics_scope_search">Mencari di ketiga hierarki</string>
     <string name="quran_topics_scope_thematic">Kerangka pilihan — akidah, ibadah, kisah</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -988,13 +988,27 @@
     <string name="surah_info_background_subtitle">%1$d bahagian</string>
     <string name="surah_info_passages_row_subtitle">%1$d bahagian merangkumi %2$d ayat</string>
     <string name="surah_info_subjects">Topik dalam surah ini</string>
-    <string name="surah_info_subjects_subtitle">Layari apa yang diperkatakan Al-Quran</string>
+    <string name="surah_info_subjects_subtitle">%1$d topik, paling banyak dirujuk dahulu</string>
     <string name="surah_info_section_other">Lain-lain</string>
     <string name="surah_passages_filter_hint">Tapis bahagian</string>
     <string name="surah_passages_reading">Sedang dibaca</string>
     <string name="surah_passages_none_title">Tiada padanan</string>
     <string name="surah_passages_none">Tiada bahagian yang sepadan. Kosongkan penapis untuk melihat kesemua %1$d.</string>
     <string name="cd_passage_open">Buka %1$s dalam pembaca</string>
+
+    <!-- Topik dalam satu surah -->
+    <string name="surah_subjects_title">Topik</string>
+    <string name="surah_subjects_subtitle">Topik dalam surah ini</string>
+    <string name="surah_subjects_filter_hint">Tapis topik ini…</string>
+    <string name="surah_subjects_count">%1$d topik</string>
+    <string name="surah_subjects_citations">%1$d rujukan</string>
+    <string name="surah_subjects_only_here">Setiap ayat tentang topik ini ada dalam surah ini</string>
+    <string name="surah_subjects_elsewhere">%1$d ayat lagi di tempat lain dalam Al-Quran</string>
+    <string name="surah_subjects_no_match">Tiada topik di sini sepadan dengan “%1$s”. Kosongkan penapis untuk melihat kesemua %2$d.</string>
+    <string name="surah_subjects_none_title">Tiada apa diindeks di sini</string>
+    <string name="surah_subjects_none">Indeks topik tidak merujuk mana-mana ayat surah ini. Selebihnya indeks masih ada.</string>
+    <string name="surah_subjects_browse_all">Semua topik</string>
+    <string name="surah_subjects_browse_all_subtitle">Layari seluruh indeks, merangkumi kesemua 114 surah</string>
 
     <!-- Topik Al-Quran -->
     <string name="quran_home_browse_subjects">Topik dalam Al-Quran</string>
@@ -1016,6 +1030,8 @@
     <string name="quran_topic_related">Topik berkaitan</string>
     <string name="quran_topic_not_found">Topik ini tiada dalam indeks.</string>
     <string name="quran_topic_verses_across">%1$d dalam %2$d surah</string>
+    <string name="quran_topic_surah_you_came_from">Surah ini</string>
+    <string name="quran_topic_in_surah">%1$d dalam %2$s</string>
     <string name="quran_topics_crumb_home">Semua topik</string>
     <string name="quran_topics_scope_search">Mencari dalam ketiga-tiga hierarki</string>
     <string name="quran_topics_scope_thematic">Rangka pilihan — akidah, ibadah, kisah</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1010,13 +1010,27 @@
     <string name="surah_info_background_subtitle">%1$d bölüm</string>
     <string name="surah_info_passages_row_subtitle">%2$d ayet boyunca %1$d bölüm</string>
     <string name="surah_info_subjects">Bu suredeki konular</string>
-    <string name="surah_info_subjects_subtitle">Kur\'an\'ın söz ettiklerine göz atın</string>
+    <string name="surah_info_subjects_subtitle">%1$d konu, en çok atıf alan önce</string>
     <string name="surah_info_section_other">Diğer</string>
     <string name="surah_passages_filter_hint">Bölümleri filtrele</string>
     <string name="surah_passages_reading">Okunuyor</string>
     <string name="surah_passages_none_title">Eşleşme yok</string>
     <string name="surah_passages_none">Hiçbir bölüm eşleşmiyor. Tümünü (%1$d) görmek için filtreyi temizleyin.</string>
     <string name="cd_passage_open">%1$s okuyucuda açılsın</string>
+
+    <!-- Bir surenin konuları -->
+    <string name="surah_subjects_title">Konular</string>
+    <string name="surah_subjects_subtitle">Bu suredeki konular</string>
+    <string name="surah_subjects_filter_hint">Bu konuları süz…</string>
+    <string name="surah_subjects_count">%1$d konu</string>
+    <string name="surah_subjects_citations">%1$d atıf</string>
+    <string name="surah_subjects_only_here">Bu konudaki her ayet bu surede</string>
+    <string name="surah_subjects_elsewhere">Kur\'an\'ın başka yerlerinde %1$d ayet daha</string>
+    <string name="surah_subjects_no_match">Burada “%1$s” ile eşleşen konu yok. Tümünü (%2$d) görmek için filtreyi temizleyin.</string>
+    <string name="surah_subjects_none_title">Burada dizinlenmiş bir şey yok</string>
+    <string name="surah_subjects_none">Konu dizini bu surenin hiçbir ayetine atıfta bulunmuyor. Dizinin geri kalanı yerinde.</string>
+    <string name="surah_subjects_browse_all">Tüm konular</string>
+    <string name="surah_subjects_browse_all_subtitle">Tüm dizine, 114 surenin hepsine göz atın</string>
 
     <!-- Kur\'an konuları -->
     <string name="quran_home_browse_subjects">Kur\'an\'daki konular</string>
@@ -1038,6 +1052,8 @@
     <string name="quran_topic_related">İlgili konular</string>
     <string name="quran_topic_not_found">Bu konu dizinde yok.</string>
     <string name="quran_topic_verses_across">%2$d surede %1$d ayet</string>
+    <string name="quran_topic_surah_you_came_from">Bu sure</string>
+    <string name="quran_topic_in_surah">%2$s içinde %1$d</string>
     <string name="quran_topics_crumb_home">Tüm konular</string>
     <string name="quran_topics_scope_search">Üç dizinin tümünde aranıyor</string>
     <string name="quran_topics_scope_thematic">Derlenmiş bir taslak — akide, ibadet, kıssalar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1250,7 +1250,7 @@
     <string name="surah_info_passages_subtitle">%1$d passages in this surah</string>
     <string name="surah_info_passages_row_subtitle">%1$d passages across %2$d verses</string>
     <string name="surah_info_subjects">Subjects in this surah</string>
-    <string name="surah_info_subjects_subtitle">Browse what the Qur\'an speaks about</string>
+    <string name="surah_info_subjects_subtitle">%1$d subjects, most-cited first</string>
     <string name="surah_info_section_name">Name</string>
     <string name="surah_info_section_revelation">Period of Revelation</string>
     <string name="surah_info_section_theme">Theme and Subject Matter</string>
@@ -1266,6 +1266,20 @@
     <string name="surah_passages_none_title">Nothing matched</string>
     <string name="surah_passages_none">No passage matches that. Clear the filter to see all %1$d.</string>
     <string name="cd_passage_open">Open %1$s in the reader</string>
+
+    <!-- Subjects in one surah -->
+    <string name="surah_subjects_title">Subjects</string>
+    <string name="surah_subjects_subtitle">Subjects in this surah</string>
+    <string name="surah_subjects_filter_hint">Filter these subjects…</string>
+    <string name="surah_subjects_count">%1$d subjects</string>
+    <string name="surah_subjects_citations">%1$d citations</string>
+    <string name="surah_subjects_only_here">Every verse on this subject is in this surah</string>
+    <string name="surah_subjects_elsewhere">%1$d more verses elsewhere in the Qur\'an</string>
+    <string name="surah_subjects_no_match">No subject here matches “%1$s”. Clear the filter to see all %2$d.</string>
+    <string name="surah_subjects_none_title">Nothing indexed here</string>
+    <string name="surah_subjects_none">The subject index doesn\'t cite any verse of this surah. The rest of the index is still there.</string>
+    <string name="surah_subjects_browse_all">All subjects</string>
+    <string name="surah_subjects_browse_all_subtitle">Browse the whole index, across all 114 surahs</string>
 
     <!-- Quran topics -->
     <string name="quran_home_browse_subjects">Subjects in the Qur\'an</string>
@@ -1287,6 +1301,8 @@
     <string name="quran_topic_related">Related subjects</string>
     <string name="quran_topic_not_found">This subject isn\'t in the index.</string>
     <string name="quran_topic_verses_across">%1$d across %2$d surahs</string>
+    <string name="quran_topic_in_surah">%1$d in %2$s</string>
+    <string name="quran_topic_surah_you_came_from">This surah</string>
     <string name="quran_topics_crumb_home">All subjects</string>
     <string name="quran_topics_scope_search">Searching all three hierarchies</string>
     <string name="quran_topics_scope_thematic">A curated outline — doctrine, worship, stories</string>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModelSurahContextTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/QuranTopicsViewModelSurahContextTest.kt
@@ -1,0 +1,309 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.SurahTopic
+import com.arshadshah.nimaz.domain.model.TopicCitation
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.GetSurahListUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicDetailUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicsForSurahUseCase
+import com.arshadshah.nimaz.domain.usecase.HasThematicContentUseCase
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A subject opened from a surah has to keep the surah.
+ *
+ * "Subjects in this surah" used to navigate to the global browser at the top of the thematic
+ * tree — the same twenty roots whichever surah you had been reading — and a subject opened from
+ * anywhere listed its citations in Qur'anic order with nothing marking the surah you came from.
+ * The reader arrived holding a specific question and every screen answered a general one.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuranTopicsViewModelSurahContextTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: QuranUseCases
+    private lateinit var forSurah: GetTopicsForSurahUseCase
+    private lateinit var getDetail: GetTopicDetailUseCase
+    private lateinit var hasContent: HasThematicContentUseCase
+    private lateinit var settings: SettingsRepository
+
+    private val patience = topic(id = 61, name = "Patience", ayahCount = 103)
+    private val theCow = topic(id = 62, name = "The cow", arabic = "البقرة", ayahCount = 7)
+
+    // Al-Baqarah leads with what it is mostly about, not with the busiest subject overall.
+    private val baqarahSubjects = listOf(
+        SurahTopic(topic = patience, versesInSurah = 12),
+        SurahTopic(topic = theCow, versesInSurah = 7),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        forSurah = mockk()
+        coEvery { forSurah.invoke(2) } returns baqarahSubjects
+        coEvery { forSurah.invoke(1) } returns emptyList()
+
+        getDetail = mockk()
+        coEvery { getDetail.invoke(any(), any()) } returns detailOf(patience)
+
+        hasContent = mockk()
+        coEvery { hasContent.invoke() } returns true
+
+        val surahs = mockk<GetSurahListUseCase>()
+        every { surahs.invoke() } returns flowOf(
+            listOf(surah(1, "The Opening"), surah(2, "The Cow"), surah(3, "The Family of Imran")),
+        )
+
+        settings = mockk(relaxed = true)
+        every { settings.quranTranslatorId } returns MutableStateFlow("sahih_international")
+
+        useCases = mockk(relaxed = true)
+        every { useCases.getTopicsForSurah } returns forSurah
+        every { useCases.getTopicDetail } returns getDetail
+        every { useCases.getSurahList } returns surahs
+        every { useCases.hasThematicContent } returns hasContent
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `a surah's subjects arrive with the surah's own name, weightiest here first`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+
+        val state = vm.surahSubjects.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.surahName).isEqualTo("The Cow")
+        assertThat(state.subjects.map { it.topic.name })
+            .containsExactly("Patience", "The cow").inOrder()
+        assertThat(state.citations).isEqualTo(19)
+    }
+
+    @Test
+    fun `re-sending the same surah does not re-query`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { forSurah.invoke(2) }
+    }
+
+    /** The list is already in memory, so filtering is a predicate and not a second query. */
+    @Test
+    fun `filtering narrows what is loaded without going back to the corpus`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QuranTopicsEvent.FilterSurahSubjects("cow"))
+        advanceUntilIdle()
+
+        assertThat(vm.surahSubjects.value.visible.map { it.topic.name })
+            .containsExactly("The cow")
+        // Still the whole list underneath — the filter is a view, not a reload.
+        assertThat(vm.surahSubjects.value.subjects).hasSize(2)
+        coVerify(exactly = 1) { forSurah.invoke(2) }
+
+        vm.onEvent(QuranTopicsEvent.ClearSurahSubjectsFilter)
+        advanceUntilIdle()
+        assertThat(vm.surahSubjects.value.visible).hasSize(2)
+    }
+
+    @Test
+    fun `the filter matches the Arabic name too`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QuranTopicsEvent.FilterSurahSubjects("البقرة"))
+        advanceUntilIdle()
+
+        assertThat(vm.surahSubjects.value.visible.map { it.topic.id }).containsExactly(62)
+    }
+
+    /**
+     * The one deliberate departure from Qur'anic order: the surah the reader came from is
+     * lifted to the front. Everything else keeps the sequence the corpus gives.
+     */
+    @Test
+    fun `the surah you came from is pinned to the top of the citations`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(61, TopicTree.THEMATIC, fromSurah = 3))
+        advanceUntilIdle()
+
+        val state = vm.detailState.value
+        assertThat(state.citationGroups.map { it.surahNumber })
+            .containsExactly(3, 1, 2).inOrder()
+        assertThat(state.citationGroups.first().isFromSurah).isTrue()
+        assertThat(state.citationGroups.drop(1).none { it.isFromSurah }).isTrue()
+    }
+
+    @Test
+    fun `the surah context carries that surah's own share of the subject`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(61, TopicTree.THEMATIC, fromSurah = 2))
+        advanceUntilIdle()
+
+        val context = vm.detailState.value.surahContext
+        assertThat(context?.surahNumber).isEqualTo(2)
+        assertThat(context?.surahName).isEqualTo("The Cow")
+        assertThat(context?.verseCount).isEqualTo(2)
+    }
+
+    /** A subject that never reaches the surah gets no context line rather than a zero. */
+    @Test
+    fun `a surah the subject does not touch produces no context`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(61, TopicTree.THEMATIC, fromSurah = 114))
+        advanceUntilIdle()
+
+        assertThat(vm.detailState.value.surahContext).isNull()
+        assertThat(vm.detailState.value.citationGroups.map { it.surahNumber })
+            .containsExactly(1, 2, 3).inOrder()
+    }
+
+    @Test
+    fun `without a surah the citations keep the corpus order and nothing is marked`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(61, TopicTree.THEMATIC))
+        advanceUntilIdle()
+
+        val state = vm.detailState.value
+        assertThat(state.surahContext).isNull()
+        assertThat(state.citationGroups.map { it.surahNumber })
+            .containsExactly(1, 2, 3).inOrder()
+        assertThat(state.citationGroups.none { it.isFromSurah }).isTrue()
+    }
+
+    /**
+     * An empty list is a sentence about the install far more often than about the surah, and
+     * the screen has to be able to tell which it is saying.
+     */
+    @Test
+    fun `an empty list separates a missing index from a surah with nothing in it`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(1))
+        advanceUntilIdle()
+        assertThat(vm.surahSubjects.value.subjects).isEmpty()
+        assertThat(vm.surahSubjects.value.isAvailable).isTrue()
+
+        coEvery { hasContent.invoke() } returns false
+        val stale = viewModel()
+        stale.onEvent(QuranTopicsEvent.LoadSurahSubjects(1))
+        advanceUntilIdle()
+        assertThat(stale.surahSubjects.value.isAvailable).isFalse()
+    }
+
+    /** A surah with rows never pays for the availability check — the rows are the answer. */
+    @Test
+    fun `a surah with subjects does not ask whether the layer exists`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(QuranTopicsEvent.LoadSurahSubjects(2))
+        advanceUntilIdle()
+
+        assertThat(vm.surahSubjects.value.isAvailable).isTrue()
+        coVerify(exactly = 0) { hasContent.invoke() }
+    }
+
+    /**
+     * A surah's subjects come from all three hierarchies, so the tree a row opens in has to be
+     * the one that actually places it — otherwise the subjects the thematic outline does not
+     * carry open with no breadcrumb and no subtopics.
+     */
+    @Test
+    fun `a subject opens in the hierarchy that places it`() {
+        assertThat(patience.homeTree).isEqualTo(TopicTree.THEMATIC)
+        assertThat(
+            topic(id = 7, name = "Egypt", thematic = false, ontology = true).homeTree
+        ).isEqualTo(TopicTree.ONTOLOGY)
+        assertThat(
+            topic(id = 8, name = "Ants", thematic = false, ontology = false).homeTree
+        ).isEqualTo(TopicTree.INDEX)
+    }
+
+    private fun viewModel() = QuranTopicsViewModel(useCases, settings)
+
+    /** Citations across three surahs, in the order the corpus gives them — by ayah id. */
+    private fun detailOf(topic: QuranTopic) = TopicDetail(
+        topic = topic,
+        tree = TopicTree.THEMATIC,
+        breadcrumb = emptyList(),
+        children = emptyList(),
+        related = emptyList(),
+        citations = listOf(
+            TopicCitation(ayahId = 5, surahNumber = 1, ayahNumber = 5),
+            TopicCitation(ayahId = 160, surahNumber = 2, ayahNumber = 153),
+            TopicCitation(ayahId = 184, surahNumber = 2, ayahNumber = 177),
+            TopicCitation(ayahId = 500, surahNumber = 3, ayahNumber = 200),
+        ),
+    )
+
+    private fun surah(number: Int, english: String) = Surah(
+        number = number,
+        nameArabic = "",
+        nameEnglish = english,
+        nameTransliteration = english,
+        revelationType = RevelationType.MEDINAN,
+        ayahCount = 7,
+        juzStart = 1,
+        orderInMushaf = number,
+    )
+
+    private fun topic(
+        id: Int,
+        name: String,
+        arabic: String = "",
+        ayahCount: Int = 12,
+        thematic: Boolean = true,
+        ontology: Boolean = false,
+    ) = QuranTopic(
+        id = id,
+        name = name,
+        arabicName = arabic,
+        description = "",
+        wikiLink = "",
+        ayahCount = ayahCount,
+        parentId = null,
+        thematicParentId = null,
+        ontologyParentId = null,
+        isThematic = thematic,
+        isOntology = ontology,
+        relatedTopicIds = emptyList(),
+    )
+}

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -32,8 +32,9 @@ flowchart LR
         QuranHub --> QuranReader & QuranPage & QuranJuz & QuranSearch & QuranBookmarks
         QuranHub --> QuranTopics
         QuranReader --> SurahInfo & Tafseer
-        QuranReader --> SurahPassages & QuranTopics
-        SurahInfo --> SurahBackground & SurahPassages & QuranTopics
+        QuranReader --> SurahPassages & SurahSubjects
+        SurahInfo --> SurahBackground & SurahPassages & SurahSubjects
+        SurahSubjects --> QuranTopicDetail & QuranTopics
         QuranTopics --> QuranTopicDetail
         SurahBackground --> QuranTopicDetail
         Tafseer --> QuranTopicDetail
@@ -172,8 +173,9 @@ All routes live in `core/navigation/Routes.kt` and are wired in `core/navigation
 | `SurahBackground` | `surahNumber: Int` | SurahBackgroundScreen — the surah's long-form background, read continuously under a sticky index of `SurahOverviewGroup` pills. Its own destination because the longest is 47 KB of prose |
 | `SurahPassages` | `surahNumber: Int, currentAyah: Int? = null` | SurahPassagesScreen — the passage outline, up to 282 rows. `currentAyah` is supplied when it is opened **from the reader**, so the passage containing that verse is marked and scrolled to; null from surah info, where there is no such place to be |
 | `Tafseer` | `surahNumber: Int, ayahNumber: Int = 1` | TafseerScreen |
-| `QuranTopics` | — | QuranTopicsScreen — the subject browser. **One route for the whole tree:** it expands in place and `QuranTopicsViewModel` holds the expanded set and the focus, so opening four levels and closing them again is one back-stack entry, not four. Reachable from the Qur'an home's browse card, the reader's overflow, and surah info |
-| `QuranTopicDetail` | `topicId: Int, tree: String = "thematic"` | QuranTopicDetailScreen. `tree` is a `TopicTree.wire` value rather than the enum, because a route argument needs a `NavType`; an unrecognised value falls back to the thematic tree. Reachable from the browser, from a `topic:` link in a surah's background, from the Tafseer screen's topic chips, and **from itself** (a description's cross-links) |
+| `SurahSubjects` | `surahNumber: Int` | SurahSubjectsScreen — **the surah-scoped subject list**, ordered by how many of *this* surah's verses each subject takes. Its own destination rather than `QuranTopics` with an argument, because it answers a different question: the browser walks a hierarchy from its roots, this is a flat list of what these verses are cited under. Reached from surah info's "Subjects in this surah" and from the reader's overflow whenever a surah is on screen — both of which used to open `QuranTopics` at the top of the thematic tree, the same twenty roots whichever surah you came from. Offers `QuranTopics` at the bottom for the general question |
+| `QuranTopics` | — | QuranTopicsScreen — the subject browser. **One route for the whole tree:** it expands in place and `QuranTopicsViewModel` holds the expanded set and the focus, so opening four levels and closing them again is one back-stack entry, not four. Reachable from the Qur'an home's browse card, from `SurahSubjects`, and from the reader's overflow in page/juz mode before a surah has resolved |
+| `QuranTopicDetail` | `topicId: Int, tree: String = "thematic", fromSurah: Int? = null` | QuranTopicDetailScreen. `tree` is a `TopicTree.wire` value rather than the enum, because a route argument needs a `NavType`; an unrecognised value falls back to the thematic tree. `fromSurah` is the surah the reader arrived from: it filters nothing, but that surah's citations are pinned to the top of the list and badged, and it **travels with every lateral move** — subtopic, related subject, `topic:` cross-link — so the surah is not dropped one hop in. Reachable from `SurahSubjects`, from the browser, from a `topic:` link in a surah's background, from the Tafseer screen's topic chips, and **from itself** |
 | `SelectReciter` | — | SelectReciterScreen |
 | `SelectTranslation` | — | SelectTranslationScreen |
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -375,7 +375,10 @@ a printed mushaf carries in its margins and a reader app usually cannot answer a
   subjects in **three** hierarchies that do not agree (the subject index, the thematic outline, the
   ontology), and 30,687 citations. The citations are rows rather than the comma-separated string
   upstream keeps them in, because the question the app asks most is the reverse one — *which topics
-  is this verse under* — which is an index lookup here and 2,512 `LIKE` scans there.
+  is this verse under* — which is an index lookup here and 2,512 `LIKE` scans there. `surah_number`
+  riding along answers the same question a surah at a time (`getTopicsForSurah`, grouped and
+  counted per topic); that one is unindexed and walks the 30,687 rows, which is once per surah off
+  the main thread and cheaper than an index would be in artifact bytes.
 
 `MIGRATION_23_24` creates all five **empty**: they are content, so the rows arrive the way every
 other content row does (§7). A device that upgrades before the schemaVersion 24 artifact lands
@@ -394,9 +397,11 @@ schemes address screens this app has: 446 cross-references the source writes as 
 **Where it surfaces.** Each of the three kinds of content has a screen the size of the content:
 
 - **Surah info** is a *hub*. It carries the cartouche, the numbers, `surah_overviews.summary` as
-  body prose, and a "Go deeper" group of three counted rows. It used to carry the background as
-  accordions and the outline as up to 282 rows in the same list, which made it a document rather
-  than an answer. Rows are drawn only where there is content behind them.
+  body prose, and a "Go deeper" group of three counted rows — sections, passages, and now subjects
+  (`countTopicsForSurah`, the one integer the row needs rather than the few hundred topics behind
+  it). It used to carry the background as accordions and the outline as up to 282 rows in the same
+  list, which made it a document rather than an answer. Rows are drawn only where there is content
+  behind them.
 - **`Route.SurahBackground`** reads `surah_overview_sections` continuously under a sticky index of
   pills labelled from `section_group` — stable across all 114 surahs, which the source's own
   `heading` is not. Each section keeps that heading as its title. The longest background runs to
@@ -406,18 +411,31 @@ schemes address screens this app has: 446 cross-references the source writes as 
   marks and scrolls to the passage containing it.
 - The **reader** prints a passage heading where the outline starts a new subject (surah mode only
   — a juz spans a dozen surahs and would cost a query per surah per page turn), and its overflow
-  reaches both the passage outline and the subject browser.
+  reaches both the passage outline and the subjects of the surah on screen.
+- **`Route.SurahSubjects`** is the **surah-scoped** answer: a flat list of the subjects this
+  surah's verses are actually cited under, ordered by `verses_here` so a surah leads with what it
+  is about rather than with whichever subject is busiest Qur'an-wide, and each row saying how far
+  the subject reaches past these verses. It exists because "Subjects in this surah" and the
+  reader's overflow both used to open `QuranTopics` at the roots of the thematic tree — the same
+  twenty nouns whichever surah you came from, with the surah dropped on the way. A row opens the
+  detail in `QuranTopic.homeTree`, the hierarchy that actually places that subject, since the
+  thematic outline carries only 695 of the 2,512. The whole index stays one tap away at the
+  bottom.
 - **`Route.QuranTopics`** browses all three hierarchies as **one tree that opens in place**: a
   node's children insert beneath it, the breadcrumb is a bar of tappable crumbs rather than a
   truncating top-bar string, and past three levels of indent a row offers to re-root the tree on
   itself. `getBranchTopicIds(tree)` is one query per tree telling every row whether it is a branch,
   which is what lets a leaf carry no disclosure control and open on its label instead. Reachable
-  from a labelled card on the Qur'an home (gated on `hasThematicContent()`), the reader's overflow,
-  and surah info.
+  from a labelled card on the Qur'an home (gated on `hasThematicContent()`), from `SurahSubjects`,
+  and from the reader's overflow in page/juz mode before a surah has resolved.
 - **`Route.QuranTopicDetail`** gives its four kinds of content four shapes: description as body
   prose, subtopics as tree rows, related subjects as chips, and the citations grouped by surah
   under sticky headers with a line of each verse — resolved for the whole list in one
-  `getTranslationsForAyahs` call, so a subject citing 153 verses costs two reads.
+  `getTranslationsForAyahs` call, so a subject citing 153 verses costs two reads. Its `fromSurah`
+  argument is the surah the reader arrived from: it filters nothing, but that surah's group is
+  lifted to the front of an otherwise Qur'anic ordering and badged as such, a badge beside the
+  verse count gives its share, and the argument rides every lateral move — subtopic, related
+  subject, `topic:` cross-link — so the context survives more than one hop.
 - The **Tafseer** screen shows the verse's subjects as chips, capped at six.
 
 Two new search kinds — `theme` and `topic` — ride the shipped FTS index, and topic search results


### PR DESCRIPTION
"Subjects in this surah" and the reader's overflow both navigated to
Route.QuranTopics — the global browser at the top of the thematic tree.
The same twenty roots (Doctrine, Stories, The Unseen) whichever surah you
had just been reading, with the surah dropped on the way. The reader
arrived holding a specific question and got the table of contents for all
114. Opening a subject from anywhere then listed its citations in Qur'anic
order with nothing marking the surah in hand, so "Patience" from
Al-Baqarah landed on Al-Fatiha's one verse with Al-Baqarah's forty
somewhere below the fold.

Route.SurahSubjects is the specific answer: a flat list of the subjects
this surah's verses are actually cited under, ordered by weight *here*, so
a surah leads with what it is about rather than with whichever subject is
busiest Qur'an-wide. Each row says how far the subject reaches past these
verses, which is what separates a subject the surah owns from one that is
everywhere and touches once. Rows open in QuranTopic.homeTree — the
hierarchy that actually places that subject — since the thematic outline
carries only 695 of the 2,512 and defaulting the rest to it produced a
detail screen with no breadcrumb and no subtopics. The whole index stays
one tap away at the bottom.

QuranTopicDetail gains fromSurah. It filters nothing — a subject's
citations are the whole of it — but that surah's group is lifted to the
front of an otherwise untouched Qur'anic ordering and badged as such, a
badge beside the total gives its share, and the argument rides every
lateral move (subtopic, related subject, topic: cross-link) so the context
survives more than one hop.

Data: quran_topic_ayahs already carries surah_number, so the surah-scoped
question is a group-and-count over it. Unindexed, therefore a walk of
30,687 rows — once per surah, off the main thread, and cheaper than an
index would be in artifact bytes. Surah info takes the count alone rather
than the few hundred topics behind it, which also fixes a row that was
drawn on hasThematicContent() and subtitled "Browse what the Qur'an speaks
about": a promise that was true and a destination that was wrong.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvSrWvQ7AYPECfwWrVU8Dg