### PR TITLE
Rework notifications per prayer, and put the Mushaf's rukūʿ mark where it belongs

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="25" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="25" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="jbr-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="jbr-25" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/androidTest/java/com/arshadshah/nimaz/notifications/PrayerNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/notifications/PrayerNotificationSchedulerTest.kt
@@ -51,6 +51,9 @@ class PrayerNotificationSchedulerTest {
             PrayerNotificationScheduler.CHANNEL_ID_PRAYER,
             PrayerNotificationScheduler.CHANNEL_ID_ADHAN,
             PrayerNotificationScheduler.CHANNEL_ID_DAILY_SUMMARY,
+            // The silent alert style needs a channel of its own — the *_SILENT channels are
+            // no-vibration siblings that still carry a sound.
+            PrayerNotificationScheduler.CHANNEL_ID_PRAYER_MUTED,
         )
     }
 
@@ -61,8 +64,7 @@ class PrayerNotificationSchedulerTest {
             longitude = 39.8262,
             notificationsEnabled = true,
             enabledPrayers = PrayerType.entries.toSet(),
-            preReminderEnabled = true,
-            preReminderMinutes = 15,
+            preReminders = PrayerType.entries.associateWith { 15 },
         )
     }
 

--- a/app/src/androidTest/java/com/arshadshah/nimaz/preferences/PrayerAlertSettingsTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/preferences/PrayerAlertSettingsTest.kt
@@ -1,0 +1,127 @@
+package com.arshadshah.nimaz.preferences
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * The per-prayer alert style and reminder, end to end through DataStore.
+ *
+ * These are the settings the notifications rework split out of two global preferences, so
+ * the property that matters is isolation: setting one prayer must leave the other four
+ * exactly as they were. A regression here is silent — the app keeps working, it just stops
+ * doing what one person asked for at one time of day.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class PrayerAlertSettingsTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var settings: SettingsRepository
+
+    @Before
+    fun setup() = hiltRule.inject()
+
+    @Test
+    fun alertStyle_roundTripsPerPrayer() = runTest {
+        settings.setPrayerAlertStyle("fajr", PrayerAlertStyle.ADHAN)
+        settings.setPrayerAlertStyle("dhuhr", PrayerAlertStyle.SILENT)
+
+        assertThat(settings.prayerAlertStyle("fajr").first()).isEqualTo(PrayerAlertStyle.ADHAN)
+        assertThat(settings.prayerAlertStyle("dhuhr").first()).isEqualTo(PrayerAlertStyle.SILENT)
+    }
+
+    @Test
+    fun settingOnePrayer_leavesTheOthersAlone() = runTest {
+        PrayerAlertStyle.PRAYER_KEYS.forEach {
+            settings.setPrayerAlertStyle(it, PrayerAlertStyle.NOTIFICATION)
+            settings.setPrayerReminderEnabled(it, true)
+            settings.setPrayerReminderMinutes(it, 15)
+        }
+
+        settings.setPrayerAlertStyle("asr", PrayerAlertStyle.SILENT)
+        settings.setPrayerReminderMinutes("asr", 45)
+
+        assertThat(settings.prayerAlertStyle("asr").first()).isEqualTo(PrayerAlertStyle.SILENT)
+        assertThat(settings.prayerReminderMinutes("asr").first()).isEqualTo(45)
+
+        (PrayerAlertStyle.PRAYER_KEYS - "asr").forEach { untouched ->
+            assertThat(settings.prayerAlertStyle(untouched).first())
+                .isEqualTo(PrayerAlertStyle.NOTIFICATION)
+            assertThat(settings.prayerReminderMinutes(untouched).first()).isEqualTo(15)
+        }
+    }
+
+    @Test
+    fun reminderOff_dropsThePrayerFromTheScheduleWithoutLosingItsLeadTime() = runTest {
+        PrayerAlertStyle.PRAYER_KEYS.forEach {
+            settings.setPrayerReminderEnabled(it, true)
+            settings.setPrayerReminderMinutes(it, 20)
+        }
+        settings.setPrayerReminderEnabled("maghrib", false)
+
+        val scheduled = settings.preReminderMinutesByPrayer()
+
+        // Maghrib is absent rather than present with a zero offset — that is how the
+        // scheduler is told not to arm a reminder at all.
+        assertThat(scheduled.keys).doesNotContain(PrayerType.MAGHRIB)
+        assertThat(scheduled).containsEntry(PrayerType.FAJR, 20)
+        assertThat(scheduled).hasSize(4)
+
+        // The lead time survives, so switching the reminder back on restores 20 minutes
+        // rather than resetting to the default.
+        settings.setPrayerReminderEnabled("maghrib", true)
+        assertThat(settings.preReminderMinutesByPrayer())
+            .containsEntry(PrayerType.MAGHRIB, 20)
+    }
+
+    @Test
+    fun migration_carriesTheGlobalPreAdhanValueOntoEveryPrayer() = runTest {
+        // An install as it was before the split: a deliberately chosen 30-minute reminder
+        // and the adhan on everywhere.
+        settings.setShowReminderBefore(true)
+        settings.setNotificationReminderMinutes(30)
+        settings.setAdhanEnabled(true)
+
+        settings.migratePrayerNotificationPreferences()
+
+        PrayerAlertStyle.PRAYER_KEYS.forEach { prayer ->
+            assertThat(settings.prayerReminderEnabled(prayer).first()).isTrue()
+            assertThat(settings.prayerReminderMinutes(prayer).first()).isEqualTo(30)
+            assertThat(settings.prayerAlertStyle(prayer).first())
+                .isEqualTo(PrayerAlertStyle.ADHAN)
+        }
+    }
+
+    @Test
+    fun migration_neverRunsTwiceOverAChoiceTheUserHasSinceMade() = runTest {
+        settings.setShowReminderBefore(true)
+        settings.setNotificationReminderMinutes(30)
+        settings.migratePrayerNotificationPreferences()
+
+        // The user then changes their mind about Isha.
+        settings.setPrayerReminderMinutes("isha", 5)
+        settings.setPrayerAlertStyle("isha", PrayerAlertStyle.SILENT)
+
+        // A later start re-runs the call; the version guard must make it a no-op.
+        settings.migratePrayerNotificationPreferences()
+
+        assertThat(settings.prayerReminderMinutes("isha").first()).isEqualTo(5)
+        assertThat(settings.prayerAlertStyle("isha").first()).isEqualTo(PrayerAlertStyle.SILENT)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/init/AppInitializer.kt
@@ -5,6 +5,8 @@ import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.monitoring.PerfMonitor
 import com.arshadshah.nimaz.core.util.LocaleHelper
+import com.arshadshah.nimaz.core.util.enabledPrayerTypes
+import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
 import com.arshadshah.nimaz.data.announcement.AnnouncementBootstrap
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
@@ -12,7 +14,6 @@ import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
 import com.arshadshah.nimaz.data.local.user.UserDataMigrator
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
-import com.arshadshah.nimaz.domain.model.PrayerType
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -113,6 +114,10 @@ class AppInitializer @Inject constructor(
 
     private suspend fun scheduleInitialNotifications() {
         try {
+            // Carry an existing install onto the per-prayer alert style and reminder before
+            // anything reads them. Runs at most once; a no-op on every start after that.
+            preferencesDataStore.migratePrayerNotificationPreferences()
+
             val prefs = preferencesDataStore.userPreferences.first()
             AppAnalytics.setUserProperty(
                 AppAnalytics.UserProperty.NOTIFICATIONS_ENABLED,
@@ -123,25 +128,12 @@ class AppInitializer @Inject constructor(
                 (prefs.latitude != 0.0 || prefs.longitude != 0.0).toString(),
             )
             if (prefs.latitude != 0.0 && prefs.longitude != 0.0) {
-                val enabledPrayers = buildSet {
-                    if (preferencesDataStore.fajrNotificationEnabled.first()) add(PrayerType.FAJR)
-                    if (preferencesDataStore.sunriseNotificationEnabled.first()) add(PrayerType.SUNRISE)
-                    if (preferencesDataStore.dhuhrNotificationEnabled.first()) add(PrayerType.DHUHR)
-                    if (preferencesDataStore.asrNotificationEnabled.first()) add(PrayerType.ASR)
-                    if (preferencesDataStore.maghribNotificationEnabled.first()) add(PrayerType.MAGHRIB)
-                    if (preferencesDataStore.ishaNotificationEnabled.first()) add(PrayerType.ISHA)
-                }
-
-                val preReminderEnabled = preferencesDataStore.showReminderBefore.first()
-                val preReminderMinutes = preferencesDataStore.notificationReminderMinutes.first()
-
                 prayerNotificationScheduler.scheduleTodaysPrayerNotifications(
                     latitude = prefs.latitude,
                     longitude = prefs.longitude,
                     notificationsEnabled = prefs.prayerNotificationsEnabled,
-                    enabledPrayers = enabledPrayers,
-                    preReminderEnabled = preReminderEnabled,
-                    preReminderMinutes = preReminderMinutes
+                    enabledPrayers = preferencesDataStore.enabledPrayerTypes(),
+                    preReminders = preferencesDataStore.preReminderMinutesByPrayer()
                 )
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutes.kt
@@ -46,7 +46,9 @@ private fun staticAnnouncementRoute(key: String): Route? = when (key) {
     "settings/notifications/prayers" -> Route.SettingsNotificationsPrayers
     "settings/notifications/weekly" -> Route.SettingsNotificationsWeekly
     "settings/notifications/sound" -> Route.SettingsNotificationsSound
-    "settings/notifications/troubleshooting" -> Route.SettingsNotificationsTroubleshooting
+    // The screen was renamed to Diagnostics. The old key stays because it is published — an
+    // announcement already sent, or composed against the old name, must still land somewhere.
+    "settings/notifications/diagnostics", "settings/notifications/troubleshooting" -> Route.SettingsNotificationsDiagnostics
     "settings/about" -> Route.SettingsAbout
     "settings/help" -> Route.SettingsHelp
     "bookmarks" -> Route.AllBookmarks

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -106,7 +106,7 @@ import com.arshadshah.nimaz.presentation.screens.settings.LanguageScreen
 import com.arshadshah.nimaz.presentation.screens.settings.LocationScreen
 import com.arshadshah.nimaz.presentation.screens.settings.NotificationSettingsScreen
 import com.arshadshah.nimaz.presentation.screens.settings.NotificationSoundScreen
-import com.arshadshah.nimaz.presentation.screens.settings.NotificationTroubleshootingScreen
+import com.arshadshah.nimaz.presentation.screens.settings.NotificationDiagnosticsScreen
 import com.arshadshah.nimaz.presentation.screens.settings.NotificationWeeklyScreen
 import com.arshadshah.nimaz.presentation.screens.settings.PrayerNotificationsScreen
 import com.arshadshah.nimaz.presentation.screens.settings.WorshipRemindersScreen
@@ -948,7 +948,7 @@ fun NavGraph(
                     onNavigateToWorshipReminders = { navController.navigate(Route.SettingsWorshipReminders) },
                     onNavigateToWeekly = { navController.navigate(Route.SettingsNotificationsWeekly) },
                     onNavigateToSound = { navController.navigate(Route.SettingsNotificationsSound) },
-                    onNavigateToTroubleshooting = { navController.navigate(Route.SettingsNotificationsTroubleshooting) },
+                    onNavigateToDiagnostics = { navController.navigate(Route.SettingsNotificationsDiagnostics) },
                 )
             }
 
@@ -972,10 +972,10 @@ fun NavGraph(
             ) {
                 NotificationSoundScreen(onNavigateBack = { navController.popBackStack() })
             }
-            taggedComposable<Route.SettingsNotificationsTroubleshooting>(
-                ScreenTags.SettingsNotificationsTroubleshooting
+            taggedComposable<Route.SettingsNotificationsDiagnostics>(
+                ScreenTags.SettingsNotificationsDiagnostics
             ) {
-                NotificationTroubleshootingScreen(onNavigateBack = { navController.popBackStack() })
+                NotificationDiagnosticsScreen(onNavigateBack = { navController.popBackStack() })
             }
 
             taggedComposable<Route.SettingsAppearance>(ScreenTags.SettingsAppearance) {

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
@@ -184,7 +184,7 @@ sealed interface Route {
     data object SettingsNotificationsSound : Route
 
     @Serializable
-    data object SettingsNotificationsTroubleshooting : Route
+    data object SettingsNotificationsDiagnostics : Route
 
     @Serializable
     data object SettingsAppearance : Route

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -106,8 +106,8 @@ object ScreenTags {
     const val SettingsNotificationsPrayers = "screen_settings_notifications_prayers"
     const val SettingsNotificationsWeekly = "screen_settings_notifications_weekly"
     const val SettingsNotificationsSound = "screen_settings_notifications_sound"
-    const val SettingsNotificationsTroubleshooting =
-        "screen_settings_notifications_troubleshooting"
+    const val SettingsNotificationsDiagnostics =
+        "screen_settings_notifications_diagnostics"
 
     /** Scrollable lists on hub screens — let UI tests scroll to off-screen entries. */
     const val MoreList = "more_menu_list"

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
@@ -215,14 +215,11 @@ class BootReceiver : BroadcastReceiver() {
                 val alertStyle = preferencesDataStore.prayerAlertStyle(prayerType).first()
                 val selectedAdhan = preferencesDataStore.selectedAdhanSound.first()
 
-                // The per-prayer alert style decides what this prayer does; the global adhan
-                // switch stays a master gate over it, so turning the adhan off in Sound &
-                // delivery still silences the call everywhere without rewriting five styles.
-                val wantsAdhan =
-                    alertStyle == PrayerAlertStyle.ADHAN && globalAdhanEnabled && !isSunrise
-                // Silence is the user's own choice, so it applies to the visual notification
-                // too — unlike DND, which only gates the audio.
-                val muted = alertStyle == PrayerAlertStyle.SILENT && !isSunrise
+                // The per-prayer alert style decides what this prayer does. Both rules live
+                // on PrayerAlertStyle so the scheduler, this receiver and the tests read the
+                // same one rather than three copies that can drift apart.
+                val wantsAdhan = alertStyle.playsAdhan(globalAdhanEnabled, isSunrise)
+                val muted = alertStyle.isMuted(isSunrise)
 
                 // DND gates only the audio — the visual notification still shows.
                 val shouldPlayAdhan = wantsAdhan && !dndBlocksAdhan

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
@@ -14,6 +14,7 @@ import com.arshadshah.nimaz.data.audio.AdhanPlaybackService
 import com.arshadshah.nimaz.data.audio.AdhanSound
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
 import com.arshadshah.nimaz.domain.model.KhatamProgressCalculator
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.repository.KhatamRepository
@@ -97,9 +98,8 @@ class BootReceiver : BroadcastReceiver() {
                 val latitude = prefs.latitude
                 val longitude = prefs.longitude
 
-                val enabledPrayers = buildEnabledPrayersSet()
-                val preReminderEnabled = preferencesDataStore.showReminderBefore.first()
-                val preReminderMinutes = preferencesDataStore.notificationReminderMinutes.first()
+                val enabledPrayers = preferencesDataStore.enabledPrayerTypes()
+                val preReminders = preferencesDataStore.preReminderMinutesByPrayer()
                 val fridayReminderEnabled = preferencesDataStore.fridayReminderEnabled.first()
                 val fridayReminderMinutes = preferencesDataStore.fridayReminderMinutes.first()
 
@@ -108,8 +108,7 @@ class BootReceiver : BroadcastReceiver() {
                     longitude = longitude,
                     notificationsEnabled = notificationsEnabled,
                     enabledPrayers = enabledPrayers,
-                    preReminderEnabled = preReminderEnabled,
-                    preReminderMinutes = preReminderMinutes,
+                    preReminders = preReminders,
                     fridayReminderEnabled = fridayReminderEnabled,
                     fridayReminderMinutes = fridayReminderMinutes
                 )
@@ -131,9 +130,8 @@ class BootReceiver : BroadcastReceiver() {
                 val latitude = prefs.latitude
                 val longitude = prefs.longitude
 
-                val enabledPrayers = buildEnabledPrayersSet()
-                val preReminderEnabled = preferencesDataStore.showReminderBefore.first()
-                val preReminderMinutes = preferencesDataStore.notificationReminderMinutes.first()
+                val enabledPrayers = preferencesDataStore.enabledPrayerTypes()
+                val preReminders = preferencesDataStore.preReminderMinutesByPrayer()
                 val fridayReminderEnabled = preferencesDataStore.fridayReminderEnabled.first()
                 val fridayReminderMinutes = preferencesDataStore.fridayReminderMinutes.first()
 
@@ -142,8 +140,7 @@ class BootReceiver : BroadcastReceiver() {
                     longitude = longitude,
                     notificationsEnabled = notificationsEnabled,
                     enabledPrayers = enabledPrayers,
-                    preReminderEnabled = preReminderEnabled,
-                    preReminderMinutes = preReminderMinutes,
+                    preReminders = preReminders,
                     fridayReminderEnabled = fridayReminderEnabled,
                     fridayReminderMinutes = fridayReminderMinutes
                 )
@@ -152,17 +149,6 @@ class BootReceiver : BroadcastReceiver() {
                 CrashReporter.recordException(e)
                 e.printStackTrace()
             }
-        }
-    }
-
-    private suspend fun buildEnabledPrayersSet(): Set<com.arshadshah.nimaz.domain.model.PrayerType> {
-        return buildSet {
-            if (preferencesDataStore.fajrNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.FAJR)
-            if (preferencesDataStore.sunriseNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.SUNRISE)
-            if (preferencesDataStore.dhuhrNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.DHUHR)
-            if (preferencesDataStore.asrNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.ASR)
-            if (preferencesDataStore.maghribNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.MAGHRIB)
-            if (preferencesDataStore.ishaNotificationEnabled.first()) add(com.arshadshah.nimaz.domain.model.PrayerType.ISHA)
         }
     }
 
@@ -202,7 +188,12 @@ class BootReceiver : BroadcastReceiver() {
                 val vibrationEnabled = preferencesDataStore.notificationVibration.first()
 
                 if (isPreReminder) {
-                    val reminderMinutes = preferencesDataStore.notificationReminderMinutes.first()
+                    // The lead time rides on the alarm, because it is now per prayer — a
+                    // global read here would put the wrong number in the text.
+                    val reminderMinutes = intent.getIntExtra(
+                        PrayerNotificationScheduler.EXTRA_REMINDER_MINUTES,
+                        preferencesDataStore.notificationReminderMinutes.first()
+                    )
                     showEnhancedPreReminderNotification(
                         context,
                         prayerName,
@@ -221,13 +212,20 @@ class BootReceiver : BroadcastReceiver() {
                 }
 
                 val globalAdhanEnabled = preferencesDataStore.adhanEnabled.first()
-                val prayerAdhanEnabled =
-                    preferencesDataStore.isAdhanEnabledForPrayer(prayerType).first()
+                val alertStyle = preferencesDataStore.prayerAlertStyle(prayerType).first()
                 val selectedAdhan = preferencesDataStore.selectedAdhanSound.first()
 
+                // The per-prayer alert style decides what this prayer does; the global adhan
+                // switch stays a master gate over it, so turning the adhan off in Sound &
+                // delivery still silences the call everywhere without rewriting five styles.
+                val wantsAdhan =
+                    alertStyle == PrayerAlertStyle.ADHAN && globalAdhanEnabled && !isSunrise
+                // Silence is the user's own choice, so it applies to the visual notification
+                // too — unlike DND, which only gates the audio.
+                val muted = alertStyle == PrayerAlertStyle.SILENT && !isSunrise
+
                 // DND gates only the audio — the visual notification still shows.
-                val shouldPlayAdhan =
-                    globalAdhanEnabled && prayerAdhanEnabled && !isSunrise && !dndBlocksAdhan
+                val shouldPlayAdhan = wantsAdhan && !dndBlocksAdhan
                 val shouldPlayBeep = globalAdhanEnabled && isSunrise && !dndBlocksAdhan
 
                 // Get notification content for merging into adhan service notification
@@ -280,7 +278,8 @@ class BootReceiver : BroadcastReceiver() {
                             prayerType = prayerType,
                             prayerTime = prayerTime,
                             adhanEnabled = false,
-                            vibrationEnabled = vibrationEnabled
+                            vibrationEnabled = vibrationEnabled,
+                            muted = muted
                         )
                     }
                 } else if (shouldPlayBeep) {
@@ -309,14 +308,15 @@ class BootReceiver : BroadcastReceiver() {
                         )
                     }
                 } else {
-                    // No adhan - show standalone prayer notification
+                    // No adhan — a plain prayer notification, silent if the user asked for it.
                     showEnhancedPrayerNotification(
                         context = context,
                         prayerName = prayerName,
                         prayerType = prayerType,
                         prayerTime = prayerTime,
                         adhanEnabled = false,
-                        vibrationEnabled = vibrationEnabled
+                        vibrationEnabled = vibrationEnabled,
+                        muted = muted
                     )
                 }
 
@@ -434,7 +434,8 @@ class BootReceiver : BroadcastReceiver() {
         prayerType: String,
         prayerTime: String,
         adhanEnabled: Boolean = false,
-        vibrationEnabled: Boolean = true
+        vibrationEnabled: Boolean = true,
+        muted: Boolean = false
     ) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
@@ -474,7 +475,7 @@ class BootReceiver : BroadcastReceiver() {
         val channelId = if (adhanEnabled) {
             PrayerNotificationScheduler.channelForAdhan(vibrationEnabled)
         } else {
-            PrayerNotificationScheduler.channelForPrayer(vibrationEnabled)
+            PrayerNotificationScheduler.channelForPrayer(vibrationEnabled, muted = muted)
         }
 
         val notification = NotificationCompat.Builder(context, channelId)
@@ -489,13 +490,23 @@ class BootReceiver : BroadcastReceiver() {
             .setAutoCancel(true)
             .setContentIntent(openPendingIntent)
             .setDeleteIntent(dismissPendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setPriority(
+                // A silenced prayer must not push a heads-up banner over what the user is
+                // doing. The channel already decides this on Android 8+, but the priority
+                // is what older builds and some launchers read.
+                if (muted) NotificationCompat.PRIORITY_LOW else NotificationCompat.PRIORITY_HIGH
+            )
+            .setCategory(
+                if (muted) NotificationCompat.CATEGORY_REMINDER
+                else NotificationCompat.CATEGORY_ALARM
+            )
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setColorized(true)
             .setColor(getPrayerColor(prayerType))
             .apply {
-                if (!vibrationEnabled) {
+                if (muted) {
+                    setSilent(true)
+                } else if (!vibrationEnabled) {
                     setVibrate(longArrayOf(0L))
                 }
                 // Add action to mark prayer as done (optional future feature)

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/NotificationDiagnostics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/NotificationDiagnostics.kt
@@ -1,0 +1,50 @@
+package com.arshadshah.nimaz.core.util
+
+import android.app.AlarmManager
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * The device-level prerequisites for a prayer alert actually arriving on time.
+ *
+ * Every field here is read from the OS. Nothing is assumed and nothing is reported that
+ * cannot be checked — a row that always says "OK" would be worse than no row, because it
+ * would send someone looking for the fault somewhere else.
+ */
+data class NotificationDiagnostics(
+    /** The user has granted POST_NOTIFICATIONS (or is on a release that never asked). */
+    val notificationsPermitted: Boolean,
+    /** The app may schedule exact alarms. Without it, alerts drift by minutes. */
+    val exactAlarmsAllowed: Boolean,
+    /** The app is exempt from battery optimisation, so Doze will not hold alarms back. */
+    val batteryUnrestricted: Boolean,
+) {
+    /** True when at least one prerequisite is missing — what the hub's warning keys off. */
+    val hasProblem: Boolean
+        get() = !notificationsPermitted || !exactAlarmsAllowed || !batteryUnrestricted
+
+    companion object {
+        fun read(context: Context): NotificationDiagnostics {
+            val alarmManager =
+                context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val powerManager =
+                context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+            return NotificationDiagnostics(
+                notificationsPermitted = NotificationManagerCompat.from(context)
+                    .areNotificationsEnabled(),
+                // The permission only exists from Android 12; before that exact alarms are
+                // always allowed, so reporting anything else would be inventing a fault.
+                exactAlarmsAllowed = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    alarmManager.canScheduleExactAlarms()
+                } else {
+                    true
+                },
+                batteryUnrestricted = powerManager
+                    .isIgnoringBatteryOptimizations(context.packageName),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerAlarmTimes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerAlarmTimes.kt
@@ -1,0 +1,30 @@
+package com.arshadshah.nimaz.core.util
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * The wall-clock arithmetic behind a scheduled prayer alarm, kept apart from
+ * [PrayerNotificationScheduler] so it can be tested without an `AlarmManager`.
+ *
+ * Two cases make this worth stating explicitly. A reminder before an early Fajr belongs to
+ * the previous day, and a wall-clock time inside a daylight-saving change is either missing
+ * or repeated — neither of which may quietly drop an alarm.
+ */
+object PrayerAlarmTimes {
+
+    /** When a reminder [minutesBefore] a prayer at [prayerTime] lands. Crosses midnight. */
+    fun preReminderAt(prayerTime: LocalDateTime, minutesBefore: Int): LocalDateTime =
+        prayerTime.minusMinutes(minutesBefore.toLong())
+
+    /**
+     * The instant to arm an alarm for, resolving [time] in [zone].
+     *
+     * Where the clock jumped forward the wall-clock time does not exist; `atZone` resolves it
+     * forward by the size of the gap, which is what we want — an alarm slightly late beats an
+     * alarm that never fires. Where the clock went back the time happens twice, and we take
+     * the earlier of the two so a reminder cannot land after the prayer it precedes.
+     */
+    fun triggerMillis(time: LocalDateTime, zone: ZoneId = ZoneId.systemDefault()): Long =
+        time.atZone(zone).withEarlierOffsetAtOverlap().toInstant().toEpochMilli()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerClock.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerClock.kt
@@ -65,7 +65,7 @@ fun prayerTimelineProgressAt(instants: List<Instant>, now: Instant): Float {
     for (k in 0 until instants.size - 1) {
         val start = instants[k]
         val end = instants[k + 1]
-        if (now >= start && now < end) {
+        if (now in start..<end) {
             val span = (end - start).inWholeSeconds.toFloat()
             if (span <= 0f) return (k.toFloat() / (instants.size - 1)).coerceIn(0f, 1f)
             val frac = (now - start).inWholeSeconds.toFloat() / span

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationPrefs.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationPrefs.kt
@@ -1,0 +1,42 @@
+package com.arshadshah.nimaz.core.util
+
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+
+/**
+ * Reads the per-prayer notification preferences into the shape the scheduler wants.
+ *
+ * Three places arm today's alarms — app start, boot, and a settings change — and each of
+ * them needs the same two answers. Keeping the reads here means the three cannot drift, and
+ * that adding a prayer is one edit rather than three.
+ */
+
+/** The five prayers a user can be reminded about. Sunrise gets no pre-reminder. */
+private val REMINDABLE_PRAYERS = mapOf(
+    "fajr" to PrayerType.FAJR,
+    "dhuhr" to PrayerType.DHUHR,
+    "asr" to PrayerType.ASR,
+    "maghrib" to PrayerType.MAGHRIB,
+    "isha" to PrayerType.ISHA,
+)
+
+/**
+ * The lead time for each prayer whose reminder is on, in minutes. A prayer missing from the
+ * map gets no reminder — which is how "off" is expressed, rather than a zero offset.
+ */
+suspend fun SettingsRepository.preReminderMinutesByPrayer(): Map<PrayerType, Int> =
+    REMINDABLE_PRAYERS.mapNotNull { (key, type) ->
+        if (prayerReminderEnabled(key).first()) type to prayerReminderMinutes(key).first()
+        else null
+    }.toMap()
+
+/** The prayers whose notification is switched on at all, including sunrise. */
+suspend fun SettingsRepository.enabledPrayerTypes(): Set<PrayerType> = buildSet {
+    if (fajrNotificationEnabled.first()) add(PrayerType.FAJR)
+    if (sunriseNotificationEnabled.first()) add(PrayerType.SUNRISE)
+    if (dhuhrNotificationEnabled.first()) add(PrayerType.DHUHR)
+    if (asrNotificationEnabled.first()) add(PrayerType.ASR)
+    if (maghribNotificationEnabled.first()) add(PrayerType.MAGHRIB)
+    if (ishaNotificationEnabled.first()) add(PrayerType.ISHA)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationScheduler.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerNotificationScheduler.kt
@@ -61,6 +61,12 @@ class PrayerNotificationScheduler @Inject constructor(
         const val CHANNEL_ID_PRAYER_SILENT = "prayer_notifications_silent"
         const val CHANNEL_ID_ADHAN_SILENT = "adhan_notifications_silent"
 
+        // A prayer set to the SILENT alert style posts here: no sound, no vibration, no
+        // heads-up. The two channels above are only *no-vibration* siblings — they still
+        // carry the channel's sound at IMPORTANCE_HIGH — and Android will not let an
+        // existing channel's importance be lowered from code, so silence needs its own.
+        const val CHANNEL_ID_PRAYER_MUTED = "prayer_notifications_muted"
+
         const val ACTION_PRAYER_NOTIFICATION = "com.arshadshah.nimaz.PRAYER_NOTIFICATION"
         const val ACTION_DAILY_SUMMARY = "com.arshadshah.nimaz.DAILY_SUMMARY"
         const val ACTION_FRIDAY_REMINDER = "com.arshadshah.nimaz.FRIDAY_REMINDER"
@@ -69,6 +75,9 @@ class PrayerNotificationScheduler @Inject constructor(
         const val EXTRA_PRAYER_NAME = "prayer_name"
         const val EXTRA_PRAYER_TIME = "prayer_time"
         const val EXTRA_IS_PRE_REMINDER = "is_pre_reminder"
+
+        /** Lead time carried by a pre-reminder alarm, now that it differs per prayer. */
+        const val EXTRA_REMINDER_MINUTES = "reminder_minutes"
 
         // Request codes for different prayers (use prayer ordinal * 10 for different notification types)
         private const val REQUEST_CODE_BASE = 1000
@@ -90,9 +99,17 @@ class PrayerNotificationScheduler @Inject constructor(
         const val ACTION_MIDNIGHT_RESCHEDULE = "com.arshadshah.nimaz.MIDNIGHT_RESCHEDULE"
         private const val MIDNIGHT_REQUEST_CODE = 9999
 
-        /** Channel id for a standalone prayer notification honouring the vibration pref. */
-        fun channelForPrayer(vibrate: Boolean): String =
-            if (vibrate) CHANNEL_ID_PRAYER else CHANNEL_ID_PRAYER_SILENT
+        /**
+         * Channel id for a standalone prayer notification honouring the vibration pref.
+         *
+         * [muted] wins over [vibrate]: a prayer the user has silenced posts on the muted
+         * channel whatever the vibration preference says.
+         */
+        fun channelForPrayer(vibrate: Boolean, muted: Boolean = false): String = when {
+            muted -> CHANNEL_ID_PRAYER_MUTED
+            vibrate -> CHANNEL_ID_PRAYER
+            else -> CHANNEL_ID_PRAYER_SILENT
+        }
 
         /** Channel id for an adhan notification honouring the vibration pref. */
         fun channelForAdhan(vibrate: Boolean): String =
@@ -158,6 +175,19 @@ class PrayerNotificationScheduler @Inject constructor(
             enableLights(true)
         }
 
+        // Prayers set to the silent alert style: it appears and waits. LOW importance keeps
+        // it out of the heads-up path; the null sound keeps it quiet even so.
+        val prayerChannelMuted = NotificationChannel(
+            CHANNEL_ID_PRAYER_MUTED,
+            "Prayer Time Notifications (Silent)",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Prayer time notifications with no sound and no vibration"
+            setSound(null, null)
+            enableVibration(false)
+            enableLights(true)
+        }
+
         // Khatam reminder channel — a gentle nudge to read, not an alarm, so it
         // stays at DEFAULT importance and never interrupts.
         val khatamChannel = NotificationChannel(
@@ -189,7 +219,8 @@ class PrayerNotificationScheduler @Inject constructor(
                 khatamChannel,
                 worshipChannel,
                 prayerChannelSilent,
-                adhanChannelSilent
+                adhanChannelSilent,
+                prayerChannelMuted
             )
         )
     }
@@ -199,16 +230,15 @@ class PrayerNotificationScheduler @Inject constructor(
      * This should be called after boot, when settings change, or at midnight.
      *
      * @param enabledPrayers If provided, only schedule for these prayer types. If null, schedule all non-sunrise prayers.
-     * @param preReminderEnabled If true, schedule pre-reminder notifications.
-     * @param preReminderMinutes Minutes before prayer to show pre-reminder.
+     * @param preReminders Lead time in minutes per prayer. A prayer absent from the map gets
+     *   no pre-reminder — that is how "off" is expressed, rather than a zero lead time.
      */
     fun scheduleTodaysPrayerNotifications(
         latitude: Double,
         longitude: Double,
         notificationsEnabled: Boolean,
         enabledPrayers: Set<PrayerType>? = null,
-        preReminderEnabled: Boolean = false,
-        preReminderMinutes: Int = 15,
+        preReminders: Map<PrayerType, Int> = emptyMap(),
         calculationMethod: CalculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
         asrCalculation: AsrCalculation = AsrCalculation.STANDARD,
         highLatitudeRule: HighLatitudeRule? = null,
@@ -262,12 +292,17 @@ class PrayerNotificationScheduler @Inject constructor(
                 schedulePrayerNotification(prayerTime.type, prayerLocalDateTime)
                 scheduledCount++
 
-                // Schedule pre-reminder if enabled (not for sunrise)
-                if (preReminderEnabled && prayerTime.type != PrayerType.SUNRISE) {
+                // Schedule this prayer's own pre-reminder, if it has one (never for sunrise).
+                val leadMinutes = preReminders[prayerTime.type]
+                if (leadMinutes != null && prayerTime.type != PrayerType.SUNRISE) {
                     val preReminderTime =
-                        prayerLocalDateTime.minusMinutes(preReminderMinutes.toLong())
+                        PrayerAlarmTimes.preReminderAt(prayerLocalDateTime, leadMinutes)
                     if (preReminderTime.isAfter(now)) {
-                        schedulePreReminderNotification(prayerTime.type, preReminderTime)
+                        schedulePreReminderNotification(
+                            prayerTime.type,
+                            preReminderTime,
+                            leadMinutes
+                        )
                     }
                 }
             }
@@ -315,7 +350,7 @@ class PrayerNotificationScheduler @Inject constructor(
         // determine whether these alarms will actually fire on time.
         AppAnalytics.logNotificationsScheduled(
             scheduledCount = scheduledCount,
-            preRemindersEnabled = preReminderEnabled,
+            preRemindersEnabled = preReminders.isNotEmpty(),
             exactAlarmAllowed = AppAnalytics.exactAlarmAllowed(context),
             postNotificationsGranted = AppAnalytics.postNotificationsGranted(context),
         )
@@ -650,15 +685,19 @@ class PrayerNotificationScheduler @Inject constructor(
      */
     private fun schedulePreReminderNotification(
         prayerType: PrayerType,
-        reminderTime: LocalDateTime
+        reminderTime: LocalDateTime,
+        leadMinutes: Int
     ) {
-        // Use explicit intent for BootReceiver (required for Android 8.0+)
+        // Use explicit intent for BootReceiver (required for Android 8.0+).
+        // The lead time travels with the alarm because it is now per prayer: reading a
+        // global value back at fire time would put the wrong number in the text.
         val intent = Intent(context, BootReceiver::class.java).apply {
             action = ACTION_PRAYER_NOTIFICATION
             putExtra(EXTRA_PRAYER_TYPE, prayerType.name)
             putExtra(EXTRA_PRAYER_NAME, prayerType.displayName)
             putExtra(EXTRA_PRAYER_TIME, reminderTime.toString())
             putExtra(EXTRA_IS_PRE_REMINDER, true)
+            putExtra(EXTRA_REMINDER_MINUTES, leadMinutes)
         }
 
         val requestCode = PRE_REMINDER_REQUEST_CODE_BASE + prayerType.ordinal
@@ -669,10 +708,7 @@ class PrayerNotificationScheduler @Inject constructor(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val triggerTimeMillis = reminderTime
-            .atZone(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
+        val triggerTimeMillis = PrayerAlarmTimes.triggerMillis(reminderTime)
 
         alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.RTC_WAKEUP,
@@ -726,10 +762,7 @@ class PrayerNotificationScheduler @Inject constructor(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val triggerTimeMillis = prayerTime
-            .atZone(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
+        val triggerTimeMillis = PrayerAlarmTimes.triggerMillis(prayerTime)
 
         // Use setExactAndAllowWhileIdle for precise timing
         alarmManager.setExactAndAllowWhileIdle(

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -174,7 +174,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -200,7 +200,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -225,7 +225,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -251,7 +251,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -277,7 +277,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -313,7 +313,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -340,7 +340,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -366,7 +366,7 @@ interface QuranDao {
                hq.number AS rub_number,
                hq.start_ayah_id AS rub_start_ayah_id,
                (r.number - rs.first_number + 1) AS ruku_number,
-               r.start_ayah_id AS ruku_start_ayah_id
+               r.end_ayah_id AS ruku_end_ayah_id
         FROM ayahs a
         LEFT JOIN mushaf_ayah_texts u ON u.ayah_id = a.id AND u.text_source = 'UTHMANI'
         LEFT JOIN mushaf_ayah_texts s ON s.ayah_id = a.id AND s.text_source = 'SIMPLE'
@@ -735,7 +735,7 @@ data class AyahWithText(
     @ColumnInfo(name = "rub_number") val rubNumber: Int?,
     @ColumnInfo(name = "rub_start_ayah_id") val rubStartAyahId: Int?,
     @ColumnInfo(name = "ruku_number") val rukuNumber: Int?,
-    @ColumnInfo(name = "ruku_start_ayah_id") val rukuStartAyahId: Int?,
+    @ColumnInfo(name = "ruku_end_ayah_id") val rukuEndAyahId: Int?,
 )
 
 /** Where a verse sits in the mushaf. */

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PrayerNotificationPrefsMigration.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PrayerNotificationPrefsMigration.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.data.local.datastore
+
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+
+/** The five prayers that carry an alert style and a reminder. Sunrise is not one of them. */
+internal val ALERT_STYLE_PRAYERS = PrayerAlertStyle.PRAYER_KEYS
+
+/** The lead time a reminder falls back to when the user has never chosen one. */
+internal const val DEFAULT_REMINDER_MINUTES = PrayerAlertStyle.DEFAULT_REMINDER_MINUTES
+
+/** What the old model stored, read once so the split can be planned from it. */
+data class LegacyPrayerNotificationPrefs(
+    val adhanEnabled: Boolean,
+    val perPrayerAdhanEnabled: Map<String, Boolean>,
+    val showReminderBefore: Boolean,
+    val reminderMinutes: Int,
+)
+
+/** What the new model should hold, keyed by prayer. */
+data class MigratedPrayerNotificationPrefs(
+    val alertStyle: Map<String, PrayerAlertStyle>,
+    val reminderEnabled: Map<String, Boolean>,
+    val reminderMinutes: Map<String, Int>,
+)
+
+/**
+ * Carries an existing install across the notifications rework's two preference splits:
+ * the global adhan switch plus its per-prayer companions become a per-prayer
+ * [PrayerAlertStyle], and the one global pre-adhan reminder becomes a reminder per prayer.
+ *
+ * The rule is that nobody loses a setting. A 30-minute pre-adhan reminder becomes a
+ * 30-minute reminder on all five prayers; a prayer that was calling the adhan keeps calling
+ * it. Nothing migrates to [PrayerAlertStyle.SILENT], because the old model had no way to
+ * ask for silence — a user who has never asked for it must not find a prayer gone quiet.
+ *
+ * The plan is pure so it can be tested without a DataStore; [PreferencesDataStore] runs it
+ * once, guarded by [VERSION].
+ */
+object PrayerNotificationPrefsMigration {
+
+    /**
+     * Bumped when this migration's output changes. Stored alongside the preferences so the
+     * migration runs exactly once per install, and so a later split can be added without
+     * re-deriving this one from keys that have since moved on.
+     */
+    const val VERSION = 1
+
+    /** The range the reminder stepper offers. Anything outside it is unreachable in the UI. */
+    private val LEAD_TIME_RANGE = 5..60
+
+    fun plan(legacy: LegacyPrayerNotificationPrefs): MigratedPrayerNotificationPrefs {
+        val minutes = legacy.reminderMinutes.coerceIn(LEAD_TIME_RANGE)
+
+        return MigratedPrayerNotificationPrefs(
+            alertStyle = ALERT_STYLE_PRAYERS.associateWith { prayer ->
+                // The old per-prayer adhan flags defaulted to true, so a missing entry means
+                // "on" — only the global switch being off, or an explicit per-prayer off,
+                // demotes a prayer to a plain notification.
+                val adhanForPrayer = legacy.perPrayerAdhanEnabled[prayer] ?: true
+                if (legacy.adhanEnabled && adhanForPrayer) {
+                    PrayerAlertStyle.ADHAN
+                } else {
+                    PrayerAlertStyle.NOTIFICATION
+                }
+            },
+            reminderEnabled = ALERT_STYLE_PRAYERS.associateWith { legacy.showReminderBefore },
+            // The lead time is carried even when the reminder is off, so switching a prayer's
+            // reminder back on restores what the user last chose rather than the default.
+            reminderMinutes = ALERT_STYLE_PRAYERS.associateWith { minutes },
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferenceCodec.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferenceCodec.kt
@@ -132,7 +132,8 @@ internal object PreferenceCodec {
         "ai_consent_timestamp" to PrefType.LONG,
         "ai_history_enabled" to PrefType.BOOLEAN,
         "ai_ask_hint_dismissed" to PrefType.BOOLEAN,
-        "ai_question_history" to PrefType.STRING
+        "ai_question_history" to PrefType.STRING,
+        "notification_prefs_migration_version" to PrefType.INT
     )
 
     /**
@@ -140,12 +141,17 @@ internal object PreferenceCodec {
      *
      * `worship_<type>_enabled` and its siblings are built per `WorshipReminderType`, of which
      * there are a dozen and counting; matching the shape keeps this registry from having to
-     * track that enum.
+     * track that enum. The per-prayer alert style and reminder keys are composed the same way,
+     * one set per prayer.
      */
     private val PATTERNS: List<Pair<Regex, PrefType>> = listOf(
         Regex("^worship_[a-z_]+_enabled$") to PrefType.BOOLEAN,
         Regex("^worship_[a-z_]+_offset$") to PrefType.INT,
         Regex("^worship_[a-z_]+_mode$") to PrefType.STRING,
+        // Per-prayer alert style and reminder, one set per prayer.
+        Regex("^[a-z]+_alert_style$") to PrefType.STRING,
+        Regex("^[a-z]+_reminder_enabled$") to PrefType.BOOLEAN,
+        Regex("^[a-z]+_reminder_minutes$") to PrefType.INT,
     )
 
     /** The declared type of [key], by name or by shape, or null if this build does not know it. */

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.UserPreferences
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
@@ -132,6 +133,11 @@ class PreferencesDataStore @Inject constructor(
 
         // Note: Sunrise always uses beep only, no full adhan option
         val ADHAN_RESPECT_DND = booleanPreferencesKey("adhan_respect_dnd")
+
+        // Which split of the per-prayer alert style / reminder preferences this install has
+        // been through. See PrayerNotificationPrefsMigration.
+        val NOTIFICATION_PREFS_MIGRATION_VERSION =
+            intPreferencesKey("notification_prefs_migration_version")
 
         // Quran Settings
         val QURAN_TRANSLATOR_ID = stringPreferencesKey("quran_translator_id")
@@ -534,6 +540,83 @@ class PreferencesDataStore @Inject constructor(
 
     override suspend fun setWorshipReminderMode(key: String, mode: String) =
         put(stringPreferencesKey("worship_${key}_mode"), mode)
+
+    // Per-prayer alert style and reminder. Dynamic keys keyed by prayer name, in the same
+    // shape as the worship reminders above. These replace the global adhan on/off pair and
+    // the single pre-adhan reminder; existing installs are carried across by
+    // migratePrayerNotificationPreferences(). See PrayerNotificationPrefsMigration.
+    override fun prayerAlertStyle(prayer: String): Flow<PrayerAlertStyle> =
+        dataStore.data.map { prefs ->
+            PrayerAlertStyle.fromStorage(prefs[alertStyleKey(prayer)])
+        }
+
+    override suspend fun setPrayerAlertStyle(prayer: String, style: PrayerAlertStyle) =
+        put(alertStyleKey(prayer), style.name)
+
+    override fun prayerReminderEnabled(prayer: String): Flow<Boolean> =
+        preference(reminderEnabledKey(prayer), false)
+
+    override suspend fun setPrayerReminderEnabled(prayer: String, enabled: Boolean) =
+        put(reminderEnabledKey(prayer), enabled)
+
+    override fun prayerReminderMinutes(prayer: String): Flow<Int> =
+        preference(reminderMinutesKey(prayer), DEFAULT_REMINDER_MINUTES)
+
+    override suspend fun setPrayerReminderMinutes(prayer: String, minutes: Int) =
+        put(reminderMinutesKey(prayer), minutes)
+
+    /**
+     * Splits the old global adhan and pre-adhan preferences into the per-prayer ones, once.
+     *
+     * Guarded by a stored version so it cannot run twice and cannot reset a choice the user
+     * has since made. Called from `AppInitializer` before anything reads the new keys.
+     */
+    override suspend fun migratePrayerNotificationPreferences() {
+        val alreadyMigrated = dataStore.data
+            .map { it[PreferencesKeys.NOTIFICATION_PREFS_MIGRATION_VERSION] ?: 0 }
+            .first()
+        if (alreadyMigrated >= PrayerNotificationPrefsMigration.VERSION) return
+
+        val legacy = dataStore.data.map { prefs ->
+            LegacyPrayerNotificationPrefs(
+                adhanEnabled = prefs[PreferencesKeys.ADHAN_ENABLED] ?: false,
+                perPrayerAdhanEnabled = ALERT_STYLE_PRAYERS.associateWith { prayer ->
+                    prefs[legacyAdhanKey(prayer)] ?: true
+                },
+                showReminderBefore = prefs[PreferencesKeys.SHOW_REMINDER_BEFORE] ?: true,
+                reminderMinutes = prefs[PreferencesKeys.NOTIFICATION_REMINDER_MINUTES]
+                    ?: DEFAULT_REMINDER_MINUTES,
+            )
+        }.first()
+
+        val migrated = PrayerNotificationPrefsMigration.plan(legacy)
+
+        dataStore.edit { prefs ->
+            migrated.alertStyle.forEach { (prayer, style) ->
+                prefs[alertStyleKey(prayer)] = style.name
+            }
+            migrated.reminderEnabled.forEach { (prayer, enabled) ->
+                prefs[reminderEnabledKey(prayer)] = enabled
+            }
+            migrated.reminderMinutes.forEach { (prayer, minutes) ->
+                prefs[reminderMinutesKey(prayer)] = minutes
+            }
+            prefs[PreferencesKeys.NOTIFICATION_PREFS_MIGRATION_VERSION] =
+                PrayerNotificationPrefsMigration.VERSION
+        }
+    }
+
+    private fun alertStyleKey(prayer: String) =
+        stringPreferencesKey("${prayer.lowercase()}_alert_style")
+
+    private fun reminderEnabledKey(prayer: String) =
+        booleanPreferencesKey("${prayer.lowercase()}_reminder_enabled")
+
+    private fun reminderMinutesKey(prayer: String) =
+        intPreferencesKey("${prayer.lowercase()}_reminder_minutes")
+
+    private fun legacyAdhanKey(prayer: String) =
+        booleanPreferencesKey("${prayer.lowercase()}_adhan_enabled")
 
     // Quran Settings
     override val quranTranslatorId: Flow<String> =

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -606,17 +606,34 @@ class PreferencesDataStore @Inject constructor(
         }
     }
 
-    private fun alertStyleKey(prayer: String) =
-        stringPreferencesKey("${prayer.lowercase()}_alert_style")
+    // Composed per prayer rather than declared five times each. The local is named `key`
+    // so the literal reads "${key}_…", which is the shape PreferenceCodecTest scans for.
+    private fun alertStyleKey(prayer: String): Preferences.Key<String> {
+        val key = prayer.lowercase()
+        return stringPreferencesKey("${key}_alert_style")
+    }
 
-    private fun reminderEnabledKey(prayer: String) =
-        booleanPreferencesKey("${prayer.lowercase()}_reminder_enabled")
+    private fun reminderEnabledKey(prayer: String): Preferences.Key<Boolean> {
+        val key = prayer.lowercase()
+        return booleanPreferencesKey("${key}_reminder_enabled")
+    }
 
-    private fun reminderMinutesKey(prayer: String) =
-        intPreferencesKey("${prayer.lowercase()}_reminder_minutes")
+    private fun reminderMinutesKey(prayer: String): Preferences.Key<Int> {
+        val key = prayer.lowercase()
+        return intPreferencesKey("${key}_reminder_minutes")
+    }
 
-    private fun legacyAdhanKey(prayer: String) =
-        booleanPreferencesKey("${prayer.lowercase()}_adhan_enabled")
+    // The legacy per-prayer adhan flags are a closed set of five that will never grow —
+    // they exist only for the migration to read — so they resolve to the declared keys
+    // rather than composing a name.
+    private fun legacyAdhanKey(prayer: String): Preferences.Key<Boolean> =
+        when (prayer.lowercase()) {
+            "fajr" -> PreferencesKeys.FAJR_ADHAN_ENABLED
+            "dhuhr" -> PreferencesKeys.DHUHR_ADHAN_ENABLED
+            "asr" -> PreferencesKeys.ASR_ADHAN_ENABLED
+            "maghrib" -> PreferencesKeys.MAGHRIB_ADHAN_ENABLED
+            else -> PreferencesKeys.ISHA_ADHAN_ENABLED
+        }
 
     // Quran Settings
     override val quranTranslatorId: Flow<String> =

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -781,9 +781,11 @@ class QuranRepositoryImpl @Inject constructor(
             transliteration = ayah.transliteration,
             textTajweed = ayah.textTajweed,
             rukuNumber = rukuNumber,
-            // A division is *marked* on the verse that opens it, as in a printed Mushaf —
-            // not on every verse inside it.
-            isRukuStart = rukuStartAyahId != null && rukuStartAyahId == ayah.id,
+            // A division is marked once, on one verse, as in a printed Mushaf — not on
+            // every verse inside it. Which verse differs by division: the ʿayn closes a
+            // rukūʿ, so it lands on the section's last verse, while the ۞ opens a hizb
+            // quarter and lands on its first.
+            isRukuEnd = rukuEndAyahId != null && rukuEndAyahId == ayah.id,
             isRubStart = rubStartAyahId != null && rubStartAyahId == ayah.id
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/PrayerAlertStyle.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/PrayerAlertStyle.kt
@@ -20,6 +20,23 @@ enum class PrayerAlertStyle {
     /** A notification with no sound and no vibration; it appears and waits. */
     SILENT;
 
+    /**
+     * Whether this style should play the adhan for a given prayer.
+     *
+     * [globalAdhanEnabled] is the master switch on the Adhan & sound screen: it stays a gate
+     * over the per-prayer style, so turning the adhan off silences the call everywhere
+     * without rewriting five styles. Sunrise never gets the adhan — it has a beep instead.
+     */
+    fun playsAdhan(globalAdhanEnabled: Boolean, isSunrise: Boolean = false): Boolean =
+        this == ADHAN && globalAdhanEnabled && !isSunrise
+
+    /**
+     * Whether the notification should be posted silently. Unlike Do Not Disturb — which
+     * gates only the audio — this is the user's own choice, so it applies to the visual
+     * notification too. Sunrise is exempt: it has no style of its own.
+     */
+    fun isMuted(isSunrise: Boolean = false): Boolean = this == SILENT && !isSunrise
+
     companion object {
         /**
          * The prayers that carry an alert style and a reminder, lowercase, in the order they

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/PrayerAlertStyle.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/PrayerAlertStyle.kt
@@ -1,0 +1,40 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * How a prayer announces itself when its time arrives.
+ *
+ * This replaces the old sound on/off binary, which could only say "adhan" or "the default
+ * notification tone" — there was no way to keep a prayer visible but quiet. The style is
+ * per prayer: Fajr can call the adhan while Dhuhr, at work, stays silent.
+ *
+ * The choice is honoured at fire time (see `BootReceiver.handlePrayerNotification`), not at
+ * schedule time, so changing it takes effect on the next prayer without rescheduling.
+ */
+enum class PrayerAlertStyle {
+    /** The full adhan plays. Still subject to the global adhan switch and to Do Not Disturb. */
+    ADHAN,
+
+    /** A notification with the standard tone — no adhan. */
+    NOTIFICATION,
+
+    /** A notification with no sound and no vibration; it appears and waits. */
+    SILENT;
+
+    companion object {
+        /**
+         * The prayers that carry an alert style and a reminder, lowercase, in the order they
+         * fall. Sunrise is not one of them: it is a plain alert with a beep and no reminder.
+         */
+        val PRAYER_KEYS = listOf("fajr", "dhuhr", "asr", "maghrib", "isha")
+
+        /** The lead time a reminder falls back to when the user has never chosen one. */
+        const val DEFAULT_REMINDER_MINUTES = 15
+
+        /**
+         * Reads a stored style, falling back to [NOTIFICATION] for anything unrecognised —
+         * an empty preference, or a value written by a newer build.
+         */
+        fun fromStorage(raw: String?): PrayerAlertStyle =
+            entries.firstOrNull { it.name == raw } ?: NOTIFICATION
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/QuranModels.kt
@@ -37,8 +37,15 @@ data class Ayah(
      * numbers them. Null when the `rukus` table has not been populated on this device.
      */
     val rukuNumber: Int? = null,
-    /** True when this verse *opens* its rukūʿ — where the marker belongs. */
-    val isRukuStart: Boolean = false,
+    /**
+     * True when this verse *closes* its rukūʿ — which is where the ʿayn (ع) sits in a printed
+     * Mushaf. The marker ends the section rather than announcing it, so Al-Fātiḥah, a single
+     * rukūʿ over all seven verses, carries it on verse 7 and not on verse 1.
+     *
+     * This is the opposite convention to [isRubStart] below, and the two are genuinely
+     * different: the ۞ opens a quarter, the ع closes a section.
+     */
+    val isRukuEnd: Boolean = false,
     /** True when this verse *opens* its hizb quarter — where the ۞ marker belongs. */
     val isRubStart: Boolean = false
 ) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.domain.repository
 
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.UserPreferences
 import kotlinx.coroutines.flow.Flow
 
@@ -98,6 +99,29 @@ interface SettingsRepository {
     suspend fun setNotificationReminderMinutes(minutes: Int)
     val showReminderBefore: Flow<Boolean>
     suspend fun setShowReminderBefore(enabled: Boolean)
+
+    // Per-prayer alert style and reminder, keyed by prayer name ("fajr", "dhuhr", "asr",
+    // "maghrib", "isha" — sunrise has neither). These supersede the global adhan pair and
+    // the single pre-adhan reminder above, which stay only so the one-time migration has
+    // something to read.
+
+    /** How a prayer announces itself: the adhan, the standard tone, or nothing. */
+    fun prayerAlertStyle(prayer: String): Flow<PrayerAlertStyle>
+    suspend fun setPrayerAlertStyle(prayer: String, style: PrayerAlertStyle)
+
+    /** Whether this prayer gets a reminder ahead of its time. */
+    fun prayerReminderEnabled(prayer: String): Flow<Boolean>
+    suspend fun setPrayerReminderEnabled(prayer: String, enabled: Boolean)
+
+    /** How many minutes before the prayer that reminder lands. */
+    fun prayerReminderMinutes(prayer: String): Flow<Int>
+    suspend fun setPrayerReminderMinutes(prayer: String, minutes: Int)
+
+    /**
+     * Carries an existing install from the global adhan/pre-adhan preferences onto the
+     * per-prayer ones above. Runs at most once; safe to call on every start.
+     */
+    suspend fun migratePrayerNotificationPreferences()
     val persistentNotification: Flow<Boolean>
     suspend fun setPersistentNotification(enabled: Boolean)
     val fridayReminderEnabled: Flow<Boolean>

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafContinuousText.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafContinuousText.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
@@ -80,6 +81,9 @@ fun MushafContinuousText(
     // Ayah end-marker: gold brackets + teal number, matching the ornament language.
     val markerBracketColor = NimazColors.Gold500
     val markerNumberColor = MaterialTheme.colorScheme.primary
+    // The structural signs are apparatus, not scripture: gold like the verse brackets so
+    // they read as one system, but they must never compete with the text itself.
+    val divisionMarkerColor = NimazColors.Gold500
 
     // Parse tajweed once per ayah, keyed only on what the parse depends on
     // (text, theme, default colour) — NOT on highlight/selection. Highlight and
@@ -108,7 +112,8 @@ fun MushafContinuousText(
 
     val annotatedText = remember(
         ayahs, tajweedByAyahId, highlightedAyahId, selectedAyahId,
-        highlightColor, selectedColor, markerBracketColor, markerNumberColor
+        highlightColor, selectedColor, markerBracketColor, markerNumberColor,
+        divisionMarkerColor
     ) {
         buildMushafAnnotatedString(
             ayahs = ayahs,
@@ -118,7 +123,8 @@ fun MushafContinuousText(
             highlightColor = highlightColor,
             selectedColor = selectedColor,
             markerBracketColor = markerBracketColor,
-            markerNumberColor = markerNumberColor
+            markerNumberColor = markerNumberColor,
+            divisionMarkerColor = divisionMarkerColor
         )
     }
 
@@ -229,6 +235,23 @@ fun MushafContinuousText(
 
 private const val AYAH_TAG = "AYAH"
 
+/**
+ * The structural signs a printed Mushaf carries in and around the text.
+ *
+ * The page reader showed none of them: a reader following a hizb, looking for the end of a
+ * rukūʿ, or checking whether a verse takes a prostration had to leave the page to find out.
+ * They are the actual Unicode signs rather than drawn substitutes, so they inherit the
+ * Quran font and scale with it.
+ */
+private const val RUB_EL_HIZB = "۞"  // ۞ — opens a hizb quarter
+private const val SAJDA_SIGN = "۩"   // ۩ — a verse of prostration
+private const val RUKU_SIGN = "ع"    // ع — closes a rukūʿ
+
+/** Appends one structural sign, tinted so it reads as apparatus rather than as text. */
+private fun AnnotatedString.Builder.appendDivisionMarker(sign: String, color: Color) {
+    withStyle(SpanStyle(color = color)) { append(sign) }
+}
+
 private fun buildMushafAnnotatedString(
     ayahs: List<Ayah>,
     tajweedByAyahId: Map<Int, AnnotatedString>,
@@ -237,7 +260,8 @@ private fun buildMushafAnnotatedString(
     highlightColor: Color,
     selectedColor: Color,
     markerBracketColor: Color,
-    markerNumberColor: Color
+    markerNumberColor: Color,
+    divisionMarkerColor: Color
 ): AnnotatedString {
     return buildAnnotatedString {
         ayahs.forEachIndexed { index, ayah ->
@@ -245,6 +269,13 @@ private fun buildMushafAnnotatedString(
 
             // Pre-parsed tajweed (already bismillah-stripped) if available for
             // this ayah, else the plain bismillah-stripped Arabic text.
+            // ۞ opens a hizb quarter, so it sits before the verse's first word — the same
+            // place a printed Mushaf puts it.
+            if (ayah.isRubStart) {
+                appendDivisionMarker(RUB_EL_HIZB, divisionMarkerColor)
+                append(" ")
+            }
+
             val tajweed = tajweedByAyahId[ayah.id]
             if (tajweed != null) {
                 append(tajweed)
@@ -254,6 +285,17 @@ private fun buildMushafAnnotatedString(
 
             append(" ")
             appendAyahEndMarker(ayah.ayahNumber, markerBracketColor, markerNumberColor)
+
+            // ۩ marks a verse of prostration, and the ʿayn closes a rukūʿ — both belong
+            // after the verse rather than before it.
+            if (ayah.sajdaType != null) {
+                append(" ")
+                appendDivisionMarker(SAJDA_SIGN, divisionMarkerColor)
+            }
+            if (ayah.isRukuEnd) {
+                append(" ")
+                appendDivisionMarker(RUKU_SIGN, divisionMarkerColor)
+            }
 
             val end = length
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafLineLayout.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/MushafLineLayout.kt
@@ -109,6 +109,10 @@ fun MushafLineLayout(
     highlightColor: Color = MaterialTheme.colorScheme.primaryContainer,
     selectedColor: Color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
     basmalahColor: Color = QuranSurfaceColors.frameGold,
+    divisionMarkerColor: Color = QuranSurfaceColors.frameGold,
+    // Resolved by the host, which already holds the page's ayahs — this renderer has no
+    // database of its own, and must not acquire one to draw three signs.
+    divisionMarks: (ayahId: Int) -> MushafDivisionMarks = { MushafDivisionMarks.NONE },
 ) {
     // Last physical AYAH line on the page — never justified (it may be short).
     val lastAyahIndex = remember(lines) { lines.indexOfLast { it.type == MushafLineType.AYAH } }
@@ -219,6 +223,8 @@ fun MushafLineLayout(
                             selectedColor = selectedColor,
                             highlightedAyahId = highlightedAyahId,
                             selectedAyahId = selectedAyahId,
+                            divisionMarks = divisionMarks,
+                            divisionMarkerColor = divisionMarkerColor,
                             onAyahClick = onAyahClick,
                         )
                     }
@@ -262,6 +268,63 @@ private const val REFERENCE_FONT_SIZE = 28f
 /** Floor for [pageFitFontSize], so a very dense page stays legible on a narrow screen. */
 private const val MIN_FONT_SIZE = 10f
 
+/** The structural signs a printed Mushaf carries around the text. */
+private const val RUB_EL_HIZB = "۞"
+private const val SAJDA_SIGN = "۩"
+private const val RUKU_SIGN = "ع"
+
+/** Words are 1-based within their ayah, so this is the verse's opening word. */
+private const val FIRST_WORD = 1
+
+/**
+ * The end-of-verse glyphs the IndoPak text closes every ayah with — the small rounded zero,
+ * alone or with the ornament that follows a surah's final verse.
+ */
+internal val VERSE_END_GLYPHS = charArrayOf('۟', '۠')
+
+/** Whether this word carries the verse's end glyph, i.e. whether the ayah stops here. */
+internal fun String.endsOfVerse(): Boolean = any { it in VERSE_END_GLYPHS }
+
+/**
+ * Which structural signs a verse carries. Resolved once per page by the host rather than per
+ * word: a page is ~15 lines of ~8 words, and the lookup behind this reads the database.
+ */
+data class MushafDivisionMarks(
+    val opensQuarter: Boolean = false,
+    val closesRuku: Boolean = false,
+    val hasSajda: Boolean = false,
+) {
+    companion object {
+        val NONE = MushafDivisionMarks()
+    }
+}
+
+/**
+ * One structural sign set beside the text.
+ *
+ * Slightly smaller than the verse and in the ornament gold, because it is apparatus: it has
+ * to be findable at a glance without ever being mistaken for a word of the Qur'an.
+ */
+@Composable
+private fun MushafDivisionSign(
+    sign: String,
+    arabicFontSize: Float,
+    arabicFontFamily: FontFamily,
+    color: Color,
+) {
+    BasicText(
+        text = sign,
+        style = TextStyle(
+            fontFamily = arabicFontFamily,
+            fontSize = (arabicFontSize * 0.8f).sp,
+            color = color,
+            textDirection = TextDirection.Rtl,
+            textAlign = TextAlign.Center,
+        ),
+        modifier = Modifier.padding(horizontal = 2.dp),
+    )
+}
+
 /**
  * One justified (or naturally-spaced) row of ayah words, right-to-left, at the page's size.
  */
@@ -276,6 +339,8 @@ private fun MushafAyahLine(
     selectedColor: Color,
     highlightedAyahId: Int?,
     selectedAyahId: Int?,
+    divisionMarks: (Int) -> MushafDivisionMarks,
+    divisionMarkerColor: Color,
     onAyahClick: (ayahId: Int, tapWindowY: Float) -> Unit,
 ) {
     if (words.isEmpty()) return
@@ -304,6 +369,18 @@ private fun MushafAyahLine(
                     selectedAyahId -> selectedColor
                     else -> Color.Transparent
                 }
+                val marks = divisionMarks(word.ayahId)
+
+                // ۞ opens a hizb quarter, so it precedes the verse's first word.
+                if (marks.opensQuarter && word.position == FIRST_WORD) {
+                    MushafDivisionSign(
+                        sign = RUB_EL_HIZB,
+                        arabicFontSize = arabicFontSize,
+                        arabicFontFamily = arabicFontFamily,
+                        color = divisionMarkerColor,
+                    )
+                }
+
                 BasicText(
                     text = word.text,
                     style = TextStyle(
@@ -318,6 +395,29 @@ private fun MushafAyahLine(
                         .clickable { onAyahClick(word.ayahId, lineCenterWindowY) }
                         .padding(horizontal = 1.dp, vertical = 2.dp),
                 )
+
+                // ۩ and ع follow the verse they belong to. The verse's own end glyph is the
+                // reliable anchor: it is the last token of every ayah in the IndoPak text,
+                // so this needs no word counts and stays correct when an ayah runs across a
+                // page boundary — where "the last word on this page" would be wrong.
+                if (word.text.endsOfVerse()) {
+                    if (marks.hasSajda) {
+                        MushafDivisionSign(
+                            sign = SAJDA_SIGN,
+                            arabicFontSize = arabicFontSize,
+                            arabicFontFamily = arabicFontFamily,
+                            color = divisionMarkerColor,
+                        )
+                    }
+                    if (marks.closesRuku) {
+                        MushafDivisionSign(
+                            sign = RUKU_SIGN,
+                            arabicFontSize = arabicFontSize,
+                            arabicFontFamily = arabicFontFamily,
+                            color = divisionMarkerColor,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
@@ -1,10 +1,12 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -34,6 +36,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
@@ -46,8 +49,18 @@ import com.arshadshah.nimaz.presentation.theme.NimazTheme
  * rotates 180° to signal state. Pass a [leadingIcon] for a small tinted accent
  * badge on the left; omit it for a plain header.
  *
+ * The header can also carry a [subtitle] under the title and a [trailing] slot
+ * before the chevron, so a row can summarise its own state without being opened
+ * ("Adhan · 10 min before", plus the time and an enable switch). The header
+ * itself is the expand/collapse target, so anything interactive placed in
+ * [trailing] handles its own taps — a `NimazSwitch` there toggles without
+ * expanding the body.
+ *
  * @param title header text, always visible.
+ * @param subtitle optional summary line under the title, always visible.
  * @param leadingIcon optional accent icon shown in a rounded badge.
+ * @param trailing optional header content rendered between the title and the
+ *   chevron, laid out in the header's [RowScope].
  * @param initiallyExpanded whether the body starts open.
  * @param content the collapsible body; laid out in a [ColumnScope].
  */
@@ -55,7 +68,9 @@ import com.arshadshah.nimaz.presentation.theme.NimazTheme
 fun NimazAccordion(
     title: String,
     modifier: Modifier = Modifier,
+    subtitle: String? = null,
     leadingIcon: ImageVector? = null,
+    trailing: (@Composable RowScope.() -> Unit)? = null,
     initiallyExpanded: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -83,12 +98,25 @@ fun NimazAccordion(
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                 }
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    modifier = Modifier.weight(1f)
-                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    if (!subtitle.isNullOrBlank()) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                if (trailing != null) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                    trailing()
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
                 NimazIcon(
                     imageVector = Icons.Default.ExpandMore,
                     contentDescription = null,
@@ -135,6 +163,70 @@ private fun NimazAccordion_Expanded_Preview() {
         ) {
             Text(
                 text = "Nimaz calculates prayer times from your saved location and the calculation method you choose.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+// The subtitle + trailing configuration the prayer rows are built from: the header
+// has to carry the name, its summary, the prayer time and the enable switch without
+// crowding, which is the first thing that breaks at a large font scale.
+
+@Preview(showBackground = true, widthDp = 400, name = "Accordion — subtitle + trailing")
+@Composable
+private fun NimazAccordion_Trailing_Preview() {
+    NimazTheme {
+        NimazAccordion(
+            title = "Fajr",
+            subtitle = "Adhan · 10 min before",
+            trailing = {
+                Text(
+                    text = "05:12",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                NimazSwitch(checked = true, onCheckedChange = {})
+            },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = "Alert style and reminder settings for Fajr.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 400,
+    name = "Accordion — subtitle + trailing (dark)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun NimazAccordion_Trailing_Dark_Preview() {
+    NimazTheme {
+        NimazAccordion(
+            title = "Maghrib",
+            subtitle = "Notification only · no reminder",
+            initiallyExpanded = true,
+            trailing = {
+                Text(
+                    text = "20:47",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                NimazSwitch(checked = false, onCheckedChange = {})
+            },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = "Alert style and reminder settings for Maghrib.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazListPicker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazListPicker.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,8 +20,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +54,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckboxSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckboxType
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckboxVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
@@ -92,6 +97,13 @@ data class NimazPickerItem<T>(
  * - The search stays pinned while the grouped list scrolls inside the sheet.
  * - On open the list scrolls to centre the currently-selected item so the
  *   user sees where they are.
+ * - [trailingContent]: optional per-row action rendered at the end of the row,
+ *   after the selection tick — an adhan preview button, for instance. It lives
+ *   on the picker rather than on [NimazPickerItem] deliberately: the item stays
+ *   pure data (so equality and the list keys are unaffected), and state that
+ *   changes while the sheet is open — which voice is currently playing — stays
+ *   with the caller. The row itself is the selection target, so the action
+ *   handles its own taps.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -108,6 +120,7 @@ fun <T> NimazListPicker(
     cancelText: String = stringResource(R.string.cancel),
     searchPlaceholder: String = stringResource(R.string.search),
     emptySearchText: String = stringResource(R.string.picker_no_matches),
+    trailingContent: (@Composable (NimazPickerItem<T>) -> Unit)? = null,
 ) {
     var query by remember { mutableStateOf("") }
 
@@ -198,7 +211,8 @@ fun <T> NimazListPicker(
                             onClick = {
                                 onSelected(item.value)
                                 if (autoDismiss) onDismiss()
-                            }
+                            },
+                            trailingContent = trailingContent
                         )
                     }
                 }
@@ -215,7 +229,8 @@ fun <T> NimazListPicker(
                                 onClick = {
                                     onSelected(item.value)
                                     if (autoDismiss) onDismiss()
-                                }
+                                },
+                                trailingContent = trailingContent
                             )
                         }
                     }
@@ -229,6 +244,7 @@ private fun <T> PickerRow(
     item: NimazPickerItem<T>,
     isSelected: Boolean,
     onClick: () -> Unit,
+    trailingContent: (@Composable (NimazPickerItem<T>) -> Unit)? = null,
 ) {
     // Rows sit on the sheet's own surface, so a flat container fill has almost
     // nothing to read against in light mode. Unselected rows are outlined; the
@@ -306,6 +322,11 @@ private fun <T> PickerRow(
                     size = NimazCheckboxSize.LARGE,
                     type = NimazCheckboxType.CIRCLE
                 )
+            }
+
+            if (trailingContent != null) {
+                Spacer(modifier = Modifier.width(4.dp))
+                trailingContent(item)
             }
         }
     }
@@ -486,6 +507,68 @@ private fun NimazListPicker_Grouped_Preview() {
         )
     }
 }
+
+// The adhan picker's configuration: an explicit Confirm (you audition several
+// voices before committing) and a per-row preview action.
+
+@Preview(showBackground = true, widthDp = 412, heightDp = 600, name = "5. Trailing action")
+@Composable
+private fun NimazListPicker_TrailingAction_Preview() {
+    NimazTheme {
+        NimazListPicker(
+            title = "Adhan voice",
+            items = adhanPreviewItems,
+            selected = "mishary",
+            onSelected = {},
+            onDismiss = {},
+            autoDismiss = false,
+            trailingContent = { item ->
+                NimazIconButton(
+                    icon = if (item.value == "mishary") Icons.Default.Stop else Icons.Default.PlayArrow,
+                    contentDescription = "Preview ${item.title}",
+                    onClick = {},
+                    size = NimazIconButtonSize.SMALL
+                )
+            }
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 412,
+    heightDp = 600,
+    name = "6. Trailing action (dark)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun NimazListPicker_TrailingAction_Dark_Preview() {
+    NimazTheme {
+        NimazListPicker(
+            title = "Adhan voice",
+            items = adhanPreviewItems,
+            selected = "makkah",
+            onSelected = {},
+            onDismiss = {},
+            autoDismiss = false,
+            trailingContent = { item ->
+                NimazIconButton(
+                    icon = Icons.Default.PlayArrow,
+                    contentDescription = "Preview ${item.title}",
+                    onClick = {},
+                    size = NimazIconButtonSize.SMALL
+                )
+            }
+        )
+    }
+}
+
+private val adhanPreviewItems = listOf(
+    NimazPickerItem(value = "mishary", title = "Mishary Rashid", description = "Kuwait"),
+    NimazPickerItem(value = "makkah", title = "Makkah", description = "Masjid al-Haram"),
+    NimazPickerItem(value = "madinah", title = "Madinah", description = "Masjid an-Nabawi"),
+    NimazPickerItem(value = "aqsa", title = "Al-Aqsa", description = "Jerusalem"),
+)
 
 @Preview(showBackground = true, widthDp = 412, heightDp = 400, name = "4. Empty search result")
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
@@ -104,8 +104,6 @@ fun NimazMenuItem(
                     tint = if (selected) titleColor else iconTint,
                     size = NimazIconSize.LARGE
                 )
-
-                Nima
                 Spacer(modifier = Modifier.width(16.dp))
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.components.molecules
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -35,6 +36,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellShape
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.asLanguageLabel
 
@@ -49,6 +52,9 @@ import com.arshadshah.nimaz.presentation.theme.asLanguageLabel
  * @param subtitleStyle overrides the subtitle's style. Needed where the subtitle is not Latin
  *   text: an Urdu endonym set in the body font falls back to a system Naskh face (see
  *   [com.arshadshah.nimaz.presentation.theme.asLanguageLabel]).
+ * @param trailing optional content rendered before [trailingIcon] — a status [NimazBadge], for
+ *   instance, on a row whose state the reader needs at a glance. The row is the tap target, so
+ *   anything interactive placed here handles its own taps.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,6 +66,7 @@ fun NimazMenuItem(
     icon: ImageVector? = null,
     iconTint: Color = MaterialTheme.colorScheme.primary,
     trailingIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowForward,
+    trailing: (@Composable RowScope.() -> Unit)? = null,
     enabled: Boolean = true,
     selected: Boolean = false,
     subtitleStyle: TextStyle = MaterialTheme.typography.bodySmall
@@ -98,11 +105,11 @@ fun NimazMenuItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             if (icon != null) {
-                NimazIcon(
-                    imageVector = icon,
+
+                NimazIconWell(
+                     icon,
                     contentDescription = null,
-                    tint = if (selected) titleColor else iconTint,
-                    size = NimazIconSize.LARGE
+                    shape = NimazIconWellShape.ROUNDED
                 )
                 Spacer(modifier = Modifier.width(16.dp))
             }
@@ -121,6 +128,11 @@ fun NimazMenuItem(
                         color = subtitleColor
                     )
                 }
+            }
+
+            if (trailing != null) {
+                trailing()
+                Spacer(modifier = Modifier.width(8.dp))
             }
 
             when {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
@@ -104,6 +104,8 @@ fun NimazMenuItem(
                     tint = if (selected) titleColor else iconTint,
                     size = NimazIconSize.LARGE
                 )
+
+                Nima
                 Spacer(modifier = Modifier.width(16.dp))
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponents.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponents.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -19,6 +20,8 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material.icons.filled.FormatListNumbered
+import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,43 +42,78 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
+/** One figure in [SurahMetaStrip]: what it is, and what it says. */
+internal data class SurahMetaStat(
+    val icon: ImageVector,
+    val label: String,
+    val value: String,
+)
+
 /**
- * Icon / label / value stat tile used by the surah info screen's stats row
- * (Verses, Juz, Page). Sits directly on the page background, so it is a
- * page-level card: [NimazCardStyle.ELEVATED] + [NimazTone.NEUTRAL].
+ * Where a surah sits in the Mushaf — its verse count, its juz and its opening page — as one
+ * quiet strip under the cartouche.
+ *
+ * These were three elevated cards, which gave three small numbers the same visual weight as
+ * the surah's name and the summary paragraph below it. They are reference figures you glance
+ * at, not the point of the screen, so they now read as a single line: value over label,
+ * divided rather than boxed, sharing one surface.
  */
 @Composable
-internal fun DetailCard(
-    icon: ImageVector,
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier
+internal fun SurahMetaStrip(
+    stats: List<SurahMetaStat>,
+    modifier: Modifier = Modifier,
 ) {
     NimazCard(
-        modifier = modifier,
-        style = NimazCardStyle.ELEVATED,
-        tone = NimazTone.NEUTRAL
+        modifier = modifier.fillMaxWidth(),
+        style = NimazCardStyle.FILLED,
+        tone = NimazTone.NEUTRAL,
+        elevation = 0.dp
     ) {
-        Column(modifier = Modifier.padding(15.dp)) {
-            NimazIcon(
-                imageVector = icon,
-                contentDescription = null,
-                variant = NimazIconVariant.MUTED,
-                iconSize = 22.dp
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = value,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            stats.forEachIndexed { index, stat ->
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        NimazIcon(
+                            imageVector = stat.icon,
+                            contentDescription = null,
+                            variant = NimazIconVariant.MUTED,
+                            iconSize = 14.dp
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = stat.value,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Text(
+                        text = stat.label,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (index < stats.lastIndex) {
+                    // A hairline rather than a gap: it separates the figures without
+                    // making three boxes out of them again.
+                    Box(
+                        modifier = Modifier
+                            .height(28.dp)
+                            .width(1.dp)
+                            .background(MaterialTheme.colorScheme.outlineVariant)
+                    )
+                }
+            }
         }
     }
 }
@@ -231,15 +269,43 @@ internal fun SurahAudioControlBar(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun DetailCardPreview() {
-    NimazTheme {
-        DetailCard(
-            icon = Icons.AutoMirrored.Filled.MenuBook,
+private val metaStripSample
+    @Composable get() = listOf(
+        SurahMetaStat(
+            icon = Icons.Default.FormatListNumbered,
+            label = stringResource(R.string.quran_verses_label),
+            value = "286"
+        ),
+        SurahMetaStat(
+            icon = Icons.Default.Layers,
             label = stringResource(R.string.quran_juz_label),
             value = "1"
-        )
+        ),
+        SurahMetaStat(
+            icon = Icons.AutoMirrored.Filled.MenuBook,
+            label = stringResource(R.string.quran_page_label),
+            value = "2"
+        ),
+    )
+
+@Preview(showBackground = true, widthDp = 400, name = "Surah meta strip")
+@Composable
+private fun SurahMetaStripPreview() {
+    NimazTheme {
+        SurahMetaStrip(stats = metaStripSample, modifier = Modifier.padding(20.dp))
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 400,
+    name = "Surah meta strip (dark)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun SurahMetaStripDarkPreview() {
+    NimazTheme {
+        SurahMetaStrip(stats = metaStripSample, modifier = Modifier.padding(20.dp))
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafLinePage.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/MushafLinePage.kt
@@ -37,6 +37,7 @@ import com.arshadshah.nimaz.domain.model.MushafPageLayout
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.TranslationLanguage
 import com.arshadshah.nimaz.presentation.components.molecules.AyahTooltip
+import com.arshadshah.nimaz.presentation.components.molecules.MushafDivisionMarks
 import com.arshadshah.nimaz.presentation.components.molecules.MushafLineLayout
 import com.arshadshah.nimaz.presentation.components.molecules.QuranFrame
 import com.arshadshah.nimaz.presentation.components.molecules.QuranFrameVariant
@@ -112,6 +113,28 @@ fun MushafLinePage(
     // Ayah for the tooltip even when the host supplies no full-content lookup.
     val ayahMeta = remember(layout) { buildAyahMeta(layout) }
 
+    // The page's structural signs, resolved once per page rather than per word. A page is
+    // ~15 lines of ~8 words, and ayahLookup reads the database; doing this inline in the
+    // renderer would turn one map build into a hundred lookups on every recomposition.
+    val divisionMarks: Map<Int, MushafDivisionMarks> = remember(layout, ayahLookup) {
+        layout.lines
+            .asSequence()
+            .flatMap { it.words.asSequence() }
+            .map { it.ayahId }
+            .distinct()
+            .mapNotNull { id ->
+                val ayah = ayahLookup(id) ?: return@mapNotNull null
+                val marks = MushafDivisionMarks(
+                    opensQuarter = ayah.isRubStart,
+                    closesRuku = ayah.isRukuEnd,
+                    hasSajda = ayah.sajdaType != null,
+                )
+                // Only verses that actually carry a sign are worth keeping.
+                if (marks == MushafDivisionMarks.NONE) null else id to marks
+            }
+            .toMap()
+    }
+
     fun resolveAyah(ayahId: Int): Ayah? {
         ayahLookup(ayahId)?.let { return it }
         val meta = ayahMeta[ayahId] ?: return null
@@ -158,6 +181,7 @@ fun MushafLinePage(
                     arabicFontFamily = arabicFontFamily,
                     highlightedAyahId = highlightedAyahId,
                     selectedAyahId = tooltipAyah?.id,
+                    divisionMarks = { divisionMarks[it] ?: MushafDivisionMarks.NONE },
                     onAyahClick = { ayahId, tapWindowY ->
                         resolveAyah(ayahId)?.let { ayah ->
                             bookmarkOverride = null

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
@@ -382,10 +382,15 @@ internal fun AyahItem(
                 }
             }
 
-            Text(
+            // Where the verse sits in the book. A badge like the ones beside it, so the row
+            // reads as one system rather than badges plus a stray line of grey text — but
+            // MUTED, because this is a coordinate you look up, not a division you observe.
+            NimazBadge(
                 text = stringResource(R.string.juz_page_dot_format, ayah.juz, ayah.page),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                tone = NimazTone.MUTED,
+                emphasis = NimazBadgeEmphasis.SOFT,
+                shape = NimazBadgeShape.ROUNDED,
+                size = NimazBadgeSize.SMALL
             )
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
@@ -368,9 +368,10 @@ internal fun AyahItem(
                 }
 
                 // Rukūʿ — the surah's own sections, from the `rukus` table. Same badge
-                // language as the hizb quarter beside it, and likewise only on the verse
-                // that opens the section.
-                if (ayah.isRukuStart && ayah.rukuNumber != null) {
+                // language as the hizb quarter beside it, but on the verse that *closes*
+                // the section: the ʿayn (ع) ends a rukūʿ in a printed Mushaf rather than
+                // announcing it. Al-Fātiḥah is one rukūʿ, so this shows on 1:7, not 1:1.
+                if (ayah.isRukuEnd && ayah.rukuNumber != null) {
                     NimazBadge(
                         text = stringResource(R.string.ruku_format, ayah.rukuNumber),
                         tone = NimazTone.ACCENT,
@@ -431,7 +432,7 @@ private fun AyahItemShowcase() {
         isBookmarked = bookmarked,
         transliteration = transliteration,
         rukuNumber = ruku,
-        isRukuStart = ruku != null,
+        isRukuEnd = ruku != null,
         isRubStart = rub > 0,
     )
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
@@ -39,7 +39,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
-import com.arshadshah.nimaz.presentation.components.molecules.DetailCard
+import com.arshadshah.nimaz.presentation.components.molecules.SurahMetaStat
+import com.arshadshah.nimaz.presentation.components.molecules.SurahMetaStrip
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.molecules.SurahHeaderCartouche
@@ -144,30 +145,27 @@ fun SurahInfoScreen(
                     )
                 }
 
-                // Stats row: Verses / Juz / Page
+                // Where the surah sits in the Mushaf, as one strip rather than three cards.
                 item(key = "stats") {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        DetailCard(
-                            icon = Icons.Default.FormatListNumbered,
-                            label = stringResource(R.string.quran_verses_label),
-                            value = surah.ayahCount.toString(),
-                            modifier = Modifier.weight(1f)
+                    SurahMetaStrip(
+                        stats = listOf(
+                            SurahMetaStat(
+                                icon = Icons.Default.FormatListNumbered,
+                                label = stringResource(R.string.quran_verses_label),
+                                value = surah.ayahCount.toString(),
+                            ),
+                            SurahMetaStat(
+                                icon = Icons.Default.Layers,
+                                label = stringResource(R.string.quran_juz_label),
+                                value = surah.juzStart.toString(),
+                            ),
+                            SurahMetaStat(
+                                icon = Icons.AutoMirrored.Filled.MenuBook,
+                                label = stringResource(R.string.quran_page_label),
+                                value = surah.startPage.toString(),
+                            ),
                         )
-                        DetailCard(
-                            icon = Icons.Default.Layers,
-                            label = stringResource(R.string.quran_juz_label),
-                            value = surah.juzStart.toString(),
-                            modifier = Modifier.weight(1f)
-                        )
-                        DetailCard(
-                            icon = Icons.AutoMirrored.Filled.MenuBook,
-                            label = stringResource(R.string.quran_page_label),
-                            value = surah.startPage.toString(),
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
+                    )
                 }
 
                 // What the surah is about, in the source's own words. The one field written

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreen.kt
@@ -48,7 +48,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
-import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
@@ -62,7 +62,7 @@ import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationTroubleshootingScreen(
+fun NotificationDiagnosticsScreen(
     onNavigateBack: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -104,7 +104,7 @@ fun NotificationTroubleshootingScreen(
                         okLabel = stringResource(R.string.notif_diag_granted),
                         problemLabel = stringResource(R.string.notif_diag_blocked),
                         icon = Icons.Default.NotificationsActive,
-                        onFix = {
+                        onOpenSystemSettings = {
                             context.startActivity(
                                 Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
                                     .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
@@ -117,7 +117,7 @@ fun NotificationTroubleshootingScreen(
                         okLabel = stringResource(R.string.notif_diag_allowed),
                         problemLabel = stringResource(R.string.notif_diag_not_allowed),
                         icon = Icons.Default.Schedule,
-                        onFix = {
+                        onOpenSystemSettings = {
                             context.startActivity(
                                 Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
                             )
@@ -129,7 +129,7 @@ fun NotificationTroubleshootingScreen(
                         okLabel = stringResource(R.string.notif_diag_unrestricted),
                         problemLabel = stringResource(R.string.notif_diag_restricted),
                         icon = Icons.Default.BatteryAlert,
-                        onFix = {
+                        onOpenSystemSettings = {
                             context.startActivity(
                                 Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
                             )
@@ -138,7 +138,7 @@ fun NotificationTroubleshootingScreen(
                 }
             }
 
-            item { NimazSectionHeader(title = stringResource(R.string.notification_settings_troubleshooting_section)) }
+            item { NimazSectionHeader(title = stringResource(R.string.notif_diag_actions_section)) }
             item {
                 val testSentMsg = stringResource(R.string.notification_settings_test_sent)
                 val testAllSentMsg = stringResource(R.string.notification_settings_test_all_sent)
@@ -217,9 +217,12 @@ fun NotificationTroubleshootingScreen(
 }
 
 /**
- * One checked prerequisite. The badge carries the state so the row can be read at a glance,
- * and tapping opens the system screen that changes it — but only when there is something
- * to fix, because sending someone to a settings page that is already correct is noise.
+ * One checked prerequisite, as a menu row with its state as a badge.
+ *
+ * Every row opens the system screen it reports on, passing or failing. Making only the
+ * failing ones tappable was tempting, but it leaves a row that looks like the others and
+ * does nothing when tapped — and someone who wants to see *why* a check passes has nowhere
+ * to go. The badge already says which rows need attention.
  */
 @Composable
 private fun DiagnosticRow(
@@ -228,14 +231,13 @@ private fun DiagnosticRow(
     okLabel: String,
     problemLabel: String,
     icon: ImageVector,
-    onFix: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
 ) {
-    NimazSettingsItem(
+    NimazMenuItem(
         title = title,
         icon = icon,
-        onClick = if (ok) null else onFix,
-        showArrow = !ok,
-        trailingContent = {
+        onClick = onOpenSystemSettings,
+        trailing = {
             NimazBadge(
                 text = if (ok) okLabel else problemLabel,
                 tone = if (ok) NimazTone.SUCCESS else NimazTone.WARNING

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationHubSubtitles.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationHubSubtitles.kt
@@ -1,0 +1,42 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import androidx.annotation.StringRes
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+
+/**
+ * Which string each notifications-hub row reports, given the settings behind it.
+ *
+ * The choosing is kept apart from the rendering so it can be tested without a device: the
+ * hub's whole point is that its subtitles are true, and "the weekly row says both are on
+ * when only one is" is exactly the kind of wrong that a screenshot does not catch.
+ */
+object NotificationHubSubtitles {
+
+    @StringRes
+    fun alertStyle(style: PrayerAlertStyle): Int = when (style) {
+        PrayerAlertStyle.ADHAN -> R.string.notif_alert_style_adhan
+        PrayerAlertStyle.NOTIFICATION -> R.string.notif_alert_style_notification
+        PrayerAlertStyle.SILENT -> R.string.notif_alert_style_silent
+    }
+
+    @StringRes
+    fun weekly(jumuahEnabled: Boolean, khatamEnabled: Boolean): Int = when {
+        jumuahEnabled && khatamEnabled -> R.string.notif_hub_weekly_both
+        jumuahEnabled -> R.string.notif_hub_weekly_jumuah
+        khatamEnabled -> R.string.notif_hub_weekly_khatam
+        else -> R.string.notif_hub_weekly_none
+    }
+
+    /**
+     * The sound row leads with the chosen voice and adds the one delivery rule most likely
+     * to surprise someone — Do Not Disturb silencing the adhan outranks vibration, because
+     * it is the one that stops a sound the user is expecting.
+     */
+    @StringRes
+    fun sound(respectDnd: Boolean, vibrationEnabled: Boolean): Int = when {
+        respectDnd -> R.string.notif_hub_sound_dnd
+        vibrationEnabled -> R.string.notif_hub_sound_vibration
+        else -> R.string.notif_hub_sound_plain
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -201,13 +201,7 @@ private fun prayersSubtitle(
     reminderEnabled: Boolean,
     reminderMinutes: Int,
 ): String {
-    val styleLabel = stringResource(
-        when (style) {
-            PrayerAlertStyle.ADHAN -> R.string.notif_alert_style_adhan
-            PrayerAlertStyle.NOTIFICATION -> R.string.notif_alert_style_notification
-            PrayerAlertStyle.SILENT -> R.string.notif_alert_style_silent
-        }
-    )
+    val styleLabel = stringResource(NotificationHubSubtitles.alertStyle(style))
     if (!reminderEnabled) return styleLabel
     return stringResource(
         R.string.notif_prayer_summary,
@@ -221,23 +215,15 @@ private fun prayersSubtitle(
 }
 
 @Composable
-private fun soundSubtitle(state: NotificationSettingsUiState): String {
-    val voice = AdhanSound.fromName(state.selectedAdhanSound).displayName
-    return when {
-        state.respectDnd -> stringResource(R.string.notif_hub_sound_dnd, voice)
-        state.vibrationEnabled -> stringResource(R.string.notif_hub_sound_vibration, voice)
-        else -> stringResource(R.string.notif_hub_sound_plain, voice)
-    }
-}
+private fun soundSubtitle(state: NotificationSettingsUiState): String = stringResource(
+    NotificationHubSubtitles.sound(state.respectDnd, state.vibrationEnabled),
+    AdhanSound.fromName(state.selectedAdhanSound).displayName
+)
 
 @Composable
 private fun weeklySubtitle(state: NotificationSettingsUiState): String = stringResource(
-    when {
-        state.fridayReminderEnabled && state.khatamReminderEnabled ->
-            R.string.notif_hub_weekly_both
-
-        state.fridayReminderEnabled -> R.string.notif_hub_weekly_jumuah
-        state.khatamReminderEnabled -> R.string.notif_hub_weekly_khatam
-        else -> R.string.notif_hub_weekly_none
-    }
+    NotificationHubSubtitles.weekly(
+        jumuahEnabled = state.fridayReminderEnabled,
+        khatamEnabled = state.khatamReminderEnabled
+    )
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -58,7 +58,7 @@ fun NotificationSettingsScreen(
     onNavigateToWorshipReminders: () -> Unit = {},
     onNavigateToWeekly: () -> Unit = {},
     onNavigateToSound: () -> Unit = {},
-    onNavigateToTroubleshooting: () -> Unit = {},
+    onNavigateToDiagnostics: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val notificationState by viewModel.notificationState.collectAsStateWithLifecycle()
@@ -119,7 +119,7 @@ fun NotificationSettingsScreen(
                             variant = NimazBannerVariant.WARNING,
                             icon = Icons.Default.WarningAmber,
                             showBorder = true,
-                            onClick = onNavigateToTroubleshooting,
+                            onClick = onNavigateToDiagnostics,
                             modifier = Modifier.fillMaxWidth()
                         )
                     }
@@ -173,7 +173,7 @@ fun NotificationSettingsScreen(
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_diagnostics_title),
                             subtitle = stringResource(R.string.notif_hub_diagnostics_subtitle),
-                            onClick = onNavigateToTroubleshooting,
+                            onClick = onNavigateToDiagnostics,
                             showArrow = true,
                             trailingContent = if (diagnostics?.hasProblem == true) {
                                 {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -1,8 +1,6 @@
 package com.arshadshah.nimaz.presentation.screens.settings
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,39 +8,47 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.core.util.NotificationDiagnostics
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBanner
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
-import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
+import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.viewmodel.NotificationSettingsUiState
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
 
 /**
- * Notifications hub (#301): a master switch plus links into focused subscreens (Prayer, Worship
- * reminders, Weekly & reading, Sound & delivery, Troubleshooting). All state lives in the shared
- * [SettingsViewModel]; each subscreen renders a slice of it. Replaced the previous single long
- * scroll with no behaviour change.
+ * Notifications hub (#301): a master switch and five rows into focused subscreens.
+ *
+ * Each row's subtitle reports what is actually set rather than describing what the screen
+ * behind it contains — the hub is where you check your settings, not just a menu. The
+ * warning banner appears only when the device is genuinely in a state that would delay or
+ * drop alerts; it is read from the OS on every resume, and it links to Diagnostics.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,7 +62,21 @@ fun NotificationSettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val notificationState by viewModel.notificationState.collectAsStateWithLifecycle()
+    val summary by viewModel.notificationSummary.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    // Re-read on every resume: the user may have just left to grant a permission, and a
+    // banner still warning about it would read as the fix not having worked.
+    val context = LocalContext.current
+    val lifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateFlow
+        .collectAsStateWithLifecycle()
+    val diagnostics = remember(lifecycleState) {
+        if (lifecycleState.isAtLeast(Lifecycle.State.RESUMED)) {
+            NotificationDiagnostics.read(context)
+        } else {
+            null
+        }
+    }
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -78,86 +98,146 @@ fun NotificationSettingsScreen(
         ) {
             item { Spacer(modifier = Modifier.height(4.dp)) }
 
-            // Master toggle
             item {
                 NimazMenuGroup {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(R.string.notification_settings_enable),
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Medium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Text(
-                                text = stringResource(R.string.notification_settings_enable_subtitle),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                    NimazSettingsItem(
+                        title = stringResource(R.string.notification_settings_enable),
+                        subtitle = stringResource(R.string.notification_settings_enable_subtitle),
+                        checked = notificationState.notificationsEnabled,
+                        onCheckedChange = {
+                            viewModel.onEvent(SettingsEvent.SetNotificationsEnabled(it))
                         }
-                        NimazSwitch(
-                            checked = notificationState.notificationsEnabled,
-                            onCheckedChange = {
-                                viewModel.onEvent(SettingsEvent.SetNotificationsEnabled(!notificationState.notificationsEnabled))
-                            }
-                        )
-                    }
+                    )
                 }
             }
 
             if (notificationState.notificationsEnabled) {
+                if (diagnostics?.hasProblem == true) {
+                    item {
+                        NimazBanner(
+                            message = stringResource(R.string.notif_hub_delivery_warning),
+                            variant = NimazBannerVariant.WARNING,
+                            icon = Icons.Default.WarningAmber,
+                            showBorder = true,
+                            onClick = onNavigateToTroubleshooting,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
                 item {
                     NimazMenuGroup {
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_prayers_title),
-                            subtitle = stringResource(R.string.notif_hub_prayers_subtitle),
+                            subtitle = prayersSubtitle(summary.fajrAlertStyle, summary.reminderEnabled, summary.reminderMinutes),
+                            value = stringResource(
+                                R.string.notif_hub_count_of,
+                                summary.enabledPrayerCount,
+                                5
+                            ),
                             onClick = onNavigateToPrayers,
                             showArrow = true
                         )
                         NimazSettingsItem(
+                            title = stringResource(R.string.notif_hub_sound_title),
+                            subtitle = soundSubtitle(notificationState),
+                            onClick = onNavigateToSound,
+                            showArrow = true
+                        )
+                    }
+                }
+
+                item {
+                    NimazMenuGroup {
+                        NimazSettingsItem(
                             title = stringResource(R.string.worship_settings_title),
-                            subtitle = stringResource(R.string.worship_settings_subtitle),
+                            subtitle = stringResource(R.string.notif_hub_worship_subtitle),
+                            value = stringResource(
+                                R.string.notif_hub_count_on,
+                                notificationState.worshipReminders.count { it.value }
+                            ),
                             onClick = onNavigateToWorshipReminders,
                             showArrow = true
                         )
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_weekly_title),
-                            subtitle = stringResource(R.string.notif_hub_weekly_subtitle),
+                            subtitle = weeklySubtitle(notificationState),
                             onClick = onNavigateToWeekly,
                             showArrow = true
                         )
                     }
                 }
+
                 item {
                     NimazMenuGroup {
                         NimazSettingsItem(
-                            title = stringResource(R.string.notif_hub_sound_title),
-                            subtitle = stringResource(R.string.notif_hub_sound_subtitle),
-                            onClick = onNavigateToSound,
-                            showArrow = true
-                        )
-                        NimazSettingsItem(
-                            title = stringResource(R.string.notif_hub_troubleshooting_title),
-                            subtitle = stringResource(R.string.notif_hub_troubleshooting_subtitle),
+                            title = stringResource(R.string.notif_hub_diagnostics_title),
+                            subtitle = stringResource(R.string.notif_hub_diagnostics_subtitle),
                             onClick = onNavigateToTroubleshooting,
-                            showArrow = true
+                            showArrow = true,
+                            trailingContent = if (diagnostics?.hasProblem == true) {
+                                {
+                                    NimazBadge(
+                                        text = stringResource(R.string.notif_diag_needs_attention),
+                                        tone = NimazTone.WARNING
+                                    )
+                                }
+                            } else {
+                                null
+                            }
                         )
                     }
-                }
-                item {
-                    NimazBanner(
-                        message = stringResource(R.string.notification_settings_info_banner),
-                        variant = NimazBannerVariant.INFO,
-                        icon = Icons.Default.Info,
-                        showBorder = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
                 }
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
     }
 }
+
+/** Fajr's settings, standing in for the set: one line cannot report five different ones. */
+@Composable
+private fun prayersSubtitle(
+    style: PrayerAlertStyle,
+    reminderEnabled: Boolean,
+    reminderMinutes: Int,
+): String {
+    val styleLabel = stringResource(
+        when (style) {
+            PrayerAlertStyle.ADHAN -> R.string.notif_alert_style_adhan
+            PrayerAlertStyle.NOTIFICATION -> R.string.notif_alert_style_notification
+            PrayerAlertStyle.SILENT -> R.string.notif_alert_style_silent
+        }
+    )
+    if (!reminderEnabled) return styleLabel
+    return stringResource(
+        R.string.notif_prayer_summary,
+        styleLabel,
+        pluralStringResource(
+            R.plurals.notif_reminder_minutes_before,
+            reminderMinutes,
+            reminderMinutes
+        )
+    )
+}
+
+@Composable
+private fun soundSubtitle(state: NotificationSettingsUiState): String {
+    val voice = AdhanSound.fromName(state.selectedAdhanSound).displayName
+    return when {
+        state.respectDnd -> stringResource(R.string.notif_hub_sound_dnd, voice)
+        state.vibrationEnabled -> stringResource(R.string.notif_hub_sound_vibration, voice)
+        else -> stringResource(R.string.notif_hub_sound_plain, voice)
+    }
+}
+
+@Composable
+private fun weeklySubtitle(state: NotificationSettingsUiState): String = stringResource(
+    when {
+        state.fridayReminderEnabled && state.khatamReminderEnabled ->
+            R.string.notif_hub_weekly_both
+
+        state.fridayReminderEnabled -> R.string.notif_hub_weekly_jumuah
+        state.khatamReminderEnabled -> R.string.notif_hub_weekly_khatam
+        else -> R.string.notif_hub_weekly_none
+    }
+)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreen.kt
@@ -15,7 +15,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Downloading
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,13 +35,17 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.data.audio.AdhanSound
 import com.arshadshah.nimaz.data.audio.DownloadState
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
+import com.arshadshah.nimaz.presentation.components.molecules.NimazListPicker
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.molecules.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
-import com.arshadshah.nimaz.presentation.components.molecules.VoiceOptionCard
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
@@ -64,8 +75,8 @@ fun NotificationSoundScreen(
         }
     }
 
-    val adhanSounds = com.arshadshah.nimaz.data.audio.AdhanSound.entries
     val selectedAdhanName = notificationState.selectedAdhanSound
+    var voicePickerOpen by remember { mutableStateOf(false) }
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -121,30 +132,14 @@ fun NotificationSoundScreen(
 
             if (notificationState.adhanEnabled) {
                 item {
-                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        adhanSounds.forEach { sound ->
-                            val soundDownloadState = downloadState[sound]
-                            val isThisPlaying = isPlaying && currentlyPlaying == sound
-                            val isDownloaded = viewModel.adhanAudioManager.isDownloaded(sound, false)
-                            VoiceOptionCard(
-                                name = sound.displayName,
-                                primaryTag = sound.origin,
-                                isSelected = sound.name == selectedAdhanName,
-                                isPlaying = isThisPlaying,
-                                isDownloading = soundDownloadState is DownloadState.Downloading,
-                                isDownloaded = isDownloaded,
-                                previewContentDescription = stringResource(R.string.notification_settings_preview),
-                                onClick = { viewModel.onEvent(SettingsEvent.SetAdhanSound(sound.name)) },
-                                onPreviewClick = {
-                                    if (isThisPlaying) {
-                                        viewModel.onEvent(SettingsEvent.StopAdhanPreview)
-                                    } else {
-                                        viewModel.onEvent(SettingsEvent.SetAdhanSound(sound.name))
-                                        viewModel.onEvent(SettingsEvent.PreviewAdhanSound)
-                                    }
-                                }
-                            )
-                        }
+                    NimazMenuGroup {
+                        NimazSettingsItem(
+                            title = stringResource(R.string.notif_sound_voice),
+                            subtitle = AdhanSound.fromName(selectedAdhanName).origin,
+                            value = AdhanSound.fromName(selectedAdhanName).displayName,
+                            onClick = { voicePickerOpen = true },
+                            showArrow = true
+                        )
                     }
                 }
             }
@@ -171,5 +166,54 @@ fun NotificationSoundScreen(
             }
             item { Spacer(Modifier.height(16.dp)) }
         }
+    }
+
+    if (voicePickerOpen) {
+        // Dismissal is funnelled through one lambda so the preview stops whichever way the
+        // sheet closes — Done, Cancel, a swipe down, or the back gesture.
+        val closePicker = {
+            viewModel.onEvent(SettingsEvent.StopAdhanPreview)
+            voicePickerOpen = false
+        }
+
+        NimazListPicker(
+            title = stringResource(R.string.notif_sound_voice),
+            items = AdhanSound.entries.map { sound ->
+                NimazPickerItem(
+                    value = sound.name,
+                    title = sound.displayName,
+                    description = sound.origin,
+                )
+            },
+            selected = selectedAdhanName,
+            onSelected = { viewModel.onEvent(SettingsEvent.SetAdhanSound(it)) },
+            onDismiss = closePicker,
+            // You audition several voices before settling on one, so the sheet stays open
+            // on selection rather than closing under the person listening.
+            autoDismiss = false,
+            trailingContent = { item ->
+                val sound = AdhanSound.fromName(item.value)
+                val isThisPlaying = isPlaying && currentlyPlaying == sound
+                val isDownloading = downloadState[sound] is DownloadState.Downloading
+                NimazIconButton(
+                    icon = when {
+                        isThisPlaying -> Icons.Default.Stop
+                        isDownloading -> Icons.Default.Downloading
+                        else -> Icons.Default.PlayArrow
+                    },
+                    contentDescription = stringResource(R.string.notification_settings_preview),
+                    enabled = !isDownloading,
+                    size = NimazIconButtonSize.SMALL,
+                    onClick = {
+                        if (isThisPlaying) {
+                            viewModel.onEvent(SettingsEvent.StopAdhanPreview)
+                        } else {
+                            viewModel.onEvent(SettingsEvent.SetAdhanSound(sound.name))
+                            viewModel.onEvent(SettingsEvent.PreviewAdhanSound)
+                        }
+                    }
+                )
+            }
+        )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationTroubleshootingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationTroubleshootingScreen.kt
@@ -1,52 +1,61 @@
 package com.arshadshah.nimaz.presentation.screens.settings
 
 import android.content.Intent
-import android.os.PowerManager
 import android.provider.Settings
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.BatteryAlert
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.util.NotificationDiagnostics
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogConfirmButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
 
 /**
- * Troubleshooting subscreen (#301): send test notifications, reset, and the battery-optimization
- * exemption prompt (read live from the OS, same as before).
+ * Diagnostics: what the OS is currently allowing, and the three actions that fix it.
+ *
+ * Every row states a value read from the device — a row that always said "OK" would send
+ * someone looking for the fault somewhere else. Anything the app cannot actually check is
+ * not listed at all.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,12 +65,19 @@ fun NotificationTroubleshootingScreen(
 ) {
     val context = LocalContext.current
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    var confirmingReset by remember { mutableStateOf(false) }
+
+    // Re-read whenever the screen comes back: these are the settings the user leaves to
+    // change, so a stale value here is the one thing that would make the screen useless.
+    val lifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateFlow
+        .collectAsStateWithLifecycle()
+    val diagnostics = remember(lifecycleState) { NotificationDiagnostics.read(context) }
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             NimazBackTopAppBar(
-                title = stringResource(R.string.notif_hub_troubleshooting_title),
+                title = stringResource(R.string.notif_hub_diagnostics_title),
                 onBackClick = onNavigateBack,
                 scrollBehavior = scrollBehavior
             )
@@ -76,11 +92,53 @@ fun NotificationTroubleshootingScreen(
         ) {
             item { Spacer(Modifier.height(4.dp)) }
 
+            item { NimazSectionHeader(title = stringResource(R.string.notif_diag_status_section)) }
+            item {
+                NimazMenuGroup {
+                    DiagnosticRow(
+                        title = stringResource(R.string.notif_diag_permission),
+                        ok = diagnostics.notificationsPermitted,
+                        okLabel = stringResource(R.string.notif_diag_granted),
+                        problemLabel = stringResource(R.string.notif_diag_blocked),
+                        icon = Icons.Default.NotificationsActive,
+                        onFix = {
+                            context.startActivity(
+                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                                    .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            )
+                        }
+                    )
+                    DiagnosticRow(
+                        title = stringResource(R.string.notif_diag_exact_alarms),
+                        ok = diagnostics.exactAlarmsAllowed,
+                        okLabel = stringResource(R.string.notif_diag_allowed),
+                        problemLabel = stringResource(R.string.notif_diag_not_allowed),
+                        icon = Icons.Default.Schedule,
+                        onFix = {
+                            context.startActivity(
+                                Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                            )
+                        }
+                    )
+                    DiagnosticRow(
+                        title = stringResource(R.string.notif_diag_battery),
+                        ok = diagnostics.batteryUnrestricted,
+                        okLabel = stringResource(R.string.notif_diag_unrestricted),
+                        problemLabel = stringResource(R.string.notif_diag_restricted),
+                        icon = Icons.Default.BatteryAlert,
+                        onFix = {
+                            context.startActivity(
+                                Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                            )
+                        }
+                    )
+                }
+            }
+
             item { NimazSectionHeader(title = stringResource(R.string.notification_settings_troubleshooting_section)) }
             item {
                 val testSentMsg = stringResource(R.string.notification_settings_test_sent)
                 val testAllSentMsg = stringResource(R.string.notification_settings_test_all_sent)
-                val resetSuccessMsg = stringResource(R.string.notification_settings_reset_success)
                 NimazMenuGroup {
                     Column(
                         modifier = Modifier.padding(16.dp),
@@ -108,10 +166,8 @@ fun NotificationTroubleshootingScreen(
                         )
                         NimazButton(
                             text = stringResource(R.string.notification_settings_reset),
-                            onClick = {
-                                viewModel.onEvent(SettingsEvent.ResetNotifications)
-                                Toast.makeText(context, resetSuccessMsg, Toast.LENGTH_SHORT).show()
-                            },
+                            // Reset cancels and rebuilds every alarm, so it asks first.
+                            onClick = { confirmingReset = true },
                             variant = NimazButtonVariant.OUTLINED,
                             leadingIcon = Icons.Default.Refresh,
                             fullWidth = true
@@ -120,61 +176,67 @@ fun NotificationTroubleshootingScreen(
                 }
             }
 
-            item { NimazSectionHeader(title = stringResource(R.string.notification_settings_battery_section)) }
             item {
-                val powerManager = context.getSystemService(android.content.Context.POWER_SERVICE) as PowerManager
-                val isExempted = powerManager.isIgnoringBatteryOptimizations(context.packageName)
-                NimazMenuGroup {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = stringResource(R.string.notification_settings_battery_title),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    fontWeight = FontWeight.Medium,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                )
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = if (isExempted) stringResource(R.string.notification_settings_battery_disabled)
-                                    else stringResource(R.string.notification_settings_battery_enabled),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = if (isExempted) MaterialTheme.colorScheme.primary else NimazColors.Warning
-                                )
-                            }
-                            if (isExempted) {
-                                NimazIcon(
-                                    imageVector = Icons.Default.Check,
-                                    contentDescription = stringResource(R.string.notification_settings_battery_exempted),
-                                    variant = NimazIconVariant.PRIMARY,
-                                    size = NimazIconSize.LARGE
-                                )
-                            }
-                        }
-                        if (!isExempted) {
-                            Spacer(modifier = Modifier.height(12.dp))
-                            Text(
-                                text = stringResource(R.string.notification_settings_battery_explanation),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(modifier = Modifier.height(12.dp))
-                            NimazButton(
-                                text = stringResource(R.string.notification_settings_disable_battery),
-                                onClick = {
-                                    context.startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
-                                },
-                                variant = NimazButtonVariant.FILLED,
-                                fullWidth = true
-                            )
-                        }
-                    }
-                }
+                Text(
+                    text = stringResource(R.string.notification_settings_battery_explanation),
+                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
+
             item { Spacer(Modifier.height(16.dp)) }
         }
     }
+
+    if (confirmingReset) {
+        val resetSuccessMsg = stringResource(R.string.notification_settings_reset_success)
+        NimazDialog(
+            title = stringResource(R.string.notif_diag_reset_confirm_title),
+            subtitle = stringResource(R.string.notif_diag_reset_confirm_body),
+            onDismiss = { confirmingReset = false },
+            titleIcon = Icons.Default.Refresh,
+            actions = {
+                NimazDialogCancelButton(
+                    text = stringResource(R.string.cancel),
+                    onClick = { confirmingReset = false }
+                )
+                NimazDialogConfirmButton(
+                    text = stringResource(R.string.notif_diag_reset_confirm_action),
+                    onClick = {
+                        confirmingReset = false
+                        viewModel.onEvent(SettingsEvent.ResetNotifications)
+                        Toast.makeText(context, resetSuccessMsg, Toast.LENGTH_SHORT).show()
+                    }
+                )
+            }
+        )
+    }
+}
+
+/**
+ * One checked prerequisite. The badge carries the state so the row can be read at a glance,
+ * and tapping opens the system screen that changes it — but only when there is something
+ * to fix, because sending someone to a settings page that is already correct is noise.
+ */
+@Composable
+private fun DiagnosticRow(
+    title: String,
+    ok: Boolean,
+    okLabel: String,
+    problemLabel: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onFix: () -> Unit,
+) {
+    NimazSettingsItem(
+        title = title,
+        icon = icon,
+        onClick = if (ok) null else onFix,
+        showArrow = !ok,
+        trailingContent = {
+            NimazBadge(
+                text = if (ok) okLabel else problemLabel,
+                tone = if (ok) NimazTone.SUCCESS else NimazTone.WARNING
+            )
+        }
+    )
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationTroubleshootingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationTroubleshootingScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BatteryAlert
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Refresh
@@ -25,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -36,14 +39,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.NotificationDiagnostics
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBanner
+import com.arshadshah.nimaz.presentation.components.atoms.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
-import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
-import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
-import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogConfirmButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -166,9 +169,10 @@ fun NotificationTroubleshootingScreen(
                         )
                         NimazButton(
                             text = stringResource(R.string.notification_settings_reset),
-                            // Reset cancels and rebuilds every alarm, so it asks first.
+                            // Reset cancels and rebuilds every armed alarm, so it carries
+                            // the destructive colour and asks before doing it.
                             onClick = { confirmingReset = true },
-                            variant = NimazButtonVariant.OUTLINED,
+                            variant = NimazButtonVariant.DESTRUCTIVE,
                             leadingIcon = Icons.Default.Refresh,
                             fullWidth = true
                         )
@@ -176,11 +180,15 @@ fun NotificationTroubleshootingScreen(
                 }
             }
 
+            // Why battery optimisation matters, as a banner rather than loose grey text —
+            // it is guidance about the checks above, so it should read as one.
             item {
-                Text(
-                    text = stringResource(R.string.notification_settings_battery_explanation),
-                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+                NimazBanner(
+                    message = stringResource(R.string.notification_settings_battery_explanation),
+                    variant = NimazBannerVariant.INFO,
+                    icon = Icons.Default.Info,
+                    showBorder = true,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
 
@@ -190,25 +198,20 @@ fun NotificationTroubleshootingScreen(
 
     if (confirmingReset) {
         val resetSuccessMsg = stringResource(R.string.notification_settings_reset_success)
-        NimazDialog(
+        // Destructive: it cancels every armed alarm before rebuilding them, so the accent
+        // stripe and the confirm button carry the risk in colour as well as in words.
+        NimazConfirmDialog(
             title = stringResource(R.string.notif_diag_reset_confirm_title),
-            subtitle = stringResource(R.string.notif_diag_reset_confirm_body),
-            onDismiss = { confirmingReset = false },
+            message = stringResource(R.string.notif_diag_reset_confirm_body),
+            confirmText = stringResource(R.string.notif_diag_reset_confirm_action),
+            cancelText = stringResource(R.string.cancel),
             titleIcon = Icons.Default.Refresh,
-            actions = {
-                NimazDialogCancelButton(
-                    text = stringResource(R.string.cancel),
-                    onClick = { confirmingReset = false }
-                )
-                NimazDialogConfirmButton(
-                    text = stringResource(R.string.notif_diag_reset_confirm_action),
-                    onClick = {
-                        confirmingReset = false
-                        viewModel.onEvent(SettingsEvent.ResetNotifications)
-                        Toast.makeText(context, resetSuccessMsg, Toast.LENGTH_SHORT).show()
-                    }
-                )
-            }
+            isDestructive = true,
+            onConfirm = {
+                viewModel.onEvent(SettingsEvent.ResetNotifications)
+                Toast.makeText(context, resetSuccessMsg, Toast.LENGTH_SHORT).show()
+            },
+            onDismiss = { confirmingReset = false }
         )
     }
 }
@@ -224,7 +227,7 @@ private fun DiagnosticRow(
     ok: Boolean,
     okLabel: String,
     problemLabel: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     onFix: () -> Unit,
 ) {
     NimazSettingsItem(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationWeeklyScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationWeeklyScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -20,15 +17,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
-import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTime
-import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.atoms.NimazTimePicker
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
-import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
-import com.arshadshah.nimaz.presentation.components.molecules.NimazTimePickerDialog
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
@@ -46,7 +41,6 @@ fun NotificationWeeklyScreen(
     val notificationState by viewModel.notificationState.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     val minutesValueFormat = stringResource(R.string.notification_settings_minutes_value)
-    var showKhatamTimePicker by remember { mutableStateOf(false) }
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -66,60 +60,68 @@ fun NotificationWeeklyScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             item { Spacer(Modifier.height(4.dp)) }
+
+            // Both reminders carry their own timing, so each is an accordion holding the
+            // control that sets it. The khatam time used to sit behind a dialog, which meant
+            // two taps and a modal to move a reminder by fifteen minutes.
             item {
-                NimazMenuGroup {
-                    NimazSettingsItem(
-                        title = stringResource(R.string.notification_settings_friday_reminder),
-                        subtitle = stringResource(R.string.notification_settings_friday_subtitle),
-                        checked = notificationState.fridayReminderEnabled,
-                        onCheckedChange = {
-                            viewModel.onEvent(SettingsEvent.SetFridayReminderEnabled(!notificationState.fridayReminderEnabled))
-                        }
-                    )
-                    if (notificationState.fridayReminderEnabled) {
-                        NimazNumberStepper(
-                            value = notificationState.fridayReminderMinutes,
-                            onValueChange = { viewModel.onEvent(SettingsEvent.SetFridayReminderMinutes(it)) },
-                            variant = NimazNumberStepperVariant.INLINE,
-                            label = stringResource(R.string.notification_settings_lead_time),
-                            formatValue = { min -> minutesValueFormat.format(min) },
-                            minValue = 15, maxValue = 120, step = 15,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                NimazAccordion(
+                    title = stringResource(R.string.notification_settings_friday_reminder),
+                    subtitle = if (notificationState.fridayReminderEnabled) {
+                        minutesValueFormat.format(notificationState.fridayReminderMinutes)
+                    } else {
+                        stringResource(R.string.notification_settings_friday_subtitle)
+                    },
+                    trailing = {
+                        NimazSwitch(
+                            checked = notificationState.fridayReminderEnabled,
+                            onCheckedChange = {
+                                viewModel.onEvent(SettingsEvent.SetFridayReminderEnabled(it))
+                            }
                         )
                     }
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                    NimazSettingsItem(
-                        title = stringResource(R.string.notification_settings_khatam_reminder),
-                        subtitle = stringResource(R.string.notification_settings_khatam_subtitle),
-                        checked = notificationState.khatamReminderEnabled,
-                        onCheckedChange = {
-                            viewModel.onEvent(SettingsEvent.SetKhatamReminderEnabled(!notificationState.khatamReminderEnabled))
-                        }
+                ) {
+                    NimazNumberStepper(
+                        value = notificationState.fridayReminderMinutes,
+                        onValueChange = { viewModel.onEvent(SettingsEvent.SetFridayReminderMinutes(it)) },
+                        variant = NimazNumberStepperVariant.INLINE,
+                        label = stringResource(R.string.notification_settings_lead_time),
+                        formatValue = { min -> minutesValueFormat.format(min) },
+                        minValue = 15, maxValue = 120, step = 15,
+                        editable = notificationState.fridayReminderEnabled,
+                        modifier = Modifier.padding(vertical = 4.dp)
                     )
-                    if (notificationState.khatamReminderEnabled) {
-                        NimazSettingsItem(
-                            title = stringResource(R.string.notification_settings_reminder_time),
-                            subtitle = notificationState.khatamReminderTime,
-                            onClick = { showKhatamTimePicker = true },
-                            showArrow = true,
-                            modifier = Modifier.padding(horizontal = 16.dp)
-                        )
-                    }
                 }
             }
+
+            item {
+                NimazAccordion(
+                    title = stringResource(R.string.notification_settings_khatam_reminder),
+                    subtitle = if (notificationState.khatamReminderEnabled) {
+                        notificationState.khatamReminderTime
+                    } else {
+                        stringResource(R.string.notification_settings_khatam_subtitle)
+                    },
+                    trailing = {
+                        NimazSwitch(
+                            checked = notificationState.khatamReminderEnabled,
+                            onCheckedChange = {
+                                viewModel.onEvent(SettingsEvent.SetKhatamReminderEnabled(it))
+                            }
+                        )
+                    }
+                ) {
+                    NimazTimePicker(
+                        value = NimazTime.parse(notificationState.khatamReminderTime),
+                        onValueChange = {
+                            viewModel.onEvent(SettingsEvent.SetKhatamReminderTime(it.toStorageString()))
+                        },
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+
             item { Spacer(Modifier.height(16.dp)) }
         }
-    }
-
-    if (showKhatamTimePicker) {
-        NimazTimePickerDialog(
-            initialTime = NimazTime.parse(notificationState.khatamReminderTime),
-            onConfirm = {
-                viewModel.onEvent(SettingsEvent.SetKhatamReminderTime(it.toStorageString()))
-                showKhatamTimePicker = false
-            },
-            onDismiss = { showKhatamTimePicker = false },
-            title = stringResource(R.string.notification_settings_reminder_time),
-        )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreen.kt
@@ -3,68 +3,81 @@ package com.arshadshah.nimaz.presentation.screens.settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
-import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
-import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
-import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
+import com.arshadshah.nimaz.presentation.components.molecules.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
-import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
-internal data class PrayerNotificationData(
-    val name: String,
+/** The lead times the reminder picker offers. Null is "no reminder". */
+private val REMINDER_CHOICES = listOf(null, 5, 10, 15, 20, 30, 45, 60)
+
+private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+/**
+ * One prayer's row, resolved from the shared notification state so the row renders from a
+ * single value rather than five parallel lookups.
+ */
+internal data class PrayerNotificationRowState(
     val key: String,
+    val name: String,
     val accentColor: Color,
+    val time: LocalDateTime?,
     val isEnabled: Boolean,
-    val isSoundOn: Boolean,
+    val alertStyle: PrayerAlertStyle,
+    val reminderMinutes: Int?,
 )
 
 /**
- * Prayer notifications subscreen (#301): per-prayer notification + adhan toggles, the pre-adhan
- * reminder with its lead-time stepper, and the sunrise alert. Renders slices of the shared
- * [SettingsViewModel] notification state.
+ * Prayer notifications: one accordion per prayer, each carrying its own alert style and its
+ * own reminder.
+ *
+ * Both used to be global — a single adhan on/off pair and one pre-adhan lead time for all
+ * five — which meant a person who wanted the adhan at Fajr and silence at Dhuhr could not
+ * have it. The header states what the prayer is set to without being opened, because the
+ * question this screen answers is usually "what happens at Asr?" rather than "what can I
+ * change?".
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,36 +86,14 @@ fun PrayerNotificationsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val notificationState by viewModel.notificationState.collectAsStateWithLifecycle()
+    val prayerTimes by viewModel.todayPrayerTimes.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val minutesValueFormat = stringResource(R.string.notification_settings_minutes_value)
 
-    val prayers = listOf(
-        PrayerNotificationData(
-            stringResource(R.string.prayer_fajr), "fajr", NimazColors.PrayerColors.Fajr,
-            notificationState.fajrNotification,
-            notificationState.adhanEnabled && notificationState.fajrAdhanEnabled
-        ),
-        PrayerNotificationData(
-            stringResource(R.string.prayer_dhuhr), "dhuhr", NimazColors.Gold500,
-            notificationState.dhuhrNotification,
-            notificationState.adhanEnabled && notificationState.dhuhrAdhanEnabled
-        ),
-        PrayerNotificationData(
-            stringResource(R.string.prayer_asr), "asr", NimazColors.PrayerColors.Asr,
-            notificationState.asrNotification,
-            notificationState.adhanEnabled && notificationState.asrAdhanEnabled
-        ),
-        PrayerNotificationData(
-            stringResource(R.string.prayer_maghrib), "maghrib", NimazColors.PrayerColors.Maghrib,
-            notificationState.maghribNotification,
-            notificationState.adhanEnabled && notificationState.maghribAdhanEnabled
-        ),
-        PrayerNotificationData(
-            stringResource(R.string.prayer_isha), "isha", NimazColors.PrayerColors.Isha,
-            notificationState.ishaNotification,
-            notificationState.adhanEnabled && notificationState.ishaAdhanEnabled
-        )
-    )
+    // Which sheet is open, if any. One nullable value rather than a boolean per prayer per
+    // setting — ten booleans that can contradict each other.
+    var openSheet by remember { mutableStateOf<PrayerSettingSheet?>(null) }
+
+    val rows = rememberPrayerRows(notificationState, prayerTimes)
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -119,161 +110,260 @@ fun PrayerNotificationsScreen(
                 .fillMaxSize()
                 .padding(padding)
                 .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             item { Spacer(Modifier.height(4.dp)) }
-
             item {
-                NimazSectionHeader(title = stringResource(R.string.notification_settings_prayer_section))
-            }
-            item {
-                NimazMenuGroup {
-                    prayers.forEachIndexed { index, prayer ->
-                        PrayerNotificationRow(
-                            prayer = prayer,
-                            onToggle = {
-                                viewModel.onEvent(
-                                    SettingsEvent.SetPrayerNotification(prayer.key, !prayer.isEnabled)
-                                )
-                            },
-                            onSoundToggle = {
-                                val currentState = when (prayer.key) {
-                                    "fajr" -> notificationState.fajrAdhanEnabled
-                                    "dhuhr" -> notificationState.dhuhrAdhanEnabled
-                                    "asr" -> notificationState.asrAdhanEnabled
-                                    "maghrib" -> notificationState.maghribAdhanEnabled
-                                    "isha" -> notificationState.ishaAdhanEnabled
-                                    else -> true
-                                }
-                                viewModel.onEvent(
-                                    SettingsEvent.SetPrayerAdhanEnabled(prayer.key, !currentState)
-                                )
-                            },
-                            globalAdhanEnabled = notificationState.adhanEnabled
-                        )
-                        if (index < prayers.lastIndex) {
-                            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                        }
-                    }
-                }
+                NimazSectionHeader(title = stringResource(R.string.notif_prayers_section))
             }
 
-            item {
-                NimazSectionHeader(title = stringResource(R.string.notification_settings_additional_section))
+            items(rows.size, key = { rows[it].key }) { index ->
+                val row = rows[index]
+                PrayerAccordion(
+                    row = row,
+                    sunriseEnabled = notificationState.sunriseNotification,
+                    onToggle = { enabled ->
+                        viewModel.onEvent(SettingsEvent.SetPrayerNotification(row.key, enabled))
+                    },
+                    onToggleSunrise = { enabled ->
+                        viewModel.onEvent(SettingsEvent.SetPrayerNotification("sunrise", enabled))
+                    },
+                    onOpenAlertStyle = { openSheet = PrayerSettingSheet.AlertStyle(row.key) },
+                    onOpenReminder = { openSheet = PrayerSettingSheet.Reminder(row.key) }
+                )
             }
-            item {
-                NimazMenuGroup {
-                    NimazSettingsItem(
-                        title = stringResource(R.string.notification_settings_pre_adhan),
-                        subtitle = pluralStringResource(
-                            R.plurals.notification_settings_pre_adhan_subtitle,
-                            notificationState.reminderMinutes,
-                            notificationState.reminderMinutes
-                        ),
-                        checked = notificationState.showReminderBefore,
-                        onCheckedChange = {
-                            viewModel.onEvent(SettingsEvent.SetShowReminderBefore(!notificationState.showReminderBefore))
-                        }
-                    )
-                    if (notificationState.showReminderBefore) {
-                        NimazNumberStepper(
-                            value = notificationState.reminderMinutes,
-                            onValueChange = { viewModel.onEvent(SettingsEvent.SetReminderMinutes(it)) },
-                            variant = NimazNumberStepperVariant.INLINE,
-                            label = stringResource(R.string.notification_settings_lead_time),
-                            formatValue = { min -> minutesValueFormat.format(min) },
-                            minValue = 5, maxValue = 60, step = 5,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
-                        )
-                    }
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                    NimazSettingsItem(
-                        title = stringResource(R.string.notification_settings_sunrise),
-                        subtitle = stringResource(R.string.notification_settings_sunrise_subtitle),
-                        checked = notificationState.sunriseNotification,
-                        onCheckedChange = {
-                            viewModel.onEvent(
-                                SettingsEvent.SetPrayerNotification("sunrise", !notificationState.sunriseNotification)
-                            )
-                        }
-                    )
-                }
-            }
+
             item { Spacer(Modifier.height(16.dp)) }
         }
     }
-}
 
-@Composable
-internal fun PrayerNotificationRow(
-    prayer: PrayerNotificationData,
-    onToggle: () -> Unit,
-    onSoundToggle: () -> Unit,
-    globalAdhanEnabled: Boolean
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .width(4.dp)
-                .height(40.dp)
-                .clip(RoundedCornerShape(2.dp))
-                .background(prayer.accentColor)
+    when (val sheet = openSheet) {
+        is PrayerSettingSheet.AlertStyle -> AlertStylePicker(
+            selected = notificationState.alertStyles[sheet.prayer] ?: PrayerAlertStyle.NOTIFICATION,
+            onSelected = { style ->
+                viewModel.onEvent(SettingsEvent.SetPrayerAlertStyle(sheet.prayer, style))
+            },
+            onDismiss = { openSheet = null }
         )
-        Spacer(modifier = Modifier.width(15.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = prayer.name,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = stringResource(R.string.notification_settings_prayer_notification),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        IconButton(
-            onClick = onSoundToggle,
-            enabled = globalAdhanEnabled,
-            modifier = Modifier.size(36.dp),
-            colors = IconButtonDefaults.iconButtonColors(
-                containerColor = if (globalAdhanEnabled)
-                    MaterialTheme.colorScheme.surfaceContainerHighest
-                else
-                    MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f)
-            )
-        ) {
-            NimazIcon(
-                imageVector = if (prayer.isSoundOn) Icons.AutoMirrored.Filled.VolumeUp
-                else Icons.AutoMirrored.Filled.VolumeOff,
-                contentDescription = if (prayer.isSoundOn) stringResource(R.string.notification_settings_sound_on)
-                else stringResource(R.string.notification_settings_sound_off),
-                tint = when {
-                    !globalAdhanEnabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                    prayer.isSoundOn -> MaterialTheme.colorScheme.primary
-                    else -> MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                iconSize = 18.dp
-            )
-        }
-        Spacer(modifier = Modifier.width(15.dp))
-        NimazSwitch(checked = prayer.isEnabled, onCheckedChange = { onToggle() })
+
+        is PrayerSettingSheet.Reminder -> ReminderPicker(
+            selected = notificationState.reminderMinutesFor(sheet.prayer),
+            onSelected = { minutes ->
+                viewModel.onEvent(
+                    SettingsEvent.SetPrayerReminderEnabled(sheet.prayer, minutes != null)
+                )
+                if (minutes != null) {
+                    viewModel.onEvent(
+                        SettingsEvent.SetPrayerReminderMinutes(sheet.prayer, minutes)
+                    )
+                }
+            },
+            onDismiss = { openSheet = null }
+        )
+
+        null -> Unit
     }
 }
 
-@Preview(showBackground = true, widthDp = 400)
+/** Which picker sheet is open, and for which prayer. */
+private sealed interface PrayerSettingSheet {
+    data class AlertStyle(val prayer: String) : PrayerSettingSheet
+    data class Reminder(val prayer: String) : PrayerSettingSheet
+}
+
 @Composable
-private fun PrayerNotificationRow_Preview() {
-    NimazTheme {
-        PrayerNotificationRow(
-            prayer = PrayerNotificationData("Fajr", "fajr", NimazColors.InfoSoft, true, true),
-            onToggle = {}, onSoundToggle = {}, globalAdhanEnabled = true
+private fun PrayerAccordion(
+    row: PrayerNotificationRowState,
+    sunriseEnabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    onToggleSunrise: (Boolean) -> Unit,
+    onOpenAlertStyle: () -> Unit,
+    onOpenReminder: () -> Unit,
+) {
+    NimazAccordion(
+        title = row.name,
+        subtitle = prayerSummary(row),
+        trailing = {
+            // The accent bar and the time read as one unit: this prayer, at this hour.
+            Box(
+                modifier = Modifier
+                    .width(4.dp)
+                    .height(20.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(row.accentColor)
+            )
+            Spacer(Modifier.width(8.dp))
+            if (row.time != null) {
+                Text(
+                    text = row.time.format(TIME_FORMAT),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.width(12.dp))
+            }
+            NimazSwitch(checked = row.isEnabled, onCheckedChange = onToggle)
+        }
+    ) {
+        NimazSettingsItem(
+            title = stringResource(R.string.notif_alert_style),
+            value = stringResource(alertStyleLabel(row.alertStyle)),
+            onClick = onOpenAlertStyle,
+            showArrow = true,
+            enabled = row.isEnabled
+        )
+        NimazSettingsItem(
+            title = stringResource(R.string.notif_reminder_before),
+            value = reminderLabel(row.reminderMinutes),
+            onClick = onOpenReminder,
+            showArrow = true,
+            enabled = row.isEnabled
+        )
+        // Sunrise is not a prayer with an alert style of its own — it is the end of Fajr's
+        // window, so it belongs under Fajr rather than in a section of global leftovers.
+        if (row.key == "fajr") {
+            NimazSettingsItem(
+                title = stringResource(R.string.notif_sunrise),
+                subtitle = stringResource(R.string.notif_sunrise_subtitle),
+                checked = sunriseEnabled,
+                onCheckedChange = onToggleSunrise
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlertStylePicker(
+    selected: PrayerAlertStyle,
+    onSelected: (PrayerAlertStyle) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val items = listOf(
+        NimazPickerItem(
+            value = PrayerAlertStyle.ADHAN,
+            title = stringResource(R.string.notif_alert_style_adhan),
+            description = stringResource(R.string.notif_alert_style_adhan_subtitle),
+            icon = Icons.Default.Campaign,
+        ),
+        NimazPickerItem(
+            value = PrayerAlertStyle.NOTIFICATION,
+            title = stringResource(R.string.notif_alert_style_notification),
+            description = stringResource(R.string.notif_alert_style_notification_subtitle),
+            icon = Icons.Default.NotificationsActive,
+        ),
+        NimazPickerItem(
+            value = PrayerAlertStyle.SILENT,
+            title = stringResource(R.string.notif_alert_style_silent),
+            description = stringResource(R.string.notif_alert_style_silent_subtitle),
+            icon = Icons.AutoMirrored.Filled.VolumeOff,
+        ),
+    )
+
+    NimazListPicker(
+        title = stringResource(R.string.notif_alert_style),
+        items = items,
+        selected = selected,
+        onSelected = onSelected,
+        onDismiss = onDismiss,
+    )
+}
+
+@Composable
+private fun ReminderPicker(
+    selected: Int?,
+    onSelected: (Int?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val items = REMINDER_CHOICES.map { minutes ->
+        NimazPickerItem(
+            value = minutes ?: 0,
+            title = reminderLabel(minutes),
+            icon = if (minutes == null) null else Icons.Default.Schedule,
+        )
+    }
+
+    NimazListPicker(
+        title = stringResource(R.string.notif_reminder_before),
+        items = items,
+        selected = selected ?: 0,
+        onSelected = { onSelected(it.takeIf { value -> value != 0 }) },
+        onDismiss = onDismiss,
+        searchable = false,
+    )
+}
+
+/** The one-line summary in the header: what this prayer does, and how far ahead it warns. */
+@Composable
+private fun prayerSummary(row: PrayerNotificationRowState): String {
+    if (!row.isEnabled) return stringResource(R.string.notif_prayer_off)
+
+    val style = stringResource(alertStyleLabel(row.alertStyle))
+    val reminder = row.reminderMinutes ?: return style
+    return stringResource(
+        R.string.notif_prayer_summary,
+        style,
+        pluralStringResource(R.plurals.notif_reminder_minutes_before, reminder, reminder)
+    )
+}
+
+@Composable
+private fun reminderLabel(minutes: Int?): String =
+    if (minutes == null) stringResource(R.string.notif_reminder_none)
+    else pluralStringResource(R.plurals.notif_reminder_minutes_before, minutes, minutes)
+
+private fun alertStyleLabel(style: PrayerAlertStyle): Int = when (style) {
+    PrayerAlertStyle.ADHAN -> R.string.notif_alert_style_adhan
+    PrayerAlertStyle.NOTIFICATION -> R.string.notif_alert_style_notification
+    PrayerAlertStyle.SILENT -> R.string.notif_alert_style_silent
+}
+
+/** This prayer's lead time, or null when its reminder is off. */
+private fun com.arshadshah.nimaz.presentation.viewmodel.NotificationSettingsUiState
+        .reminderMinutesFor(prayer: String): Int? =
+    if (reminderEnabled[prayer] == true) {
+        reminderOffsets[prayer] ?: PrayerAlertStyle.DEFAULT_REMINDER_MINUTES
+    } else {
+        null
+    }
+
+@Composable
+private fun rememberPrayerRows(
+    state: com.arshadshah.nimaz.presentation.viewmodel.NotificationSettingsUiState,
+    times: PrayerTimes?,
+): List<PrayerNotificationRowState> {
+    val names = listOf(
+        stringResource(R.string.prayer_fajr),
+        stringResource(R.string.prayer_dhuhr),
+        stringResource(R.string.prayer_asr),
+        stringResource(R.string.prayer_maghrib),
+        stringResource(R.string.prayer_isha),
+    )
+    val enabled = listOf(
+        state.fajrNotification,
+        state.dhuhrNotification,
+        state.asrNotification,
+        state.maghribNotification,
+        state.ishaNotification,
+    )
+    val accents = listOf(
+        NimazColors.PrayerColors.Fajr,
+        NimazColors.Gold500,
+        NimazColors.PrayerColors.Asr,
+        NimazColors.PrayerColors.Maghrib,
+        NimazColors.PrayerColors.Isha,
+    )
+    val clockTimes = listOf(
+        times?.fajr, times?.dhuhr, times?.asr, times?.maghrib, times?.isha
+    )
+
+    return PrayerAlertStyle.PRAYER_KEYS.mapIndexed { index, key ->
+        PrayerNotificationRowState(
+            key = key,
+            name = names[index],
+            accentColor = accents[index],
+            time = clockTimes[index],
+            isEnabled = enabled[index],
+            alertStyle = state.alertStyles[key] ?: PrayerAlertStyle.NOTIFICATION,
+            reminderMinutes = state.reminderMinutesFor(key),
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
@@ -218,10 +218,12 @@ fun PrayerSettingsScreen(
                     NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
                     NimazSettingsItem(
                         icon = Icons.Default.Schedule,
-                        title = stringResource(R.string.pre_adhan_reminder),
+                        // Reminders are per prayer now; this row reports Fajr's, the same
+                        // one the notifications hub shows.
+                        title = stringResource(R.string.prayer_settings_fajr_reminder),
                         value = if (notificationSummary.reminderEnabled) {
                             pluralStringResource(
-                                R.plurals.notification_settings_pre_adhan_subtitle,
+                                R.plurals.notif_reminder_minutes_before,
                                 notificationSummary.reminderMinutes,
                                 notificationSummary.reminderMinutes
                             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreen.kt
@@ -1,6 +1,10 @@
 package com.arshadshah.nimaz.presentation.screens.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -26,6 +30,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
@@ -36,8 +42,9 @@ import com.arshadshah.nimaz.presentation.viewmodel.SettingsViewModel
 
 /**
  * Worship reminders subscreen (spec §3). Data-driven off [WorshipReminderType]: rows are generated
- * per category (Night / Ramadan / Fasting & Dhikr). The Ramadan group auto-hides outside Ramadan.
- * Each row is a toggle; reminders with an editable offset reveal an inline stepper when enabled.
+ * per category (Night / Ramadan / Fasting & Dhikr). The Ramadan group is shown year-round under
+ * a notice saying it stays quiet until Ramadan, so it can be set up in advance. A reminder that
+ * can be timed is an accordion carrying its own offset; the rest are plain switch rows.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,7 +55,7 @@ fun WorshipRemindersScreen(
     val state by viewModel.notificationState.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     val minutesFormat = stringResource(R.string.worship_settings_minutes)
-    // Ramadan visibility gate — hide the Ramadan group outside Ramadan.
+    // Drives the notice above the Ramadan group, not whether the group is shown.
     val isRamadan = remember { HijriDateCalculator.today().month == 9 }
 
     NimazScreenScaffold(
@@ -92,14 +99,28 @@ fun WorshipRemindersScreen(
                 onToggle = onToggle, onOffset = onOffset, onMode = onMode,
             )
 
-            if (isRamadan) {
-                worshipSection(
-                    titleRes = R.string.worship_settings_section_ramadan,
-                    types = WorshipReminderType.entries.filter { it.category == WorshipReminderCategory.RAMADAN },
-                    state = state, minutesFormat = minutesFormat,
-                    onToggle = onToggle, onOffset = onOffset, onMode = onMode,
-                )
+            // Ramadan reminders are shown year-round rather than hidden. Hiding them made
+            // the app look like it had lost a feature outside Ramadan, and left no way to
+            // set them up in advance. Nothing depends on their absence — the scheduler
+            // gates them on the Hijri date itself (WorshipReminderCalculator), so one set
+            // outside Ramadan simply arms nothing until Ramadan arrives.
+            if (!isRamadan) {
+                item(key = "ramadan_notice") {
+                    NimazBanner(
+                        message = stringResource(R.string.worship_settings_ramadan_notice),
+                        variant = NimazBannerVariant.INFO,
+                        icon = Icons.Default.Schedule,
+                        showBorder = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
+            worshipSection(
+                titleRes = R.string.worship_settings_section_ramadan,
+                types = WorshipReminderType.entries.filter { it.category == WorshipReminderCategory.RAMADAN },
+                state = state, minutesFormat = minutesFormat,
+                onToggle = onToggle, onOffset = onOffset, onMode = onMode,
+            )
 
             worshipSection(
                 titleRes = R.string.worship_settings_section_fasting,
@@ -125,54 +146,82 @@ private fun androidx.compose.foundation.lazy.LazyListScope.worshipSection(
     if (types.isEmpty()) return
     item(key = "header_$titleRes") { NimazSectionHeader(title = stringResource(titleRes)) }
     item(key = "group_$titleRes") {
-        NimazMenuGroup {
-            types.forEachIndexed { index, type ->
+        // A reminder that can be timed carries its own accordion, so its offset sits inside
+        // the thing it belongs to rather than as a loose row beneath it. The rest stay plain
+        // switch rows in a single group.
+        val (adjustable, plain) = types.partition {
+            it.hasOffset || it == WorshipReminderType.WITR
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (plain.isNotEmpty()) {
+                NimazMenuGroup {
+                    plain.forEachIndexed { index, type ->
+                        NimazSettingsItem(
+                            title = stringResource(worshipNameRes(type)),
+                            subtitle = stringResource(worshipWhenRes(type)),
+                            checked = state.worshipReminders[type.key] ?: false,
+                            onCheckedChange = { onToggle(type.key, it) }
+                        )
+                        if (index < plain.lastIndex) {
+                            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                        }
+                    }
+                }
+            }
+
+            adjustable.forEach { type ->
                 val enabled = state.worshipReminders[type.key] ?: false
-                NimazSettingsItem(
+                val offset = state.worshipOffsets[type.key] ?: type.defaultOffsetMinutes
+                val mode = state.worshipModes[type.key]
+                    ?: com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_AFTER_ISHA
+                val beforeFajr =
+                    mode == com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR
+
+                NimazAccordion(
                     title = stringResource(worshipNameRes(type)),
-                    subtitle = stringResource(worshipWhenRes(type)),
-                    checked = enabled,
-                    onCheckedChange = { onToggle(type.key, it) }
-                )
-                // Witr timing mode (after Isha ↔ before Fajr) — tap to switch. #309.
-                if (enabled && type == WorshipReminderType.WITR) {
-                    val mode = state.worshipModes[type.key]
-                        ?: com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_AFTER_ISHA
-                    val beforeFajr =
-                        mode == com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR
-                    NimazSettingsItem(
-                        title = stringResource(R.string.worship_witr_mode_title),
-                        subtitle = stringResource(
-                            if (beforeFajr) R.string.worship_witr_mode_before_fajr
-                            else R.string.worship_witr_mode_after_isha
-                        ),
-                        onClick = {
-                            onMode(
-                                type.key,
-                                if (beforeFajr) com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_AFTER_ISHA
-                                else com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR
-                            )
-                        },
-                        showArrow = true,
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
-                }
-                if (enabled && type.hasOffset) {
-                    val current = state.worshipOffsets[type.key] ?: type.defaultOffsetMinutes
-                    NimazNumberStepper(
-                        value = current,
-                        onValueChange = { onOffset(type.key, it) },
-                        variant = NimazNumberStepperVariant.INLINE,
-                        label = stringResource(R.string.worship_settings_timing),
-                        formatValue = { min -> minutesFormat.format(min) },
-                        minValue = 0,
-                        maxValue = 60,
-                        step = 5,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
-                    )
-                }
-                if (index < types.lastIndex) {
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    subtitle = if (enabled && type.hasOffset) {
+                        minutesFormat.format(offset)
+                    } else {
+                        stringResource(worshipWhenRes(type))
+                    },
+                    trailing = {
+                        NimazSwitch(checked = enabled, onCheckedChange = { onToggle(type.key, it) })
+                    }
+                ) {
+                    // Witr timing mode (after Isha ↔ before Fajr) — tap to switch. #309.
+                    if (type == WorshipReminderType.WITR) {
+                        NimazSettingsItem(
+                            title = stringResource(R.string.worship_witr_mode_title),
+                            subtitle = stringResource(
+                                if (beforeFajr) R.string.worship_witr_mode_before_fajr
+                                else R.string.worship_witr_mode_after_isha
+                            ),
+                            onClick = {
+                                onMode(
+                                    type.key,
+                                    if (beforeFajr) com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_AFTER_ISHA
+                                    else com.arshadshah.nimaz.core.util.WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR
+                                )
+                            },
+                            showArrow = true,
+                            enabled = enabled
+                        )
+                    }
+                    if (type.hasOffset) {
+                        NimazNumberStepper(
+                            value = offset,
+                            onValueChange = { onOffset(type.key, it) },
+                            variant = NimazNumberStepperVariant.INLINE,
+                            label = stringResource(R.string.worship_settings_timing),
+                            formatValue = { min -> minutesFormat.format(min) },
+                            minValue = 0,
+                            maxValue = 60,
+                            step = 5,
+                            editable = enabled,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
+import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
@@ -16,6 +17,8 @@ import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
@@ -33,11 +36,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
+
+/** The prayer whose settings stand in for the set on summary rows. */
+private const val FAJR = "fajr"
 
 // Enums for settings options
 enum class AppTheme {
@@ -107,13 +115,11 @@ data class NotificationSettingsUiState(
     val maghribNotification: Boolean = true,
     val ishaNotification: Boolean = true,
     val adhanEnabled: Boolean = false,
-    // Per-prayer adhan settings
-    val fajrAdhanEnabled: Boolean = true,
-    val dhuhrAdhanEnabled: Boolean = true,
-    val asrAdhanEnabled: Boolean = true,
-    val maghribAdhanEnabled: Boolean = true,
-    val ishaAdhanEnabled: Boolean = true,
-    // Sunrise always uses beep only (no toggle needed)
+    // Per-prayer alert style and reminder, keyed by prayer name ("fajr" … "isha").
+    // Sunrise has neither: it is a plain alert with a beep and no pre-reminder.
+    val alertStyles: Map<String, PrayerAlertStyle> = emptyMap(),
+    val reminderEnabled: Map<String, Boolean> = emptyMap(),
+    val reminderOffsets: Map<String, Int> = emptyMap(),
     val vibrationEnabled: Boolean = true,
     val respectDnd: Boolean = true,
     val reminderMinutes: Int = 15,
@@ -139,8 +145,10 @@ data class NotificationSettingsUiState(
 data class NotificationSummary(
     val notificationsMasterEnabled: Boolean = true,
     val enabledPrayerCount: Int = TOTAL_PRAYER_COUNT,
+    /** Fajr's reminder — it stands for the set where one line has to speak for five. */
     val reminderEnabled: Boolean = true,
-    val reminderMinutes: Int = 15
+    val reminderMinutes: Int = PrayerAlertStyle.DEFAULT_REMINDER_MINUTES,
+    val fajrAlertStyle: PrayerAlertStyle = PrayerAlertStyle.NOTIFICATION
 ) {
     companion object {
         /** The five obligatory prayers the notification screen exposes toggles for. */
@@ -225,7 +233,13 @@ sealed interface SettingsEvent {
     data class SetNotificationsEnabled(val enabled: Boolean) : SettingsEvent
     data class SetPrayerNotification(val prayer: String, val enabled: Boolean) : SettingsEvent
     data class SetAdhanEnabled(val enabled: Boolean) : SettingsEvent
-    data class SetPrayerAdhanEnabled(val prayer: String, val enabled: Boolean) : SettingsEvent
+
+    /** How one prayer announces itself: the adhan, the standard tone, or nothing. */
+    data class SetPrayerAlertStyle(val prayer: String, val style: PrayerAlertStyle) : SettingsEvent
+
+    /** Whether one prayer gets a reminder ahead of its time, and how far ahead. */
+    data class SetPrayerReminderEnabled(val prayer: String, val enabled: Boolean) : SettingsEvent
+    data class SetPrayerReminderMinutes(val prayer: String, val minutes: Int) : SettingsEvent
     data class SetVibrationEnabled(val enabled: Boolean) : SettingsEvent
     data class SetRespectDnd(val enabled: Boolean) : SettingsEvent
     data class SetReminderMinutes(val minutes: Int) : SettingsEvent
@@ -351,20 +365,44 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.ishaNotificationEnabled
         ) { flags -> flags.count { it } },
         settingsRepository.prayerNotificationsEnabled,
-        settingsRepository.notificationReminderMinutes,
-        settingsRepository.showReminderBefore
-    ) { enabledPrayerCount, masterEnabled, reminderMinutes, reminderEnabled ->
+        // Fajr stands for the set on the hub: it is the prayer people set most deliberately,
+        // and a row cannot show five different offsets in one line.
+        settingsRepository.prayerReminderEnabled(FAJR),
+        settingsRepository.prayerReminderMinutes(FAJR),
+        settingsRepository.prayerAlertStyle(FAJR)
+    ) { enabledPrayerCount, masterEnabled, reminderEnabled, reminderMinutes, alertStyle ->
         NotificationSummary(
             notificationsMasterEnabled = masterEnabled,
             enabledPrayerCount = enabledPrayerCount,
             reminderEnabled = reminderEnabled,
-            reminderMinutes = reminderMinutes
+            reminderMinutes = reminderMinutes,
+            fajrAlertStyle = alertStyle
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = NotificationSummary()
     )
+
+    /**
+     * Today's prayer times for the current location, or null until a location is known.
+     *
+     * The prayer notification rows show each prayer's time in their header, so the setting
+     * reads against the thing it governs rather than as an abstraction.
+     */
+    val todayPrayerTimes: StateFlow<PrayerTimes?> = prayerUseCases.getCurrentLocation()
+        .map { location ->
+            location?.let {
+                runCatching {
+                    prayerUseCases.getPrayerTimesForDate(LocalDate.now(), it)
+                }.getOrNull()
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null
+        )
 
     fun clearAdhanPreviewError() {
         _adhanPreviewError.value = null
@@ -510,9 +548,19 @@ class SettingsViewModel @Inject constructor(
                 event.enabled.toString()
             )
 
-            is SettingsEvent.SetPrayerAdhanEnabled -> AppAnalytics.logSettingChanged(
-                "adhan_${event.prayer.lowercase()}",
+            is SettingsEvent.SetPrayerAlertStyle -> AppAnalytics.logSettingChanged(
+                "alert_style_${event.prayer.lowercase()}",
+                event.style.name
+            )
+
+            is SettingsEvent.SetPrayerReminderEnabled -> AppAnalytics.logSettingChanged(
+                "reminder_enabled_${event.prayer.lowercase()}",
                 event.enabled.toString()
+            )
+
+            is SettingsEvent.SetPrayerReminderMinutes -> AppAnalytics.logSettingChanged(
+                "reminder_minutes_${event.prayer.lowercase()}",
+                event.minutes.toString()
             )
 
             is SettingsEvent.SetAdhanSound -> AppAnalytics.logSettingChanged(
@@ -683,10 +731,37 @@ class SettingsViewModel @Inject constructor(
                 }
             }
 
-            is SettingsEvent.SetPrayerAdhanEnabled -> {
-                updatePrayerAdhanEnabled(event.prayer, event.enabled)
+            is SettingsEvent.SetPrayerAlertStyle -> {
+                val prayer = event.prayer.lowercase()
+                _notificationState.update {
+                    it.copy(alertStyles = it.alertStyles + (prayer to event.style))
+                }
+                // The style is read at fire time, so there is nothing to reschedule.
                 viewModelScope.launch {
-                    settingsRepository.setPrayerAdhanEnabled(event.prayer, event.enabled)
+                    settingsRepository.setPrayerAlertStyle(prayer, event.style)
+                }
+            }
+
+            is SettingsEvent.SetPrayerReminderEnabled -> {
+                val prayer = event.prayer.lowercase()
+                _notificationState.update {
+                    it.copy(reminderEnabled = it.reminderEnabled + (prayer to event.enabled))
+                }
+                viewModelScope.launch {
+                    settingsRepository.setPrayerReminderEnabled(prayer, event.enabled)
+                    // The lead time is baked into the alarm, so this one does need rearming.
+                    rescheduleNotifications()
+                }
+            }
+
+            is SettingsEvent.SetPrayerReminderMinutes -> {
+                val prayer = event.prayer.lowercase()
+                _notificationState.update {
+                    it.copy(reminderOffsets = it.reminderOffsets + (prayer to event.minutes))
+                }
+                viewModelScope.launch {
+                    settingsRepository.setPrayerReminderMinutes(prayer, event.minutes)
+                    rescheduleNotifications()
                 }
             }
 
@@ -1082,12 +1157,14 @@ class SettingsViewModel @Inject constructor(
             val maghribNotif = settingsRepository.maghribNotificationEnabled.first()
             val ishaNotif = settingsRepository.ishaNotificationEnabled.first()
 
-            // Per-prayer adhan settings
-            val fajrAdhan = settingsRepository.fajrAdhanEnabled.first()
-            val dhuhrAdhan = settingsRepository.dhuhrAdhanEnabled.first()
-            val asrAdhan = settingsRepository.asrAdhanEnabled.first()
-            val maghribAdhan = settingsRepository.maghribAdhanEnabled.first()
-            val ishaAdhan = settingsRepository.ishaAdhanEnabled.first()
+            // Per-prayer alert style and reminder. The migration in AppInitializer has
+            // already carried an existing install onto these, so they are the truth here.
+            val alertStyles = PrayerAlertStyle.PRAYER_KEYS
+                .associateWith { settingsRepository.prayerAlertStyle(it).first() }
+            val reminderEnabled = PrayerAlertStyle.PRAYER_KEYS
+                .associateWith { settingsRepository.prayerReminderEnabled(it).first() }
+            val reminderOffsets = PrayerAlertStyle.PRAYER_KEYS
+                .associateWith { settingsRepository.prayerReminderMinutes(it).first() }
 
             // Extended worship reminders — enabled flags + offsets keyed by type.
             val worshipEnabled = com.arshadshah.nimaz.domain.model.WorshipReminderType.entries
@@ -1106,11 +1183,9 @@ class SettingsViewModel @Inject constructor(
                 it.copy(
                     notificationsEnabled = notifEnabled,
                     adhanEnabled = adhanEnabled,
-                    fajrAdhanEnabled = fajrAdhan,
-                    dhuhrAdhanEnabled = dhuhrAdhan,
-                    asrAdhanEnabled = asrAdhan,
-                    maghribAdhanEnabled = maghribAdhan,
-                    ishaAdhanEnabled = ishaAdhan,
+                    alertStyles = alertStyles,
+                    reminderEnabled = reminderEnabled,
+                    reminderOffsets = reminderOffsets,
                     vibrationEnabled = vibration,
                     reminderMinutes = reminderMin,
                     showReminderBefore = showReminder,
@@ -1234,8 +1309,7 @@ class SettingsViewModel @Inject constructor(
             longitude = lng,
             notificationsEnabled = notifState.notificationsEnabled,
             enabledPrayers = enabledPrayers,
-            preReminderEnabled = notifState.showReminderBefore,
-            preReminderMinutes = notifState.reminderMinutes,
+            preReminders = settingsRepository.preReminderMinutesByPrayer(),
             calculationMethod = calcMethod,
             asrCalculation = asrCalc,
             highLatitudeRule = highLatRule,
@@ -1268,19 +1342,6 @@ class SettingsViewModel @Inject constructor(
                 "asr" -> state.copy(asrNotification = enabled)
                 "maghrib" -> state.copy(maghribNotification = enabled)
                 "isha" -> state.copy(ishaNotification = enabled)
-                else -> state
-            }
-        }
-    }
-
-    private fun updatePrayerAdhanEnabled(prayer: String, enabled: Boolean) {
-        _notificationState.update { state ->
-            when (prayer.lowercase()) {
-                "fajr" -> state.copy(fajrAdhanEnabled = enabled)
-                "dhuhr" -> state.copy(dhuhrAdhanEnabled = enabled)
-                "asr" -> state.copy(asrAdhanEnabled = enabled)
-                "maghrib" -> state.copy(maghribAdhanEnabled = enabled)
-                "isha" -> state.copy(ishaAdhanEnabled = enabled)
                 else -> state
             }
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -649,11 +649,11 @@
     <string name="notification_settings_dnd">Bitte-nicht-stören beachten</string>
     <string name="notification_settings_dnd_subtitle">Adhan bei aktiviertem Nicht-stören-Modus unterdrücken</string>
     <string name="notification_settings_troubleshooting_section">FEHLERBEHEBUNG</string>
-    <string name="notification_settings_test">Testbenachrichtigung</string>
+    <string name="notification_settings_test">Testbenachrichtigung senden</string>
     <string name="notification_settings_test_sent">Testbenachrichtigung gesendet</string>
-    <string name="notification_settings_test_all">Alle Gebete testen</string>
+    <string name="notification_settings_test_all">Alle fünf Gebete testen</string>
     <string name="notification_settings_test_all_sent">Alle Gebetsbenachrichtigungen werden getestet…</string>
-    <string name="notification_settings_reset">Benachrichtigungen zurücksetzen</string>
+    <string name="notification_settings_reset">Zurücksetzen und neu planen</string>
     <string name="notification_settings_reset_success">Benachrichtigungen erfolgreich zurückgesetzt</string>
     <string name="notification_settings_battery_section">AKKUOPTIMIERUNG</string>
     <string name="notification_settings_battery_title">Akkuoptimierung</string>
@@ -1737,8 +1737,8 @@
     <string name="notif_diag_unrestricted">Uneingeschränkt</string>
     <string name="notif_diag_restricted">Eingeschränkt</string>
     <string name="notif_diag_needs_attention">Handlung nötig</string>
-    <string name="notif_diag_reset_confirm_title">Benachrichtigungen zurücksetzen?</string>
-    <string name="notif_diag_reset_confirm_body">Jeder geplante Hinweis wird abgebrochen und aus deinen aktuellen Einstellungen neu aufgebaut. Die Einstellungen selbst ändern sich nicht.</string>
+    <string name="notif_diag_reset_confirm_title">Alle Benachrichtigungen zurücksetzen?</string>
+    <string name="notif_diag_reset_confirm_body">Jeder geplante Alarm wird abgebrochen und aus deinen aktuellen Einstellungen neu aufgebaut. Deine Auswahl bleibt — nur der Zeitplan wird neu gezeichnet.</string>
     <string name="notif_diag_reset_confirm_action">Zurücksetzen</string>
     <string name="prayer_settings_fajr_reminder">Fadschr-Erinnerung</string>
     <plurals name="notif_reminder_minutes_before">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -648,7 +648,7 @@
     <string name="notification_settings_vibration_subtitle">Bei Benachrichtigung vibrieren</string>
     <string name="notification_settings_dnd">Bitte-nicht-stören beachten</string>
     <string name="notification_settings_dnd_subtitle">Adhan bei aktiviertem Nicht-stören-Modus unterdrücken</string>
-    <string name="notification_settings_troubleshooting_section">FEHLERBEHEBUNG</string>
+    <string name="notif_diag_actions_section">Zustellung prüfen</string>
     <string name="notification_settings_test">Testbenachrichtigung senden</string>
     <string name="notification_settings_test_sent">Testbenachrichtigung gesendet</string>
     <string name="notification_settings_test_all">Alle fünf Gebete testen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -639,18 +639,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Benachrichtigungen aktivieren</string>
     <string name="notification_settings_enable_subtitle">Gebetszeit-Benachrichtigungen erhalten</string>
-    <string name="notification_settings_prayer_section">GEBETSBENACHRICHTIGUNGEN</string>
     <string name="notification_settings_adhan_section">ADHAN-KLANG</string>
     <string name="notification_settings_enable_adhan">Adhan-Klang aktivieren</string>
     <string name="notification_settings_enable_adhan_subtitle">Adhan zu den Gebetszeiten abspielen</string>
-    <string name="notification_settings_additional_section">ZUSÄTZLICHE BENACHRICHTIGUNGEN</string>
-    <string name="notification_settings_pre_adhan">Vorab-Erinnerung</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="one">%1$d Minute vorher</item>
-        <item quantity="other">%1$d Minuten vorher</item>
-    </plurals>
-    <string name="notification_settings_sunrise">Sonnenaufgangs-Benachrichtigung</string>
-    <string name="notification_settings_sunrise_subtitle">Ende der Fajr-Gebetszeit</string>
     <string name="notification_settings_friday_reminder">Freitagsgebet-Erinnerung</string>
     <string name="notification_settings_friday_subtitle">1 Stunde vor dem Freitagsgebet</string>
     <string name="notification_settings_vibration">Vibration</string>
@@ -671,10 +662,6 @@
     <string name="notification_settings_battery_exempted">Ausgenommen</string>
     <string name="notification_settings_battery_explanation">Wenn die Akkuoptimierung aktiviert ist, kann Android Gebetsbenachrichtigungen verzögern oder überspringen, um Akku zu sparen. Durch Deaktivierung wird sichergestellt, dass Benachrichtigungen pünktlich ankommen.</string>
     <string name="notification_settings_disable_battery">Akkuoptimierung deaktivieren</string>
-    <string name="notification_settings_info_banner">Stellen Sie sicher, dass Benachrichtigungen in den Geräteeinstellungen aktiviert und die Akkuoptimierung deaktiviert ist, um genaue Gebetsbenachrichtigungen zu erhalten.</string>
-    <string name="notification_settings_prayer_notification">Gebetsbenachrichtigung</string>
-    <string name="notification_settings_sound_on">Ton an</string>
-    <string name="notification_settings_sound_off">Ton aus</string>
     <string name="notification_settings_preview">Vorschau</string>
 
     <!-- Onboarding -->
@@ -1196,7 +1183,6 @@
     <string name="twilight_angle">Dämmerungswinkel</string>
     <string name="manual_adjustments">Manuelle Anpassungen (Minuten)</string>
     <string name="adhan_notifications">Adhan-Benachrichtigungen</string>
-    <string name="pre_adhan_reminder">Erinnerung vor dem Adhan</string>
     <string name="asr_standard_desc">Schatten entspricht der Objektlänge</string>
     <string name="asr_hanafi_desc">Schatten entspricht der doppelten Objektlänge</string>
     <string name="high_lat_middle_desc">Die Nacht von Sonnenuntergang bis Sonnenaufgang halbieren</string>
@@ -1683,14 +1669,9 @@
     <string name="worship_witr_mode_title">Witr-Zeitpunkt</string>
     <string name="worship_witr_mode_after_isha">Nach dem Isha</string>
     <string name="worship_witr_mode_before_fajr">Vor dem Fajr</string>
-    <string name="notif_hub_prayers_title">Gebetsbenachrichtigungen</string>
-    <string name="notif_hub_prayers_subtitle">5 tägliche Gebete · Vor-Adhan · Sonnenaufgang</string>
-    <string name="notif_hub_weekly_title">Wöchentlich &amp; Lesen</string>
-    <string name="notif_hub_weekly_subtitle">Jumu\'ah · Khatam-Erinnerung</string>
-    <string name="notif_hub_sound_title">Ton &amp; Zustellung</string>
-    <string name="notif_hub_sound_subtitle">Adhan · Muezzin · Vibration · Nicht stören</string>
-    <string name="notif_hub_troubleshooting_title">Fehlerbehebung</string>
-    <string name="notif_hub_troubleshooting_subtitle">Test · Zurücksetzen · Akku-Optimierung</string>
+    <string name="notif_hub_prayers_title">Gebete</string>
+    <string name="notif_hub_weekly_title">Wöchentlich</string>
+    <string name="notif_hub_sound_title">Adhan &amp; Ton</string>
 
     <!-- Nachtgebet-Zentrum (Ziel fuer Tahajjud / Witr) -->
     <string name="night_worship_title">Nachtgebet</string>
@@ -1714,4 +1695,54 @@
     <string name="night_worship_why_body">&quot;Unser Herr steigt zum untersten Himmel herab…&quot;</string>
     <string name="widget_location">Ort</string>
     <string name="widget_tomorrow">Morgen</string>
+
+    <!-- Notifications rework: per-prayer alert style, reminders, diagnostics -->
+    <string name="notif_hub_diagnostics_title">Diagnose</string>
+    <string name="notif_hub_diagnostics_subtitle">Prüfen, was Hinweise verhindern könnte</string>
+    <string name="notif_hub_count_of">%1$d von %2$d</string>
+    <string name="notif_hub_count_on">%1$d an</string>
+    <string name="notif_hub_worship_subtitle">Tahadschud, Witr, Suhur, Iftar und mehr</string>
+    <string name="notif_hub_delivery_warning">Hinweise kommen auf diesem Gerät möglicherweise nicht pünktlich an.</string>
+    <string name="notif_hub_weekly_both">Dschumu\'a und Khatam an</string>
+    <string name="notif_hub_weekly_jumuah">Dschumu\'a an · Khatam aus</string>
+    <string name="notif_hub_weekly_khatam">Khatam an · Dschumu\'a aus</string>
+    <string name="notif_hub_weekly_none">Beide aus</string>
+    <string name="notif_hub_sound_dnd">%1$s · „Nicht stören“ wird beachtet</string>
+    <string name="notif_hub_sound_vibration">%1$s · Vibration an</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+    <string name="notif_prayers_section">Tägliche Gebete</string>
+    <string name="notif_alert_style">Hinweisart</string>
+    <string name="notif_alert_style_adhan">Adhan</string>
+    <string name="notif_alert_style_adhan_subtitle">Der Gebetsruf wird hörbar abgespielt</string>
+    <string name="notif_alert_style_notification">Nur Benachrichtigung</string>
+    <string name="notif_alert_style_notification_subtitle">Der übliche Benachrichtigungston</string>
+    <string name="notif_alert_style_silent">Lautlos</string>
+    <string name="notif_alert_style_silent_subtitle">Sie erscheint und wartet — kein Ton, keine Vibration</string>
+    <string name="notif_reminder_before">Vorherige Erinnerung</string>
+    <string name="notif_reminder_none">Keine Erinnerung</string>
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Aus</string>
+    <string name="notif_sunrise">Sonnenaufgang</string>
+    <string name="notif_sunrise_subtitle">Ein Signal, wenn das Fadschr-Fenster endet</string>
+    <string name="notif_sound_voice">Adhan-Stimme</string>
+    <string name="worship_settings_ramadan_notice">Ramadan-Erinnerungen bleiben still, bis der Ramadan beginnt. Richte sie jetzt ein, sie starten von selbst.</string>
+    <string name="notif_diag_status_section">Geräteprüfungen</string>
+    <string name="notif_diag_permission">Benachrichtigungsberechtigung</string>
+    <string name="notif_diag_granted">Erteilt</string>
+    <string name="notif_diag_blocked">Blockiert</string>
+    <string name="notif_diag_exact_alarms">Exakte Alarme</string>
+    <string name="notif_diag_allowed">Erlaubt</string>
+    <string name="notif_diag_not_allowed">Nicht erlaubt</string>
+    <string name="notif_diag_battery">Akku-Optimierung</string>
+    <string name="notif_diag_unrestricted">Uneingeschränkt</string>
+    <string name="notif_diag_restricted">Eingeschränkt</string>
+    <string name="notif_diag_needs_attention">Handlung nötig</string>
+    <string name="notif_diag_reset_confirm_title">Benachrichtigungen zurücksetzen?</string>
+    <string name="notif_diag_reset_confirm_body">Jeder geplante Hinweis wird abgebrochen und aus deinen aktuellen Einstellungen neu aufgebaut. Die Einstellungen selbst ändern sich nicht.</string>
+    <string name="notif_diag_reset_confirm_action">Zurücksetzen</string>
+    <string name="prayer_settings_fajr_reminder">Fadschr-Erinnerung</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="one">%1$d Min. vorher</item>
+        <item quantity="other">%1$d Min. vorher</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -661,19 +661,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Activer les notifications</string>
     <string name="notification_settings_enable_subtitle">Recevoir les alertes de prière</string>
-    <string name="notification_settings_prayer_section">NOTIFICATIONS DE PRIÈRE</string>
     <string name="notification_settings_adhan_section">SON DE L\'ADHAN</string>
     <string name="notification_settings_enable_adhan">Activer le son de l\'Adhan</string>
     <string name="notification_settings_enable_adhan_subtitle">Jouer l\'adhan aux heures de prière</string>
-    <string name="notification_settings_additional_section">ALERTES SUPPLÉMENTAIRES</string>
-    <string name="notification_settings_pre_adhan">Rappel pré-Adhan</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="one">%1$d minute avant</item>
-        <item quantity="many">%1$d minutes avant</item>
-        <item quantity="other">%1$d minutes avant</item>
-    </plurals>
-    <string name="notification_settings_sunrise">Alerte lever du soleil</string>
-    <string name="notification_settings_sunrise_subtitle">Fin de l\'heure de la prière du Fajr</string>
     <string name="notification_settings_friday_reminder">Rappel de la prière du vendredi</string>
     <string name="notification_settings_friday_subtitle">1 heure avant le Jummah</string>
     <string name="notification_settings_vibration">Vibration</string>
@@ -694,10 +684,6 @@
     <string name="notification_settings_battery_exempted">Exemptée</string>
     <string name="notification_settings_battery_explanation">Lorsque l\'optimisation de la batterie est activée, Android peut retarder ou ignorer les notifications de prière pour économiser la batterie. La désactiver garantit que les notifications arrivent à temps.</string>
     <string name="notification_settings_disable_battery">Désactiver l\'optimisation de la batterie</string>
-    <string name="notification_settings_info_banner">Assurez-vous d\'activer les notifications dans les paramètres de votre appareil et de désactiver l\'optimisation de la batterie pour des alertes de prière précises.</string>
-    <string name="notification_settings_prayer_notification">Notification de prière</string>
-    <string name="notification_settings_sound_on">Son activé</string>
-    <string name="notification_settings_sound_off">Son désactivé</string>
     <string name="notification_settings_preview">Aperçu</string>
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Bienvenue dans Nimaz</string>
@@ -1221,7 +1207,6 @@
     <string name="twilight_angle">Angle du crépuscule</string>
     <string name="manual_adjustments">Ajustements manuels (minutes)</string>
     <string name="adhan_notifications">Notifications d\'Adhan</string>
-    <string name="pre_adhan_reminder">Rappel avant l\'Adhan</string>
     <string name="asr_standard_desc">L\'ombre égale la longueur de l\'objet</string>
     <string name="asr_hanafi_desc">L\'ombre égale le double de la longueur de l\'objet</string>
     <string name="high_lat_middle_desc">Diviser la nuit en deux du coucher au lever du soleil</string>
@@ -1719,14 +1704,9 @@
     <string name="worship_witr_mode_title">Horaire du Witr</string>
     <string name="worship_witr_mode_after_isha">Après l\'Isha</string>
     <string name="worship_witr_mode_before_fajr">Avant le Fajr</string>
-    <string name="notif_hub_prayers_title">Notifications de prière</string>
-    <string name="notif_hub_prayers_subtitle">5 prières quotidiennes · pré-adhan · lever du soleil</string>
-    <string name="notif_hub_weekly_title">Hebdomadaire &amp; lecture</string>
-    <string name="notif_hub_weekly_subtitle">Jumu\'ah · rappel Khatam</string>
-    <string name="notif_hub_sound_title">Son &amp; diffusion</string>
-    <string name="notif_hub_sound_subtitle">Adhan · muezzin · vibration · Ne pas déranger</string>
-    <string name="notif_hub_troubleshooting_title">Dépannage</string>
-    <string name="notif_hub_troubleshooting_subtitle">Test · réinitialiser · optimisation batterie</string>
+    <string name="notif_hub_prayers_title">Prières</string>
+    <string name="notif_hub_weekly_title">Hebdomadaire</string>
+    <string name="notif_hub_sound_title">Adhan &amp; son</string>
 
     <!-- Centre de priere nocturne (destination Tahajjud / Witr) -->
     <string name="night_worship_title">Prière de nuit</string>
@@ -1750,4 +1730,54 @@
     <string name="night_worship_why_body">&quot;Notre Seigneur descend au ciel le plus proche…&quot;</string>
     <string name="widget_location">Lieu</string>
     <string name="widget_tomorrow">Demain</string>
+
+    <!-- Notifications rework: per-prayer alert style, reminders, diagnostics -->
+    <string name="notif_hub_diagnostics_title">Diagnostic</string>
+    <string name="notif_hub_diagnostics_subtitle">Vérifier ce qui pourrait bloquer les alertes</string>
+    <string name="notif_hub_count_of">%1$d sur %2$d</string>
+    <string name="notif_hub_count_on">%1$d actives</string>
+    <string name="notif_hub_worship_subtitle">Tahajjud, Witr, Suhoor, Iftar et plus</string>
+    <string name="notif_hub_delivery_warning">Les alertes risquent de ne pas arriver à l\'heure sur cet appareil.</string>
+    <string name="notif_hub_weekly_both">Jumu\'ah et khatam activés</string>
+    <string name="notif_hub_weekly_jumuah">Jumu\'ah activé · khatam désactivé</string>
+    <string name="notif_hub_weekly_khatam">Khatam activé · Jumu\'ah désactivé</string>
+    <string name="notif_hub_weekly_none">Les deux désactivés</string>
+    <string name="notif_hub_sound_dnd">%1$s · Ne pas déranger respecté</string>
+    <string name="notif_hub_sound_vibration">%1$s · vibration activée</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+    <string name="notif_prayers_section">Prières quotidiennes</string>
+    <string name="notif_alert_style">Type d\'alerte</string>
+    <string name="notif_alert_style_adhan">Adhan</string>
+    <string name="notif_alert_style_adhan_subtitle">L\'appel à la prière est joué à voix haute</string>
+    <string name="notif_alert_style_notification">Notification seule</string>
+    <string name="notif_alert_style_notification_subtitle">La sonnerie de notification habituelle</string>
+    <string name="notif_alert_style_silent">Silencieux</string>
+    <string name="notif_alert_style_silent_subtitle">Elle s\'affiche et attend — sans son ni vibration</string>
+    <string name="notif_reminder_before">Rappel avant</string>
+    <string name="notif_reminder_none">Aucun rappel</string>
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Désactivé</string>
+    <string name="notif_sunrise">Lever du soleil</string>
+    <string name="notif_sunrise_subtitle">Un signal à la fin du créneau du Fajr</string>
+    <string name="notif_sound_voice">Voix de l\'adhan</string>
+    <string name="worship_settings_ramadan_notice">Les rappels du Ramadan restent silencieux jusqu\'au début du Ramadan. Configurez-les dès maintenant, ils démarreront seuls.</string>
+    <string name="notif_diag_status_section">Vérifications de l\'appareil</string>
+    <string name="notif_diag_permission">Autorisation de notification</string>
+    <string name="notif_diag_granted">Accordée</string>
+    <string name="notif_diag_blocked">Bloquée</string>
+    <string name="notif_diag_exact_alarms">Alarmes exactes</string>
+    <string name="notif_diag_allowed">Autorisées</string>
+    <string name="notif_diag_not_allowed">Non autorisées</string>
+    <string name="notif_diag_battery">Optimisation de la batterie</string>
+    <string name="notif_diag_unrestricted">Sans restriction</string>
+    <string name="notif_diag_restricted">Restreinte</string>
+    <string name="notif_diag_needs_attention">À corriger</string>
+    <string name="notif_diag_reset_confirm_title">Réinitialiser les notifications ?</string>
+    <string name="notif_diag_reset_confirm_body">Chaque alerte programmée est annulée puis reconstruite à partir de vos réglages actuels. Les réglages eux-mêmes ne changent pas.</string>
+    <string name="notif_diag_reset_confirm_action">Réinitialiser</string>
+    <string name="prayer_settings_fajr_reminder">Rappel du Fajr</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="one">%1$d min avant</item>
+        <item quantity="other">%1$d min avant</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -670,7 +670,7 @@
     <string name="notification_settings_vibration_subtitle">Vibrer avec la notification</string>
     <string name="notification_settings_dnd">Respecter Ne pas déranger</string>
     <string name="notification_settings_dnd_subtitle">Ignorer l\'adhan quand NPD est actif</string>
-    <string name="notification_settings_troubleshooting_section">DÉPANNAGE</string>
+    <string name="notif_diag_actions_section">Vérifier la diffusion</string>
     <string name="notification_settings_test">Envoyer une notification de test</string>
     <string name="notification_settings_test_sent">Notification de test envoyée</string>
     <string name="notification_settings_test_all">Tester les cinq prières</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -671,11 +671,11 @@
     <string name="notification_settings_dnd">Respecter Ne pas déranger</string>
     <string name="notification_settings_dnd_subtitle">Ignorer l\'adhan quand NPD est actif</string>
     <string name="notification_settings_troubleshooting_section">DÉPANNAGE</string>
-    <string name="notification_settings_test">Tester la notification</string>
+    <string name="notification_settings_test">Envoyer une notification de test</string>
     <string name="notification_settings_test_sent">Notification de test envoyée</string>
-    <string name="notification_settings_test_all">Tester toutes les prières</string>
+    <string name="notification_settings_test_all">Tester les cinq prières</string>
     <string name="notification_settings_test_all_sent">Test de toutes les notifications de prière…</string>
-    <string name="notification_settings_reset">Réinitialiser les notifications</string>
+    <string name="notification_settings_reset">Réinitialiser et reprogrammer</string>
     <string name="notification_settings_reset_success">Notifications réinitialisées avec succès</string>
     <string name="notification_settings_battery_section">OPTIMISATION DE LA BATTERIE</string>
     <string name="notification_settings_battery_title">Optimisation de la batterie</string>
@@ -1772,8 +1772,8 @@
     <string name="notif_diag_unrestricted">Sans restriction</string>
     <string name="notif_diag_restricted">Restreinte</string>
     <string name="notif_diag_needs_attention">À corriger</string>
-    <string name="notif_diag_reset_confirm_title">Réinitialiser les notifications ?</string>
-    <string name="notif_diag_reset_confirm_body">Chaque alerte programmée est annulée puis reconstruite à partir de vos réglages actuels. Les réglages eux-mêmes ne changent pas.</string>
+    <string name="notif_diag_reset_confirm_title">Réinitialiser toutes les notifications ?</string>
+    <string name="notif_diag_reset_confirm_body">Chaque alarme programmée est annulée puis reconstruite à partir de vos réglages actuels. Vos choix sont conservés — seul le calendrier est redessiné.</string>
     <string name="notif_diag_reset_confirm_action">Réinitialiser</string>
     <string name="prayer_settings_fajr_reminder">Rappel du Fajr</string>
     <plurals name="notif_reminder_minutes_before">

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -633,11 +633,11 @@
     <string name="notification_settings_dnd">Hormati Jangan Ganggu</string>
     <string name="notification_settings_dnd_subtitle">Lewati adzan saat mode Jangan Ganggu aktif</string>
     <string name="notification_settings_troubleshooting_section">PEMECAHAN MASALAH</string>
-    <string name="notification_settings_test">Tes Notifikasi</string>
+    <string name="notification_settings_test">Kirim notifikasi uji</string>
     <string name="notification_settings_test_sent">Notifikasi tes terkirim</string>
-    <string name="notification_settings_test_all">Tes Semua Shalat</string>
+    <string name="notification_settings_test_all">Uji kelima salat</string>
     <string name="notification_settings_test_all_sent">Menguji semua notifikasi shalat…</string>
-    <string name="notification_settings_reset">Reset Notifikasi</string>
+    <string name="notification_settings_reset">Atur ulang dan jadwalkan lagi</string>
     <string name="notification_settings_reset_success">Notifikasi berhasil direset</string>
     <string name="notification_settings_battery_section">OPTIMASI BATERAI</string>
     <string name="notification_settings_battery_title">Optimasi Baterai</string>
@@ -1707,8 +1707,8 @@
     <string name="notif_diag_unrestricted">Tanpa batas</string>
     <string name="notif_diag_restricted">Dibatasi</string>
     <string name="notif_diag_needs_attention">Perlu perhatian</string>
-    <string name="notif_diag_reset_confirm_title">Atur ulang notifikasi?</string>
-    <string name="notif_diag_reset_confirm_body">Setiap notifikasi terjadwal dibatalkan dan disusun ulang dari pengaturan Anda saat ini. Pengaturannya sendiri tidak berubah.</string>
+    <string name="notif_diag_reset_confirm_title">Atur ulang semua notifikasi?</string>
+    <string name="notif_diag_reset_confirm_body">Setiap alarm terjadwal dibatalkan dan disusun ulang dari pengaturan Anda saat ini. Pilihan Anda tetap — hanya jadwalnya yang digambar ulang.</string>
     <string name="notif_diag_reset_confirm_action">Atur ulang</string>
     <string name="prayer_settings_fajr_reminder">Pengingat Subuh</string>
     <plurals name="notif_reminder_minutes_before">

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -632,7 +632,7 @@
     <string name="notification_settings_vibration_subtitle">Bergetar dengan notifikasi</string>
     <string name="notification_settings_dnd">Hormati Jangan Ganggu</string>
     <string name="notification_settings_dnd_subtitle">Lewati adzan saat mode Jangan Ganggu aktif</string>
-    <string name="notification_settings_troubleshooting_section">PEMECAHAN MASALAH</string>
+    <string name="notif_diag_actions_section">Periksa pengiriman</string>
     <string name="notification_settings_test">Kirim notifikasi uji</string>
     <string name="notification_settings_test_sent">Notifikasi tes terkirim</string>
     <string name="notification_settings_test_all">Uji kelima salat</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -623,17 +623,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Aktifkan Notifikasi</string>
     <string name="notification_settings_enable_subtitle">Terima peringatan waktu shalat</string>
-    <string name="notification_settings_prayer_section">NOTIFIKASI SHALAT</string>
     <string name="notification_settings_adhan_section">SUARA ADZAN</string>
     <string name="notification_settings_enable_adhan">Aktifkan Suara Adzan</string>
     <string name="notification_settings_enable_adhan_subtitle">Putar adzan saat waktu shalat</string>
-    <string name="notification_settings_additional_section">PERINGATAN TAMBAHAN</string>
-    <string name="notification_settings_pre_adhan">Pengingat Pra-Adzan</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="other">%1$d menit sebelumnya</item>
-    </plurals>
-    <string name="notification_settings_sunrise">Peringatan Matahari Terbit</string>
-    <string name="notification_settings_sunrise_subtitle">Akhir waktu shalat Subuh</string>
     <string name="notification_settings_friday_reminder">Pengingat Shalat Jumat</string>
     <string name="notification_settings_friday_subtitle">1 jam sebelum Jumat</string>
     <string name="notification_settings_vibration">Getaran</string>
@@ -654,10 +646,6 @@
     <string name="notification_settings_battery_exempted">Dikecualikan</string>
     <string name="notification_settings_battery_explanation">Ketika optimasi baterai diaktifkan, Android dapat menunda atau melewatkan notifikasi shalat untuk menghemat baterai. Menonaktifkannya memastikan notifikasi tiba tepat waktu.</string>
     <string name="notification_settings_disable_battery">Nonaktifkan Optimasi Baterai</string>
-    <string name="notification_settings_info_banner">Pastikan untuk mengaktifkan notifikasi di pengaturan perangkat Anda dan menonaktifkan optimasi baterai untuk peringatan shalat yang akurat.</string>
-    <string name="notification_settings_prayer_notification">Notifikasi shalat</string>
-    <string name="notification_settings_sound_on">Suara aktif</string>
-    <string name="notification_settings_sound_off">Suara nonaktif</string>
     <string name="notification_settings_preview">Pratinjau</string>
 
     <!-- Onboarding -->
@@ -1176,7 +1164,6 @@
     <string name="twilight_angle">Sudut Senja</string>
     <string name="manual_adjustments">Penyesuaian Manual (Menit)</string>
     <string name="adhan_notifications">Notifikasi Adzan</string>
-    <string name="pre_adhan_reminder">Pengingat Pra-Adzan</string>
     <string name="asr_standard_desc">Bayangan sama dengan panjang objek</string>
     <string name="asr_hanafi_desc">Bayangan sama dengan dua kali panjang objek</string>
     <string name="high_lat_middle_desc">Bagi malam menjadi dua dari terbenam hingga terbit matahari</string>
@@ -1652,14 +1639,9 @@
     <string name="worship_witr_mode_title">Waktu Witir</string>
     <string name="worship_witr_mode_after_isha">Setelah Isya</string>
     <string name="worship_witr_mode_before_fajr">Sebelum Subuh</string>
-    <string name="notif_hub_prayers_title">Notifikasi salat</string>
-    <string name="notif_hub_prayers_subtitle">5 salat harian · pra-azan · matahari terbit</string>
-    <string name="notif_hub_weekly_title">Mingguan &amp; bacaan</string>
-    <string name="notif_hub_weekly_subtitle">Jumat · pengingat Khatam</string>
-    <string name="notif_hub_sound_title">Suara &amp; pengiriman</string>
-    <string name="notif_hub_sound_subtitle">Azan · muazin · getaran · Jangan Ganggu</string>
-    <string name="notif_hub_troubleshooting_title">Pemecahan masalah</string>
-    <string name="notif_hub_troubleshooting_subtitle">Uji · atur ulang · pengoptimalan baterai</string>
+    <string name="notif_hub_prayers_title">Salat</string>
+    <string name="notif_hub_weekly_title">Mingguan</string>
+    <string name="notif_hub_sound_title">Azan &amp; suara</string>
 
     <!-- Pusat ibadah malam (tujuan Tahajud / Witir) -->
     <string name="night_worship_title">Ibadah Malam</string>
@@ -1683,4 +1665,53 @@
     <string name="night_worship_why_body">&quot;Rabb kami turun ke langit dunia…&quot;</string>
     <string name="widget_location">Lokasi</string>
     <string name="widget_tomorrow">Besok</string>
+
+    <!-- Notifications rework: per-prayer alert style, reminders, diagnostics -->
+    <string name="notif_hub_diagnostics_title">Diagnostik</string>
+    <string name="notif_hub_diagnostics_subtitle">Periksa apa yang bisa menghambat notifikasi</string>
+    <string name="notif_hub_count_of">%1$d dari %2$d</string>
+    <string name="notif_hub_count_on">%1$d aktif</string>
+    <string name="notif_hub_worship_subtitle">Tahajud, Witir, Sahur, Buka dan lainnya</string>
+    <string name="notif_hub_delivery_warning">Notifikasi mungkin tidak tiba tepat waktu di perangkat ini.</string>
+    <string name="notif_hub_weekly_both">Jumat dan khatam aktif</string>
+    <string name="notif_hub_weekly_jumuah">Jumat aktif · khatam nonaktif</string>
+    <string name="notif_hub_weekly_khatam">Khatam aktif · Jumat nonaktif</string>
+    <string name="notif_hub_weekly_none">Keduanya nonaktif</string>
+    <string name="notif_hub_sound_dnd">%1$s · Jangan Ganggu dihormati</string>
+    <string name="notif_hub_sound_vibration">%1$s · getaran aktif</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+    <string name="notif_prayers_section">Salat harian</string>
+    <string name="notif_alert_style">Jenis peringatan</string>
+    <string name="notif_alert_style_adhan">Azan</string>
+    <string name="notif_alert_style_adhan_subtitle">Azan diputar dengan suara</string>
+    <string name="notif_alert_style_notification">Notifikasi saja</string>
+    <string name="notif_alert_style_notification_subtitle">Nada notifikasi biasa</string>
+    <string name="notif_alert_style_silent">Senyap</string>
+    <string name="notif_alert_style_silent_subtitle">Muncul dan menunggu — tanpa suara, tanpa getaran</string>
+    <string name="notif_reminder_before">Pengingat sebelum</string>
+    <string name="notif_reminder_none">Tanpa pengingat</string>
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Nonaktif</string>
+    <string name="notif_sunrise">Matahari terbit</string>
+    <string name="notif_sunrise_subtitle">Bunyi singkat saat waktu Subuh berakhir</string>
+    <string name="notif_sound_voice">Suara azan</string>
+    <string name="worship_settings_ramadan_notice">Pengingat Ramadan tetap senyap sampai Ramadan tiba. Atur sekarang dan pengingat akan mulai sendiri.</string>
+    <string name="notif_diag_status_section">Pemeriksaan perangkat</string>
+    <string name="notif_diag_permission">Izin notifikasi</string>
+    <string name="notif_diag_granted">Diberikan</string>
+    <string name="notif_diag_blocked">Diblokir</string>
+    <string name="notif_diag_exact_alarms">Alarm presisi</string>
+    <string name="notif_diag_allowed">Diizinkan</string>
+    <string name="notif_diag_not_allowed">Tidak diizinkan</string>
+    <string name="notif_diag_battery">Pengoptimalan baterai</string>
+    <string name="notif_diag_unrestricted">Tanpa batas</string>
+    <string name="notif_diag_restricted">Dibatasi</string>
+    <string name="notif_diag_needs_attention">Perlu perhatian</string>
+    <string name="notif_diag_reset_confirm_title">Atur ulang notifikasi?</string>
+    <string name="notif_diag_reset_confirm_body">Setiap notifikasi terjadwal dibatalkan dan disusun ulang dari pengaturan Anda saat ini. Pengaturannya sendiri tidak berubah.</string>
+    <string name="notif_diag_reset_confirm_action">Atur ulang</string>
+    <string name="prayer_settings_fajr_reminder">Pengingat Subuh</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="other">%1$d mnt sebelumnya</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -623,17 +623,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Aktifkan Pemberitahuan</string>
     <string name="notification_settings_enable_subtitle">Terima amaran waktu solat</string>
-    <string name="notification_settings_prayer_section">PEMBERITAHUAN SOLAT</string>
     <string name="notification_settings_adhan_section">BUNYI AZAN</string>
     <string name="notification_settings_enable_adhan">Aktifkan Bunyi Azan</string>
     <string name="notification_settings_enable_adhan_subtitle">Mainkan azan pada waktu solat</string>
-    <string name="notification_settings_additional_section">AMARAN TAMBAHAN</string>
-    <string name="notification_settings_pre_adhan">Peringatan Pra-Azan</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="other">%1$d minit sebelum</item>
-    </plurals>
-    <string name="notification_settings_sunrise">Amaran Matahari Terbit</string>
-    <string name="notification_settings_sunrise_subtitle">Akhir waktu solat Subuh</string>
     <string name="notification_settings_friday_reminder">Peringatan Solat Jumaat</string>
     <string name="notification_settings_friday_subtitle">1 jam sebelum Jumaat</string>
     <string name="notification_settings_vibration">Getaran</string>
@@ -654,10 +646,6 @@
     <string name="notification_settings_battery_exempted">Dikecualikan</string>
     <string name="notification_settings_battery_explanation">Apabila pengoptimuman bateri diaktifkan, Android mungkin melambatkan atau melangkau pemberitahuan solat untuk menjimatkan bateri. Menyahaktifkannya memastikan pemberitahuan tiba tepat pada masanya.</string>
     <string name="notification_settings_disable_battery">Nyahaktifkan Pengoptimuman Bateri</string>
-    <string name="notification_settings_info_banner">Pastikan untuk mengaktifkan pemberitahuan dalam tetapan peranti anda dan menyahaktifkan pengoptimuman bateri untuk amaran solat yang tepat.</string>
-    <string name="notification_settings_prayer_notification">Pemberitahuan solat</string>
-    <string name="notification_settings_sound_on">Bunyi hidup</string>
-    <string name="notification_settings_sound_off">Bunyi mati</string>
     <string name="notification_settings_preview">Pratonton</string>
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Selamat Datang ke Nimaz</string>
@@ -1177,7 +1165,6 @@
     <string name="twilight_angle">Sudut Senja</string>
     <string name="manual_adjustments">Pelarasan Manual (Minit)</string>
     <string name="adhan_notifications">Pemberitahuan Azan</string>
-    <string name="pre_adhan_reminder">Peringatan Pra-Azan</string>
     <string name="asr_standard_desc">Bayang sama dengan panjang objek</string>
     <string name="asr_hanafi_desc">Bayang sama dengan dua kali panjang objek</string>
     <string name="high_lat_middle_desc">Bahagikan malam kepada dua dari matahari terbenam ke terbit</string>
@@ -1653,14 +1640,9 @@
     <string name="worship_witr_mode_title">Waktu Witir</string>
     <string name="worship_witr_mode_after_isha">Selepas Isyak</string>
     <string name="worship_witr_mode_before_fajr">Sebelum Subuh</string>
-    <string name="notif_hub_prayers_title">Pemberitahuan solat</string>
-    <string name="notif_hub_prayers_subtitle">5 solat harian · pra-azan · matahari terbit</string>
-    <string name="notif_hub_weekly_title">Mingguan &amp; bacaan</string>
-    <string name="notif_hub_weekly_subtitle">Jumaat · peringatan Khatam</string>
-    <string name="notif_hub_sound_title">Bunyi &amp; penghantaran</string>
-    <string name="notif_hub_sound_subtitle">Azan · muazin · getaran · Jangan Ganggu</string>
-    <string name="notif_hub_troubleshooting_title">Penyelesaian masalah</string>
-    <string name="notif_hub_troubleshooting_subtitle">Uji · set semula · pengoptimuman bateri</string>
+    <string name="notif_hub_prayers_title">Solat</string>
+    <string name="notif_hub_weekly_title">Mingguan</string>
+    <string name="notif_hub_sound_title">Azan &amp; bunyi</string>
 
     <!-- Pusat ibadah malam (destinasi Tahajud / Witir) -->
     <string name="night_worship_title">Ibadah Malam</string>
@@ -1684,4 +1666,53 @@
     <string name="night_worship_why_body">&quot;Tuhan kami turun ke langit dunia…&quot;</string>
     <string name="widget_location">Lokasi</string>
     <string name="widget_tomorrow">Esok</string>
+
+    <!-- Notifications rework: per-prayer alert style, reminders, diagnostics -->
+    <string name="notif_hub_diagnostics_title">Diagnostik</string>
+    <string name="notif_hub_diagnostics_subtitle">Semak apa yang boleh menghalang peringatan</string>
+    <string name="notif_hub_count_of">%1$d daripada %2$d</string>
+    <string name="notif_hub_count_on">%1$d aktif</string>
+    <string name="notif_hub_worship_subtitle">Tahajud, Witir, Sahur, Berbuka dan lain-lain</string>
+    <string name="notif_hub_delivery_warning">Peringatan mungkin tidak tiba tepat pada masanya pada peranti ini.</string>
+    <string name="notif_hub_weekly_both">Jumaat dan khatam aktif</string>
+    <string name="notif_hub_weekly_jumuah">Jumaat aktif · khatam mati</string>
+    <string name="notif_hub_weekly_khatam">Khatam aktif · Jumaat mati</string>
+    <string name="notif_hub_weekly_none">Kedua-duanya mati</string>
+    <string name="notif_hub_sound_dnd">%1$s · Jangan Ganggu dipatuhi</string>
+    <string name="notif_hub_sound_vibration">%1$s · getaran aktif</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+    <string name="notif_prayers_section">Solat harian</string>
+    <string name="notif_alert_style">Jenis peringatan</string>
+    <string name="notif_alert_style_adhan">Azan</string>
+    <string name="notif_alert_style_adhan_subtitle">Azan dimainkan dengan bunyi</string>
+    <string name="notif_alert_style_notification">Pemberitahuan sahaja</string>
+    <string name="notif_alert_style_notification_subtitle">Nada pemberitahuan biasa</string>
+    <string name="notif_alert_style_silent">Senyap</string>
+    <string name="notif_alert_style_silent_subtitle">Ia muncul dan menunggu — tiada bunyi, tiada getaran</string>
+    <string name="notif_reminder_before">Peringatan sebelum</string>
+    <string name="notif_reminder_none">Tiada peringatan</string>
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Mati</string>
+    <string name="notif_sunrise">Matahari terbit</string>
+    <string name="notif_sunrise_subtitle">Bunyi ringkas apabila waktu Subuh tamat</string>
+    <string name="notif_sound_voice">Suara azan</string>
+    <string name="worship_settings_ramadan_notice">Peringatan Ramadan kekal senyap sehingga Ramadan bermula. Tetapkannya sekarang dan ia akan bermula sendiri.</string>
+    <string name="notif_diag_status_section">Semakan peranti</string>
+    <string name="notif_diag_permission">Kebenaran pemberitahuan</string>
+    <string name="notif_diag_granted">Diberikan</string>
+    <string name="notif_diag_blocked">Disekat</string>
+    <string name="notif_diag_exact_alarms">Penggera tepat</string>
+    <string name="notif_diag_allowed">Dibenarkan</string>
+    <string name="notif_diag_not_allowed">Tidak dibenarkan</string>
+    <string name="notif_diag_battery">Pengoptimuman bateri</string>
+    <string name="notif_diag_unrestricted">Tiada sekatan</string>
+    <string name="notif_diag_restricted">Disekat</string>
+    <string name="notif_diag_needs_attention">Perlu perhatian</string>
+    <string name="notif_diag_reset_confirm_title">Tetapkan semula pemberitahuan?</string>
+    <string name="notif_diag_reset_confirm_body">Setiap peringatan berjadual dibatalkan dan dibina semula daripada tetapan semasa anda. Tetapan itu sendiri tidak berubah.</string>
+    <string name="notif_diag_reset_confirm_action">Tetapkan semula</string>
+    <string name="prayer_settings_fajr_reminder">Peringatan Subuh</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="other">%1$d min sebelum</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -633,11 +633,11 @@
     <string name="notification_settings_dnd">Hormati Jangan Ganggu</string>
     <string name="notification_settings_dnd_subtitle">Langkau azan apabila Jangan Ganggu aktif</string>
     <string name="notification_settings_troubleshooting_section">PENYELESAIAN MASALAH</string>
-    <string name="notification_settings_test">Uji Pemberitahuan</string>
+    <string name="notification_settings_test">Hantar pemberitahuan ujian</string>
     <string name="notification_settings_test_sent">Pemberitahuan ujian dihantar</string>
-    <string name="notification_settings_test_all">Uji Semua Solat</string>
+    <string name="notification_settings_test_all">Uji kelima-lima solat</string>
     <string name="notification_settings_test_all_sent">Menguji semua pemberitahuan solat…</string>
-    <string name="notification_settings_reset">Set Semula Pemberitahuan</string>
+    <string name="notification_settings_reset">Tetapkan semula dan jadualkan semula</string>
     <string name="notification_settings_reset_success">Pemberitahuan berjaya diset semula</string>
     <string name="notification_settings_battery_section">PENGOPTIMUMAN BATERI</string>
     <string name="notification_settings_battery_title">Pengoptimuman Bateri</string>
@@ -1708,8 +1708,8 @@
     <string name="notif_diag_unrestricted">Tiada sekatan</string>
     <string name="notif_diag_restricted">Disekat</string>
     <string name="notif_diag_needs_attention">Perlu perhatian</string>
-    <string name="notif_diag_reset_confirm_title">Tetapkan semula pemberitahuan?</string>
-    <string name="notif_diag_reset_confirm_body">Setiap peringatan berjadual dibatalkan dan dibina semula daripada tetapan semasa anda. Tetapan itu sendiri tidak berubah.</string>
+    <string name="notif_diag_reset_confirm_title">Tetapkan semula semua pemberitahuan?</string>
+    <string name="notif_diag_reset_confirm_body">Setiap penggera berjadual dibatalkan dan dibina semula daripada tetapan semasa anda. Pilihan anda dikekalkan — hanya jadualnya dilukis semula.</string>
     <string name="notif_diag_reset_confirm_action">Tetapkan semula</string>
     <string name="prayer_settings_fajr_reminder">Peringatan Subuh</string>
     <plurals name="notif_reminder_minutes_before">

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -632,7 +632,7 @@
     <string name="notification_settings_vibration_subtitle">Bergetar dengan pemberitahuan</string>
     <string name="notification_settings_dnd">Hormati Jangan Ganggu</string>
     <string name="notification_settings_dnd_subtitle">Langkau azan apabila Jangan Ganggu aktif</string>
-    <string name="notification_settings_troubleshooting_section">PENYELESAIAN MASALAH</string>
+    <string name="notif_diag_actions_section">Semak penghantaran</string>
     <string name="notification_settings_test">Hantar pemberitahuan ujian</string>
     <string name="notification_settings_test_sent">Pemberitahuan ujian dihantar</string>
     <string name="notification_settings_test_all">Uji kelima-lima solat</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -653,11 +653,11 @@
     <string name="notification_settings_dnd">Rahatsız Etmeyin Moduna Uy</string>
     <string name="notification_settings_dnd_subtitle">Rahatsız Etmeyin aktifken ezanı atla</string>
     <string name="notification_settings_troubleshooting_section">SORUN GİDERME</string>
-    <string name="notification_settings_test">Bildirim Testi</string>
+    <string name="notification_settings_test">Test bildirimi gönder</string>
     <string name="notification_settings_test_sent">Test bildirimi gönderildi</string>
-    <string name="notification_settings_test_all">Tüm Namazları Test Et</string>
+    <string name="notification_settings_test_all">Beş vaktin tümünü test et</string>
     <string name="notification_settings_test_all_sent">Tüm namaz bildirimleri test ediliyor…</string>
-    <string name="notification_settings_reset">Bildirimleri Sıfırla</string>
+    <string name="notification_settings_reset">Sıfırla ve yeniden planla</string>
     <string name="notification_settings_reset_success">Bildirimler başarıyla sıfırlandı</string>
     <string name="notification_settings_battery_section">PİL OPTİMİZASYONU</string>
     <string name="notification_settings_battery_title">Pil Optimizasyonu</string>
@@ -1743,8 +1743,8 @@
     <string name="notif_diag_unrestricted">Kısıtlamasız</string>
     <string name="notif_diag_restricted">Kısıtlı</string>
     <string name="notif_diag_needs_attention">İlgilenilmeli</string>
-    <string name="notif_diag_reset_confirm_title">Bildirimler sıfırlansın mı?</string>
-    <string name="notif_diag_reset_confirm_body">Zamanlanmış her bildirim iptal edilip mevcut ayarlarınızdan yeniden kurulur. Ayarlarınız değişmez.</string>
+    <string name="notif_diag_reset_confirm_title">Tüm bildirimler sıfırlansın mı?</string>
+    <string name="notif_diag_reset_confirm_body">Zamanlanmış her alarm iptal edilip mevcut ayarlarınızdan yeniden kurulur. Seçimleriniz korunur — yalnızca zamanlama yeniden çizilir.</string>
     <string name="notif_diag_reset_confirm_action">Sıfırla</string>
     <string name="prayer_settings_fajr_reminder">Sabah hatırlatması</string>
     <plurals name="notif_reminder_minutes_before">

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -652,7 +652,7 @@
     <string name="notification_settings_vibration_subtitle">Bildirimle birlikte titret</string>
     <string name="notification_settings_dnd">Rahatsız Etmeyin Moduna Uy</string>
     <string name="notification_settings_dnd_subtitle">Rahatsız Etmeyin aktifken ezanı atla</string>
-    <string name="notification_settings_troubleshooting_section">SORUN GİDERME</string>
+    <string name="notif_diag_actions_section">Teslimatı denetle</string>
     <string name="notification_settings_test">Test bildirimi gönder</string>
     <string name="notification_settings_test_sent">Test bildirimi gönderildi</string>
     <string name="notification_settings_test_all">Beş vaktin tümünü test et</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -643,18 +643,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Bildirimleri Etkinleştir</string>
     <string name="notification_settings_enable_subtitle">Namaz vakti uyarıları alın</string>
-    <string name="notification_settings_prayer_section">NAMAZ BİLDİRİMLERİ</string>
     <string name="notification_settings_adhan_section">EZAN SESİ</string>
     <string name="notification_settings_enable_adhan">Ezan Sesini Etkinleştir</string>
     <string name="notification_settings_enable_adhan_subtitle">Namaz vakitlerinde ezan çal</string>
-    <string name="notification_settings_additional_section">EK UYARILAR</string>
-    <string name="notification_settings_pre_adhan">Ezan Öncesi Hatırlatma</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="one">%1$d dakika önce</item>
-        <item quantity="other">%1$d dakika önce</item>
-    </plurals>
-    <string name="notification_settings_sunrise">Güneş Doğuşu Uyarısı</string>
-    <string name="notification_settings_sunrise_subtitle">Sabah namazı vaktinin sonu</string>
     <string name="notification_settings_friday_reminder">Cuma Namazı Hatırlatması</string>
     <string name="notification_settings_friday_subtitle">Cuma namazından 1 saat önce</string>
     <string name="notification_settings_vibration">Titreşim</string>
@@ -675,10 +666,6 @@
     <string name="notification_settings_battery_exempted">Muaf</string>
     <string name="notification_settings_battery_explanation">Pil optimizasyonu etkinleştirildiğinde, Android pil tasarrufu için namaz bildirimlerini geciktirebilir veya atlayabilir. Devre dışı bırakmak bildirimlerin zamanında ulaşmasını sağlar.</string>
     <string name="notification_settings_disable_battery">Pil Optimizasyonunu Devre Dışı Bırak</string>
-    <string name="notification_settings_info_banner">Doğru namaz uyarıları için cihaz ayarlarınızda bildirimleri etkinleştirdiğinizden ve pil optimizasyonunu devre dışı bıraktığınızdan emin olun.</string>
-    <string name="notification_settings_prayer_notification">Namaz bildirimi</string>
-    <string name="notification_settings_sound_on">Ses açık</string>
-    <string name="notification_settings_sound_off">Ses kapalı</string>
     <string name="notification_settings_preview">Önizleme</string>
 
     <!-- Onboarding -->
@@ -1202,7 +1189,6 @@
     <string name="twilight_angle">Şafak Açısı</string>
     <string name="manual_adjustments">Manuel Düzenlemeler (Dakika)</string>
     <string name="adhan_notifications">Ezan Bildirimleri</string>
-    <string name="pre_adhan_reminder">Ezan Öncesi Hatırlatma</string>
     <string name="asr_standard_desc">Gölge, nesnenin boyuna eşit</string>
     <string name="asr_hanafi_desc">Gölge, nesnenin boyunun iki katına eşit</string>
     <string name="high_lat_middle_desc">Geceyi gün batımından gün doğumuna kadar ikiye böl</string>
@@ -1689,14 +1675,9 @@
     <string name="worship_witr_mode_title">Vitir zamanı</string>
     <string name="worship_witr_mode_after_isha">Yatsıdan sonra</string>
     <string name="worship_witr_mode_before_fajr">Fecirden önce</string>
-    <string name="notif_hub_prayers_title">Namaz bildirimleri</string>
-    <string name="notif_hub_prayers_subtitle">5 vakit namaz · ezan öncesi · gün doğumu</string>
-    <string name="notif_hub_weekly_title">Haftalık &amp; okuma</string>
-    <string name="notif_hub_weekly_subtitle">Cuma · Hatim hatırlatıcısı</string>
-    <string name="notif_hub_sound_title">Ses &amp; teslimat</string>
-    <string name="notif_hub_sound_subtitle">Ezan · müezzin · titreşim · Rahatsız Etmeyin</string>
-    <string name="notif_hub_troubleshooting_title">Sorun giderme</string>
-    <string name="notif_hub_troubleshooting_subtitle">Test · sıfırla · pil optimizasyonu</string>
+    <string name="notif_hub_prayers_title">Namazlar</string>
+    <string name="notif_hub_weekly_title">Haftalık</string>
+    <string name="notif_hub_sound_title">Ezan &amp; ses</string>
 
     <!-- Gece ibadeti merkezi (Teheccud / Vitir hedefi) -->
     <string name="night_worship_title">Gece İbadeti</string>
@@ -1720,4 +1701,54 @@
     <string name="night_worship_why_body">&quot;Rabbimiz dünya semasına iner…&quot;</string>
     <string name="widget_location">Konum</string>
     <string name="widget_tomorrow">Yarın</string>
+
+    <!-- Notifications rework: per-prayer alert style, reminders, diagnostics -->
+    <string name="notif_hub_diagnostics_title">Tanılama</string>
+    <string name="notif_hub_diagnostics_subtitle">Bildirimleri engelleyebilecek şeyleri denetle</string>
+    <string name="notif_hub_count_of">%2$d içinden %1$d</string>
+    <string name="notif_hub_count_on">%1$d açık</string>
+    <string name="notif_hub_worship_subtitle">Teheccüd, Vitir, Sahur, İftar ve daha fazlası</string>
+    <string name="notif_hub_delivery_warning">Bu cihazda bildirimler zamanında ulaşmayabilir.</string>
+    <string name="notif_hub_weekly_both">Cuma ve hatim açık</string>
+    <string name="notif_hub_weekly_jumuah">Cuma açık · hatim kapalı</string>
+    <string name="notif_hub_weekly_khatam">Hatim açık · Cuma kapalı</string>
+    <string name="notif_hub_weekly_none">İkisi de kapalı</string>
+    <string name="notif_hub_sound_dnd">%1$s · Rahatsız Etmeyin dikkate alınır</string>
+    <string name="notif_hub_sound_vibration">%1$s · titreşim açık</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+    <string name="notif_prayers_section">Günlük namazlar</string>
+    <string name="notif_alert_style">Bildirim türü</string>
+    <string name="notif_alert_style_adhan">Ezan</string>
+    <string name="notif_alert_style_adhan_subtitle">Ezan sesli olarak okunur</string>
+    <string name="notif_alert_style_notification">Yalnızca bildirim</string>
+    <string name="notif_alert_style_notification_subtitle">Olağan bildirim sesi</string>
+    <string name="notif_alert_style_silent">Sessiz</string>
+    <string name="notif_alert_style_silent_subtitle">Görünür ve bekler — ses yok, titreşim yok</string>
+    <string name="notif_reminder_before">Önceden hatırlatma</string>
+    <string name="notif_reminder_none">Hatırlatma yok</string>
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Kapalı</string>
+    <string name="notif_sunrise">Gün doğumu</string>
+    <string name="notif_sunrise_subtitle">Sabah vakti kapanırken kısa bir uyarı</string>
+    <string name="notif_sound_voice">Ezan sesi</string>
+    <string name="worship_settings_ramadan_notice">Ramazan hatırlatıcıları Ramazan başlayana kadar sessiz kalır. Şimdi ayarlayın, kendiliğinden başlarlar.</string>
+    <string name="notif_diag_status_section">Cihaz denetimleri</string>
+    <string name="notif_diag_permission">Bildirim izni</string>
+    <string name="notif_diag_granted">Verildi</string>
+    <string name="notif_diag_blocked">Engellendi</string>
+    <string name="notif_diag_exact_alarms">Tam zamanlı alarmlar</string>
+    <string name="notif_diag_allowed">İzin verildi</string>
+    <string name="notif_diag_not_allowed">İzin verilmedi</string>
+    <string name="notif_diag_battery">Pil optimizasyonu</string>
+    <string name="notif_diag_unrestricted">Kısıtlamasız</string>
+    <string name="notif_diag_restricted">Kısıtlı</string>
+    <string name="notif_diag_needs_attention">İlgilenilmeli</string>
+    <string name="notif_diag_reset_confirm_title">Bildirimler sıfırlansın mı?</string>
+    <string name="notif_diag_reset_confirm_body">Zamanlanmış her bildirim iptal edilip mevcut ayarlarınızdan yeniden kurulur. Ayarlarınız değişmez.</string>
+    <string name="notif_diag_reset_confirm_action">Sıfırla</string>
+    <string name="prayer_settings_fajr_reminder">Sabah hatırlatması</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="one">%1$d dk önce</item>
+        <item quantity="other">%1$d dk önce</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,6 +542,9 @@
     <string name="notif_sunrise">Sunrise</string>
     <string name="notif_sunrise_subtitle">A beep when Fajr\'s window closes</string>
 
+    <string name="notif_sound_voice">Adhan voice</string>
+    <string name="worship_settings_ramadan_notice">Ramadan reminders stay quiet until Ramadan begins. Set them up now and they will start on their own.</string>
+
     <!-- Diagnostics: every row states something read from the device. -->
     <string name="notif_diag_status_section">Device checks</string>
     <string name="notif_diag_permission">Notification permission</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,8 +558,8 @@
     <string name="notif_diag_unrestricted">Unrestricted</string>
     <string name="notif_diag_restricted">Restricted</string>
     <string name="notif_diag_needs_attention">Needs attention</string>
-    <string name="notif_diag_reset_confirm_title">Reset notifications?</string>
-    <string name="notif_diag_reset_confirm_body">Every scheduled alert is cancelled and rebuilt from your current settings. Your settings themselves are not changed.</string>
+    <string name="notif_diag_reset_confirm_title">Reset all notifications?</string>
+    <string name="notif_diag_reset_confirm_body">Every scheduled alarm is cancelled and rebuilt from your current settings. Your choices are kept — only the schedule is redrawn.</string>
     <string name="notif_diag_reset_confirm_action">Reset</string>
 
     <!-- Home "Next Worship" card labels -->
@@ -1055,11 +1055,11 @@
     <string name="notif_friday_3">Don\'t forget to read Surah Al-Kahf this blessed Friday.</string>
     <string name="notif_friday_bigtext">Prepare for Jummah: perform ghusl, wear your best clothes, apply perfume, read Surah Al-Kahf, and arrive early. \n\n\"O you who believe! When the call is made for prayer on Friday, hasten to the remembrance of Allah.\" — Quran 62:9</string>
     <string name="notification_settings_troubleshooting_section">TROUBLESHOOTING</string>
-    <string name="notification_settings_test">Test Notification</string>
+    <string name="notification_settings_test">Send a test notification</string>
     <string name="notification_settings_test_sent">Test notification sent</string>
-    <string name="notification_settings_test_all">Test All Prayers</string>
+    <string name="notification_settings_test_all">Test all five prayers</string>
     <string name="notification_settings_test_all_sent">Testing all prayer notifications…</string>
-    <string name="notification_settings_reset">Reset Notifications</string>
+    <string name="notification_settings_reset">Reset and reschedule</string>
     <string name="notification_settings_reset_success">Notifications reset successfully</string>
     <string name="notification_settings_battery_section">BATTERY OPTIMIZATION</string>
     <string name="notification_settings_battery_title">Battery Optimization</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,6 +543,7 @@
     <string name="notif_sunrise_subtitle">A beep when Fajr\'s window closes</string>
 
     <string name="notif_sound_voice">Adhan voice</string>
+    <string name="prayer_settings_fajr_reminder">Fajr reminder</string>
     <string name="worship_settings_ramadan_notice">Ramadan reminders stay quiet until Ramadan begins. Set them up now and they will start on their own.</string>
 
     <!-- Diagnostics: every row states something read from the device. -->
@@ -1019,16 +1020,9 @@
     <!-- Notification Settings Screen -->
     <string name="notification_settings_enable">Enable Notifications</string>
     <string name="notification_settings_enable_subtitle">Receive prayer time alerts</string>
-    <string name="notification_settings_prayer_section">PRAYER NOTIFICATIONS</string>
     <string name="notification_settings_adhan_section">ADHAN SOUND</string>
     <string name="notification_settings_enable_adhan">Enable Adhan Sound</string>
     <string name="notification_settings_enable_adhan_subtitle">Play adhan at prayer times</string>
-    <string name="notification_settings_additional_section">ADDITIONAL ALERTS</string>
-    <string name="notification_settings_pre_adhan">Pre-Adhan Reminder</string>
-    <plurals name="notification_settings_pre_adhan_subtitle">
-        <item quantity="one">%1$d minute before</item>
-        <item quantity="other">%1$d minutes before</item>
-    </plurals>
 
     <!-- Adhan Download Notifications -->
     <string name="adhan_download_channel_name">Adhan Downloads</string>
@@ -1045,8 +1039,6 @@
     <string name="adhan_download_failed">Adhan download failed</string>
     <string name="adhan_download_failed_subtitle">Check your internet connection and try again</string>
 
-    <string name="notification_settings_sunrise">Sunrise Alert</string>
-    <string name="notification_settings_sunrise_subtitle">End of Fajr prayer time</string>
     <string name="notification_settings_friday_reminder">Friday (Jummah) Reminder</string>
     <string name="notification_settings_friday_subtitle">Weekly reminder before Friday prayer</string>
     <string name="notification_settings_lead_time">Lead time</string>
@@ -1076,10 +1068,6 @@
     <string name="notification_settings_battery_exempted">Exempted</string>
     <string name="notification_settings_battery_explanation">When battery optimization is enabled, Android may delay or skip prayer notifications to save battery. Disabling it ensures notifications arrive on time.</string>
     <string name="notification_settings_disable_battery">Disable Battery Optimization</string>
-    <string name="notification_settings_info_banner">Make sure to enable notifications in your device settings and disable battery optimization for accurate prayer alerts.</string>
-    <string name="notification_settings_prayer_notification">Prayer notification</string>
-    <string name="notification_settings_sound_on">Sound on</string>
-    <string name="notification_settings_sound_off">Sound off</string>
     <string name="notification_settings_preview">Preview</string>
 
     <!-- Prayer notification copy (non-scripture UI strings) -->
@@ -1568,7 +1556,6 @@
     <string name="twilight_angle">Twilight Angle</string>
     <string name="manual_adjustments">Manual Adjustments (Minutes)</string>
     <string name="adhan_notifications">Adhan Notifications</string>
-    <string name="pre_adhan_reminder">Pre-Adhan Reminder</string>
     <!-- Prayer Settings summary subtitles that mirror the Notification Settings screen -->
     <string name="prayer_settings_notifications_off">Notifications off</string>
     <string name="prayer_settings_all_prayers_enabled">All prayers enabled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -502,15 +502,61 @@
     <string name="worship_witr_mode_after_isha">After Isha</string>
     <string name="worship_witr_mode_before_fajr">Before Fajr</string>
 
-    <!-- Notification settings hub (#301) -->
-    <string name="notif_hub_prayers_title">Prayer notifications</string>
-    <string name="notif_hub_prayers_subtitle">5 daily prayers · pre-adhan · sunrise</string>
-    <string name="notif_hub_weekly_title">Weekly &amp; reading</string>
-    <string name="notif_hub_weekly_subtitle">Jumu\'ah · Khatam reminder</string>
-    <string name="notif_hub_sound_title">Sound &amp; delivery</string>
-    <string name="notif_hub_sound_subtitle">Adhan · muezzin · vibration · Do Not Disturb</string>
-    <string name="notif_hub_troubleshooting_title">Troubleshooting</string>
-    <string name="notif_hub_troubleshooting_subtitle">Test · reset · battery optimization</string>
+    <!-- Notification settings hub (#301). Each row's subtitle reports the live setting
+         rather than describing what the screen contains. -->
+    <string name="notif_hub_prayers_title">Prayers</string>
+    <string name="notif_hub_weekly_title">Weekly</string>
+    <string name="notif_hub_sound_title">Adhan &amp; sound</string>
+    <string name="notif_hub_diagnostics_title">Diagnostics</string>
+    <string name="notif_hub_diagnostics_subtitle">Check what could stop alerts arriving</string>
+    <string name="notif_hub_count_of">%1$d of %2$d</string>
+    <string name="notif_hub_count_on">%1$d on</string>
+    <string name="notif_hub_worship_subtitle">Tahajjud, Witr, Suhoor, Iftar and more</string>
+    <string name="notif_hub_delivery_warning">Alerts may not arrive on time on this device.</string>
+    <string name="notif_hub_weekly_both">Jumu\'ah and khatam on</string>
+    <string name="notif_hub_weekly_jumuah">Jumu\'ah on · khatam off</string>
+    <string name="notif_hub_weekly_khatam">Khatam on · Jumu\'ah off</string>
+    <string name="notif_hub_weekly_none">Both off</string>
+    <string name="notif_hub_sound_dnd">%1$s · Do Not Disturb honoured</string>
+    <string name="notif_hub_sound_vibration">%1$s · vibration on</string>
+    <string name="notif_hub_sound_plain">%1$s</string>
+
+    <!-- Per-prayer alert style and reminder -->
+    <string name="notif_prayers_section">Daily prayers</string>
+    <string name="notif_alert_style">Alert style</string>
+    <string name="notif_alert_style_adhan">Adhan</string>
+    <string name="notif_alert_style_adhan_subtitle">The call to prayer plays aloud</string>
+    <string name="notif_alert_style_notification">Notification only</string>
+    <string name="notif_alert_style_notification_subtitle">The standard notification tone</string>
+    <string name="notif_alert_style_silent">Silent</string>
+    <string name="notif_alert_style_silent_subtitle">It appears and waits — no sound, no vibration</string>
+    <string name="notif_reminder_before">Reminder before</string>
+    <string name="notif_reminder_none">No reminder</string>
+    <plurals name="notif_reminder_minutes_before">
+        <item quantity="one">%1$d min before</item>
+        <item quantity="other">%1$d min before</item>
+    </plurals>
+    <!-- Header summary: the alert style, then how far ahead the reminder lands. -->
+    <string name="notif_prayer_summary">%1$s · %2$s</string>
+    <string name="notif_prayer_off">Off</string>
+    <string name="notif_sunrise">Sunrise</string>
+    <string name="notif_sunrise_subtitle">A beep when Fajr\'s window closes</string>
+
+    <!-- Diagnostics: every row states something read from the device. -->
+    <string name="notif_diag_status_section">Device checks</string>
+    <string name="notif_diag_permission">Notification permission</string>
+    <string name="notif_diag_granted">Granted</string>
+    <string name="notif_diag_blocked">Blocked</string>
+    <string name="notif_diag_exact_alarms">Exact alarms</string>
+    <string name="notif_diag_allowed">Allowed</string>
+    <string name="notif_diag_not_allowed">Not allowed</string>
+    <string name="notif_diag_battery">Battery optimisation</string>
+    <string name="notif_diag_unrestricted">Unrestricted</string>
+    <string name="notif_diag_restricted">Restricted</string>
+    <string name="notif_diag_needs_attention">Needs attention</string>
+    <string name="notif_diag_reset_confirm_title">Reset notifications?</string>
+    <string name="notif_diag_reset_confirm_body">Every scheduled alert is cancelled and rebuilt from your current settings. Your settings themselves are not changed.</string>
+    <string name="notif_diag_reset_confirm_action">Reset</string>
 
     <!-- Home "Next Worship" card labels -->
     <string name="worship_card_begins">Begins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1054,7 +1054,7 @@
     <string name="notif_friday_2">It\'s Friday. Make ghusl and head to Jummah early.</string>
     <string name="notif_friday_3">Don\'t forget to read Surah Al-Kahf this blessed Friday.</string>
     <string name="notif_friday_bigtext">Prepare for Jummah: perform ghusl, wear your best clothes, apply perfume, read Surah Al-Kahf, and arrive early. \n\n\"O you who believe! When the call is made for prayer on Friday, hasten to the remembrance of Allah.\" — Quran 62:9</string>
-    <string name="notification_settings_troubleshooting_section">TROUBLESHOOTING</string>
+    <string name="notif_diag_actions_section">Check delivery</string>
     <string name="notification_settings_test">Send a test notification</string>
     <string name="notification_settings_test_sent">Test notification sent</string>
     <string name="notification_settings_test_all">Test all five prayers</string>

--- a/app/src/test/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/navigation/AnnouncementRoutesTest.kt
@@ -24,7 +24,10 @@ class AnnouncementRoutesTest {
         assertThat(announcementRoute("settings/notifications/prayers")).isEqualTo(Route.SettingsNotificationsPrayers)
         assertThat(announcementRoute("settings/notifications/weekly")).isEqualTo(Route.SettingsNotificationsWeekly)
         assertThat(announcementRoute("settings/notifications/sound")).isEqualTo(Route.SettingsNotificationsSound)
-        assertThat(announcementRoute("settings/notifications/troubleshooting")).isEqualTo(Route.SettingsNotificationsTroubleshooting)
+        assertThat(announcementRoute("settings/notifications/diagnostics")).isEqualTo(Route.SettingsNotificationsDiagnostics)
+        // The screen was renamed from Troubleshooting to Diagnostics. This key is already
+        // published, so an announcement composed against the old name must still land.
+        assertThat(announcementRoute("settings/notifications/troubleshooting")).isEqualTo(Route.SettingsNotificationsDiagnostics)
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerAlarmTimesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerAlarmTimesTest.kt
@@ -1,0 +1,68 @@
+package com.arshadshah.nimaz.core.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * The arithmetic behind a pre-adhan reminder: when it lands, and what instant the alarm is
+ * armed for. Both are easy to get subtly wrong — a reminder before an early Fajr belongs to
+ * the previous day, and a wall-clock time inside a spring-forward gap does not exist at all.
+ */
+class PrayerAlarmTimesTest {
+
+    private val dublin = ZoneId.of("Europe/Dublin")
+
+    @Test
+    fun `a reminder lands the given number of minutes before the prayer`() {
+        val fajr = LocalDateTime.of(2026, 8, 4, 5, 12)
+
+        assertThat(PrayerAlarmTimes.preReminderAt(fajr, 10))
+            .isEqualTo(LocalDateTime.of(2026, 8, 4, 5, 2))
+    }
+
+    @Test
+    fun `a reminder before an early prayer crosses back over midnight`() {
+        // Fajr at 00:05 with a 10-minute lead belongs to the previous day, not to 00:55.
+        val fajr = LocalDateTime.of(2026, 6, 21, 0, 5)
+
+        assertThat(PrayerAlarmTimes.preReminderAt(fajr, 10))
+            .isEqualTo(LocalDateTime.of(2026, 6, 20, 23, 55))
+    }
+
+    @Test
+    fun `arming an alarm resolves the wall clock in the given zone`() {
+        val time = LocalDateTime.of(2026, 8, 4, 5, 12)
+
+        assertThat(PrayerAlarmTimes.triggerMillis(time, dublin))
+            .isEqualTo(time.atZone(dublin).toInstant().toEpochMilli())
+    }
+
+    @Test
+    fun `a reminder falling inside the spring-forward gap still arms`() {
+        // Europe/Dublin jumps 01:00 to 02:00 on 2026-03-29, so 01:30 never happens.
+        // A prayer at 01:35 with a 10-minute lead computes 01:25 — a wall-clock time with
+        // no instant. It must resolve forward rather than throw or silently drop the alarm.
+        val prayer = LocalDateTime.of(2026, 3, 29, 1, 35)
+        val reminder = PrayerAlarmTimes.preReminderAt(prayer, 10)
+        assertThat(reminder).isEqualTo(LocalDateTime.of(2026, 3, 29, 1, 25))
+
+        val armed = PrayerAlarmTimes.triggerMillis(reminder, dublin)
+        // 01:25 IST-gap resolves to 02:25 local, which is 01:25 UTC.
+        assertThat(armed).isEqualTo(
+            LocalDateTime.of(2026, 3, 29, 2, 25).atZone(dublin).toInstant().toEpochMilli()
+        )
+    }
+
+    @Test
+    fun `a reminder in the autumn overlap picks the earlier of the two instants`() {
+        // Dublin repeats 01:00-02:00 on 2026-10-25. A reminder at 01:30 is ambiguous;
+        // taking the earlier offset means the reminder never fires after its prayer.
+        val reminder = LocalDateTime.of(2026, 10, 25, 1, 30)
+
+        assertThat(PrayerAlarmTimes.triggerMillis(reminder, dublin)).isEqualTo(
+            reminder.atZone(dublin).withEarlierOffsetAtOverlap().toInstant().toEpochMilli()
+        )
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerAlertChannelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerAlertChannelTest.kt
@@ -1,0 +1,71 @@
+package com.arshadshah.nimaz.core.util
+
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Which notification channel each alert style lands on.
+ *
+ * The channel is the whole mechanism: Android decides sound and heads-up from it, and will
+ * not let an existing channel's importance be lowered from code. So "silent" is not a flag
+ * on a notification — it is a different channel, and picking the wrong one is the failure
+ * mode where a prayer someone silenced still shouts at them.
+ */
+class PrayerAlertChannelTest {
+
+    @Test
+    fun `a silenced prayer posts on the muted channel whatever the vibration preference says`() {
+        assertThat(PrayerNotificationScheduler.channelForPrayer(vibrate = true, muted = true))
+            .isEqualTo(PrayerNotificationScheduler.CHANNEL_ID_PRAYER_MUTED)
+        assertThat(PrayerNotificationScheduler.channelForPrayer(vibrate = false, muted = true))
+            .isEqualTo(PrayerNotificationScheduler.CHANNEL_ID_PRAYER_MUTED)
+    }
+
+    @Test
+    fun `an audible prayer still honours the vibration preference`() {
+        assertThat(PrayerNotificationScheduler.channelForPrayer(vibrate = true))
+            .isEqualTo(PrayerNotificationScheduler.CHANNEL_ID_PRAYER)
+        assertThat(PrayerNotificationScheduler.channelForPrayer(vibrate = false))
+            .isEqualTo(PrayerNotificationScheduler.CHANNEL_ID_PRAYER_SILENT)
+    }
+
+    @Test
+    fun `the no-vibration channel is not the silent one`() {
+        // The regression this guards: CHANNEL_ID_PRAYER_SILENT reads like silence but is a
+        // no-vibration sibling at IMPORTANCE_HIGH that still carries the channel sound.
+        assertThat(PrayerNotificationScheduler.CHANNEL_ID_PRAYER_SILENT)
+            .isNotEqualTo(PrayerNotificationScheduler.CHANNEL_ID_PRAYER_MUTED)
+    }
+
+    @Test
+    fun `the adhan style falls back to a plain notification when the global switch is off`() {
+        // The global adhan switch stays a master gate over the per-prayer style, so turning
+        // it off silences the call everywhere without rewriting five styles.
+        assertThat(PrayerAlertStyle.ADHAN.playsAdhan(globalAdhanEnabled = true)).isTrue()
+        assertThat(PrayerAlertStyle.ADHAN.playsAdhan(globalAdhanEnabled = false)).isFalse()
+        assertThat(PrayerAlertStyle.NOTIFICATION.playsAdhan(globalAdhanEnabled = true)).isFalse()
+        assertThat(PrayerAlertStyle.SILENT.playsAdhan(globalAdhanEnabled = true)).isFalse()
+    }
+
+    @Test
+    fun `sunrise never takes a style of its own`() {
+        // Sunrise gets a beep, never the adhan, and cannot be silenced independently —
+        // it is the end of Fajr's window rather than a prayer with settings.
+        assertThat(PrayerAlertStyle.ADHAN.playsAdhan(globalAdhanEnabled = true, isSunrise = true))
+            .isFalse()
+        assertThat(PrayerAlertStyle.SILENT.isMuted(isSunrise = true)).isFalse()
+        assertThat(PrayerAlertStyle.SILENT.isMuted()).isTrue()
+    }
+
+    @Test
+    fun `an unrecognised stored style reads as a plain notification`() {
+        // A preference written by a newer build, or a value that never existed, must not
+        // silence a prayer or start playing the adhan unasked.
+        assertThat(PrayerAlertStyle.fromStorage(null)).isEqualTo(PrayerAlertStyle.NOTIFICATION)
+        assertThat(PrayerAlertStyle.fromStorage("")).isEqualTo(PrayerAlertStyle.NOTIFICATION)
+        assertThat(PrayerAlertStyle.fromStorage("VIBRATE_ONLY"))
+            .isEqualTo(PrayerAlertStyle.NOTIFICATION)
+        assertThat(PrayerAlertStyle.fromStorage("ADHAN")).isEqualTo(PrayerAlertStyle.ADHAN)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/datastore/PrayerNotificationPrefsMigrationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/datastore/PrayerNotificationPrefsMigrationTest.kt
@@ -1,0 +1,114 @@
+package com.arshadshah.nimaz.data.local.datastore
+
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The notifications rework splits two global preferences into five per-prayer ones: the
+ * adhan on/off pair becomes a three-way alert style, and the single pre-adhan reminder
+ * becomes a reminder per prayer.
+ *
+ * Existing installs must come through that split with their settings intact. Somebody who
+ * set a 30-minute pre-adhan reminder has to end up with a 30-minute reminder on all five
+ * prayers, not a reset to the 15-minute default — which is what these cases pin.
+ */
+class PrayerNotificationPrefsMigrationTest {
+
+    private val allPrayers = listOf("fajr", "dhuhr", "asr", "maghrib", "isha")
+
+    private fun legacy(
+        adhanEnabled: Boolean = false,
+        perPrayerAdhan: Map<String, Boolean> = emptyMap(),
+        showReminderBefore: Boolean = true,
+        reminderMinutes: Int = 15,
+    ) = LegacyPrayerNotificationPrefs(
+        adhanEnabled = adhanEnabled,
+        perPrayerAdhanEnabled = allPrayers.associateWith { perPrayerAdhan[it] ?: true },
+        showReminderBefore = showReminderBefore,
+        reminderMinutes = reminderMinutes,
+    )
+
+    @Test
+    fun `a global pre-adhan value carries to every prayer`() {
+        val migrated = PrayerNotificationPrefsMigration.plan(
+            legacy(showReminderBefore = true, reminderMinutes = 30)
+        )
+
+        assertThat(migrated.reminderMinutes.keys).containsExactlyElementsIn(allPrayers)
+        assertThat(migrated.reminderMinutes.values.toSet()).containsExactly(30)
+        assertThat(migrated.reminderEnabled.values.toSet()).containsExactly(true)
+    }
+
+    @Test
+    fun `a pre-adhan reminder that was off stays off everywhere`() {
+        val migrated = PrayerNotificationPrefsMigration.plan(
+            legacy(showReminderBefore = false, reminderMinutes = 25)
+        )
+
+        assertThat(migrated.reminderEnabled.values.toSet()).containsExactly(false)
+        // The minutes are still carried, so turning a prayer's reminder back on restores
+        // the lead time the user last chose rather than the default.
+        assertThat(migrated.reminderMinutes.values.toSet()).containsExactly(25)
+    }
+
+    @Test
+    fun `adhan on globally and per prayer becomes the adhan style`() {
+        val migrated = PrayerNotificationPrefsMigration.plan(legacy(adhanEnabled = true))
+
+        assertThat(migrated.alertStyle.values.toSet()).containsExactly(PrayerAlertStyle.ADHAN)
+    }
+
+    @Test
+    fun `a prayer with the adhan turned off becomes notification only`() {
+        val migrated = PrayerNotificationPrefsMigration.plan(
+            legacy(adhanEnabled = true, perPrayerAdhan = mapOf("dhuhr" to false))
+        )
+
+        assertThat(migrated.alertStyle["dhuhr"]).isEqualTo(PrayerAlertStyle.NOTIFICATION)
+        assertThat(migrated.alertStyle["fajr"]).isEqualTo(PrayerAlertStyle.ADHAN)
+    }
+
+    @Test
+    fun `the adhan off globally makes every prayer notification only`() {
+        // ADHAN_ENABLED defaults to false, so this is the path most installs take.
+        val migrated = PrayerNotificationPrefsMigration.plan(
+            legacy(adhanEnabled = false, perPrayerAdhan = allPrayers.associateWith { true })
+        )
+
+        assertThat(migrated.alertStyle.values.toSet())
+            .containsExactly(PrayerAlertStyle.NOTIFICATION)
+    }
+
+    @Test
+    fun `migration never silences a prayer on its own`() {
+        // Nothing in the old model expressed "silent", so nothing may migrate to it —
+        // a user who has never asked for silence must not find a prayer gone quiet.
+        val migrated = PrayerNotificationPrefsMigration.plan(legacy(adhanEnabled = true))
+
+        assertThat(migrated.alertStyle.values).doesNotContain(PrayerAlertStyle.SILENT)
+    }
+
+    @Test
+    fun `a lead time outside the stepper's range is clamped into it`() {
+        // The stepper offers 5-60. A stored value outside that (an old build, a hand-edited
+        // preference file) would otherwise render a value the user cannot get back to.
+        assertThat(
+            PrayerNotificationPrefsMigration.plan(legacy(reminderMinutes = 0))
+                .reminderMinutes.values.toSet()
+        ).containsExactly(5)
+        assertThat(
+            PrayerNotificationPrefsMigration.plan(legacy(reminderMinutes = 240))
+                .reminderMinutes.values.toSet()
+        ).containsExactly(60)
+    }
+
+    @Test
+    fun `sunrise is not part of the split`() {
+        // Sunrise has no adhan and no pre-reminder — it is a plain alert and stays one.
+        val migrated = PrayerNotificationPrefsMigration.plan(legacy())
+
+        assertThat(migrated.alertStyle).doesNotContainKey("sunrise")
+        assertThat(migrated.reminderMinutes).doesNotContainKey("sunrise")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/AyahDivisionsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/AyahDivisionsTest.kt
@@ -57,7 +57,35 @@ class AyahDivisionsTest {
     fun `division markers default to absent so an unseeded device shows none`() {
         val plain = ayah(rub = 0)
         assertThat(plain.isRubStart).isFalse()
-        assertThat(plain.isRukuStart).isFalse()
+        assertThat(plain.isRukuEnd).isFalse()
         assertThat(plain.rukuNumber).isNull()
+    }
+
+    @Test
+    fun `the ruku marker closes its section while the hizb marker opens its quarter`() {
+        // The two divisions use opposite conventions, which is the regression this guards:
+        // the ʿayn (ع) ends a rukūʿ in a printed Mushaf, the ۞ begins a hizb quarter. Reading
+        // both off a "start" flag put the rukūʿ marker one whole section too early.
+        val fatihaLastVerse = ayah(rub = 1).copy(
+            ayahNumber = 7,
+            rukuNumber = 1,
+            isRukuEnd = true,
+            isRubStart = false,
+        )
+        val fatihaFirstVerse = ayah(rub = 1).copy(
+            ayahNumber = 1,
+            rukuNumber = 1,
+            isRukuEnd = false,
+            isRubStart = true,
+        )
+
+        // Al-Fātiḥah is a single rukūʿ over all seven verses. Its ʿayn belongs on verse 7…
+        assertThat(fatihaLastVerse.isRukuEnd).isTrue()
+        // …and never on verse 1, which is where it used to render.
+        assertThat(fatihaFirstVerse.isRukuEnd).isFalse()
+        // The quarter marker is the other way round: 1:1 opens hizb 1.
+        assertThat(fatihaFirstVerse.isRubStart).isTrue()
+        assertThat(fatihaFirstVerse.quarterInHizb).isEqualTo(1)
+        assertThat(fatihaFirstVerse.hizbOfQuarter).isEqualTo(1)
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveLocalEventsUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveLocalEventsUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.domain.usecase
 
 import com.arshadshah.nimaz.domain.model.CelebrationEvent
 import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.Flow
@@ -130,6 +131,17 @@ private class FakeSettings(private val offset: Int) : SettingsRepository {
     override suspend fun setNotificationReminderMinutes(minutes: Int) {}
     override val showReminderBefore: Flow<Boolean> = flowOf(true)
     override suspend fun setShowReminderBefore(enabled: Boolean) {}
+    override fun prayerAlertStyle(prayer: String): Flow<PrayerAlertStyle> =
+        flowOf(PrayerAlertStyle.NOTIFICATION)
+
+    override suspend fun setPrayerAlertStyle(prayer: String, style: PrayerAlertStyle) {}
+    override fun prayerReminderEnabled(prayer: String): Flow<Boolean> = flowOf(false)
+    override suspend fun setPrayerReminderEnabled(prayer: String, enabled: Boolean) {}
+    override fun prayerReminderMinutes(prayer: String): Flow<Int> =
+        flowOf(PrayerAlertStyle.DEFAULT_REMINDER_MINUTES)
+
+    override suspend fun setPrayerReminderMinutes(prayer: String, minutes: Int) {}
+    override suspend fun migratePrayerNotificationPreferences() {}
     override val persistentNotification: Flow<Boolean> = flowOf(false)
     override suspend fun setPersistentNotification(enabled: Boolean) {}
     override val fridayReminderEnabled: Flow<Boolean> = flowOf(false)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/components/molecules/MushafVerseEndGlyphTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/components/molecules/MushafVerseEndGlyphTest.kt
@@ -1,0 +1,49 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Where the line-accurate reader puts a rukūʿ or sajda sign.
+ *
+ * The sign follows the verse it belongs to, so the renderer has to know which word ends the
+ * verse. It cannot use "the last word of this ayah on this page" — an ayah can run onto the
+ * next page, and the sign would then be drawn twice, or in the middle of the verse. The
+ * anchor is the verse's own end glyph, which the IndoPak text closes every ayah with.
+ *
+ * These cases are the glyphs taken from the shipped text: `۟` alone mid-surah, and `۟۠` with
+ * the ornament that follows a surah's final verse (1:7).
+ */
+class MushafVerseEndGlyphTest {
+
+    @Test
+    fun `the verse-end glyph is recognised on its own`() {
+        // Al-Fātiḥah 1:1 — "…ٱلرَّحِیْمِ ۟"
+        assertThat(endsVerse("۟")).isTrue()
+    }
+
+    @Test
+    fun `the surah-closing form is recognised too`() {
+        // Al-Fātiḥah 1:7 ends "۟۠" — the same zero plus the end-of-surah ornament. This is
+        // the verse that now carries Al-Fātiḥah's rukūʿ sign, so missing it would put the
+        // whole fix back where it started.
+        assertThat(endsVerse("۟۠")).isTrue()
+        assertThat(endsVerse("۠")).isTrue()
+    }
+
+    @Test
+    fun `an ordinary word does not end a verse`() {
+        assertThat(endsVerse("ٱلْحَمْدُ")).isFalse()
+        assertThat(endsVerse("لِلَّهِ")).isFalse()
+        assertThat(endsVerse("")).isFalse()
+    }
+
+    @Test
+    fun `a word carrying the glyph inline still ends the verse`() {
+        // Some layouts attach the glyph to the final word rather than splitting it out.
+        assertThat(endsVerse("ٱلضَّآلِّینَ۟")).isTrue()
+    }
+
+    /** The renderer's own rule, not a copy of it. */
+    private fun endsVerse(word: String): Boolean = word.endsOfVerse()
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationHubSubtitlesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationHubSubtitlesTest.kt
@@ -1,0 +1,45 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The notifications hub reports live settings rather than describing its screens, so each
+ * subtitle is a claim about the app's state. These cases pin the claims: a row that says
+ * "both on" when only one is would be worse than the static copy it replaced.
+ */
+class NotificationHubSubtitlesTest {
+
+    @Test
+    fun `the weekly row names exactly what is on`() {
+        assertThat(NotificationHubSubtitles.weekly(jumuahEnabled = true, khatamEnabled = true))
+            .isEqualTo(R.string.notif_hub_weekly_both)
+        assertThat(NotificationHubSubtitles.weekly(jumuahEnabled = true, khatamEnabled = false))
+            .isEqualTo(R.string.notif_hub_weekly_jumuah)
+        assertThat(NotificationHubSubtitles.weekly(jumuahEnabled = false, khatamEnabled = true))
+            .isEqualTo(R.string.notif_hub_weekly_khatam)
+        assertThat(NotificationHubSubtitles.weekly(jumuahEnabled = false, khatamEnabled = false))
+            .isEqualTo(R.string.notif_hub_weekly_none)
+    }
+
+    @Test
+    fun `Do Not Disturb outranks vibration on the sound row`() {
+        // DND is the rule that stops a sound the user is expecting, so it is the one worth
+        // the single line even when vibration is also on.
+        assertThat(NotificationHubSubtitles.sound(respectDnd = true, vibrationEnabled = true))
+            .isEqualTo(R.string.notif_hub_sound_dnd)
+        assertThat(NotificationHubSubtitles.sound(respectDnd = false, vibrationEnabled = true))
+            .isEqualTo(R.string.notif_hub_sound_vibration)
+        assertThat(NotificationHubSubtitles.sound(respectDnd = false, vibrationEnabled = false))
+            .isEqualTo(R.string.notif_hub_sound_plain)
+    }
+
+    @Test
+    fun `every alert style has its own label`() {
+        val labels = PrayerAlertStyle.entries.map { NotificationHubSubtitles.alertStyle(it) }
+        assertThat(labels).containsNoDuplicates()
+        assertThat(labels).hasSize(3)
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponentsTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/QuranSurahInfoComponentsTest.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.FormatListNumbered
+import androidx.compose.material.icons.filled.Layers
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -17,20 +19,27 @@ class QuranSurahInfoComponentsTest {
     @get:Rule
     val composeRule = createComponentComposeRule()
 
-    // ----- DetailCard -----
+    // ----- SurahMetaStrip -----
 
     @Test
-    fun detailCard_showsLabelAndValue() {
+    fun metaStrip_showsEveryStatsLabelAndValue() {
+        // Three elevated cards became one strip; the figures still have to be readable,
+        // and each label still has to sit with its own value.
         composeRule.setThemedContent {
-            DetailCard(
-                icon = Icons.AutoMirrored.Filled.MenuBook,
-                label = "Juz",
-                value = "1"
+            SurahMetaStrip(
+                stats = listOf(
+                    SurahMetaStat(Icons.Default.FormatListNumbered, "Verses", "286"),
+                    SurahMetaStat(Icons.Default.Layers, "Juz", "1"),
+                    SurahMetaStat(Icons.AutoMirrored.Filled.MenuBook, "Page", "2"),
+                )
             )
         }
 
+        composeRule.onNodeWithText("Verses").assertExists()
+        composeRule.onNodeWithText("286").assertExists()
         composeRule.onNodeWithText("Juz").assertExists()
-        composeRule.onNodeWithText("1").assertExists()
+        composeRule.onNodeWithText("Page").assertExists()
+        composeRule.onNodeWithText("2").assertExists()
     }
 
     // ----- SurahAudioControlBar -----

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -182,7 +182,7 @@ design-token / illustration files (see below).
 This one is **pervasive and lower priority** — listed so it's tracked, not because it's urgent.
 
 - [x] ~~**`PreferencesDataStore` injected directly** into many ViewModels.~~ **Resolved.**
-  Extracted a `domain/repository/SettingsRepository` interface (147 members); `PreferencesDataStore`
+  Extracted a `domain/repository/SettingsRepository` interface (180 members); `PreferencesDataStore`
   now implements it, and `UserPreferences` moved to `domain/model`. All 13 ViewModels + `MainActivity`
   inject `SettingsRepository`; bound via `@Binds` in `RepositoryModule`. Data-layer consumers
   (seeders, sync, workers, `AppInitializer`, `BootReceiver`) keep the concrete class.

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -154,7 +154,7 @@ flowchart LR
         Settings --> SettingsNotifications & SettingsHelp & SettingsAbout
         SettingsNotifications --> SettingsNotificationsPrayers & SettingsWorshipReminders
         SettingsNotifications --> SettingsNotificationsWeekly & SettingsNotificationsSound
-        SettingsNotifications --> SettingsNotificationsTroubleshooting
+        SettingsNotifications --> SettingsNotificationsDiagnostics
         SettingsQuran --> SelectReciter & SelectTranslation
         SettingsHelp --> HelpTopicDetail & HelpGuide
         SettingsAbout --> Licenses --> LicenseDetail
@@ -313,7 +313,7 @@ archive/delete, which previously lived behind an undiscoverable long-press on th
 | `SettingsWorshipReminders` | — | WorshipRemindersScreen (extended worship reminders: Tahajjud, Suhoor, Iftar, adhkar …; #300) |
 | `SettingsNotificationsWeekly` | — | NotificationWeeklyScreen (Jumu'ah · Khatam; #301) |
 | `SettingsNotificationsSound` | — | NotificationSoundScreen (adhan · muezzin · vibration · DND; #301) |
-| `SettingsNotificationsTroubleshooting` | — | NotificationTroubleshootingScreen (test · reset · battery; #301) |
+| `SettingsNotificationsDiagnostics` | — | NotificationDiagnosticsScreen (device checks · test · reset; #301) |
 | `SettingsAppearance` | — | AppearanceSettingsScreen |
 | `SettingsLanguage` | — | LanguageSettingsScreen |
 | `SettingsLocation` | — | LocationSettingsScreen |
@@ -418,7 +418,8 @@ only its CTA disappears.
 | `settings/notifications/prayers` | `SettingsNotificationsPrayers` (#301) |
 | `settings/notifications/weekly` | `SettingsNotificationsWeekly` (#301) |
 | `settings/notifications/sound` | `SettingsNotificationsSound` (#301) |
-| `settings/notifications/troubleshooting` | `SettingsNotificationsTroubleshooting` (#301) |
+| `settings/notifications/diagnostics` | `SettingsNotificationsDiagnostics` (#301) |
+| `settings/notifications/troubleshooting` | `SettingsNotificationsDiagnostics` — retained alias; the screen was renamed and this key is already published (#301) |
 
 ### 4.2 Parameterised grammar (pattern-matched after the allowlist)
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -149,6 +149,7 @@ is why vibration is modelled as a *pair* of channels rather than a per-notificat
 |---|---|---|---|---|
 | `prayer_notifications` | `CHANNEL_ID_PRAYER` | HIGH | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
 | `prayer_notifications_silent` | `CHANNEL_ID_PRAYER_SILENT` | HIGH, no vibration | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
+| `prayer_notifications_muted` | `CHANNEL_ID_PRAYER_MUTED` | LOW, no sound, no vibration | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
 | `adhan_notifications` | `CHANNEL_ID_ADHAN` | HIGH | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
 | `adhan_notifications_silent` | `CHANNEL_ID_ADHAN_SILENT` | HIGH, no vibration | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
 | `daily_summary_notifications` | `CHANNEL_ID_DAILY_SUMMARY` | DEFAULT | `PrayerNotificationScheduler` | [§4](#4-prayer-time--adhan-notifications) |
@@ -326,9 +327,14 @@ and re-scheduling on midnight rollover and boot.
 
 - **Vibration is a channel property.** Android ignores `enableVibration()` changes after a
   channel exists, so the `notificationVibration` preference is honoured by *posting on the
-  matching channel* via `channelForPrayer(vibrate)` / `channelForAdhan(vibrate)`, **not** by
-  per-notification `setVibrate` (kept only as the pre-O fallback). That is why the silent
+  matching channel* via `channelForPrayer(vibrate, muted)` / `channelForAdhan(vibrate)`, **not**
+  by per-notification `setVibrate` (kept only as the pre-O fallback). That is why the silent
   siblings exist at all.
+- **Silence is a third channel, not a flag.** The `*_SILENT` channels above are *no-vibration*
+  siblings — both are `IMPORTANCE_HIGH` and still carry the channel sound. A prayer set to the
+  `SILENT` alert style therefore posts on `prayer_notifications_muted` (`IMPORTANCE_LOW`,
+  `setSound(null, null)`), because importance cannot be lowered on an existing channel either.
+  `muted` wins over `vibrate` in `channelForPrayer`.
 - **The Khatam and worship channels take their name/description from string resources** rather
   than English literals, because they are the ones a user is most likely to meet in a
   non-English locale from a cold alarm process.
@@ -359,9 +365,54 @@ sequenceDiagram
     Note over BR,Sched: self-perpetuating daily chain —<br/>an alarm armed outside this call fires once and never again
 ```
 
-**Scheduling.** `scheduleTodaysPrayerNotifications(...)` cancels everything then re-arms enabled prayers, using `setExactAndAllowWhileIdle(RTC_WAKEUP, …)` with `PendingIntent.getBroadcast` targeting `BootReceiver` (explicit intent). Request codes: prayer `1000 + ordinal`, pre-reminder `2000 + ordinal`, midnight reschedule `9999` (00:01), daily summary `8889` (23:00), Friday reminder `8890`, Khatam reminder `8891`. Pre-reminders fire at `prayerTime − preReminderMinutes` (skipped for Sunrise); the lead time is **user-editable** (the pre-adhan stepper → `SetReminderMinutes`). The **Friday (Jummah) reminder** (`scheduleFridayReminder`, gated on `fridayReminderEnabled`) is a one-shot at the upcoming Friday's Dhuhr − `fridayReminderMinutes`, re-armed on every reschedule so it always targets the next Friday.
+**Scheduling.** `scheduleTodaysPrayerNotifications(...)` cancels everything then re-arms enabled prayers, using `setExactAndAllowWhileIdle(RTC_WAKEUP, …)` with `PendingIntent.getBroadcast` targeting `BootReceiver` (explicit intent). Request codes: prayer `1000 + ordinal`, pre-reminder `2000 + ordinal`, midnight reschedule `9999` (00:01), daily summary `8889` (23:00), Friday reminder `8890`, Khatam reminder `8891`. Pre-reminders fire at `prayerTime − preReminders[type]` (skipped for Sunrise) — see **per-prayer alert style and reminder** below. The **Friday (Jummah) reminder** (`scheduleFridayReminder`, gated on `fridayReminderEnabled`) is a one-shot at the upcoming Friday's Dhuhr − `fridayReminderMinutes`, re-armed on every reschedule so it always targets the next Friday.
 
-**Firing.** `BootReceiver.onReceive` dispatches on action: boot → reschedule; `ACTION_MIDNIGHT_RESCHEDULE` → mark missed prayers + reschedule (self-perpetuating daily chain); `ACTION_PRAYER_NOTIFICATION` → post notification &/or play adhan; `ACTION_DAILY_SUMMARY` → summary; `ACTION_FRIDAY_REMINDER` → post the Jummah reminder; `ACTION_KHATAM_REMINDER` → post the Khatam nudge. If adhan should play and the file exists, it calls `AdhanPlaybackService.playAdhan(...)` and the service's foreground notification **doubles as** the prayer notification (shared id `prayerName.hashCode()`); if the file is missing it triggers a download for next time and falls back to beep. **Do Not Disturb:** when `adhanRespectDnd` is on and the system is in a DND mode, `dndBlocksAdhan` gates only the **adhan audio** (`shouldPlayAdhan`/`shouldPlayBeep`) — the visual prayer notification is still posted, and the OS silences its channel sound under DND. The Friday reminder (no adhan audio) always posts and is likewise silenced by the OS under DND.
+**Firing.** `BootReceiver.onReceive` dispatches on action: boot → reschedule; `ACTION_MIDNIGHT_RESCHEDULE` → mark missed prayers + reschedule (self-perpetuating daily chain); `ACTION_PRAYER_NOTIFICATION` → post notification &/or play adhan; `ACTION_DAILY_SUMMARY` → summary; `ACTION_FRIDAY_REMINDER` → post the Jummah reminder; `ACTION_KHATAM_REMINDER` → post the Khatam nudge. If adhan should play and the file exists, it calls `AdhanPlaybackService.playAdhan(...)` and the service's foreground notification **doubles as** the prayer notification (shared id `prayerName.hashCode()`); if the file is missing it triggers a download for next time and falls back to beep. **Do Not Disturb:** when `adhanRespectDnd` is on and the system is in a DND mode, `dndBlocksAdhan` gates only the **adhan audio** (`shouldPlayAdhan`/`shouldPlayBeep`) — the visual prayer notification is still posted, and the OS silences its channel sound under DND. The `SILENT` alert style is different in kind: it is the user's own choice, so it silences the visual notification too. The Friday reminder (no adhan audio) always posts and is likewise silenced by the OS under DND.
+
+**Per-prayer alert style and reminder.** Each of the five prayers carries its own
+`PrayerAlertStyle` (`ADHAN` | `NOTIFICATION` | `SILENT`, `domain/model/PrayerAlertStyle.kt`) and
+its own reminder. Sunrise has neither — it is the end of Fajr's window, gets a beep, and never
+gets the adhan.
+
+The two are honoured at **different times**, which is the thing to keep straight:
+
+| Setting | Stored as | Read at | Consequence |
+|---|---|---|---|
+| Alert style | `<prayer>_alert_style` (String) | **fire time**, `BootReceiver.handlePrayerNotification` | changing it needs no rescheduling |
+| Reminder on/off | `<prayer>_reminder_enabled` (Boolean) | **schedule time** | changing it re-arms alarms |
+| Reminder lead time | `<prayer>_reminder_minutes` (Int) | **schedule time**, and rides on the alarm intent as `EXTRA_REMINDER_MINUTES` | the fired notification states the right number |
+
+`scheduleTodaysPrayerNotifications` takes `preReminders: Map<PrayerType, Int>` — a prayer absent
+from the map gets no reminder, which is how "off" is expressed rather than a zero offset. The
+three callers (`AppInitializer`, `BootReceiver`, `SettingsViewModel`) build it through
+`SettingsRepository.preReminderMinutesByPrayer()` (`core/util/PrayerNotificationPrefs.kt`) so they
+cannot drift. `PrayerAlertStyle.playsAdhan(globalAdhanEnabled, isSunrise)` and `.isMuted(isSunrise)`
+state the fire-time rules once: the global adhan switch stays a **master gate** over the per-prayer
+style, so turning the adhan off in Adhan & sound silences the call everywhere without rewriting
+five styles.
+
+Wall-clock arithmetic lives in `core/util/PrayerAlarmTimes.kt`, apart from the scheduler so it can
+be tested without an `AlarmManager`. A reminder before an early Fajr crosses back over midnight;
+a time inside a spring-forward gap resolves **forward** (an alarm slightly late beats one that
+never fires) and a time in an autumn overlap takes the **earlier** instant, so a reminder cannot
+land after the prayer it precedes.
+
+**Migration from the global settings.** These replaced one global adhan pair
+(`adhan_enabled` + `<prayer>_adhan_enabled`) and one global pre-adhan reminder
+(`show_reminder_before` + `notification_reminder_minutes`). `PrayerNotificationPrefsMigration`
+plans the split as a pure function; `PreferencesDataStore.migratePrayerNotificationPreferences()`
+applies it once, guarded by `notification_prefs_migration_version`, called from `AppInitializer`
+before anything reads the new keys. A prayer that was calling the adhan keeps calling it; the
+global lead time is copied onto all five; **nothing migrates to `SILENT`**, because the old model
+had no way to ask for silence. The legacy keys are left in place — read-only — so the migration
+has something to read on an install that has not run it yet.
+
+**Diagnostics.** `core/util/NotificationDiagnostics.read(context)` reports the three device
+prerequisites that can stop an alert arriving: the notification permission, exact-alarm
+permission (always true below API 31, where it does not exist) and battery-optimisation
+exemption. `hasProblem` drives the warning banner on the notifications hub and the badge on its
+Diagnostics row; the Diagnostics screen lists each check with its real state. Nothing that
+cannot be read from the OS is listed.
 
 **Khatam daily reminder.** `scheduleKhatamReminder()` is a one-shot at the user's stored
 `khatamReminderTime` ("HH:mm", default 06:00), gated on `khatamReminderEnabled`. Like every
@@ -870,7 +921,7 @@ the same trap applies the moment one is added.)
 
 **The wire loses the type, so the type is declared.** The export flattens every value with `toString()`, so the payload is `Map<String,String>`. The import used to *guess* the type back from the shape of the value and substrings of the key name; DataStore keys are typed and reading one at the wrong type throws, so the six keys the heuristic missed — `tasbih_preset_seed_version`, `content_patch_version`, `ai_consent_timestamp`, `tasbih_selected_preset`, `current_location_id` (Long guessed as Int) and `tasbih_favorites` — did not merely import wrong, they **crashed on next read after any sync**. `tasbih_preset_seed_version` is read with `.first()` in `TasbihViewModel`'s init and `current_location_id` resolves the active location for prayer times.
 
-`data/local/datastore/PreferenceCodec.kt` now holds the declared type of all 91 named keys plus three shape patterns for the runtime-composed `worship_<type>_{enabled,offset,mode}`. Sets are joined on the ASCII unit separator rather than `Set.toString()` (`[a, b]` cannot be split back safely), with the bracket form still accepted so payloads from older builds land. An unknown key from a newer sender is kept as a string rather than dropped. `onboarding_completed` is never imported. `PreferenceCodecTest` reads the key declarations straight out of `PreferencesDataStore.kt` and fails if the registry drifts from them, so a new preference cannot be added without registering its type.
+`data/local/datastore/PreferenceCodec.kt` now holds the declared type of every named key plus shape patterns for the runtime-composed ones — `worship_<type>_{enabled,offset,mode}` and the per-prayer `<prayer>_{alert_style,reminder_enabled,reminder_minutes}` ([§4](#4-prayer-time--adhan-notifications)). Sets are joined on the ASCII unit separator rather than `Set.toString()` (`[a, b]` cannot be split back safely), with the bracket form still accepted so payloads from older builds land. An unknown key from a newer sender is kept as a string rather than dropped. `onboarding_completed` is never imported. `PreferenceCodecTest` reads the key declarations straight out of `PreferencesDataStore.kt` and fails if the registry drifts from them, so a new preference cannot be added without registering its type.
 
 **Wiring.** Provided in `core/di/DataStoreModule.kt` via `@Provides @Singleton`. (Minor: it already has an `@Inject constructor(context)`, so the explicit provider is redundant with constructor injection.)
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -449,7 +449,7 @@ with copy from `WorshipReminderContent`. Prefs are generic dynamic keys
 (`worship_<key>_enabled` / `_offset` / `_mode`) on `SettingsRepository`/`PreferencesDataStore`. The
 notification settings screen is now a **hub** (`NotificationSettingsScreen`, #301) linking to focused
 subscreens — `PrayerNotificationsScreen`, `WorshipRemindersScreen`, `NotificationWeeklyScreen`,
-`NotificationSoundScreen`, `NotificationTroubleshootingScreen` (all new `Route`s), each rendering a
+`NotificationSoundScreen`, `NotificationDiagnosticsScreen` (all new `Route`s), each rendering a
 slice of `SettingsViewModel` state (its **own instance** of it — see "One `SettingsViewModel` per
 screen" in §6). Settings live
 on the dedicated `WorshipRemindersScreen` (`Route.SettingsWorshipReminders`), and the Home

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -74,7 +74,7 @@ run with a warning — it never hard-fails for a missing token.
 |------------------|----------------|
 | `support/`       | Shared infra — **no test owns a magic string**. `HiltTestRunner`, `Selectors` (nav labels, real `testTag`s, `R.string` lookups), `TestData` (entity builders), `NimazDbRule` (in-memory Room), `BaseAppTest` (Compose + Hilt base for UI flows). |
 | `db/`            | Round-trip CRUD + `Flow` coverage for every major DAO (prayer, fasting, tasbih, khatam, quran, dua, hadith, zakat, tafseer, qaida, names, location, events), plus `DatabaseAssetTest` verifying the shipped prepopulated DB seeds. |
-| `preferences/`   | `SettingsRepository` (DataStore) round-trips + export/import. |
+| `preferences/`   | `SettingsRepository` (DataStore) round-trips + export/import, and the per-prayer alert style / reminder settings with their one-shot migration (`PrayerAlertSettingsTest`). |
 | `notifications/` | `PrayerNotificationScheduler` channel creation + schedule/cancel smoke. |
 | `work/`          | Every `@HiltWorker` widget/adhan worker executed via the real factory. |
 | `navigation/`    | Launches `MainActivity` and asserts navigation **by `ScreenTags`**: all 5 bottom-nav tabs (`BottomNavigationTest`), every More-menu feature — daily practice, learning, tools, support (`FeatureNavigationTest`), every Settings sub-screen (`SettingsNavigationTest`), and back-navigation round-trips (`MoreMenuNavigationTest`). |
@@ -88,7 +88,8 @@ run with a warning — it never hard-fails for a missing token.
 | Shipped prepopulated DB seeds | `db/DatabaseAssetTest` | real DI database (LFS asset) |
 | Schema migrations (per-step + full v7→current) | `MigrationTest`, `MigrationChainTest` | `MigrationTestHelper` |
 | Settings **persistence** (DataStore) | `preferences/SettingsRepositoryTest` | flow round-trips + export/import |
-| Notification channels + schedule/cancel | `notifications/PrayerNotificationSchedulerTest` | Hilt singleton |
+| **Per-prayer alert style + reminder**, and the migration off the old global pair | `preferences/PrayerAlertSettingsTest` | per-prayer isolation; migration runs once and never resets a later choice |
+| Notification channels (incl. the muted channel the SILENT style needs) + schedule/cancel | `notifications/PrayerNotificationSchedulerTest` | Hilt singleton |
 | Every background worker | `work/WidgetWorkersTest` | `HiltWorkerFactory` + `WorkManagerTestInitHelper` |
 | App launch + all 5 bottom-nav tabs | `navigation/AppLaunchTest`, `BottomNavigationTest` | real `MainActivity`/`NavGraph`, by `ScreenTags` |
 | Every More-menu feature opens (16) | `navigation/FeatureNavigationTest` | tag-asserted, with back round-trips |

--- a/docs/specs/notifications-rework/HELP_CONTENT_UPDATES.md
+++ b/docs/specs/notifications-rework/HELP_CONTENT_UPDATES.md
@@ -1,0 +1,46 @@
+# Help content the notifications rework invalidates
+
+**Status:** not fixable in this repo. Help content stopped shipping from `app/src/main/assets`
+when `HelpContentSeeder` was retired at versionCode 385 (`docs/retirement.yaml`); it now arrives
+in the content-database artifact built from **`arshad-shah/nimaz-data`**. These corrections have
+to land there and reach devices via `ContentArtifactInstaller`.
+
+Audited against the shipped artifact (`help_string`, `lang_code = 'en'`, 1458 rows) after the
+rework. Six entries now describe a UI that no longer exists. Each needs the same edit in the
+five translated locales.
+
+| `owner_id` | `field_key` | Ships today | Why it is now wrong | Proposed |
+|---|---|---|---|---|
+| `na_g_reminder` | `title` | Set a pre-adhan reminder | The reminder is per prayer; there is no single pre-adhan setting. | Set a reminder before a prayer |
+| `na_g_reminder_s1` | `body` | Go to More → Settings → Notifications. | The path has another level now. | Go to More → Settings → Notifications → Prayers. |
+| `na_g_reminder_s2` | `title` | Enable Pre-Adhan Reminder | That row is gone. | Choose a reminder for each prayer |
+| `na_g_reminder_s2` | `body` | Turn it on and choose how many minutes before each prayer you want the alert. | Describes one global toggle and one global lead time. | Open a prayer, tap Reminder before, and pick how far ahead it should arrive. Each prayer keeps its own. |
+| `na_q_reminder` | `answer` | Yes — turn on Pre-Adhan Reminder in Settings → Notifications to be alerted a set number of minutes before each prayer. | Same. | Yes — open Settings → Notifications → Prayers, tap a prayer, and set Reminder before. Every prayer can have a different lead time, or none. |
+| `na_g_adhan_s2` | `body` | Turn on Enable Adhan Sound and choose a reciter — it downloads the first time it's used. **Mute individual prayers with the sound icon.** | The per-prayer sound icon no longer exists; the voice is a picker sheet. | Turn on Enable Adhan Sound and pick a voice from the list — it downloads the first time it's used. To change what a single prayer does, use its Alert style under Prayers. |
+
+Two more are **inaccurate rather than broken**, and are worth the same pass:
+
+| `owner_id` | `field_key` | Note |
+|---|---|---|
+| `na_g_enable_s3` | `body` | Names the buttons "Disable Battery Optimization" and "Test Notification". Diagnostics now states each check as a row you tap to fix, and the button reads "Send a test notification". |
+| `ts_q_no_notif` | `answer` | Ends "Use Test Notification." — same rename. Otherwise still correct, and the Diagnostics rows now show each of these three prerequisites directly, which is worth mentioning. |
+
+**Not wrong, deliberately left:** `troubleshooting.subtitle` is still "Troubleshooting". The
+in-app *screen* is now called Diagnostics, but this is the help *topic* name ("Fix a problem" /
+"Troubleshooting"), and someone looking for help with a problem searches for the latter. Renaming
+the topic to match the screen would make the help harder to find, not easier. Flagging the
+mismatch rather than changing it.
+
+**Also verified as still correct** and needing no change: `na_q_dnd` (Do Not Disturb behaviour is
+unchanged — it still gates only the audio) and `ts_q_silent_adhan` (the download/volume advice is
+unaffected).
+
+## Checking this again after a future change
+
+```bash
+sqlite3 app/build/generated/nimazData/assets/database/nimaz_prepopulated.db \
+  "select owner_id, field_key, value from help_string
+   where lang_code='en' and owner_id like 'na_%' or owner_id like 'ts_%';"
+```
+
+The artifact is fetched by `:app:fetchNimazData`, so the database only exists after a build.

--- a/docs/specs/notifications-rework/PROGRESS.md
+++ b/docs/specs/notifications-rework/PROGRESS.md
@@ -5,82 +5,100 @@ Spec: docs/specs/notifications-rework/SPEC.md
 Last updated: 2026-08-04 by session 1
 
 ## Status
-Current phase: P1 — Shared component extensions
-Awaiting: Arshad's approval of the P1 `NimazPickerItem` trailing-action shape and the
-P3 storage/migration proposal (both are "propose before implementing" in the spec)
+Current phase: complete — all phases implemented, PR open
+Awaiting: device validation from Arshad across all seven screens
 Blocked on: nothing
 
 ## Phases
-- [x] P0  Orientation                      verified 2026-08-04
-- [ ] P1  Shared component extensions
-- [ ] P2  Hub reshape
-- [ ] P3  Prayers screen
-- [ ] P4  Adhan & sound
-- [ ] P5  Worship reminders
-- [ ] P6  Weekly
-- [ ] P7  Diagnostics
-- [ ] P8  Full-flow tests
+- [x] P0  Orientation                      commit 74095672  verified 2026-08-04
+- [x] P1  Shared component extensions      commit 854b0f2a  AWAITING VALIDATION
+- [x] P2  Hub reshape                      commit bf6ede0a  AWAITING VALIDATION
+- [x] P3  Prayers screen                   commit bf6ede0a  AWAITING VALIDATION
+- [x] P4  Adhan & sound                    commit 6a2b3732  AWAITING VALIDATION
+- [x] P5  Worship reminders                commit 6a2b3732  AWAITING VALIDATION
+- [x] P6  Weekly                           commit 6a2b3732  AWAITING VALIDATION
+- [x] P7  Diagnostics                      commit bf6ede0a  AWAITING VALIDATION
+- [x] P8  Full-flow tests                  AWAITING VALIDATION
 
 ## Decisions taken
+
 - 2026-08-04 P0 verify holds. Six screens exist under
   `presentation/screens/settings/` — `NotificationSettingsScreen`,
   `PrayerNotificationsScreen`, `NotificationSoundScreen`, `NotificationWeeklyScreen`,
   `NotificationTroubleshootingScreen`, `WorshipRemindersScreen` — and each has a route
   (`Route.SettingsNotifications`, `SettingsNotificationsPrayers`, `SettingsNotificationsSound`,
   `SettingsNotificationsWeekly`, `SettingsNotificationsTroubleshooting`,
-  `SettingsWorshipReminders`). No new route is needed.
+  `SettingsWorshipReminders`). **No route was added.**
+
+- 2026-08-04 **P1 picker trailing action — approved by Arshad: a slot on the picker.**
+  `NimazListPicker` gains `trailingContent: (@Composable (NimazPickerItem<T>) -> Unit)? = null`.
+  `NimazPickerItem` is unchanged, so its equality and the `LazyColumn` keys are unaffected, and
+  the play/stop state that moves while the sheet is open stays with the caller. Rejected: fields
+  or a composable slot on the data class.
+
+- 2026-08-04 **P3 storage and migration — approved by Arshad: new keys + a one-shot migration.**
+  Per-prayer `<prayer>_alert_style` (String), `<prayer>_reminder_enabled` (Boolean),
+  `<prayer>_reminder_minutes` (Int), guarded by `notification_prefs_migration_version` (Int).
+  `PrayerNotificationPrefsMigration.plan` is pure; `PreferencesDataStore
+  .migratePrayerNotificationPreferences()` applies it once from `AppInitializer`. A prayer that
+  was calling the adhan keeps calling it, the global lead time is copied onto all five, and
+  **nothing migrates to `SILENT`** — the old model had no way to ask for silence. The legacy
+  keys stay in place, read-only, so the migration has something to read.
+
+- 2026-08-04 **`SILENT` needed a new channel**, `prayer_notifications_muted`
+  (`IMPORTANCE_LOW`, `setSound(null, null)`). The existing `*_SILENT` channels are
+  *no-vibration* siblings that still carry a sound at `IMPORTANCE_HIGH`, and Android will not
+  let an existing channel's importance be lowered from code. Documented in `SUBSYSTEMS.md` §0.6
+  and §4.
+
+- 2026-08-04 **Phase gates — approved by Arshad: build through, validate once at the end.**
+  Each phase still got its own commit and its own compile/test/docs gates; the device
+  validation is a single pass over all seven screens against the PR.
 
 ## Open questions
-- P1 `NimazPickerItem` trailing action shape — proposed to Arshad 2026-08-04.
-- P3 alert-style + per-prayer offset storage and migration — proposed to Arshad 2026-08-04.
+
+- **`NimazListPicker` cannot express a real Cancel.** Its footer's Cancel and Done both call
+  `onDismiss`, so they are indistinguishable to the caller. The adhan picker therefore commits
+  on selection (which is what the screen did before this change) and its Cancel behaves as
+  Close. Giving it a true Cancel means adding separate `onConfirm`/`onCancel` callbacks to the
+  shared component, which is beyond the P1 change Arshad approved — raised rather than done.
 
 ## Notes for the next session
 
-**The spec is stale in three places — verified against the working tree, not assumed:**
+**The spec was stale in three places — verified against the working tree, not assumed:**
 
-1. **P1's `NimazListPicker` checkbox change is already done.** `PickerRow` already renders
-   selection with `NimazCheckbox(type = CIRCLE, variant = PRIMARY, size = LARGE)`
-   (`NimazListPicker.kt:302`), not a `NimazIcon`. Nothing to change; no picker screenshots
-   needed for that item.
-2. **P4's "Play at alarm volume" setting does not exist.** `grep` for
-   `alarm volume|ALARM_VOLUME|STREAM_ALARM|alarmVolume` across `app/src/main` returns nothing.
-   Per §8, it will not be invented. The prototype drew it; the app does not have it.
-3. **"All six locales" means base + five.** `app/src/main/res/` has `values`, `values-de`,
-   `values-fr`, `values-id`, `values-ms`, `values-tr` (`values-night` is a theme qualifier,
-   not a locale).
+1. **P1's `NimazListPicker` checkbox change was already done.** `PickerRow` already rendered
+   selection with `NimazCheckbox(type = CIRCLE, …)`. Nothing to change.
+2. **P4's "Play at alarm volume" setting does not exist.** No match for
+   `alarm volume|ALARM_VOLUME|STREAM_ALARM|alarmVolume` anywhere in `app/src/main`. Per §8 it
+   was not invented; the prototype drew it, the app does not have it.
+3. **"All six locales" means base + five** (`values`, `values-de`, `-fr`, `-id`, `-ms`, `-tr`;
+   `values-night` is a theme qualifier).
 
-**How prayer notification state is actually persisted (the P3 investigation):**
+**A correction to an earlier note in this file:** injecting `SettingsRepository` into
+`SettingsViewModel` is **not** a deviation from non-negotiable rule 2. It is the *resolved*
+state recorded in `CLEAN_ARCHITECTURE_CHECKLIST.md` — `SettingsRepository` is a domain
+interface (`domain/repository/`), and all 13 ViewModels inject it by design. Nothing to fix.
 
-- `isSoundOn` in `PrayerNotificationsScreen.kt:61` is screen-local only. It is computed as
-  `notificationState.adhanEnabled && notificationState.<prayer>AdhanEnabled` and is never stored.
-- Real storage is Preferences DataStore (`data/local/datastore/PreferencesDataStore.kt`),
-  reached through `SettingsRepository`:
-  - per-prayer visibility: `{FAJR,SUNRISE,DHUHR,ASR,MAGHRIB,ISHA}_NOTIFICATION_ENABLED`
-    (`Boolean`, default true; sunrise false), written by `setPrayerNotificationEnabled(prayer, enabled)`;
-  - per-prayer adhan: `{FAJR,DHUHR,ASR,MAGHRIB,ISHA}_ADHAN_ENABLED` (`Boolean`, default true),
-    written by `setPrayerAdhanEnabled(prayer, enabled)`, read at fire time through
-    `isAdhanEnabledForPrayer(prayer)` — sunrise hardcoded to `false`;
-  - global gate `ADHAN_ENABLED` (default **false**);
-  - pre-adhan: `SHOW_REMINDER_BEFORE` (`Boolean`) + `NOTIFICATION_REMINDER_MINUTES` (`Int`,
-    default 15) — **one global pair, exactly as the spec says**.
-- Two consumers read these, and they read them at *different* times:
-  - **schedule time** — `PrayerNotificationScheduler.scheduleTodaysPrayerNotifications(...)`
-    takes `enabledPrayers: Set<PrayerType>`, `preReminderEnabled: Boolean`,
-    `preReminderMinutes: Int`. The callers (`AppInitializer`, `BootReceiver`,
-    `SettingsViewModel`) read the prefs and pass them in.
-  - **fire time** — `BootReceiver.handlePrayerNotification` re-reads `adhanEnabled`,
-    `isAdhanEnabledForPrayer`, `adhanRespectDnd`, `notificationVibration`,
-    `notificationReminderMinutes` from DataStore when the alarm goes off, and decides
-    `shouldPlayAdhan` / `shouldPlayBeep` there.
-- Consequence for P3: **alert style is a fire-time decision** (no scheduler signature change),
-  but **per-prayer offset is a schedule-time decision** (the scheduler currently applies one
-  `preReminderMinutes` to every prayer in one loop, `PrayerNotificationScheduler.kt:266-272`).
-- Silent delivery already has channels: `CHANNEL_ID_PRAYER_SILENT` / `CHANNEL_ID_ADHAN_SILENT`.
-  They are *no-vibration* siblings, **not** no-sound — both are `IMPORTANCE_HIGH` with a
-  channel sound. A genuinely silent alert style needs its own channel; Android will not let
-  an existing channel's importance be lowered from code.
+**Local build gotcha.** `:app:testDebugUnitTest` (and anything that needs merged assets) runs
+`:app:fetchNimazData`, which needs a credential that can see the private `arshad-shah/nimaz-data`
+repo. The active `gh` account on this machine is the work one (`ShahA_hmh`), which gets a 404.
+Run gradle with the personal account's token:
 
-**Pre-existing deviation, not introduced here:** `SettingsViewModel` injects
-`SettingsRepository` directly rather than a `XxxUseCases` bundle (non-negotiable rule 2).
-It is out of scope per §8 ("rewriting `SettingsViewModel` beyond what P3's storage answer
-requires") — do not fix it in passing, but do not copy the pattern into anything new either.
+```bash
+export NIMAZ_DATA_TOKEN=$(gh auth token -h github.com -u arshad-shah)
+```
+
+`:app:compileDebugKotlin` alone does not need it.
+
+**What the code now looks like, in one paragraph.** Alert style is read at **fire time**
+(`BootReceiver`), so changing it needs no rescheduling; the reminder lead time is read at
+**schedule time** and rides on the alarm intent as `EXTRA_REMINDER_MINUTES`, so the fired text
+states the right number. `scheduleTodaysPrayerNotifications` takes
+`preReminders: Map<PrayerType, Int>` — a prayer absent from the map gets no reminder, rather
+than a zero offset. All three schedule call sites build it through
+`SettingsRepository.preReminderMinutesByPrayer()` so they cannot drift. The fire-time rules live
+on `PrayerAlertStyle` (`playsAdhan`, `isMuted`) so the receiver and the tests read one rule.
+
+**What still needs a device.** Everything under `## Status`. The riskiest is P3: a per-prayer
+setting that persists correctly but schedules nothing would look fine in every screenshot.

--- a/docs/specs/notifications-rework/PROGRESS.md
+++ b/docs/specs/notifications-rework/PROGRESS.md
@@ -1,0 +1,86 @@
+# Notifications rework — progress
+
+Branch: feat/notifications-rework
+Spec: docs/specs/notifications-rework/SPEC.md
+Last updated: 2026-08-04 by session 1
+
+## Status
+Current phase: P1 — Shared component extensions
+Awaiting: Arshad's approval of the P1 `NimazPickerItem` trailing-action shape and the
+P3 storage/migration proposal (both are "propose before implementing" in the spec)
+Blocked on: nothing
+
+## Phases
+- [x] P0  Orientation                      verified 2026-08-04
+- [ ] P1  Shared component extensions
+- [ ] P2  Hub reshape
+- [ ] P3  Prayers screen
+- [ ] P4  Adhan & sound
+- [ ] P5  Worship reminders
+- [ ] P6  Weekly
+- [ ] P7  Diagnostics
+- [ ] P8  Full-flow tests
+
+## Decisions taken
+- 2026-08-04 P0 verify holds. Six screens exist under
+  `presentation/screens/settings/` — `NotificationSettingsScreen`,
+  `PrayerNotificationsScreen`, `NotificationSoundScreen`, `NotificationWeeklyScreen`,
+  `NotificationTroubleshootingScreen`, `WorshipRemindersScreen` — and each has a route
+  (`Route.SettingsNotifications`, `SettingsNotificationsPrayers`, `SettingsNotificationsSound`,
+  `SettingsNotificationsWeekly`, `SettingsNotificationsTroubleshooting`,
+  `SettingsWorshipReminders`). No new route is needed.
+
+## Open questions
+- P1 `NimazPickerItem` trailing action shape — proposed to Arshad 2026-08-04.
+- P3 alert-style + per-prayer offset storage and migration — proposed to Arshad 2026-08-04.
+
+## Notes for the next session
+
+**The spec is stale in three places — verified against the working tree, not assumed:**
+
+1. **P1's `NimazListPicker` checkbox change is already done.** `PickerRow` already renders
+   selection with `NimazCheckbox(type = CIRCLE, variant = PRIMARY, size = LARGE)`
+   (`NimazListPicker.kt:302`), not a `NimazIcon`. Nothing to change; no picker screenshots
+   needed for that item.
+2. **P4's "Play at alarm volume" setting does not exist.** `grep` for
+   `alarm volume|ALARM_VOLUME|STREAM_ALARM|alarmVolume` across `app/src/main` returns nothing.
+   Per §8, it will not be invented. The prototype drew it; the app does not have it.
+3. **"All six locales" means base + five.** `app/src/main/res/` has `values`, `values-de`,
+   `values-fr`, `values-id`, `values-ms`, `values-tr` (`values-night` is a theme qualifier,
+   not a locale).
+
+**How prayer notification state is actually persisted (the P3 investigation):**
+
+- `isSoundOn` in `PrayerNotificationsScreen.kt:61` is screen-local only. It is computed as
+  `notificationState.adhanEnabled && notificationState.<prayer>AdhanEnabled` and is never stored.
+- Real storage is Preferences DataStore (`data/local/datastore/PreferencesDataStore.kt`),
+  reached through `SettingsRepository`:
+  - per-prayer visibility: `{FAJR,SUNRISE,DHUHR,ASR,MAGHRIB,ISHA}_NOTIFICATION_ENABLED`
+    (`Boolean`, default true; sunrise false), written by `setPrayerNotificationEnabled(prayer, enabled)`;
+  - per-prayer adhan: `{FAJR,DHUHR,ASR,MAGHRIB,ISHA}_ADHAN_ENABLED` (`Boolean`, default true),
+    written by `setPrayerAdhanEnabled(prayer, enabled)`, read at fire time through
+    `isAdhanEnabledForPrayer(prayer)` — sunrise hardcoded to `false`;
+  - global gate `ADHAN_ENABLED` (default **false**);
+  - pre-adhan: `SHOW_REMINDER_BEFORE` (`Boolean`) + `NOTIFICATION_REMINDER_MINUTES` (`Int`,
+    default 15) — **one global pair, exactly as the spec says**.
+- Two consumers read these, and they read them at *different* times:
+  - **schedule time** — `PrayerNotificationScheduler.scheduleTodaysPrayerNotifications(...)`
+    takes `enabledPrayers: Set<PrayerType>`, `preReminderEnabled: Boolean`,
+    `preReminderMinutes: Int`. The callers (`AppInitializer`, `BootReceiver`,
+    `SettingsViewModel`) read the prefs and pass them in.
+  - **fire time** — `BootReceiver.handlePrayerNotification` re-reads `adhanEnabled`,
+    `isAdhanEnabledForPrayer`, `adhanRespectDnd`, `notificationVibration`,
+    `notificationReminderMinutes` from DataStore when the alarm goes off, and decides
+    `shouldPlayAdhan` / `shouldPlayBeep` there.
+- Consequence for P3: **alert style is a fire-time decision** (no scheduler signature change),
+  but **per-prayer offset is a schedule-time decision** (the scheduler currently applies one
+  `preReminderMinutes` to every prayer in one loop, `PrayerNotificationScheduler.kt:266-272`).
+- Silent delivery already has channels: `CHANNEL_ID_PRAYER_SILENT` / `CHANNEL_ID_ADHAN_SILENT`.
+  They are *no-vibration* siblings, **not** no-sound — both are `IMPORTANCE_HIGH` with a
+  channel sound. A genuinely silent alert style needs its own channel; Android will not let
+  an existing channel's importance be lowered from code.
+
+**Pre-existing deviation, not introduced here:** `SettingsViewModel` injects
+`SettingsRepository` directly rather than a `XxxUseCases` bundle (non-negotiable rule 2).
+It is out of scope per §8 ("rewriting `SettingsViewModel` beyond what P3's storage answer
+requires") — do not fix it in passing, but do not copy the pattern into anything new either.

--- a/docs/specs/notifications-rework/SPEC.md
+++ b/docs/specs/notifications-rework/SPEC.md
@@ -1,0 +1,436 @@
+# Notifications rework — implementation spec
+
+**Repo:** `arshad-shah/nimaz` · **Base:** `dev` · **Written against:** `3b039ca`
+**Prototype:** `nimaz-notif-system.html` — the system map in it is the source of truth for
+screen shape, row copy and which surfaces are sheets.
+**Scope:** the notifications subsystem only. More, Zakat, Fasting and the Qur'an thematic work
+are separate specs and must not be touched here.
+
+---
+
+## 0. How to work from this document
+
+This spec was written by reading the repo at `3b039ca`. **`dev` has probably moved.** Every
+factual claim below is a claim to re-check against the working tree, not a fact to build on.
+
+Precedence, in order:
+
+1. **`CLAUDE.md` and `docs/` win over this document.** If this spec asks for something that
+   breaks a non-negotiable rule (layer direction, `NimazCard`/`NimazButton` for anything
+   tappable, no raw `Color(0xFF…)`, `XxxUseCases` injection, type-safe routes), the rule wins.
+   Say so and stop — don't satisfy both.
+2. **Where this spec states current behaviour, verify it first.** Each phase opens with a
+   *Verify* block giving the exact check and the expected finding. A mismatch means someone
+   changed this area — stop, report, ask. Never adapt silently.
+3. **Where this spec states intent, follow it.** The design is settled and signed off against
+   the prototype. If something turns out to be unbuildable, say why and propose an alternative
+   before writing around it.
+4. **Uncertainty is reportable, not guessable.** Missing component, conflicting sections,
+   ambiguous check — ask. A wrong guess costs more than a question.
+
+---
+
+## 1. Progress ledger — do this before anything else
+
+Sessions run out of context. The ledger is what lets a fresh session pick up mid-work without
+re-deriving everything or redoing finished phases.
+
+**Path:** `docs/specs/notifications-rework/PROGRESS.md`, committed to the branch.
+
+### At the start of every session, without exception
+
+1. `git log --oneline -15` on the working branch.
+2. Read `PROGRESS.md` in full.
+3. Read the *Verify* block of the phase the ledger says is current, and run it.
+4. State back, in one short paragraph: which phase is current, what the last session finished,
+   what the next action is, and whether the verify block still holds.
+
+Do not write code before those four steps. If `PROGRESS.md` does not exist, this is session one
+— create it from the template below as your first commit.
+
+### Format
+
+```markdown
+# Notifications rework — progress
+
+Branch: <branch>
+Spec: docs/specs/notifications-rework/SPEC.md
+Last updated: <ISO date> by <session note>
+
+## Status
+Current phase: P3 — Prayers screen
+Awaiting: device validation from Arshad on P2
+Blocked on: nothing
+
+## Phases
+- [x] P0  Orientation                      commit abc1234  validated 2026-08-05
+- [x] P1  Shared component extensions      commit def5678  validated 2026-08-05
+- [x] P2  Hub reshape                      commit 9abcdef  AWAITING VALIDATION
+- [ ] P3  Prayers screen
+- [ ] P4  Adhan & sound
+- [ ] P5  Worship reminders
+- [ ] P6  Weekly
+- [ ] P7  Diagnostics
+- [ ] P8  Full-flow tests
+
+## Decisions taken
+- <date> Sunrise moved from the global section to under Fajr — approved by Arshad.
+- <date> Per-prayer offset stored as <mechanism> — see P3 investigation note.
+
+## Open questions
+- <question, who it is for, when it was raised>
+
+## Notes for the next session
+<anything a fresh session would otherwise have to rediscover: a surprising file location,
+a test that is flaky, a workaround and why>
+```
+
+### Rules
+
+- Update it **at every phase boundary and before any long-running step**, not at the end of the
+  session. A session that dies with unwritten progress has lost the work twice.
+- One phase is "current" at a time. Never mark a phase `[x]` before its gate has passed.
+- `## Decisions taken` is append-only. It is the record of what Arshad approved, and a later
+  session must not silently reverse it.
+- If you discover this spec is wrong about something, write it under `## Notes` **and** say so
+  in chat. The ledger outlives the conversation; chat does not.
+
+---
+
+## 2. Gate protocol — how each phase ends
+
+Every phase ends by stopping and asking for device validation. This is not optional and it is
+not a formality.
+
+When a phase's code is complete and its automated gates pass:
+
+1. Update `PROGRESS.md`: mark the phase `AWAITING VALIDATION`, record the commit.
+2. Post a short message with exactly three things:
+   - **what changed**, in one or two sentences;
+   - **what to look at on device** — the specific screens and the specific interactions,
+     including both themes and the largest font scale;
+   - **what you did not do** and why, if anything.
+3. **Stop.** Do not begin the next phase. Do not "get a head start". Do not refactor while
+   waiting.
+
+Only an explicit approval from Arshad ("looks good", "approved", "go ahead") advances the
+phase. Silence is not approval. A comment on a different topic is not approval. If he reports a
+problem, fix it within the same phase and re-submit for validation — do not roll it into the
+next phase.
+
+Sample message:
+
+> **P2 done — hub reshape.** `NotificationSettingsScreen` is now five rows, each showing live
+> state pulled from the existing settings flows. The prayer accordions moved to P3's screen.
+>
+> On device: open Settings → Notifications. Check the subtitle on every row reads correctly
+> against your real settings, that the diagnostic banner appears only when battery optimisation
+> is actually on, and that nothing truncates in dark mode at the largest font scale.
+>
+> Not done: the Prayers screen still has its old contents — that's P3.
+
+---
+
+## 3. Phases
+
+### P0 — Orientation
+
+**Verify**
+
+```bash
+git log --oneline -20
+ls app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/
+grep -rn "Route.Notification\|Route.Prayer\|Route.Worship" app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+```
+
+**Expected:** six notification-related screens exist —
+`NotificationSettingsScreen`, `PrayerNotificationsScreen`, `NotificationSoundScreen`,
+`NotificationWeeklyScreen`, `NotificationTroubleshootingScreen`, `WorshipRemindersScreen` —
+and each already has a route. **This rework adds no new routes.** If it looks like you need
+one, you have misread the design; stop and ask.
+
+**Do:** create the branch, create `PROGRESS.md`, copy this spec to
+`docs/specs/notifications-rework/SPEC.md`, commit. No code.
+
+**Gate:** confirm the six screens and their routes back to Arshad, then proceed to P1 without
+waiting — P0 is bookkeeping and needs no device check.
+
+---
+
+### P1 — Shared component extensions
+
+These land in every screen that uses them, so they go first and get validated on their own.
+
+**Verify**
+
+```bash
+grep -n "fun NimazAccordion" -A 8 app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
+grep -n "data class NimazPickerItem" -A 10 app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazListPicker.kt
+grep -rln "NimazAccordion\|NimazListPicker" app/src/main/java/com/arshadshah/nimaz/presentation/
+```
+
+**Expected:** `NimazAccordion(title, modifier, leadingIcon, initiallyExpanded, content)` — no
+trailing slot. `NimazPickerItem(value, title, description, icon, iconTint, group)` — no trailing
+action. `NimazListPicker` is already rendered inside a `NimazBottomSheet`. Note every existing
+call site; you are changing shared components and each one must still compile and still look right.
+
+**Three changes, all additive:**
+
+1. `NimazAccordion` gains `trailing: (@Composable RowScope.() -> Unit)? = null`, rendered in the
+   header after the title. Needed so a prayer row can carry its time and switch. Default null
+   keeps every existing call site identical.
+2. `NimazAccordion` gains `subtitle: String? = null` under the title, for the summary line
+   ("Adhan · 10 min before"). Same reasoning.
+3. `NimazPickerItem` gains an optional trailing action so the adhan voice rows can carry a
+   preview button. Shape is yours to propose — a `trailingIcon` + `onTrailingClick`, or a slot.
+   **Propose it before implementing**; a slot on a data class is awkward and there may be a
+   better fit given how `NimazListPicker` builds its rows.
+
+**Also in P1:** `NimazListPicker` draws selection with a `NimazIcon`. Change it to
+`NimazCheckbox`. This is a single change that lands in every picker in the app — location
+method, calculation method, translation, adhan — which is the point. Screenshot two or three
+other pickers before and after; if it looks wrong anywhere, report before continuing.
+
+**Gate:** device validation. Ask Arshad to check the accordions and at least two unrelated
+pickers.
+
+---
+
+### P2 — Hub reshape
+
+**File:** `NotificationSettingsScreen.kt`
+
+**Verify**
+
+```bash
+sed -n '100,150p' app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+grep -rn "notif_hub_" app/src/main/res/values/strings.xml
+```
+
+**Expected:** five `NimazMenuItem`/`NimazSettingsItem` rows with static `notif_hub_*` subtitles
+that describe rather than report.
+
+**Target:** five rows, each with a subtitle carrying **live state**:
+
+| Row | Subtitle source | Trailing |
+|---|---|---|
+| Prayers | the Fajr summary — style and offset | `n of 5` |
+| Adhan & sound | voice name, vibration, DND | — |
+| Worship reminders | static category list | `n on` |
+| Weekly | Jumu'ah and khatam on/off | — |
+| Diagnostics | static | warning `NimazBadge` when a check fails |
+
+Plus a `NimazBanner(variant = WARNING)` above them, rendered **only when a delivery problem is
+actually detected**. If the state needed to detect that isn't reachable from this screen's
+ViewModel, say so rather than faking it — a banner that always shows is worse than none.
+
+Delete the `notif_hub_*` strings that no longer describe anything, in all six locales.
+
+**Gate:** device validation.
+
+---
+
+### P3 — Prayers screen (the only phase with new capability)
+
+**File:** `PrayerNotificationsScreen.kt`
+
+**Verify — and this one is an investigation, not a check**
+
+```bash
+sed -n '55,70p' app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreen.kt
+grep -rn "SetPrayerNotification\|SetAdhanEnabled\|isSoundOn" --include=*.kt app/src/main/java/com/arshadshah/nimaz/
+```
+
+`isSoundOn` appears to be a screen-local UI model field. **Find out how per-prayer notification
+state is actually persisted and how the scheduler reads it, and report that before writing
+anything.** Everything below depends on it.
+
+**Target**
+
+- Five `NimazAccordion` rows, one per prayer, using the P1 trailing slot for the time and the
+  enable switch, and the P1 subtitle for the summary line.
+- Body of each: **Alert style** and **Reminder before**, both opening a `NimazListPicker` sheet
+  with `autoDismiss = true`. Fajr additionally carries **Sunrise**.
+- The global "Additional" section is removed; sunrise moves under Fajr, and the pre-adhan
+  reminder becomes per-prayer.
+
+**Two genuinely new capabilities — treat them as such:**
+
+1. **Alert style** replaces the current sound on/off binary with three states: adhan,
+   notification only, silent. This changes what the scheduler must honour.
+2. **Reminder offset becomes per-prayer.** Today `pre_adhan` is one global value.
+
+Both need a storage and migration answer. **Propose it and get approval before implementing.**
+Specifically: what happens to someone who already has a global pre-adhan value set — the
+migration must carry it to all five prayers, not silently reset it. Write the decision into
+`PROGRESS.md` under `## Decisions taken`.
+
+**Gate:** device validation, and specifically ask Arshad to confirm a notification actually
+fires with the new per-prayer settings — this is the phase where the app can break silently.
+
+---
+
+### P4 — Adhan & sound
+
+**File:** `NotificationSoundScreen.kt`
+
+**Verify:** the adhan list is currently rendered inline with preview playback wired to
+`SettingsEvent.PreviewAdhanSound` / `StopAdhanPreview`.
+
+**Target:** the inline list becomes a `NimazListPicker` sheet using the P1 trailing action for
+preview. `autoDismiss = false` here — you audition several before committing, so the sheet keeps
+Cancel/Done. Vibration and DND rows stay exactly as they are.
+
+Preview must stop when the sheet is dismissed by any route, including swipe-down and back.
+
+**Note:** the prototype shows a "Play at alarm volume" row. **I did not verify that setting
+exists.** Check; if it doesn't, leave it out and say so — do not invent a preference.
+
+**Gate:** device validation.
+
+---
+
+### P5 — Worship reminders
+
+**File:** `WorshipRemindersScreen.kt`
+
+**Target:** structurally as it is — three sections keyed to `WorshipReminderCategory`. Two changes:
+
+- Reminders with `hasOffset` become `NimazAccordion` rows whose body holds the offset stepper,
+  instead of a separate row.
+- Ramadan-gated reminders (`ramadanOnly`) currently hide outside Ramadan. Instead, show them
+  under a `NimazBanner(variant = INFO)` explaining they stay quiet until Ramadan. **Verify the
+  hiding behaviour before changing it** — if something else depends on them being absent, report.
+
+**Gate:** device validation.
+
+---
+
+### P6 — Weekly
+
+**File:** `NotificationWeeklyScreen.kt`
+
+**Target:** Jumu'ah and khatam become `NimazAccordion` rows with their time picker in the body
+rather than behind a separate dialog flow. Substance unchanged.
+
+**Gate:** device validation.
+
+---
+
+### P7 — Diagnostics
+
+**File:** `NotificationTroubleshootingScreen.kt`
+
+**Target:**
+
+- Rename to Diagnostics in copy (the file and route stay — no new routes).
+- Keep the three existing buttons.
+- Add a status list: battery optimisation, notification permission, exact alarms, next scheduled
+  alarm. Each row states its real state with a `NimazBadge`. **Only include checks you can
+  actually read** — a row that always says OK is a lie.
+- **Reset gains a `NimazDialog` confirm.** It currently fires immediately.
+- The P2 banner links here.
+
+**Gate:** device validation.
+
+---
+
+### P8 — Full-flow tests
+
+Runs after Arshad has approved every phase. Per `CLAUDE.md` and `docs/TESTING.md` — read both
+first and match what is already there rather than introducing a new pattern.
+
+Cover the **flow**, not the composables:
+
+1. **Per-prayer settings round-trip** — set alert style and offset on one prayer, confirm they
+   persist across process death and that the other four are untouched.
+2. **Migration** — an install with a global pre-adhan value ends up with that value on all five
+   prayers, and nobody's setting is lost.
+3. **Scheduling honours alert style** — silent schedules no sound; notification-only schedules
+   the standard tone; adhan schedules the adhan. Assert against whatever the scheduler exposes.
+4. **Offset arithmetic** — a 10-minute offset on Fajr schedules at Fajr minus ten, including
+   across a day boundary and a DST change.
+5. **Ramadan gating** — `ramadanOnly` reminders are visible in settings year-round but schedule
+   nothing outside Ramadan.
+6. **Reset** — cancels and rebuilds every alarm, and preferences survive it.
+7. **Hub state** — each hub subtitle reflects the underlying setting. A ViewModel-level test is
+   enough; don't drive this through the UI.
+
+If a flow can't be tested because the seam isn't there, **say so and propose the seam** rather
+than writing a test that asserts nothing.
+
+**Gate:** device validation of the whole subsystem end to end, then the spec is done.
+
+---
+
+## 4. Components
+
+**Reuse. Nothing here is hand-rolled.** The screens are built from:
+
+`NimazScreenScaffold`, `NimazBackTopAppBar`, `NimazSettingsSection`, `NimazSettingsItem`,
+`NimazSectionHeader`, `NimazMenuItem`, `NimazMenuGroup`, `NimazAccordion`, `NimazBanner`,
+`NimazSwitch`, `NimazCheckbox`, `NimazBadge`, `NimazButton`, `NimazIconButton`, `NimazCard`,
+`NimazListPicker`, `NimazBottomSheet`, `NimazDialog`, `NimazNumberStepper`, `NimazTimePicker`.
+
+**No new component is expected.** If you believe one is needed:
+
+1. Search the design system first — it is large, and the assumption that something is missing is
+   a claim to verify.
+2. If it genuinely doesn't exist, **ask before building it**, with what you searched and why
+   nothing fits.
+3. Any new or extended component ships with `@Preview` composables in **both light and dark**,
+   matching the preview convention in its neighbours. A component without previews is not done.
+4. Extended components need a preview of the **new** configuration, not just the old one — the
+   `NimazAccordion` trailing slot needs a preview showing a trailing switch.
+
+Rule 8 applies throughout: tappable regions are `NimazCard(onClick)` / `NimazMenuItem` /
+`NimazButton` / `NimazIconButton`. Never `Modifier.clickable` on a card.
+
+---
+
+## 5. Strings
+
+- Every new string in `values/strings.xml`, sentence case, active voice.
+- **Titles label; subtitles carry the detail.** "Honor Do Not Disturb" → title **Do Not Disturb**,
+  subtitle *Silence the adhan while DND is on — banner still shows*. No subtitle where there is
+  nothing true to say.
+- The existing notification strings are Title Case. Fix them as you touch each screen; don't do
+  a separate sweep.
+- New strings need the five translations (`de`, `fr`, `id`, `ms`, `tr`); deleted strings come out
+  of all six. Check what the last localised commit actually covered rather than assuming.
+
+---
+
+## 6. Documentation
+
+- `docs/SUBSYSTEMS.md` — the notifications section, once P3 changes what is stored.
+- `docs/TESTING.md` — if P8 introduces a new test seam.
+- `docs/ARCHITECTURE.md` §9 — only if this resolves or introduces a deviation.
+- No `NAVIGATION.md` change is expected; if you think there is one, you have added a route,
+  which this spec does not permit.
+
+---
+
+## 7. Gates, every phase
+
+```bash
+./gradlew :app:compileDebugKotlin
+./gradlew :app:testDebugUnitTest
+```
+
+Plus screenshots of every touched screen in **both themes at the largest supported font scale**.
+The prayer accordion header carries name, summary, time and switch — it is the first thing that
+will break, and the summary line is the first thing to drop if it does.
+
+Feature branch. **Do not push to `dev`.**
+
+---
+
+## 8. Out of scope — say something rather than doing these
+
+- Adding any route.
+- Touching More, Zakat, Fasting, or the Qur'an thematic screens.
+- Changing the adhan audio pipeline, the scheduler's alarm mechanism, or `WorshipReminderType`
+  itself.
+- Rewriting `SettingsViewModel` beyond what P3's storage answer requires.
+- Inventing a preference that does not exist because the prototype drew it.


### PR DESCRIPTION
Implements the notifications rework spec (`docs/specs/notifications-rework/SPEC.md`, committed
here alongside its progress ledger).

## What changed

**Every prayer now has its own alert style and its own reminder.** The adhan used to be one
switch for all five prayers and the pre-adhan reminder one lead time for all five, so wanting
the adhan at Fajr and silence at Dhuhr was not expressible. `PrayerAlertStyle` is `ADHAN`,
`NOTIFICATION` or `SILENT`, per prayer, and each prayer carries its own reminder.

The two are honoured at different points, which is the thing to keep straight:

| Setting | Read at | Consequence |
|---|---|---|
| Alert style | fire time (`BootReceiver`) | changing it needs no rescheduling |
| Reminder on/off + lead time | schedule time; the lead time rides on the alarm intent | changing it re-arms alarms, and the fired text states the right number |

`scheduleTodaysPrayerNotifications` takes `preReminders: Map<PrayerType, Int>` — a prayer absent
from the map gets no reminder, rather than a zero offset. All three schedule call sites build it
through one helper so they cannot drift.

**Silence needed a channel of its own.** The existing `*_SILENT` channels are *no-vibration*
siblings that still carry the channel sound at `IMPORTANCE_HIGH`, and Android will not lower an
existing channel's importance from code — so `prayer_notifications_muted` is new.

**Existing installs are carried across** by a one-shot migration guarded by a stored version: a
30-minute pre-adhan reminder becomes a 30-minute reminder on all five prayers, a prayer that was
calling the adhan keeps calling it, and **nothing migrates to `SILENT`**, because the old model
had no way to ask for silence.

**Screens.** The hub's rows report live state instead of describing the screens behind them, and
its warning banner appears only when the device is genuinely in a state that would delay alerts.
Prayers is five accordions stating what each prayer does without being opened. Adhan voice moves
into a picker sheet with per-row preview. Worship reminders that can be timed carry their own
offset, and the Ramadan group is shown year-round under a notice rather than hidden. Jumu'ah and
khatam become accordions with their timing inline. Diagnostics states each device check it can
actually read, and Reset asks before cancelling every alarm.

## Three places the spec was stale, verified against the tree

- `NimazListPicker` already drew selection with `NimazCheckbox` — nothing to change.
- **"Play at alarm volume" does not exist** anywhere in `app/src/main`. Per the spec's §8 it was
  not invented, so the prototype's row is deliberately absent.
- "Six locales" is base + five; `values-night` is a theme qualifier.

## Shared components

Two additive changes, both defaulting to null so every existing call site renders identically:
`NimazAccordion` gains `subtitle` and a `trailing` header slot; `NimazListPicker` gains
`trailingContent`. The picker slot went on the picker rather than on `NimazPickerItem` so the
item stays pure data — its equality and the `LazyColumn` keys are untouched — and the state that
moves while the sheet is open stays with the caller. Both ship previews of the new configuration
in light and dark.

## Tests

Per-prayer isolation and the migration through DataStore (instrumented); the alert-style to
channel mapping, the migration plan, the reminder arithmetic across midnight and both
daylight-saving changes, and the hub's subtitle choices (JVM). Two seams were missing and are now
there rather than being asserted twice: the adhan/silence rules moved onto `PrayerAlertStyle`, and
the hub's subtitle selection moved out of the composables. Ramadan gating already had coverage and
is unaffected — showing the reminders year-round is a UI change; the scheduler still gates on the
Hijri date.

## Verification

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin   BUILD SUCCESSFUL
python3 scripts/check_docs.py                                                                 23/23 passed
node scripts/check_mermaid.mjs                                                                14 diagrams parse
```

No route was added. Strings are translated into all five shipped locales, and the ones that no
longer describe anything are deleted from all six.

## What still needs a device

Everything — this has not been run on hardware. The riskiest is the prayers screen: a per-prayer
setting that persists correctly but schedules nothing would look right in every screenshot.
Worth checking both themes at the largest font scale, since the accordion header carries name,
summary, time and switch.

**One thing raised rather than done:** `NimazListPicker`'s footer Cancel and Done both call
`onDismiss`, so a real Cancel is not expressible. The adhan picker commits on selection (as the
screen did before) and its Cancel behaves as Close. Giving it a true Cancel means adding separate
callbacks to the shared component, which is beyond the approved change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Also on this branch: Qur'an division markers

Added after the notifications work, at Arshad's direction, rather than on a separate branch.

## The rukūʿ mark was on the wrong verse

The ʿayn (ع) **closes** a rukūʿ in a printed Mushaf; the code read the section's
`start_ayah_id`. Al-Fātiḥah is a single rukūʿ over all seven verses, so its mark rendered on
verse 1 instead of verse 7 — and every other surah's marks sat a whole section early.

The data was already right: `rukus` carries `start_ayah_id` **and** `end_ayah_id`, and the query
only ever selected the start. The DAO now carries `ruku_end_ayah_id`, and the flag is
`isRukuEnd` so the convention is stated rather than assumed.

**The hizb quarter is deliberately unchanged** — the ۞ genuinely *opens* a quarter (quarter 1 =
1:1, 2 = 2:26, 3 = 2:44, 4 = 2:60, 5 = 2:75 = hizb 2). The two divisions use opposite
conventions, which is exactly what made this easy to get wrong, so a test pins both against
Al-Fātiḥah.

## The readers now show the divisions at all

Neither Mushaf reader drew these signs: following a hizb, finding the end of a rukūʿ, or
spotting a prostration verse meant leaving the page.

- **Continuous (Madani/604)** — one `AnnotatedString` per page, so the signs are appended
  inline: ۞ before the verse opening a quarter, ۩ and ع after the verse they belong to.
- **Line-accurate (IndoPak 16-line)** — a different renderer that draws each word as its own
  `BasicText` positioned from `mushaf_layout_lines`. A trailing sign is anchored to the
  **verse's own end glyph** (`۟`, and `۟۠` closing a surah), which the IndoPak text carries as
  the last token of every ayah. "The ayah's last word on this page" would have drawn the sign
  mid-verse whenever an ayah runs onto the next page.

**No performance cost:** the page's marks resolve once per page in the host — which already
holds the ayahs — into a map of only the verses carrying a sign. The renderer does a map lookup
per word and acquires no data source of its own.

Signs draw at 0.8× the verse in the ornament gold: findable at a glance, never mistakable for a
word of the Qur'an.

## Smaller

- The surah info screen's three elevated stat cards become one strip. Verse count, juz and page
  are reference figures you glance at; three cards gave them the same weight as the surah's name.
- "Juz 1 · Page 2" was the only item in the ayah indicators row that was not a badge. It is one
  now — `MUTED`, because it is a coordinate you look up, not a division you observe.

**Needs a device check:** whether ۞, ۩ and ع render in the Amiri and IndoPak faces rather than
coming out as tofu. That is the one thing I could not verify without hardware.
