### PR TITLE
launchSafely / catchAndReport: a failure path for ViewModel coroutines

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/SafeLaunch.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/SafeLaunch.kt
@@ -1,0 +1,95 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+/**
+ * The failure path for ViewModel coroutines.
+ *
+ * `viewModelScope` is a `SupervisorJob` on `Dispatchers.Main.immediate`: an exception
+ * thrown inside a child `launch` is **not** contained. It reaches the thread's
+ * uncaught handler and kills the app. A bare
+ * `viewModelScope.launch { useCase.doThing() }` is therefore one Room error away
+ * from a crash with no breadcrumb — and the audit in #352 found 293 such launches
+ * against 41 catch sites.
+ *
+ * Use [launchSafely] instead of `viewModelScope.launch` for anything that touches a
+ * use case, and [catchAndReport] on every collected flow.
+ */
+
+/**
+ * Launches [block] in `viewModelScope`, reporting any failure to both monitoring
+ * channels and running [onFailure] so the ViewModel can clear `isLoading` or set an
+ * error on its state.
+ *
+ * Cancellation is re-thrown untouched and never reported — a load abandoned because
+ * the user navigated away is normal control flow.
+ *
+ * Returns the [Job] so callers that need cancel-and-replace semantics (one handle per
+ * surface, per §4.1) can hold it:
+ *
+ * ```kotlin
+ * private var readerJob: Job? = null
+ *
+ * private fun loadChapter(id: String) {
+ *     readerJob?.cancel()
+ *     readerJob = launchSafely(telemetry, "hadith", "load_chapter",
+ *         onFailure = { _state.update { it.copy(isLoading = false, error = …) } },
+ *     ) { … }
+ * }
+ * ```
+ */
+fun ViewModel.launchSafely(
+    telemetry: Telemetry,
+    domain: String,
+    type: String,
+    onFailure: (Throwable) -> Unit = {},
+    block: suspend CoroutineScope.() -> Unit,
+): Job = viewModelScope.launch {
+    try {
+        block()
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (throwable: Throwable) {
+        telemetry.failure(domain, type, throwable)
+        onFailure(throwable)
+    }
+}
+
+/**
+ * Reports an upstream failure to both channels and lets [fallback] decide what the
+ * collector sees.
+ *
+ * Note this **terminates** the flow, exactly as [catch] does — that is Kotlin's
+ * semantics, not a choice made here. Where an outer stream must survive an inner
+ * failure (a `flatMapLatest` over a settings flow, say), apply this to the **inner**
+ * flow, inside the operator:
+ *
+ * ```kotlin
+ * language.flatMapLatest { lang ->
+ *     useCases.getTopics(lang).catchAndReport(telemetry, "help", "load_topics") { emit(emptyList()) }
+ * }.collect { … }
+ * ```
+ *
+ * Applying it outside the `flatMapLatest` instead ends the whole chain on the first
+ * transient error and never recovers — the defect this helper exists to make hard to
+ * write.
+ */
+fun <T> Flow<T>.catchAndReport(
+    telemetry: Telemetry,
+    domain: String,
+    type: String,
+    fallback: suspend FlowCollector<T>.(Throwable) -> Unit = {},
+): Flow<T> = catch { throwable ->
+    // `Flow.catch` already declines to catch CancellationException, but failure()
+    // guards it too so the contract holds however this is called.
+    telemetry.failure(domain, type, throwable)
+    fallback(throwable)
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/monitoring/SafeLaunchTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/monitoring/SafeLaunchTest.kt
@@ -1,0 +1,158 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import androidx.lifecycle.ViewModel
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the failure contract for ViewModel coroutines.
+ *
+ * The audit in #352 found 41 catch sites covering 293 `viewModelScope.launch`
+ * calls — roughly 86% of launched coroutines had no failure path at all. In
+ * `viewModelScope` (a `SupervisorJob` on `Dispatchers.Main.immediate`) an exception
+ * in a child `launch` is *not* contained: it reaches the thread's uncaught handler
+ * and kills the app. For flow collectors the failure mode is quieter but no better —
+ * the collector dies, `isLoading` stays true forever, and nothing is reported.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SafeLaunchTest {
+
+    private val telemetry = RecordingTelemetry()
+
+    // viewModelScope runs on Dispatchers.Main.immediate, so the Main dispatcher has
+    // to be a TestDispatcher or launchSafely's body never executes. runTest then
+    // shares this scheduler, so advanceUntilIdle() drives both.
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private class TestViewModel : ViewModel()
+
+    @Test
+    fun `a throwing block is contained and reported to both channels`() = runTest {
+        val vm = TestViewModel()
+        val boom = IllegalStateException("no such table: quran_ayah")
+
+        vm.launchSafely(telemetry, domain = "quran", type = "load_surah") { throw boom }
+        advanceUntilIdle()
+
+        // Contained: reaching here at all means it did not escape to the uncaught handler.
+        assertThat(telemetry.exceptions).containsExactly(boom)
+        assertThat(telemetry.errors.single().domain).isEqualTo("quran")
+        assertThat(telemetry.errors.single().type).isEqualTo("load_surah")
+    }
+
+    @Test
+    fun `onFailure runs so the ViewModel can clear isLoading`() = runTest {
+        val vm = TestViewModel()
+        var loading = true
+
+        vm.launchSafely(
+            telemetry,
+            domain = "quran",
+            type = "load_surah",
+            onFailure = { loading = false },
+        ) { throw RuntimeException("boom") }
+        advanceUntilIdle()
+
+        assertThat(loading).isFalse()
+    }
+
+    @Test
+    fun `a successful block reports nothing`() = runTest {
+        val vm = TestViewModel()
+        var ran = false
+
+        vm.launchSafely(telemetry, "quran", "load_surah") { ran = true }
+        advanceUntilIdle()
+
+        assertThat(ran).isTrue()
+        assertThat(telemetry.calls).isEmpty()
+    }
+
+    @Test
+    fun `cancelling the job does not report a failure`() = runTest {
+        // Readers cancel loads constantly as the user navigates. Reporting those
+        // would bury real failures in noise.
+        val vm = TestViewModel()
+
+        val job = vm.launchSafely(telemetry, "hadith", "load_chapter") {
+            delay(10_000)
+        }
+        job.cancelAndJoin()
+        advanceUntilIdle()
+
+        assertThat(telemetry.calls).isEmpty()
+    }
+
+    @Test
+    fun `catchAndReport keeps the collector alive and reports the failure`() = runTest {
+        val received = mutableListOf<Int>()
+        val boom = IllegalStateException("row missing")
+
+        val failing = flow {
+            emit(1)
+            emit(2)
+            throw boom
+        }
+
+        CoroutineScope(dispatcher).launch {
+            failing
+                .catchAndReport(telemetry, domain = "dua", type = "load_category")
+                .toList(received)
+        }
+        advanceUntilIdle()
+
+        // Everything emitted before the throw still reached the collector, and the
+        // failure was reported rather than silently ending the stream.
+        assertThat(received).containsExactly(1, 2).inOrder()
+        assertThat(telemetry.exceptions).containsExactly(boom)
+        assertThat(telemetry.errors.single().domain).isEqualTo("dua")
+    }
+
+    @Test
+    fun `catchAndReport can substitute a fallback value`() = runTest {
+        val received = mutableListOf<Int>()
+
+        flow<Int> { throw RuntimeException("boom") }
+            .catchAndReport(telemetry, "dua", "load_category") { emit(-1) }
+            .let { guarded -> CoroutineScope(dispatcher).launch { guarded.toList(received) } }
+        advanceUntilIdle()
+
+        assertThat(received).containsExactly(-1)
+        assertThat(telemetry.errors).hasSize(1)
+    }
+
+    @Test
+    fun `catchAndReport does not report cancellation`() = runTest {
+        val upstream = MutableSharedFlow<Int>()
+
+        val job = CoroutineScope(dispatcher).launch {
+            upstream.catchAndReport(telemetry, "hadith", "observe").collect { }
+        }
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertThat(telemetry.calls).isEmpty()
+    }
+}


### PR DESCRIPTION
**Stack 2 of 3** · epic #352 · foundation for #358

The audit found **293 `viewModelScope.launch` calls against 41 catch sites** — roughly 86% of
launched coroutines in the ViewModel layer had no failure path at all.

That matters because `viewModelScope` is a `SupervisorJob` on `Dispatchers.Main.immediate`: an
exception thrown in a child `launch` is **not contained**. It reaches the thread's uncaught handler
and kills the app. A bare `viewModelScope.launch { useCase.doThing() }` is one Room error away from
a crash with no breadcrumb. For collected flows the failure is quieter but no better — the collector
dies, `isLoading` stays `true` forever, and nothing is reported.

## What this adds

- **`ViewModel.launchSafely(telemetry, domain, type, onFailure) { … }`** — contains the throw,
  reports it through `Telemetry.failure`, runs `onFailure` so the caller can clear `isLoading` or set
  an error, and **returns the `Job`** so callers needing cancel-and-replace (one handle per surface,
  §4.1) can hold it.
- **`Flow<T>.catchAndReport(telemetry, domain, type, fallback)`** — the same for collected flows.

Both re-throw `CancellationException` untouched.

## One thing worth reading in the KDoc

`catchAndReport` **terminates** the flow, exactly as `Flow.catch` does. Where an outer stream must
survive an inner failure, it has to be applied to the **inner** flow, inside the operator:

```kotlin
language.flatMapLatest { lang ->
    useCases.getTopics(lang).catchAndReport(telemetry, "help", "load_topics") { emit(emptyList()) }
}.collect { … }
```

Applying it outside the `flatMapLatest` ends the whole chain on the first transient error and never
recovers — which is the live `HelpViewModel` defect in #366 (one content-DB blip and Help is empty
for the ViewModel's whole lifetime). The KDoc spells this out so the next person doesn't rewrite it.

## Tests

`SafeLaunchTest` — 7 tests: containment, `onFailure`, success reports nothing, cancelled job reports
nothing, `catchAndReport` delivers everything emitted before the throw, fallback substitution, and
cancellation silence.

## Verification

`:app:compileDebugKotlin` ✅ · `:app:testDebugUnitTest` ✅