### PR TITLE
Instrument the two ViewModels that had none (one could crash the app)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SurahThematicViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SurahThematicViewModel.kt
@@ -7,6 +7,8 @@ import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.SurahOverview
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +17,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -40,6 +41,8 @@ data class SurahBackgroundState(
      */
     val proseFontSize: Float = DEFAULT_PROSE_FONT_SIZE,
     val isLoading: Boolean = true,
+    /** Set when the background fails to load, so the screen can say so rather than look empty. */
+    val error: String? = null,
 )
 
 data class SurahPassagesState(
@@ -47,6 +50,8 @@ data class SurahPassagesState(
     val passages: List<AyahTheme> = emptyList(),
     val query: String = "",
     val isLoading: Boolean = true,
+    /** Set when the passages fail to load. */
+    val error: String? = null,
 ) {
     /**
      * The outline, narrowed by the filter.
@@ -82,6 +87,7 @@ sealed interface SurahThematicEvent {
 class SurahThematicViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
     settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _backgroundState = MutableStateFlow(SurahBackgroundState())
@@ -104,8 +110,11 @@ class SurahThematicViewModel @Inject constructor(
         when (event) {
             is SurahThematicEvent.Load -> load(event.surahNumber)
 
-            is SurahThematicEvent.Filter ->
+            is SurahThematicEvent.Filter -> {
                 _passagesState.update { it.copy(query = event.query) }
+                // Logged post-filter with the length only, never the query itself.
+                if (event.query.isNotBlank()) telemetry.search(DOMAIN, event.query.trim().length)
+            }
 
             SurahThematicEvent.ClearFilter ->
                 _passagesState.update { it.copy(query = "") }
@@ -116,9 +125,20 @@ class SurahThematicViewModel @Inject constructor(
         if (loadedSurah == surahNumber && loadJob?.isActive != true) return
         loadedSurah = surahNumber
         loadJob?.cancel()
-        loadJob = viewModelScope.launch {
-            _backgroundState.update { it.copy(isLoading = true) }
-            _passagesState.update { it.copy(isLoading = true) }
+        loadJob = launchSafely(
+            telemetry,
+            domain = DOMAIN,
+            type = "load",
+            onFailure = { throwable ->
+                // The surah was never actually loaded, so clear the marker: otherwise the
+                // guard above would short-circuit a later retry and strand the screen.
+                loadedSurah = null
+                _backgroundState.update { it.copy(isLoading = false, error = throwable.message) }
+                _passagesState.update { it.copy(isLoading = false, error = throwable.message) }
+            },
+        ) {
+            _backgroundState.update { it.copy(isLoading = true, error = null) }
+            _passagesState.update { it.copy(isLoading = true, error = null) }
 
             val surah = quranUseCases.getSurahByNumber(surahNumber)
             val overview = quranUseCases.getSurahOverview(surahNumber)
@@ -130,8 +150,10 @@ class SurahThematicViewModel @Inject constructor(
             _passagesState.update {
                 it.copy(surah = surah, passages = passages, isLoading = false)
             }
+            telemetry.featureUsed(DOMAIN, "open")
         }
     }
 }
 
 private const val DEFAULT_PROSE_FONT_SIZE = 16f
+private const val DOMAIN = "surah_thematic"

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerChaptersViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerChaptersViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.TafseerNoteItem
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
@@ -10,10 +12,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 /**
@@ -23,13 +25,20 @@ import javax.inject.Inject
 data class TafseerChaptersUiState(
     val surahs: List<Surah> = emptyList(),
     val notes: List<TafseerNoteItem> = emptyList(),
-    val isLoading: Boolean = true
+    val isLoading: Boolean = true,
+    /**
+     * Set when the surah list or the notes fail to load. Without it a content-database
+     * failure rendered as an empty picker with the spinner turned off — indistinguishable
+     * from "you have no notes yet".
+     */
+    val error: String? = null,
 )
 
 @HiltViewModel
 class TafseerChaptersViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
-    private val tafseerUseCases: TafseerUseCases
+    private val tafseerUseCases: TafseerUseCases,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TafseerChaptersUiState())
@@ -42,8 +51,14 @@ class TafseerChaptersViewModel @Inject constructor(
         ) { surahs, notes ->
             TafseerChaptersUiState(surahs = surahs, notes = notes, isLoading = false)
         }
-            .onEach { _state.value = it }
-            .catch { _state.value = _state.value.copy(isLoading = false) }
+            .onEach { loaded -> _state.update { loaded } }
+            .catchAndReport(telemetry, DOMAIN, "load") { throwable ->
+                _state.update { it.copy(isLoading = false, error = throwable.message) }
+            }
             .launchIn(viewModelScope)
+    }
+
+    private companion object {
+        const val DOMAIN = "tafseer_chapters"
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerChaptersViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerChaptersViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.TafseerUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `TafseerChaptersViewModel` had **zero instrumentation** — neither `AppAnalytics`
+ * nor `CrashReporter` was imported — and its `.catch { }` did not even bind the
+ * throwable. A failure loading the 114-surah list produced an empty screen with the
+ * spinner turned off, no message, no Crashlytics record and no `app_error` event.
+ *
+ * The first test here could not pass before this change, because the state had no
+ * `error` field at all. Refs #358, #359.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TafseerChaptersViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private lateinit var quranUseCases: QuranUseCases
+    private lateinit var tafseerUseCases: TafseerUseCases
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        quranUseCases = mockk(relaxed = true)
+        tafseerUseCases = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = TafseerChaptersViewModel(quranUseCases, tafseerUseCases, telemetry)
+
+    @Test
+    fun `a failing surah list surfaces an error instead of an empty screen`() = runTest {
+        val boom = IllegalStateException("no such table: surah")
+        every { quranUseCases.getSurahList() } returns flow { throw boom }
+        every { tafseerUseCases.getTafseerNotes() } returns flowOf(emptyList())
+
+        val state = viewModel().state
+        advanceUntilIdle()
+
+        assertThat(state.value.isLoading).isFalse()
+        assertThat(state.value.error).isNotNull()
+        // Identity is not asserted: coroutine stacktrace recovery hands the catch a
+        // copy of the original throwable, so compare what survives that copy.
+        assertThat(telemetry.exceptions.single()).hasMessageThat().isEqualTo(boom.message)
+        assertThat(telemetry.errors.single().domain).isEqualTo("tafseer_chapters")
+    }
+
+    @Test
+    fun `a successful load clears loading and reports nothing`() = runTest {
+        val surahs = listOf(
+            Surah(
+                number = 1,
+                nameArabic = "الفاتحة",
+                nameEnglish = "The Opening",
+                nameTransliteration = "Al-Fatihah",
+                revelationType = RevelationType.MECCAN,
+                ayahCount = 7,
+                juzStart = 1,
+                orderInMushaf = 1,
+            )
+        )
+        every { quranUseCases.getSurahList() } returns flowOf(surahs)
+        every { tafseerUseCases.getTafseerNotes() } returns flowOf(emptyList())
+
+        val state = viewModel().state
+        advanceUntilIdle()
+
+        assertThat(state.value.surahs).hasSize(1)
+        assertThat(state.value.isLoading).isFalse()
+        assertThat(state.value.error).isNull()
+        assertThat(telemetry.calls).isEmpty()
+    }
+}


### PR DESCRIPTION
**Stack 3 of 3** · epic #352 · part of #358 and #359

`SurahThematicViewModel` and `TafseerChaptersViewModel` were the only two ViewModels in the app
importing **neither** `AppAnalytics` nor `CrashReporter`. This puts the seams from the two PRs below
to work on them.

## The crash

`SurahThematicViewModel.load()` made three suspend calls — `getSurahByNumber`, `getSurahOverview`,
`getSurahThemes` — with no guard, *after* setting `isLoading = true`. Since `viewModelScope` does not
contain a child `launch`'s exception, opening a surah whose overview row is missing from a partially
installed content database (a supported state per `docs/SUBSYSTEMS.md` §5 — `ContentArtifactInstaller`
replaces the DB) **crashed the app**, with a spinner as the last thing on screen and no Crashlytics
record.

It now runs through `launchSafely`, surfaces the failure on both states, and **clears `loadedSurah`**
on failure — otherwise the already-loaded guard at the top of `load()` would short-circuit a retry
and strand the screen on a spinner forever.

## The silent one

`TafseerChaptersViewModel`'s `.catch { }` did not even bind the throwable, and the state had no
`error` field, so a failure loading the 114-surah list rendered as an empty picker with the spinner
turned off — indistinguishable from "you have no notes yet".

## Analytics

First usage instrumentation for both: opening a surah's background, and filtering the passage outline
— logged post-filter via `search()` with the **query length only, never the query**.

## Tests

`TafseerChaptersViewModelTest` — the first test **could not have passed before this change**, because
the state had no `error` field to assert on. That is the point: it forces the fix rather than
documenting it.

Note the assertion compares the exception's *message*, not its identity — kotlinx coroutines'
stacktrace recovery hands the catch a copy.

## Verification

`:app:compileDebugKotlin` ✅ · `:app:testDebugUnitTest` ✅ · `check_docs.py` 23/23 ✅