### PR TITLE
Help: recover from a transient failure instead of dying permanently

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModel.kt
@@ -2,8 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.domain.model.HelpGuideDetail
 import com.arshadshah.nimaz.domain.model.HelpSearchResult
 import com.arshadshah.nimaz.domain.model.HelpTopic
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -59,7 +60,8 @@ sealed interface HelpEvent {
 @HiltViewModel
 class HelpViewModel @Inject constructor(
     private val useCases: HelpUseCases,
-    preferences: SettingsRepository
+    preferences: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val language: StateFlow<String> = preferences.appLanguage
@@ -87,38 +89,48 @@ class HelpViewModel @Inject constructor(
     init {
         // Topics re-resolve when the app language changes.
         viewModelScope.launch {
-            language.flatMapLatest { lang -> useCases.getTopics(lang) }
-                .catch { e ->
-                    CrashReporter.recordException(e)
-                    AppAnalytics.logError("help", "load_topics", e.message)
-                    _homeState.update { it.copy(isLoading = false, error = e.message) }
+            language
+                .flatMapLatest { lang ->
+                    // Guarded INSIDE flatMapLatest. Flow.catch completes the flow it is
+                    // applied to, so catching outside ended the whole chain on the first
+                    // transient failure and Help stayed empty for the ViewModel's life.
+                    // Here only the inner attempt ends; the language collector survives,
+                    // so a language change or a retry recovers.
+                    useCases.getTopics(lang)
+                        .catchAndReport(telemetry, DOMAIN, "load_topics") { throwable ->
+                            _homeState.update {
+                                it.copy(isLoading = false, error = throwable.message)
+                            }
+                        }
                 }
                 .collect { topics ->
                     _homeState.update {
-                        it.copy(
-                            topics = topics,
-                            isLoading = false
-                        )
+                        it.copy(topics = topics, isLoading = false, error = null)
                     }
                 }
         }
         // Search results, debounced.
         viewModelScope.launch {
-            combine(query.debounce(200), language) { q, lang -> q to lang }
+            combine(query.debounce(SEARCH_DEBOUNCE_MS), language) { q, lang -> q to lang }
                 .flatMapLatest { (q, lang) ->
-                    if (q.isBlank()) flowOf(emptyList()) else useCases.search(q, lang)
+                    if (q.isBlank()) {
+                        flowOf(q to emptyList())
+                    } else {
+                        // Logged here, post-debounce: HelpScreen wires Search to
+                        // onQueryChange, so logging in onEvent counted keystrokes.
+                        // Length only — the query itself never reaches analytics.
+                        telemetry.search(DOMAIN, q.trim().length)
+                        useCases.search(q, lang)
+                            .catchAndReport(telemetry, DOMAIN, "search") { emit(emptyList()) }
+                            .map { results -> q to results }
+                    }
                 }
-                .catch { e ->
-                    CrashReporter.recordException(e)
-                    AppAnalytics.logError("help", "search", e.message)
-                    /* keep last results on error */
-                }
-                .collect { results ->
+                .collect { (searchedQuery, results) ->
+                    // isSearching is derived from the query these results are FOR, not from
+                    // query.value at emission time — those are different flows and could
+                    // disagree, rendering results under an already-cleared search box.
                     _homeState.update {
-                        it.copy(
-                            results = results,
-                            isSearching = query.value.isNotBlank()
-                        )
+                        it.copy(results = results, isSearching = searchedQuery.isNotBlank())
                     }
                 }
         }
@@ -127,21 +139,25 @@ class HelpViewModel @Inject constructor(
     fun onEvent(event: HelpEvent) {
         when (event) {
             is HelpEvent.Search -> {
-                AppAnalytics.logFeatureUsed("help", "search")
                 query.value = event.query
                 _homeState.update { it.copy(query = event.query) }
             }
 
             is HelpEvent.LoadTopic -> {
-                AppAnalytics.logFeatureUsed("help", "open_topic")
+                telemetry.featureUsed(DOMAIN, "open_topic")
                 loadTopic(event.topicId)
             }
 
             is HelpEvent.LoadGuide -> {
-                AppAnalytics.logFeatureUsed("help", "open_guide")
+                telemetry.featureUsed(DOMAIN, "open_guide")
                 loadGuide(event.guideId)
             }
         }
+    }
+
+    private companion object {
+        const val DOMAIN = "help"
+        const val SEARCH_DEBOUNCE_MS = 200L
     }
 
     private fun loadTopic(topicId: String) {
@@ -149,10 +165,8 @@ class HelpViewModel @Inject constructor(
         topicJob?.cancel()
         topicJob = viewModelScope.launch {
             language.flatMapLatest { lang -> useCases.getTopicDetail(topicId, lang) }
-                .catch { e ->
-                    CrashReporter.recordException(e)
-                    AppAnalytics.logError("help", "load_topic", e.message)
-                    _topicState.update { it.copy(isLoading = false, error = e.message) }
+                .catchAndReport(telemetry, DOMAIN, "load_topic") { throwable ->
+                    _topicState.update { it.copy(isLoading = false, error = throwable.message) }
                 }
                 .collect { detail ->
                     _topicState.update {
@@ -170,10 +184,8 @@ class HelpViewModel @Inject constructor(
         guideJob?.cancel()
         guideJob = viewModelScope.launch {
             language.flatMapLatest { lang -> useCases.getGuide(guideId, lang) }
-                .catch { e ->
-                    CrashReporter.recordException(e)
-                    AppAnalytics.logError("help", "load_guide", e.message)
-                    _guideState.update { it.copy(isLoading = false, error = e.message) }
+                .catchAndReport(telemetry, DOMAIN, "load_guide") { throwable ->
+                    _guideState.update { it.copy(isLoading = false, error = throwable.message) }
                 }
                 .collect { guide ->
                     _guideState.update {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelLoadScopeTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelLoadScopeTest.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+
 import com.arshadshah.nimaz.domain.model.HelpGuideDetail
 import com.arshadshah.nimaz.domain.model.HelpItem
 import com.arshadshah.nimaz.domain.model.HelpTopic
@@ -79,7 +81,7 @@ class HelpViewModelLoadScopeTest {
 
     @Test
     fun `a previously opened topic cannot overwrite the topic on screen`() = runTest {
-        val vm = HelpViewModel(useCases, prefs)
+        val vm = HelpViewModel(useCases, prefs, RecordingTelemetry())
 
         vm.onEvent(HelpEvent.LoadTopic("t1"))
         advanceUntilIdle()
@@ -96,7 +98,7 @@ class HelpViewModelLoadScopeTest {
 
     @Test
     fun `a previously opened guide cannot overwrite the guide on screen`() = runTest {
-        val vm = HelpViewModel(useCases, prefs)
+        val vm = HelpViewModel(useCases, prefs, RecordingTelemetry())
 
         vm.onEvent(HelpEvent.LoadGuide("g1"))
         advanceUntilIdle()
@@ -113,7 +115,7 @@ class HelpViewModelLoadScopeTest {
 
     @Test
     fun `reopening a topic re-subscribes to it`() = runTest {
-        val vm = HelpViewModel(useCases, prefs)
+        val vm = HelpViewModel(useCases, prefs, RecordingTelemetry())
 
         vm.onEvent(HelpEvent.LoadTopic("t1"))
         advanceUntilIdle()

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelRecoveryTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelRecoveryTest.kt
@@ -1,0 +1,138 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.HelpSearchResult
+import com.arshadshah.nimaz.domain.model.HelpTopic
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.HelpUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `Flow.catch` **completes** the flow it is applied to. Both Help collectors put it
+ * *outside* the `flatMapLatest`, so one transient failure ended the whole chain —
+ * `language` is a `StateFlow` that never completes on its own, but once an upstream
+ * throw was caught the `collect` returned and the coroutine finished.
+ *
+ * The user-visible result: open Help while the content database is momentarily
+ * locked and the topic list is empty **for the ViewModel's entire lifetime**.
+ * Changing the app language, retrying, and navigating in and out of Help do not
+ * recover it.
+ *
+ * These tests fail against the previous implementation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HelpViewModelRecoveryTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private lateinit var useCases: HelpUseCases
+    private lateinit var prefs: SettingsRepository
+    private val language = MutableStateFlow("en")
+
+    private val topic = HelpTopic(
+        id = "wudu",
+        iconKey = "water",
+        colorKey = "blue",
+        title = "Wudu",
+        subtitle = "How to perform wudu",
+        order = 0,
+        itemCount = 3,
+    )
+
+    private val hit = HelpSearchResult(
+        topicId = "wudu",
+        itemId = null,
+        isGuide = false,
+        title = "Wudu",
+        snippet = "How to perform wudu",
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        prefs = mockk(relaxed = true)
+        every { prefs.appLanguage } returns language
+        every { useCases.search(any(), any()) } returns flowOf(emptyList())
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `topics recover after a transient failure when the language changes`() = runTest {
+        var attempt = 0
+        every { useCases.getTopics(any()) } answers {
+            attempt++
+            if (attempt == 1) flow { throw IllegalStateException("database is locked") }
+            else flowOf(listOf(topic))
+        }
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+
+        // First attempt failed and was reported.
+        assertThat(vm.homeState.value.topics).isEmpty()
+        assertThat(vm.homeState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.domain }).contains("help")
+
+        // The outer collector must still be alive: a language change re-resolves topics.
+        language.value = "tr"
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.topics).containsExactly(topic)
+        assertThat(vm.homeState.value.error).isNull()
+    }
+
+    @Test
+    fun `search results are never shown under a query that has since been cleared`() = runTest {
+        every { useCases.getTopics(any()) } returns flowOf(emptyList())
+        every { useCases.search("wudu", any()) } returns flowOf(listOf(hit))
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+
+        vm.onEvent(HelpEvent.Search("wudu"))
+        advanceUntilIdle()
+        assertThat(vm.homeState.value.results).isNotEmpty()
+
+        vm.onEvent(HelpEvent.Search(""))
+        advanceUntilIdle()
+
+        // isSearching used to be read from query.value at emission time — a different,
+        // undebounced flow — so results and the query could disagree.
+        assertThat(vm.homeState.value.results).isEmpty()
+        assertThat(vm.homeState.value.isSearching).isFalse()
+    }
+
+    @Test
+    fun `search is logged once per debounced query, not once per keystroke`() = runTest {
+        every { useCases.getTopics(any()) } returns flowOf(emptyList())
+        every { useCases.search(any(), any()) } returns flowOf(listOf(hit))
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+
+        // HelpScreen wires Search to onQueryChange, so typing emits one event per character.
+        "wudu".forEachIndexed { index, _ -> vm.onEvent(HelpEvent.Search("wudu".take(index + 1))) }
+        advanceUntilIdle()
+
+        assertThat(telemetry.searches).hasSize(1)
+        assertThat(telemetry.searches.single().queryLength).isEqualTo(4)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HelpViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+
 import app.cash.turbine.test
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.model.HelpTopic
@@ -44,7 +46,7 @@ class HelpViewModelTest {
 
     @Test
     fun loadsTopicsOnInit() = runTest {
-        val vm = HelpViewModel(useCases, prefs)
+        val vm = HelpViewModel(useCases, prefs, RecordingTelemetry())
         advanceUntilIdle()
         vm.homeState.test {
             val state = expectMostRecentItem()


### PR DESCRIPTION
**Stack 5 of 5** · epic #352 · fixes #366 T4, T5 and part of #359

`Flow.catch` **completes** the flow it is applied to. Both Help collectors applied it *outside* the
`flatMapLatest`:

```kotlin
language.flatMapLatest { lang -> useCases.getTopics(lang) }
    .catch { … }        // ← terminal: the chain ends here
    .collect { … }
```

`language` is a `StateFlow` that never completes on its own — but once an upstream throw was caught,
the `collect` returned and the coroutine finished. **Open Help while the content database is
momentarily locked and the topic list is empty for the ViewModel's entire lifetime.** Changing the
app language, retrying, and navigating in and out of Help do not recover it.

Guarding **inside** the `flatMapLatest` ends only the failed attempt and leaves the outer collector
alive — the pattern `catchAndReport`'s KDoc documents in #370.

## Two more defects on the same screen

- **Results could render under an already-cleared search box.** `isSearching` was read from
  `query.value` at emission time — a *different*, undebounced flow — so a slow search landing after
  the user cleared the field set `results` to the old hits with `query` empty. The query is now
  carried through the pipeline and both fields come from the same tuple.
- **Search was logged once per keystroke.** `HelpScreen` wires `Search` to `onQueryChange`, so
  typing "wudu" emitted four `feature_used` events, plus a fifth on clear. It now logs once per
  debounced query through the purpose-built search API — length only, never the query text.

The `debounce(200)` magic number is now a named constant.

## Tests

`HelpViewModelRecoveryTest` — three tests, all of which **fail against the previous
implementation**: topics recover after a transient failure when the language changes; results are
never shown under a cleared query; search is logged once per debounced query rather than per
keystroke.

The last one is only assertable because of the `Telemetry` seam in #369 — before it, no test in this
repo could tell you how many analytics events an action produced.

## Verification

`:app:compileDebugKotlin` ✅ · full `:app:testDebugUnitTest` ✅