### PR TITLE
Fasting: give the day a working toggle, and stop it lying about exemptions

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
@@ -58,6 +58,7 @@ import com.arshadshah.nimaz.domain.model.FastStatus
 import com.arshadshah.nimaz.domain.model.FastType
 import com.arshadshah.nimaz.domain.model.MakeupFast
 import com.arshadshah.nimaz.domain.model.MakeupFastStatus
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.atoms.GradientCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeDefaults
@@ -257,6 +258,7 @@ fun FastTrackerScreen(
                                 ramadanDay = if (ramadanState.isRamadan) ramadanState.currentDay else null,
                                 suhoorAt = state.suhoorAt,
                                 iftarAt = state.iftarAt,
+                                canToggle = state.canToggleToday,
                                 onToggleFast = { viewModel.onEvent(FastingEvent.ToggleTodayFast) }
                             )
                         }
@@ -526,6 +528,7 @@ private fun TodayFastSection(
     ramadanDay: Int?,
     suhoorAt: kotlin.time.Instant?,
     iftarAt: kotlin.time.Instant?,
+    canToggle: Boolean,
     onToggleFast: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -617,6 +620,47 @@ private fun TodayFastSection(
                             color = statusColor
                         )
                     }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // The one-tap log for the day.
+                //
+                // `onToggleFast` was previously passed into this composable and never
+                // invoked, so FastingEvent.ToggleTodayFast had no producer at all and
+                // the day could only be logged through the management sheet.
+                //
+                // Disabled for EXEMPTED and MAKEUP_DUE: those are considered states
+                // recorded in the sheet with a reason attached, and a single tap must
+                // not silently overwrite one. The subtitle says where to change it
+                // rather than leaving a control that looks live and does nothing.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.fasting_log_today),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = when {
+                                !canToggle -> stringResource(R.string.fasting_log_managed_in_sheet)
+                                isFasting -> stringResource(R.string.fasting_log_on_subtitle)
+                                else -> stringResource(R.string.fasting_log_off_subtitle)
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    NimazSwitch(
+                        checked = isFasting,
+                        enabled = canToggle,
+                        onCheckedChange = { onToggleFast() },
+                        contentDescription = stringResource(R.string.fasting_log_today)
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -2,8 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.core.util.formatClockTime
@@ -44,7 +43,25 @@ data class FastingTrackerUiState(
     val isSuhoorTime: Boolean = false,
     val isLoading: Boolean = true,
     val error: String? = null
-)
+) {
+    /**
+     * Whether the one-tap "fasting today" control can act on the selected day.
+     *
+     * `FastStatus` has four values, and only `FASTED`/`NOT_FASTED` are two ends of a
+     * toggle. `EXEMPTED` and `MAKEUP_DUE` are considered states recorded in the day
+     * sheet — with a reason attached — so a single tap must not silently overwrite
+     * them. The toggle renders disabled for those, with [toggleBlockedReason] saying
+     * why, rather than looking live and doing nothing (which is what it used to do).
+     */
+    val canToggleToday: Boolean
+        get() = todayRecord == null ||
+            todayRecord.status == FastStatus.FASTED ||
+            todayRecord.status == FastStatus.NOT_FASTED
+
+    /** The status blocking the toggle, or null when it is actionable. */
+    val toggleBlockedReason: FastStatus?
+        get() = if (canToggleToday) null else todayRecord?.status
+}
 
 data class RamadanTrackerUiState(
     val ramadanRecords: List<FastRecord> = emptyList(),
@@ -129,8 +146,10 @@ sealed interface FastingEvent {
 class FastingViewModel @Inject constructor(
     private val fastingUseCases: FastingUseCases,
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
+
 
     private val _trackerState = MutableStateFlow(FastingTrackerUiState())
     val trackerState: StateFlow<FastingTrackerUiState> = _trackerState.asStateFlow()
@@ -157,8 +176,8 @@ class FastingViewModel @Inject constructor(
 
     // No `use24HourFormat` mirror: suhoor/iftar are instants, formatted at the leaf.
 
-    companion object {
-        // Default location: Dublin, Ireland (fallback)
+    private companion object {
+        const val DOMAIN = "fasting"
     }
 
     init {
@@ -204,34 +223,33 @@ class FastingViewModel @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            CrashReporter.recordException(e)
-            AppAnalytics.logError("fasting", "load_prayer_times", e.message)
+            telemetry.failure(DOMAIN, "load_prayer_times", e)
             // Keep default placeholder times
         }
     }
 
     fun onEvent(event: FastingEvent) {
         when (event) {
-            is FastingEvent.StartFast -> AppAnalytics.logFastTracked("start", event.fastType.name)
-            is FastingEvent.CompleteFast -> AppAnalytics.logFastTracked("complete")
-            is FastingEvent.BreakFast -> AppAnalytics.logFastTracked("break")
-            is FastingEvent.MissFast -> AppAnalytics.logFastTracked("miss")
-            is FastingEvent.LogRecommendedFast -> AppAnalytics.logFastTracked(
+            is FastingEvent.StartFast -> telemetry.fastTracked("start", event.fastType.name)
+            is FastingEvent.CompleteFast -> telemetry.fastTracked("complete")
+            is FastingEvent.BreakFast -> telemetry.fastTracked("break")
+            is FastingEvent.MissFast -> telemetry.fastTracked("miss")
+            is FastingEvent.LogRecommendedFast -> telemetry.fastTracked(
                 "recommended",
                 event.fastType.name
             )
 
-            is FastingEvent.PayFidya -> AppAnalytics.logFeatureUsed("fasting", "pay_fidya")
-            is FastingEvent.AddMakeupFast -> AppAnalytics.logFeatureUsed("fasting", "add_makeup")
+            is FastingEvent.PayFidya -> telemetry.featureUsed(DOMAIN, "pay_fidya")
+            is FastingEvent.AddMakeupFast -> telemetry.featureUsed(DOMAIN, "add_makeup")
             is FastingEvent.CompleteMakeupFast ->
-                AppAnalytics.logFeatureUsed("fasting", "complete_makeup")
+                telemetry.featureUsed(DOMAIN, "complete_makeup")
             // Status/type only — never the user's exemption reason or note text.
-            is FastingEvent.SaveFastForDate -> AppAnalytics.logFastTracked(
+            is FastingEvent.SaveFastForDate -> telemetry.fastTracked(
                 "save_for_date",
                 event.fastType.name
             )
 
-            is FastingEvent.DeleteFastRecord -> AppAnalytics.logFastTracked("delete")
+            is FastingEvent.DeleteFastRecord -> telemetry.fastTracked("delete")
             else -> {}
         }
         when (event) {
@@ -385,7 +403,13 @@ class FastingViewModel @Inject constructor(
                     }
                 }
 
-                else -> {}
+                // Exhaustive on purpose: these two are managed in the day sheet, where
+                // the reason lives, and the screen disables the toggle for them via
+                // canToggleToday. Reaching here means the UI let through a tap it should
+                // not have, so it is recorded rather than silently dropped.
+                FastStatus.EXEMPTED,
+                FastStatus.MAKEUP_DUE ->
+                    telemetry.featureUsed(DOMAIN, "toggle_blocked_${currentRecord.status.name.lowercase()}")
             }
         }
     }
@@ -644,6 +668,10 @@ class FastingViewModel @Inject constructor(
             loadCalendarMonth()
             loadStats()
             loadRamadan()
+            // saveFastForDate auto-creates a makeup fast for a missed or exempted
+            // Ramadan day. Deleting the record left that row behind for ever and the
+            // pending count stale on screen, because this path never reloaded it.
+            loadMakeupFasts()
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -609,7 +609,7 @@
         <item quantity="one">In %1$d Tag</item>
         <item quantity="other">In %1$d Tagen</item>
     </plurals>
-    <string name="fasting_log_today">Heutigen Fastentag erfassen</string>
+    <string name="fasting_log_today">Fasten für heute erfassen</string>
     <string name="fasting_no_makeup">Keine nachzuholenden Fastentage</string>
     <string name="fasting_all_up_to_date">Alle Ihre Fastentage sind aktuell!</string>
     <string name="fasting_fasts_to_makeup">Nachzuholende Fastentage</string>
@@ -1748,4 +1748,7 @@
     <string name="zakat_gold_price_label">Goldpreis pro Gramm</string>
     <string name="zakat_silver_price_label">Silberpreis pro Gramm</string>
     <string name="zakat_metal_prices_hint">Schätzwerte — bitte an den lokalen Kurs anpassen. Der Nisab-Schwellenwert wird daraus berechnet.</string>
+    <string name="fasting_log_on_subtitle">Erfasst — zum Rückgängigmachen tippen</string>
+    <string name="fasting_log_off_subtitle">Noch nicht erfasst</string>
+    <string name="fasting_log_managed_in_sheet">Wird in den Tagesdetails verwaltet</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -629,7 +629,7 @@
         <item quantity="many">Dans %1$d jours</item>
         <item quantity="other">Dans %1$d jours</item>
     </plurals>
-    <string name="fasting_log_today">Enregistrer le jeûne d\'aujourd\'hui</string>
+    <string name="fasting_log_today">Enregistrer le jeûne d’aujourd’hui</string>
     <string name="fasting_no_makeup">Pas de jeûne de rattrapage</string>
     <string name="fasting_all_up_to_date">Tous vos jeûnes sont à jour !</string>
     <string name="fasting_fasts_to_makeup">Jeûnes à rattraper</string>
@@ -1783,4 +1783,7 @@
     <string name="zakat_gold_price_label">Prix de l’or par gramme</string>
     <string name="zakat_silver_price_label">Prix de l’argent par gramme</string>
     <string name="zakat_metal_prices_hint">Estimations — indiquez votre cours local. Le seuil du nisab en découle.</string>
+    <string name="fasting_log_on_subtitle">Enregistré — appuyez pour annuler</string>
+    <string name="fasting_log_off_subtitle">Pas encore enregistré</string>
+    <string name="fasting_log_managed_in_sheet">Géré dans les détails du jour</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -593,7 +593,7 @@
     <plurals name="fasting_in_days_format">
         <item quantity="other">Dalam %1$d hari</item>
     </plurals>
-    <string name="fasting_log_today">Catat Puasa Hari Ini</string>
+    <string name="fasting_log_today">Catat puasa hari ini</string>
     <string name="fasting_no_makeup">Tidak Ada Puasa Qadha</string>
     <string name="fasting_all_up_to_date">Semua puasa Anda sudah terpenuhi!</string>
     <string name="fasting_fasts_to_makeup">Puasa yang Harus Diqadha</string>
@@ -1717,4 +1717,7 @@
     <string name="zakat_gold_price_label">Harga emas per gram</string>
     <string name="zakat_silver_price_label">Harga perak per gram</string>
     <string name="zakat_metal_prices_hint">Perkiraan — sesuaikan dengan harga setempat. Ambang nisab dihitung dari nilai ini.</string>
+    <string name="fasting_log_on_subtitle">Tercatat — ketuk untuk membatalkan</string>
+    <string name="fasting_log_off_subtitle">Belum dicatat</string>
+    <string name="fasting_log_managed_in_sheet">Dikelola di rincian hari ini</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -593,7 +593,7 @@
     <plurals name="fasting_in_days_format">
         <item quantity="other">Dalam %1$d hari</item>
     </plurals>
-    <string name="fasting_log_today">Rekod Puasa Hari Ini</string>
+    <string name="fasting_log_today">Rekod puasa hari ini</string>
     <string name="fasting_no_makeup">Tiada Puasa Ganti</string>
     <string name="fasting_all_up_to_date">Semua puasa anda sudah dikemas kini!</string>
     <string name="fasting_fasts_to_makeup">Puasa untuk Diganti</string>
@@ -1718,4 +1718,7 @@
     <string name="zakat_gold_price_label">Harga emas segram</string>
     <string name="zakat_silver_price_label">Harga perak segram</string>
     <string name="zakat_metal_prices_hint">Anggaran — tetapkan mengikut harga tempatan. Ambang nisab dikira daripadanya.</string>
+    <string name="fasting_log_on_subtitle">Direkod — ketik untuk batalkan</string>
+    <string name="fasting_log_off_subtitle">Belum direkod</string>
+    <string name="fasting_log_managed_in_sheet">Diurus dalam butiran hari</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -612,7 +612,7 @@
         <item quantity="one">%1$d gün sonra</item>
         <item quantity="other">%1$d gün sonra</item>
     </plurals>
-    <string name="fasting_log_today">Bugünün Orucunu Kaydet</string>
+    <string name="fasting_log_today">Bugünün orucunu kaydet</string>
     <string name="fasting_no_makeup">Kaza Orucu Yok</string>
     <string name="fasting_all_up_to_date">Tüm oruçlarınız güncel!</string>
     <string name="fasting_fasts_to_makeup">Kaza Edilecek Oruçlar</string>
@@ -1754,4 +1754,7 @@
     <string name="zakat_gold_price_label">Gram başına altın fiyatı</string>
     <string name="zakat_silver_price_label">Gram başına gümüş fiyatı</string>
     <string name="zakat_metal_prices_hint">Tahmini değerler — yerel kurunuza göre ayarlayın. Nisap eşiği bunlardan hesaplanır.</string>
+    <string name="fasting_log_on_subtitle">Kaydedildi — geri almak için dokunun</string>
+    <string name="fasting_log_off_subtitle">Henüz kaydedilmedi</string>
+    <string name="fasting_log_managed_in_sheet">Gün ayrıntılarında yönetilir</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -977,7 +977,7 @@
         <item quantity="one">In %1$d day</item>
         <item quantity="other">In %1$d days</item>
     </plurals>
-    <string name="fasting_log_today">Log Today\'s Fast</string>
+    <string name="fasting_log_today">Log today\'s fast</string>
     <string name="fasting_no_makeup">No Makeup Fasts</string>
     <string name="fasting_all_up_to_date">All your fasts are up to date!</string>
     <string name="fasting_fasts_to_makeup">Fasts to Make Up</string>
@@ -1919,4 +1919,7 @@
     <string name="zakat_gold_price_label">Gold price per gram</string>
     <string name="zakat_silver_price_label">Silver price per gram</string>
     <string name="zakat_metal_prices_hint">Estimates — set these to your local rate. The nisab threshold is worked out from them.</string>
+    <string name="fasting_log_on_subtitle">Logged — tap to undo</string>
+    <string name="fasting_log_off_subtitle">Not logged yet</string>
+    <string name="fasting_log_managed_in_sheet">Managed in the day\'s details</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingToggleTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingToggleTest.kt
@@ -1,0 +1,78 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * `FastStatus` has **four** values, and `toggleTodayFast()` handled two of them with a
+ * silent `else -> {}`. Marking a day exempted (menstruation, illness, travel) and then
+ * using the one-tap control did nothing at all — no change, no error, no feedback.
+ *
+ * The decision taken was that an exemption is a considered state recorded in the day
+ * sheet *with a reason attached*, so a single tap must not silently overwrite it. The
+ * control is disabled instead, and says where to change it.
+ */
+class FastingToggleTest {
+
+    private fun stateWith(status: FastStatus?) = FastingTrackerUiState(
+        todayRecord = status?.let {
+            FastRecord(
+                id = 1L,
+                date = LocalDate.of(2026, 3, 12).toEpochDay() * 86_400_000L,
+                hijriDate = null,
+                hijriMonth = 9,
+                hijriYear = 1447,
+                fastType = FastType.RAMADAN,
+                status = it,
+                exemptionReason = null,
+                suhoorTime = null,
+                iftarTime = null,
+                note = null,
+                createdAt = 0L,
+                updatedAt = 0L,
+            )
+        }
+    )
+
+    @Test
+    fun `a day with no record is toggleable`() {
+        assertThat(stateWith(null).canToggleToday).isTrue()
+        assertThat(stateWith(null).toggleBlockedReason).isNull()
+    }
+
+    @Test
+    fun `fasted and not-fasted are the two ends of the toggle`() {
+        assertThat(stateWith(FastStatus.FASTED).canToggleToday).isTrue()
+        assertThat(stateWith(FastStatus.NOT_FASTED).canToggleToday).isTrue()
+    }
+
+    @Test
+    fun `an exempted day is not toggleable, and says why`() {
+        val state = stateWith(FastStatus.EXEMPTED)
+
+        assertThat(state.canToggleToday).isFalse()
+        assertThat(state.toggleBlockedReason).isEqualTo(FastStatus.EXEMPTED)
+    }
+
+    @Test
+    fun `a makeup-due day is not toggleable, and says why`() {
+        val state = stateWith(FastStatus.MAKEUP_DUE)
+
+        assertThat(state.canToggleToday).isFalse()
+        assertThat(state.toggleBlockedReason).isEqualTo(FastStatus.MAKEUP_DUE)
+    }
+
+    @Test
+    fun `every FastStatus is accounted for`() {
+        // Guards the decision itself: a fifth status must force a choice here rather
+        // than silently defaulting to "toggleable" or "blocked".
+        val classified = FastStatus.entries.map { stateWith(it).canToggleToday }
+
+        assertThat(classified).hasSize(4)
+        assertThat(classified.count { it }).isEqualTo(2)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+
 import app.cash.turbine.test
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -74,7 +76,12 @@ class FastingViewModelTest {
     }
 
     private fun createViewModel(): FastingViewModel {
-        return FastingViewModel(buildFastingUseCases(repository), prayerTimeCalculator, settingsRepository)
+        return FastingViewModel(
+            buildFastingUseCases(repository),
+            prayerTimeCalculator,
+            settingsRepository,
+            RecordingTelemetry(),
+        )
     }
 
     private fun dateToEpoch(date: LocalDate): Long {


### PR DESCRIPTION
**Stack 6 of 6** · epic #352 · fixes #366 T16 + T17

## The toggle did not exist

`TodayFastSection` took an `onToggleFast` lambda and **never invoked it**. `grep -n onToggleFast`
finds exactly two hits: the parameter declaration and the call site, with nothing in between. So
`FastingEvent.ToggleTodayFast` had **no producer at all**, and a day could only be logged through
the management sheet.

This is a correction to the audit, which recorded it as "the tap target looks live and is dead" —
in fact there was no tap target. This PR adds the switch that was assumed to be there.

## The handler was wrong for half its inputs

`FastStatus` has **four** values — `FASTED`, `NOT_FASTED`, `EXEMPTED`, `MAKEUP_DUE` — and
`toggleTodayFast()` handled the first two with a silent `else -> {}`. Wiring the switch as-is would
have shipped a control that visibly refuses to move.

**Decision taken:** an exemption is a considered state recorded in the day sheet *with a reason
attached* (menstruation, illness, travel), so one tap must not silently overwrite it.

- `FastingTrackerUiState.canToggleToday` drives the switch's `enabled` state.
- The subtitle reads "Managed in the day's details" rather than leaving a dead-looking control.
- The `when` is now **exhaustive** — the unreachable branch records rather than swallows, so a
  fifth status has to be classified deliberately instead of silently becoming a no-op.

## The makeup count went stale on delete

`saveFastForDate` auto-creates a `MakeupFast` for a missed or exempted Ramadan day.
`deleteFastRecord` reloaded calendar, stats and Ramadan — but **not makeup fasts** — so deleting the
record left the makeup row on screen and in the database for ever.

Worth fixing now specifically because #368 promotes that number to a `NimazBadge` **and** a "3 makeup
fasts pending" subtitle on the More screen. Two new surfaces for a known-wrong count.

## Tests

`FastingToggleTest` — five tests, including one that asserts **every** `FastStatus` is classified, so
adding a value forces a decision here rather than defaulting to "toggleable".

## Notes for #368

Spec §4 chose "one `NimazSwitch`" for this control. That is what this PR ships, so the redesign can
restyle it rather than introduce it — and the four-state problem is already solved behind
`canToggleToday`.

## Verification

`:app:compileDebugKotlin` ✅ · full `:app:testDebugUnitTest` ✅ · `check_docs.py` 23/23 ✅ ·
new strings translated into all five shipped locales