### PR TITLE
Bookmarks: search, sort and a guarded clear-all, on batched queries

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/QuranDao.kt
@@ -215,6 +215,7 @@ interface QuranDao {
     )
     suspend fun getAyahWithTextById(ayahId: Int): AyahWithText?
 
+
     @Query(
         """
         SELECT a.*,

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/DuaRepositoryImpl.kt
@@ -64,6 +64,12 @@ class DuaRepositoryImpl @Inject constructor(
             .map { it.toDomain() }
     }
 
+    override suspend fun getDuasByIds(duaIds: List<String>): List<Dua> {
+        val numeric = duaIds.mapNotNull { it.toIntOrNull() }
+        if (numeric.isEmpty()) return emptyList()
+        return duaDao.getDuasByIds(numeric).map { it.toDomain() }
+    }
+
     override suspend fun getDuaById(duaId: String): Dua? {
         return duaDao.getDuaById(duaId.toIntOrNull() ?: return null)?.toDomain()
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/HadithRepositoryImpl.kt
@@ -120,6 +120,12 @@ class HadithRepositoryImpl @Inject constructor(
         return hadithDao.getHadithsByBook(bookId.toIntOrNull() ?: 0).mapItems { it.toDomain() }
     }
 
+    override suspend fun getHadithsByIds(hadithIds: List<String>): List<Hadith> {
+        val numeric = hadithIds.mapNotNull { it.toIntOrNull() }
+        if (numeric.isEmpty()) return emptyList()
+        return hadithDao.getHadithsByIds(numeric).map { it.toDomain() }
+    }
+
     override suspend fun getHadithById(hadithId: String): Hadith? {
         return hadithDao.getHadithById(hadithId.toIntOrNull() ?: return null)?.toDomain()
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/QuranRepositoryImpl.kt
@@ -136,6 +136,11 @@ class QuranRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAyahsByIds(ayahIds: List<Int>): List<Ayah> {
+        if (ayahIds.isEmpty()) return emptyList()
+        return quranDao.getAyahsWithTextByIds(ayahIds).map { it.toDomain() }
+    }
+
     override suspend fun getAyahById(ayahId: Int): Ayah? {
         return quranDao.getAyahWithTextById(ayahId)?.toDomain()
     }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/DuaRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/DuaRepository.kt
@@ -17,6 +17,9 @@ interface DuaRepository {
     fun getDuasByCategory(categoryId: String): Flow<List<Dua>>
     suspend fun getDuasByCategoryOnce(categoryId: String): List<Dua>
     suspend fun getDuaById(duaId: String): Dua?
+
+    /** Batched [getDuaById]; order is not guaranteed, look results up by id. */
+    suspend fun getDuasByIds(duaIds: List<String>): List<Dua>
     fun getDuasByOccasion(occasion: DuaOccasion): Flow<List<Dua>>
 
     // Search operations

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/HadithRepository.kt
@@ -25,6 +25,9 @@ interface HadithRepository {
     fun getHadithsByChapter(chapterId: String): Flow<List<Hadith>>
     fun getHadithsByBook(bookId: String): Flow<List<Hadith>>
     suspend fun getHadithById(hadithId: String): Hadith?
+
+    /** Batched [getHadithById]; order is not guaranteed, look results up by id. */
+    suspend fun getHadithsByIds(hadithIds: List<String>): List<Hadith>
     suspend fun getHadithByNumber(bookId: String, hadithNumber: Int): Hadith?
 
     /**

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/QuranRepository.kt
@@ -31,6 +31,9 @@ interface QuranRepository {
     // Ayah operations
     fun getAyahsBySurah(surahNumber: Int): Flow<List<Ayah>>
     suspend fun getAyahById(ayahId: Int): Ayah?
+
+    /** Batched [getAyahById]; order is not guaranteed, look results up by id. */
+    suspend fun getAyahsByIds(ayahIds: List<Int>): List<Ayah>
     fun getAyahsByJuz(juzNumber: Int, translatorId: String? = null): Flow<List<Ayah>>
     /**
      * The ayahs printed on [pageNumber] of [script]'s edition. Ayah-flow editions (Madani)

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/DuaUseCases.kt
@@ -40,6 +40,10 @@ class GetCategoryByIdUseCase @Inject constructor(private val repository: DuaRepo
 
 class GetDuaByIdUseCase @Inject constructor(private val repository: DuaRepository) {
     suspend operator fun invoke(duaId: String): Dua? = repository.getDuaById(duaId)
+
+    /** Batched lookup, keyed by dua id, for callers enriching a whole list at once. */
+    suspend fun forIds(duaIds: List<String>): Map<String, Dua> =
+        repository.getDuasByIds(duaIds).associateBy { it.id }
 }
 
 class GetDuasByCategoryUseCase @Inject constructor(private val repository: DuaRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/HadithUseCases.kt
@@ -57,6 +57,10 @@ class GetHadithsByChapterUseCase @Inject constructor(private val repository: Had
 
 class GetHadithByIdUseCase @Inject constructor(private val repository: HadithRepository) {
     suspend operator fun invoke(hadithId: String): Hadith? = repository.getHadithById(hadithId)
+
+    /** Batched lookup, keyed by hadith id, for callers enriching a whole list at once. */
+    suspend fun forIds(hadithIds: List<String>): Map<String, Hadith> =
+        repository.getHadithsByIds(hadithIds).associateBy { it.id }
 }
 
 class GetHadithByNumberUseCase @Inject constructor(private val repository: HadithRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/QuranUseCases.kt
@@ -47,6 +47,10 @@ class GetAyahByIdUseCase @Inject constructor(
     private val repository: QuranRepository
 ) {
     suspend operator fun invoke(ayahId: Int): Ayah? = repository.getAyahById(ayahId)
+
+    /** Batched lookup, keyed by ayah id, for callers enriching a whole list at once. */
+    suspend fun forIds(ayahIds: List<Int>): Map<Int, Ayah> =
+        repository.getAyahsByIds(ayahIds).associateBy { it.id }
 }
 
 class GetAyahsByJuzUseCase @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
@@ -1,5 +1,17 @@
 package com.arshadshah.nimaz.presentation.screens.bookmarks
 
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material3.IconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogDestructiveButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownMenu
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownRow
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
+import com.arshadshah.nimaz.presentation.viewmodel.BookmarkSortOrder
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,6 +91,8 @@ fun BookmarksScreen(
     // The bookmark whose note is being edited (null = no editor showing). The
     // overflow menu is an anchored dropdown owned by each card.
     var noteTarget by remember { mutableStateOf<UnifiedBookmark?>(null) }
+    var sortMenuExpanded by remember { mutableStateOf(false) }
+    var showClearAllDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
     // Drive the Undo snackbar off the most recently deleted bookmark.
@@ -100,6 +114,14 @@ fun BookmarksScreen(
         }
     }
 
+    if (showClearAllDialog) {
+        ClearAllBookmarksDialog(
+            total = statsState.totalBookmarks,
+            onConfirm = { viewModel.onEvent(BookmarksEvent.ClearAllBookmarks) },
+            onDismiss = { showClearAllDialog = false },
+        )
+    }
+
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
@@ -109,7 +131,41 @@ fun BookmarksScreen(
                     stringResource(R.string.bookmarks_count, statsState.totalBookmarks)
                 } else null,
                 onBackClick = onNavigateBack,
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                actions = {
+                    if (state.allBookmarks.isNotEmpty()) {
+                        IconButton(onClick = { sortMenuExpanded = true }) {
+                            NimazIcon(
+                                Icons.AutoMirrored.Filled.Sort,
+                                contentDescription = stringResource(R.string.bookmarks_sort)
+                            )
+                        }
+                        NimazDropdownMenu(
+                            expanded = sortMenuExpanded,
+                            onDismissRequest = { sortMenuExpanded = false },
+                        ) {
+                            BookmarkSortOrder.entries.forEach { order ->
+                                NimazDropdownRow(
+                                    text = stringResource(order.labelRes()),
+                                    selected = state.sortOrder == order,
+                                    onClick = {
+                                        sortMenuExpanded = false
+                                        viewModel.onEvent(BookmarksEvent.SetSortOrder(order))
+                                    },
+                                )
+                            }
+                            NimazDropdownRow(
+                                text = stringResource(R.string.bookmarks_clear_all),
+                                leadingIcon = Icons.Filled.DeleteSweep,
+                                destructive = true,
+                                onClick = {
+                                    sortMenuExpanded = false
+                                    showClearAllDialog = true
+                                },
+                            )
+                        }
+                    }
+                }
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -148,6 +204,17 @@ fun BookmarksScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     item {
+                        NimazSearchBar(
+                            query = state.searchQuery,
+                            onQueryChange = {
+                                viewModel.onEvent(BookmarksEvent.SetSearchQuery(it))
+                            },
+                            onClear = { viewModel.onEvent(BookmarksEvent.SetSearchQuery("")) },
+                            placeholder = stringResource(R.string.bookmarks_search_placeholder)
+                        )
+                    }
+
+                    item {
                         BookmarkFilterTabs(
                             selectedFilter = state.selectedFilter,
                             allCount = statsState.totalBookmarks,
@@ -156,6 +223,19 @@ fun BookmarksScreen(
                             duaCount = statsState.duaCount,
                             onFilterSelected = { viewModel.onEvent(BookmarksEvent.SetFilter(it)) }
                         )
+                    }
+
+                    if (state.filteredBookmarks.isEmpty()) {
+                        item {
+                            NimazEmptyState(
+                                title = stringResource(R.string.bookmarks_no_matches),
+                                message = stringResource(R.string.bookmarks_no_matches_hint),
+                                icon = Icons.Default.Bookmark,
+                                iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    .copy(alpha = 0.5f),
+                                modifier = Modifier.padding(vertical = 32.dp)
+                            )
+                        }
                     }
 
                     items(
@@ -331,6 +411,56 @@ private fun NoteEditorSheet(
             placeholder = { Text(stringResource(R.string.note_hint)) }
         )
         Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+/**
+ * The label for a sort order. Lives here rather than on the enum so the enum stays a
+ * plain domain-shaped value with no Android dependency.
+ */
+@StringRes
+private fun BookmarkSortOrder.labelRes(): Int = when (this) {
+    BookmarkSortOrder.DATE_NEWEST -> R.string.bookmarks_sort_newest
+    BookmarkSortOrder.DATE_OLDEST -> R.string.bookmarks_sort_oldest
+    BookmarkSortOrder.TYPE -> R.string.bookmarks_sort_type
+    BookmarkSortOrder.ALPHABETICAL -> R.string.bookmarks_sort_alphabetical
+}
+
+/**
+ * Confirmation for clearing every bookmark.
+ *
+ * Destructive, irreversible, and — by decision — **not undoable**: the dialog is the
+ * safety net, so it names exactly what disappears rather than saying "are you sure".
+ * Quran, Hadith and Dua bookmarks all go, which is not obvious from a button on a
+ * screen that is currently filtered to one of them.
+ */
+@Composable
+private fun ClearAllBookmarksDialog(
+    total: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    NimazDialog(
+        title = stringResource(R.string.bookmarks_clear_all_title),
+        titleIcon = Icons.Filled.DeleteSweep,
+        accentColor = MaterialTheme.colorScheme.error,
+        onDismiss = onDismiss,
+        actions = {
+            NimazDialogCancelButton(onClick = onDismiss)
+            NimazDialogDestructiveButton(
+                text = stringResource(R.string.bookmarks_clear_all_confirm),
+                onClick = {
+                    onConfirm()
+                    onDismiss()
+                },
+            )
+        },
+    ) {
+        Text(
+            text = stringResource(R.string.bookmarks_clear_all_body, total),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModel.kt
@@ -184,9 +184,13 @@ class BookmarksViewModel @Inject constructor(
                     }
                 }
                 .collect { bookmarks ->
+                // One query for the whole list. This used to be a suspend call per row
+                // inside the collector, so N bookmarks meant N round-trips on every
+                // re-emission — and clearing them all re-emitted once per delete, making
+                // the wipe O(N^2).
+                val texts = quranUseCases.getAyahById.forIds(bookmarks.map { it.ayahId })
                 val mapped = bookmarks.map { bm ->
-                    bm.toUnified()
-                        .copy(arabicText = quranUseCases.getAyahById(bm.ayahId)?.textArabic)
+                    bm.toUnified().copy(arabicText = texts[bm.ayahId]?.textArabic)
                 }
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.QURAN } +
@@ -220,9 +224,9 @@ class BookmarksViewModel @Inject constructor(
                     }
                 }
                 .collect { bookmarks ->
+                val texts = hadithUseCases.getHadithById.forIds(bookmarks.map { it.hadithId })
                 val mapped = bookmarks.map { bm ->
-                    bm.toUnified()
-                        .copy(arabicText = hadithUseCases.getHadithById(bm.hadithId)?.textArabic)
+                    bm.toUnified().copy(arabicText = texts[bm.hadithId]?.textArabic)
                 }
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.HADITH } +
@@ -256,8 +260,9 @@ class BookmarksViewModel @Inject constructor(
                     }
                 }
                 .collect { bookmarks ->
+                val texts = duaUseCases.getDuaById.forIds(bookmarks.map { it.duaId })
                 val mapped = bookmarks.map { bm ->
-                    bm.toUnified().copy(arabicText = duaUseCases.getDuaById(bm.duaId)?.textArabic)
+                    bm.toUnified().copy(arabicText = texts[bm.duaId]?.textArabic)
                 }
                 _bookmarksState.update { state ->
                     val unified = state.allBookmarks.filter { it.type != BookmarkType.DUA } +

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1751,4 +1751,16 @@
     <string name="fasting_log_on_subtitle">Erfasst — zum Rückgängigmachen tippen</string>
     <string name="fasting_log_off_subtitle">Noch nicht erfasst</string>
     <string name="fasting_log_managed_in_sheet">Wird in den Tagesdetails verwaltet</string>
+    <string name="bookmarks_search_placeholder">Lesezeichen durchsuchen</string>
+    <string name="bookmarks_sort">Sortieren</string>
+    <string name="bookmarks_sort_newest">Neueste zuerst</string>
+    <string name="bookmarks_sort_oldest">Älteste zuerst</string>
+    <string name="bookmarks_sort_type">Nach Typ</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">Keine Treffer</string>
+    <string name="bookmarks_no_matches_hint">Versuchen Sie eine andere Suche oder entfernen Sie den Filter.</string>
+    <string name="bookmarks_clear_all">Alle Lesezeichen löschen</string>
+    <string name="bookmarks_clear_all_title">Alle Lesezeichen löschen?</string>
+    <string name="bookmarks_clear_all_confirm">Alle löschen</string>
+    <string name="bookmarks_clear_all_body">Damit werden alle %1$d Lesezeichen entfernt — Koran, Hadith und Bittgebete. Dies kann nicht rückgängig gemacht werden.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1786,4 +1786,16 @@
     <string name="fasting_log_on_subtitle">Enregistré — appuyez pour annuler</string>
     <string name="fasting_log_off_subtitle">Pas encore enregistré</string>
     <string name="fasting_log_managed_in_sheet">Géré dans les détails du jour</string>
+    <string name="bookmarks_search_placeholder">Rechercher dans les favoris</string>
+    <string name="bookmarks_sort">Trier</string>
+    <string name="bookmarks_sort_newest">Plus récents d’abord</string>
+    <string name="bookmarks_sort_oldest">Plus anciens d’abord</string>
+    <string name="bookmarks_sort_type">Par type</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">Aucun résultat</string>
+    <string name="bookmarks_no_matches_hint">Essayez une autre recherche ou retirez le filtre.</string>
+    <string name="bookmarks_clear_all">Effacer tous les favoris</string>
+    <string name="bookmarks_clear_all_title">Effacer tous les favoris ?</string>
+    <string name="bookmarks_clear_all_confirm">Tout effacer</string>
+    <string name="bookmarks_clear_all_body">Cela supprime les %1$d favoris — Coran, Hadith et invocations. Action irréversible.</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1720,4 +1720,16 @@
     <string name="fasting_log_on_subtitle">Tercatat — ketuk untuk membatalkan</string>
     <string name="fasting_log_off_subtitle">Belum dicatat</string>
     <string name="fasting_log_managed_in_sheet">Dikelola di rincian hari ini</string>
+    <string name="bookmarks_search_placeholder">Cari markah</string>
+    <string name="bookmarks_sort">Urutkan</string>
+    <string name="bookmarks_sort_newest">Terbaru dulu</string>
+    <string name="bookmarks_sort_oldest">Terlama dulu</string>
+    <string name="bookmarks_sort_type">Menurut jenis</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">Tidak ada hasil</string>
+    <string name="bookmarks_no_matches_hint">Coba pencarian lain, atau hapus filternya.</string>
+    <string name="bookmarks_clear_all">Hapus semua markah</string>
+    <string name="bookmarks_clear_all_title">Hapus semua markah?</string>
+    <string name="bookmarks_clear_all_confirm">Hapus semua</string>
+    <string name="bookmarks_clear_all_body">Ini menghapus semua %1$d markah — Al-Qur\'an, Hadis, dan Doa. Tindakan ini tidak dapat dibatalkan.</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1721,4 +1721,16 @@
     <string name="fasting_log_on_subtitle">Direkod — ketik untuk batalkan</string>
     <string name="fasting_log_off_subtitle">Belum direkod</string>
     <string name="fasting_log_managed_in_sheet">Diurus dalam butiran hari</string>
+    <string name="bookmarks_search_placeholder">Cari penanda buku</string>
+    <string name="bookmarks_sort">Isih</string>
+    <string name="bookmarks_sort_newest">Terbaharu dahulu</string>
+    <string name="bookmarks_sort_oldest">Terlama dahulu</string>
+    <string name="bookmarks_sort_type">Mengikut jenis</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">Tiada padanan</string>
+    <string name="bookmarks_no_matches_hint">Cuba carian lain, atau buang penapis.</string>
+    <string name="bookmarks_clear_all">Kosongkan semua penanda buku</string>
+    <string name="bookmarks_clear_all_title">Kosongkan semua penanda buku?</string>
+    <string name="bookmarks_clear_all_confirm">Kosongkan semua</string>
+    <string name="bookmarks_clear_all_body">Ini membuang kesemua %1$d penanda buku — Al-Quran, Hadis dan Doa. Ia tidak boleh dibatalkan.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1757,4 +1757,16 @@
     <string name="fasting_log_on_subtitle">Kaydedildi — geri almak için dokunun</string>
     <string name="fasting_log_off_subtitle">Henüz kaydedilmedi</string>
     <string name="fasting_log_managed_in_sheet">Gün ayrıntılarında yönetilir</string>
+    <string name="bookmarks_search_placeholder">Yer imlerinde ara</string>
+    <string name="bookmarks_sort">Sırala</string>
+    <string name="bookmarks_sort_newest">Önce en yeni</string>
+    <string name="bookmarks_sort_oldest">Önce en eski</string>
+    <string name="bookmarks_sort_type">Türe göre</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">Eşleşme yok</string>
+    <string name="bookmarks_no_matches_hint">Farklı bir arama deneyin veya filtreyi kaldırın.</string>
+    <string name="bookmarks_clear_all">Tüm yer imlerini sil</string>
+    <string name="bookmarks_clear_all_title">Tüm yer imleri silinsin mi?</string>
+    <string name="bookmarks_clear_all_confirm">Tümünü sil</string>
+    <string name="bookmarks_clear_all_body">Bu, %1$d yer iminin tamamını siler — Kur\'an, Hadis ve Dua. Geri alınamaz.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1922,4 +1922,16 @@
     <string name="fasting_log_on_subtitle">Logged — tap to undo</string>
     <string name="fasting_log_off_subtitle">Not logged yet</string>
     <string name="fasting_log_managed_in_sheet">Managed in the day\'s details</string>
+    <string name="bookmarks_search_placeholder">Search bookmarks</string>
+    <string name="bookmarks_sort">Sort</string>
+    <string name="bookmarks_sort_newest">Newest first</string>
+    <string name="bookmarks_sort_oldest">Oldest first</string>
+    <string name="bookmarks_sort_type">By type</string>
+    <string name="bookmarks_sort_alphabetical">A–Z</string>
+    <string name="bookmarks_no_matches">No matches</string>
+    <string name="bookmarks_no_matches_hint">Try a different search, or clear the filter.</string>
+    <string name="bookmarks_clear_all">Clear all bookmarks</string>
+    <string name="bookmarks_clear_all_title">Clear all bookmarks?</string>
+    <string name="bookmarks_clear_all_confirm">Clear all</string>
+    <string name="bookmarks_clear_all_body">This removes all %1$d bookmarks — Qur\'an, Hadith and Dua. It cannot be undone.</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/BookmarksViewModelTest.kt
@@ -9,6 +9,7 @@ import com.arshadshah.nimaz.domain.usecase.DuaUseCases
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -147,6 +148,23 @@ class BookmarksViewModelTest {
 
         assertThat(vm.bookmarksState.value.recentlyDeleted).isNull()
         coVerify(exactly = 0) { quran.insertBookmark(any()) }
+    }
+
+    @Test
+    fun `enrichment is one batched query, not one per bookmark`() = runTest {
+        val getAyahById = mockk<com.arshadshah.nimaz.domain.usecase.GetAyahByIdUseCase>(relaxed = true)
+        coEvery { getAyahById.forIds(any()) } returns emptyMap()
+        every { quran.getAyahById } returns getAyahById
+        quranBookmarks.value = (1..50).map { quranBookmark(it, it.toLong()) }
+
+        viewModel()
+        advanceUntilIdle()
+
+        // Was a suspend call per row inside the collector: 50 bookmarks meant 50
+        // sequential round-trips on every re-emission, and clearing them all re-emitted
+        // once per delete — O(N^2) on the most destructive action in the feature.
+        coVerify(exactly = 1) { getAyahById.forIds(any()) }
+        coVerify(exactly = 0) { getAyahById.invoke(any()) }
     }
 
     @Test


### PR DESCRIPTION
**Stack 8 of 8** · epic #352 · fixes #366 T11, completes #357's Bookmarks decision

Completes the work started in #376, which added `SetSearchQuery`/`SetSortOrder` but deliberately
left them without a producer.

## Batching first, because it is the prerequisite

Each loader enriched every bookmark with its own suspend lookup **inside** the Room collector
(`getAyahById`, `getHadithById`, `getDuaById`). N bookmarks meant N sequential round-trips on
*every* re-emission — and `clearAllBookmarks` deletes one row at a time, re-emitting once per
delete, so a wipe was **O(N²)**.

Wiring a confirmation dialog onto that would have shipped a guaranteed freeze on the most
destructive action in the feature. So the batching lands in the same PR, not after it.

**The batched DAO queries already existed** — `getAyahsWithTextByIds`, `getHadithsByIds`,
`getDuasByIds`, all added for the #330 search work. This is repository and use-case wiring, not new
SQL. I removed the duplicates I had started writing once I found them.

A test pins the behaviour: 50 bookmarks ⇒ exactly one `forIds` call and **zero** single-id calls.

## Then the UI the state was already built for

- **Search bar** — `searchQuery` and the search branch of `applyFilters` shipped with no way to set
  them, so the branch was unreachable.
- **Sort menu** — all four `BookmarkSortOrder` values. Sorting was permanently `DATE_NEWEST`;
  three of the four branches were dead.
- **Empty state** for a filtered-to-nothing list, so search returning nothing is not silent.
- **Clear all**, behind a confirmation dialog.

## The dialog

Per the decision on #357, it is **destructive with no undo**, and it says so.

It also names *what* disappears — Quran, Hadith **and** Dua bookmarks all go, which is not obvious
from a menu item on a screen that may be filtered to one of them — and includes the count.

No snackbar undo, deliberately: it would have to hold every deleted row in memory until it timed
out, and it would inherit the single-`var` undo bug fixed in #376 rather than reusing a mechanism
that works.

## Verification

`:app:compileDebugKotlin` ✅ · full `:app:testDebugUnitTest` ✅ · `check_docs.py` 23/23 ✅ ·
new strings translated into all five shipped locales

## Still deferred

`@ApplicationContext Context` is still in this ViewModel (#360) — removing it means moving
`UnifiedBookmark.title`/`subtitle` to `@StringRes` + args and resolving at the leaf, which also
fixes the locale-change staleness. That belongs with the #360 sweep rather than here.