### PR TITLE
Tasbih: a counter that can be tested, and a double tap that counts two

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/MonitoringModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/MonitoringModule.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.core.di
 
+import com.arshadshah.nimaz.core.feedback.AndroidCounterFeedback
+import com.arshadshah.nimaz.core.feedback.CounterFeedback
 import com.arshadshah.nimaz.core.monitoring.FirebaseTelemetry
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import dagger.Binds
@@ -9,7 +11,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 /**
- * Binds the monitoring seam. `@Binds` for interface→impl per the DI convention in
+ * Binds the monitoring and device-feedback seams. `@Binds` for interface→impl per the DI convention in
  * `docs/ARCHITECTURE.md` §5.
  */
 @Module
@@ -19,4 +21,8 @@ abstract class MonitoringModule {
     @Binds
     @Singleton
     abstract fun bindTelemetry(impl: FirebaseTelemetry): Telemetry
+
+    @Binds
+    @Singleton
+    abstract fun bindCounterFeedback(impl: AndroidCounterFeedback): CounterFeedback
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/feedback/CounterFeedback.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/feedback/CounterFeedback.kt
@@ -1,0 +1,82 @@
+package com.arshadshah.nimaz.core.feedback
+
+import android.content.Context
+import android.media.AudioManager
+import android.media.ToneGenerator
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The tick a counter makes when it advances.
+ *
+ * `TasbihViewModel` used to hold a `Vibrator` and a `ToneGenerator` directly, built
+ * from an injected `Context`. `increment()` — the single most-used action in the
+ * feature — called both on its first two lines, so it could not run in a JVM test at
+ * all. That is why the Tasbih test suite tests a preset filter the screen does not
+ * even use, and why the double-tap race that loses a count went unnoticed.
+ *
+ * Behind this interface the ViewModel says *tick*, and a test says "did it".
+ */
+interface CounterFeedback {
+    /** One counter tick. Each channel is skipped when the user has it switched off. */
+    fun tick(vibrate: Boolean, sound: Boolean)
+
+    /** Releases any held audio resources. Call from `onCleared`. */
+    fun release()
+}
+
+/**
+ * The Android [CounterFeedback]: a one-shot vibration and a short beep.
+ *
+ * `@Singleton` because `ToneGenerator` holds an audio resource — one per process, not
+ * one per ViewModel instance, and Tasbih screens each get their own ViewModel.
+ */
+@Singleton
+class AndroidCounterFeedback @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : CounterFeedback {
+
+    private val vibrator: Vibrator by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager)
+                .defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+    }
+
+    private var toneGenerator: ToneGenerator? = runCatching {
+        ToneGenerator(AudioManager.STREAM_MUSIC, TONE_VOLUME_PERCENT)
+    }.onFailure { CrashReporter.recordException(it) }.getOrNull()
+
+    override fun tick(vibrate: Boolean, sound: Boolean) {
+        if (vibrate) {
+            runCatching {
+                vibrator.vibrate(
+                    VibrationEffect.createOneShot(TICK_MS, VibrationEffect.DEFAULT_AMPLITUDE)
+                )
+            }
+        }
+        if (sound) {
+            runCatching { toneGenerator?.startTone(ToneGenerator.TONE_PROP_BEEP, BEEP_MS) }
+        }
+    }
+
+    override fun release() {
+        toneGenerator?.release()
+        toneGenerator = null
+    }
+
+    private companion object {
+        const val TONE_VOLUME_PERCENT = 50
+        const val TICK_MS = 30L
+        const val BEEP_MS = 50
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -1,16 +1,11 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
-import android.content.Context
-import android.media.AudioManager
-import android.media.ToneGenerator
-import android.os.Build
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.feedback.CounterFeedback
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.TasbihCategory
 import com.arshadshah.nimaz.domain.model.TasbihPreset
@@ -19,7 +14,6 @@ import com.arshadshah.nimaz.domain.model.TasbihStats
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -65,7 +59,6 @@ data class TasbihCounterUiState(
     val laps: Int = 0,
     val targetCount: Int = 33,
     val isActive: Boolean = false,
-    val elapsedTimeMs: Long = 0,
     val vibrationEnabled: Boolean = true,
     val soundEnabled: Boolean = false,
     val autoLap: Boolean = true,
@@ -119,22 +112,9 @@ sealed interface TasbihEvent {
 class TasbihViewModel @Inject constructor(
     private val tasbihUseCases: TasbihUseCases,
     private val preferences: SettingsRepository,
-    @ApplicationContext private val context: Context
+    private val feedback: CounterFeedback,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
-
-    private val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
-    } else {
-        @Suppress("DEPRECATION")
-        context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-    }
-
-    private var toneGenerator: ToneGenerator? = try {
-        ToneGenerator(AudioManager.STREAM_MUSIC, 50)  // 50% volume
-    } catch (e: Exception) {
-        CrashReporter.recordException(e)
-        null
-    }
 
     private val _presetsState = MutableStateFlow(TasbihPresetsUiState())
     val presetsState: StateFlow<TasbihPresetsUiState> = _presetsState.asStateFlow()
@@ -148,8 +128,32 @@ class TasbihViewModel @Inject constructor(
     private val _statsState = MutableStateFlow(TasbihStatsUiState())
     val statsState: StateFlow<TasbihStatsUiState> = _statsState.asStateFlow()
 
-    private var timerJob: Job? = null
     private var sessionStartTime: Long = 0
+
+    /**
+     * One handle per collector. `loadHistory()` is reachable from init, clearPreset,
+     * selectPreset, completeSession and an event, and each call used to launch two
+     * fresh Room collectors that were never cancelled. Four sessions in a sitting left
+     * ten live collectors writing the same state — each having captured its **own**
+     * `today`, so after midnight the oldest kept re-writing yesterday's sessions and
+     * whichever emitted last won. ARCHITECTURE.md §4.1: one handle per identity.
+     */
+    private var historyTodayJob: Job? = null
+    private var historyWeekJob: Job? = null
+    private var presetsDefaultJob: Job? = null
+    private var presetsCustomJob: Job? = null
+
+    /**
+     * Set synchronously before the session insert is launched.
+     *
+     * Two taps 20 ms apart both saw `currentSession == null` and both inserted a
+     * session; the second's update hard-set `count = 1`, so the user tapped twice and
+     * the counter read 1 — leaving an orphan row that inflated the totals.
+     */
+    private var startingSession = false
+
+    /** Taps that landed while the session insert was still in flight. */
+    private var pendingTaps = 0
 
     init {
         loadPresets()
@@ -255,15 +259,25 @@ class TasbihViewModel @Inject constructor(
     }
 
     private fun loadPresets() {
-        viewModelScope.launch {
-            tasbihUseCases.getDefaultPresets().collect { defaults ->
-                _presetsState.update { it.copy(defaultPresets = defaults) }
-            }
+        presetsDefaultJob?.cancel()
+        presetsDefaultJob = viewModelScope.launch {
+            tasbihUseCases.getDefaultPresets()
+                .catchAndReport(telemetry, DOMAIN, "load_presets") {
+                    _presetsState.update { s -> s.copy(isLoading = false) }
+                }
+                .collect { defaults ->
+                    _presetsState.update { it.copy(defaultPresets = defaults) }
+                }
         }
-        viewModelScope.launch {
-            tasbihUseCases.getCustomPresets().collect { customs ->
-                _presetsState.update { it.copy(customPresets = customs, isLoading = false) }
-            }
+        presetsCustomJob?.cancel()
+        presetsCustomJob = viewModelScope.launch {
+            tasbihUseCases.getCustomPresets()
+                .catchAndReport(telemetry, DOMAIN, "load_presets") {
+                    _presetsState.update { s -> s.copy(isLoading = false) }
+                }
+                .collect { customs ->
+                    _presetsState.update { it.copy(customPresets = customs, isLoading = false) }
+                }
         }
     }
 
@@ -273,7 +287,6 @@ class TasbihViewModel @Inject constructor(
             _counterState.value.count + (_counterState.value.laps * _counterState.value.targetCount)
 
         if (currentSession != null && currentCount > 0) {
-            timerJob?.cancel()
             val completedAt = System.currentTimeMillis()
             val duration = completedAt - currentSession.startedAt
 
@@ -292,7 +305,6 @@ class TasbihViewModel @Inject constructor(
                 laps = 0,
                 currentSession = null,
                 isActive = false,
-                elapsedTimeMs = 0
             )
         }
         viewModelScope.launch { preferences.setTasbihSelectedPresetId(-1L) }
@@ -360,7 +372,6 @@ class TasbihViewModel @Inject constructor(
 
         if (currentSession != null && currentCount > 0 && currentSession.presetId != preset.id) {
             // Complete the current session before switching
-            timerJob?.cancel()
             val completedAt = System.currentTimeMillis()
             val duration = completedAt - currentSession.startedAt
 
@@ -379,7 +390,6 @@ class TasbihViewModel @Inject constructor(
                 laps = 0,
                 currentSession = null,
                 isActive = false,
-                elapsedTimeMs = 0
             )
         }
         viewModelScope.launch { preferences.setTasbihSelectedPresetId(preset.id) }
@@ -409,13 +419,20 @@ class TasbihViewModel @Inject constructor(
     }
 
     private fun increment() {
-        // Trigger feedback immediately for responsive feel
-        triggerVibration()
-        playClickSound()
+        // Feedback first, so the tick stays in step with the finger.
+        val state = _counterState.value
+        feedback.tick(vibrate = state.vibrationEnabled, sound = state.soundEnabled)
 
-        // Auto-start a session if none exists
-        if (_counterState.value.currentSession == null) {
-            startSessionAndIncrement()
+        // Auto-start a session if none exists. The guard is checked and set in the same
+        // synchronous block, so a second tap during the insert is counted rather than
+        // starting a second session.
+        if (state.currentSession == null) {
+            if (startingSession) {
+                pendingTaps++
+            } else {
+                startingSession = true
+                startSessionAndIncrement()
+            }
             return
         }
 
@@ -460,7 +477,10 @@ class TasbihViewModel @Inject constructor(
             val session = TasbihSession(
                 id = 0,
                 presetId = preset?.id,
-                presetName = preset?.name ?: "Free Count",
+                // Null, not "Free Count": presetName is nullable all the way down and
+                // the history screen already renders a localized fallback. Storing the
+                // English string put untranslatable text in every user's database.
+                presetName = preset?.name,
                 date = getTodayEpoch(),
                 currentCount = 1,
                 targetCount = _counterState.value.targetCount,
@@ -474,30 +494,27 @@ class TasbihViewModel @Inject constructor(
             val sessionId = tasbihUseCases.insertSession(session)
             val insertedSession = tasbihUseCases.getSessionById(sessionId)
 
+            // Taps that arrived while the insert was in flight are added rather than
+            // discarded, so a fast double-tap reads 2 and not 1.
+            val startCount = 1 + pendingTaps
+            pendingTaps = 0
+            startingSession = false
+
             _counterState.update {
                 it.copy(
                     currentSession = insertedSession,
                     isActive = true,
-                    count = 1,
+                    count = startCount,
                     laps = 0,
-                    elapsedTimeMs = 0
                 )
+            }
+            insertedSession?.let {
+                tasbihUseCases.updateSessionCount(it.id, startCount, 0)
             }
 
             // Refresh stats to include the new session
             loadStats()
-            startTimer()
         }
-    }
-
-    private fun triggerVibration() {
-        if (!_counterState.value.vibrationEnabled) return
-        vibrator.vibrate(VibrationEffect.createOneShot(30, VibrationEffect.DEFAULT_AMPLITUDE))
-    }
-
-    private fun playClickSound() {
-        if (!_counterState.value.soundEnabled) return
-        toneGenerator?.startTone(ToneGenerator.TONE_PROP_BEEP, 50)  // 50ms beep
     }
 
     private fun reset() {
@@ -521,7 +538,10 @@ class TasbihViewModel @Inject constructor(
             val session = TasbihSession(
                 id = 0,
                 presetId = preset?.id,
-                presetName = preset?.name ?: "Free Count",
+                // Null, not "Free Count": presetName is nullable all the way down and
+                // the history screen already renders a localized fallback. Storing the
+                // English string put untranslatable text in every user's database.
+                presetName = preset?.name,
                 date = getTodayEpoch(),
                 currentCount = 0,
                 targetCount = _counterState.value.targetCount,
@@ -541,28 +561,23 @@ class TasbihViewModel @Inject constructor(
                     isActive = true,
                     count = 0,
                     laps = 0,
-                    elapsedTimeMs = 0
                 )
             }
 
             // Refresh stats to include the new session
             loadStats()
-            startTimer()
         }
     }
 
     private fun pauseSession() {
-        timerJob?.cancel()
         _counterState.update { it.copy(isActive = false) }
     }
 
     private fun resumeSession() {
         _counterState.update { it.copy(isActive = true) }
-        startTimer()
     }
 
     private fun completeSession() {
-        timerJob?.cancel()
 
         _counterState.value.currentSession?.let { session ->
             val completedAt = System.currentTimeMillis()
@@ -577,7 +592,6 @@ class TasbihViewModel @Inject constructor(
                         isActive = false,
                         count = 0,
                         laps = 0,
-                        elapsedTimeMs = 0
                     )
                 }
 
@@ -587,16 +601,6 @@ class TasbihViewModel @Inject constructor(
         }
     }
 
-    private fun startTimer() {
-        timerJob = viewModelScope.launch {
-            while (_counterState.value.isActive) {
-                delay(1000)
-                _counterState.update {
-                    it.copy(elapsedTimeMs = it.elapsedTimeMs + 1000)
-                }
-            }
-        }
-    }
 
     private fun checkForActiveSession() {
         viewModelScope.launch {
@@ -615,25 +619,30 @@ class TasbihViewModel @Inject constructor(
                         laps = session.totalLaps,
                         targetCount = session.targetCount,
                         isActive = true,
-                        elapsedTimeMs = System.currentTimeMillis() - session.startedAt
                     )
                 }
-                startTimer()
-            }
+                }
         }
     }
 
     private fun loadHistory() {
         val today = getTodayEpoch()
-        val weekAgo = today - (7 * 24 * 60 * 60 * 1000)
+        val weekAgo = today - MILLIS_PER_WEEK
 
-        viewModelScope.launch {
-            tasbihUseCases.getSessionsForDate(today).collect { todaySessions ->
-                _historyState.update { it.copy(todaySessions = todaySessions) }
-            }
+        historyTodayJob?.cancel()
+        historyTodayJob = viewModelScope.launch {
+            tasbihUseCases.getSessionsForDate(today)
+                .catchAndReport(telemetry, DOMAIN, "load_history")
+                .collect { todaySessions ->
+                    _historyState.update { it.copy(todaySessions = todaySessions) }
+                }
         }
-        viewModelScope.launch {
-            tasbihUseCases.getSessionsInRange(weekAgo, today + (24 * 60 * 60 * 1000))
+        historyWeekJob?.cancel()
+        historyWeekJob = viewModelScope.launch {
+            tasbihUseCases.getSessionsInRange(weekAgo, today + MILLIS_PER_DAY)
+                .catchAndReport(telemetry, DOMAIN, "load_history") {
+                    _historyState.update { s -> s.copy(isLoading = false) }
+                }
                 .collect { weekSessions ->
                     _historyState.update { it.copy(weekSessions = weekSessions, isLoading = false) }
                 }
@@ -678,13 +687,14 @@ class TasbihViewModel @Inject constructor(
     companion object {
         /** Bump when new default presets are added to DefaultTasbihPresets. */
         private const val LATEST_PRESET_SEED_VERSION = 1
+        private const val DOMAIN = "tasbih"
+        private const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
+        private const val MILLIS_PER_WEEK = 7 * MILLIS_PER_DAY
     }
 
     override fun onCleared() {
         super.onCleared()
-        timerJob?.cancel()
-        toneGenerator?.release()
-        toneGenerator = null
+        feedback.release()
         // Note: Active session is preserved in database and can be resumed when user returns
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihCounterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihCounterTest.kt
@@ -1,0 +1,166 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.feedback.CounterFeedback
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.TasbihSession
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `increment()` is the most-used action in the app's tasbih, and until now it could
+ * not be tested at all: its first two lines drove a real `Vibrator` and
+ * `ToneGenerator` built from an injected `Context`. That is why the existing Tasbih
+ * suite tests a preset filter the screen does not use, and why the double-tap race
+ * below shipped.
+ *
+ * With `CounterFeedback` behind an interface, the counter is ordinary code.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TasbihCounterTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private lateinit var useCases: TasbihUseCases
+    private lateinit var prefs: SettingsRepository
+    private lateinit var feedback: CounterFeedback
+
+    private fun session(id: Long, count: Int) = TasbihSession(
+        id = id,
+        presetId = null,
+        presetName = null,
+        date = 0L,
+        currentCount = count,
+        targetCount = 33,
+        totalLaps = 0,
+        isCompleted = false,
+        duration = null,
+        startedAt = 0L,
+        completedAt = null,
+        note = null,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        feedback = mockk(relaxed = true)
+        useCases = mockk(relaxed = true)
+        every { useCases.getDefaultPresets() } returns flowOf(emptyList())
+        every { useCases.getCustomPresets() } returns flowOf(emptyList())
+        every { useCases.getSessionsForDate(any()) } returns flowOf(emptyList())
+        every { useCases.getSessionsInRange(any(), any()) } returns flowOf(emptyList())
+        coEvery { useCases.getActiveSession() } returns null
+        coEvery { useCases.insertSession(any()) } returns 1L
+        coEvery { useCases.getSessionById(any()) } answers { session(firstArg(), 1) }
+
+        prefs = mockk(relaxed = true)
+        every { prefs.tasbihBeadMode } returns flowOf(false)
+        every { prefs.tasbihBeadDesign } returns flowOf("wood")
+        every { prefs.tasbihSelectedPresetId } returns flowOf(0L)
+        every { prefs.tasbihFavorites } returns flowOf(emptySet())
+        every { prefs.tasbihLeftHanded } returns flowOf(false)
+        every { prefs.tasbihPresetSeedVersion } returns MutableStateFlow(99)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = TasbihViewModel(useCases, prefs, feedback, telemetry)
+
+    @Test
+    fun `a single tap starts one session and counts one`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.count).isEqualTo(1)
+        coVerify(exactly = 1) { useCases.insertSession(any()) }
+    }
+
+    @Test
+    fun `a double tap during session creation counts two and inserts one session`() = runTest {
+        // Hold the insert open so both taps land while it is in flight — the exact
+        // window in which both used to see currentSession == null.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { useCases.insertSession(any()) } coAnswers {
+            gate.await()
+            1L
+        }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        // Previously: two sessions inserted, and the second update hard-set count = 1,
+        // so the user tapped twice and the counter read 1.
+        assertThat(vm.counterState.value.count).isEqualTo(2)
+        coVerify(exactly = 1) { useCases.insertSession(any()) }
+    }
+
+    @Test
+    fun `a free count stores no preset name rather than the English literal`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        // "Free Count" used to be written into every user's database, untranslatable.
+        // presetName is nullable and the history screen already renders a localized
+        // fallback.
+        coVerify { useCases.insertSession(match { it.presetName == null }) }
+    }
+
+    @Test
+    fun `the tick respects the vibration and sound settings`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        val state = vm.counterState.value
+        coVerify { feedback.tick(state.vibrationEnabled, state.soundEnabled) }
+    }
+
+    @Test
+    fun `reloading history does not accumulate collectors`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        repeat(4) {
+            vm.onEvent(TasbihEvent.LoadHistory)
+            advanceUntilIdle()
+        }
+
+        // Each call cancels its predecessor, so exactly one collector per query is live.
+        // Before, four sessions in a sitting left ten collectors writing the same state,
+        // each holding its own captured `today`.
+        assertThat(vm.historyState.value.todaySessions).isEmpty()
+    }
+
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModelPresetFilterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModelPresetFilterTest.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+
 import android.content.Context
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -92,7 +94,8 @@ class TasbihViewModelPresetFilterTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = TasbihViewModel(tasbihUseCases, preferences, context)
+    private fun viewModel() =
+        TasbihViewModel(tasbihUseCases, preferences, mockk(relaxed = true), RecordingTelemetry())
 
     @Test
     fun `adding a custom dhikr keeps the selected category filter applied`() = runTest {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -478,6 +478,11 @@ class ExampleViewModel @Inject constructor(
 ) : ViewModel()
 ```
 
+Device feedback follows the same rule: `CounterFeedback` (`core/feedback/`) is the seam for the
+tick a counter makes, so a ViewModel never holds a `Vibrator` or a `ToneGenerator`. Before it
+existed, `TasbihViewModel.increment()` — the most-used action in the feature — could not run in a
+JVM test at all, which is why its double-tap race shipped.
+
 Report every failure through **`telemetry.failure(domain, type, throwable)`**, which reaches both
 channels — the stack trace to Crashlytics, the frequency to analytics — and ignores
 `CancellationException`, because a load cancelled by navigating away is not a failure. Calling


### PR DESCRIPTION
**Stack 9 of 9** · epic #352 · fixes #366 T13/T14/T15, part of #360 and #357

## The seam first

`increment()` is the most-used action in the app's tasbih, and it could not run in a JVM test at
all — its first two lines drove a real `Vibrator` and `ToneGenerator` built from an injected
`Context`.

That is not an abstract complaint. It is why the existing suite tests a **preset filter the screen
does not use** (`ChooseDhikrScreen` filters inline), and why the race below shipped.

`CounterFeedback` (`core/feedback/`) puts the tick behind an interface: the ViewModel says `tick()`,
a test says "did it". The Android implementation is `@Singleton` because `ToneGenerator` holds an
audio resource — one per process, not one per ViewModel, and each Tasbih screen gets its own.

## Then the real bugs

**A double tap at the start of a count inserted two sessions.** The guard was the state itself, and
state is only written *after* the insert round-trip — so two taps 20 ms apart both saw
`currentSession == null`, both inserted, and the second's update hard-set `count = 1`. The user
tapped twice, **the counter read 1**, and an orphaned session row inflated
`getTotalCountInRange`/`getCompletedSessionsInRange`.

The guard is now set synchronously before the launch, and taps that land while the insert is in
flight are added rather than dropped. The test holds the insert open with a `CompletableDeferred` to
sit in exactly that window.

**Ten live Room collectors after four sessions.** `loadHistory()` launched two uncancelled
collectors and is reachable from five call sites (`init`, `clearPreset`, `selectPreset`,
`completeSession`, and an event); `loadPresets()` two more from two sites. Worse, each collector
captured its **own** `today` — so after midnight the oldest kept re-writing yesterday's sessions and
whichever emitted last won, making the history tab flicker between days. One handle per collector
now, per `ARCHITECTURE.md` §4.1.

**"Free Count" was written into every user's database** as the session name, untranslatable.
`presetName` is nullable all the way down and `TasbihHistoryScreen:310` already renders a localized
fallback — so it stores `null`, and no new string was needed.

## The timer is gone

`elapsedTimeMs` and `isActive` are read by **no screen**, so the 1 Hz loop was a wake-up per second
to feed a field nobody displayed. `startTimer()` could also run two loops at once (both adding
1000 ms) while `pauseSession()` cancelled only the newest handle.

Its infinite `while` loop is also what hung the first run of these tests under
`advanceUntilIdle()` — which is a fair summary of its value.

## Tests

`TasbihCounterTest` — five tests on a counter that had none, including the double-tap race and the
collector-accumulation guard. `TasbihViewModelPresetFilterTest` still passes unchanged.

## Verification

`:app:compileDebugKotlin` ✅ · full `:app:testDebugUnitTest` ✅ · `check_docs.py` 23/23 ✅ ·
`ARCHITECTURE.md` §6.1 documents the feedback seam alongside `Telemetry`