### PR TITLE
fix(prayer): stats that follow the table, and a week that is seven days

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
@@ -1,8 +1,8 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.PrayerName
@@ -12,11 +12,12 @@ import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -55,6 +56,26 @@ enum class StatsPeriod {
     WEEK, MONTH, YEAR, ALL_TIME
 }
 
+/**
+ * The **inclusive** first and last day a [StatsPeriod] covers, ending today.
+ *
+ * Every window used to start a day too early: `WEEK` ran `today-7 .. today` and the caller
+ * then made the end exclusive with `plusDays(1)`, so the query spanned eight days. A user
+ * who prayed all five prayers for seven days but missed three on the eighth day back read
+ * "37/40" under a chip labelled *Week*. The end is still made exclusive by the caller, so a
+ * window of `n` days starts `n - 1` days back.
+ *
+ * `ALL_TIME` is a floor rather than a window — nothing is counted out of it — so it keeps its
+ * ten-year reach.
+ */
+internal fun statsWindow(period: StatsPeriod, today: LocalDate): Pair<LocalDate, LocalDate> =
+    when (period) {
+        StatsPeriod.WEEK -> today.minusDays(6)
+        StatsPeriod.MONTH -> today.minusMonths(1).plusDays(1)
+        StatsPeriod.YEAR -> today.minusYears(1).plusDays(1)
+        StatsPeriod.ALL_TIME -> today.minusYears(10)
+    } to today
+
 sealed interface PrayerTrackerEvent {
     data class SelectDate(val date: LocalDate) : PrayerTrackerEvent
     data class UpdatePrayerStatus(
@@ -79,7 +100,8 @@ sealed interface PrayerTrackerEvent {
 
 @HiltViewModel
 class PrayerTrackerViewModel @Inject constructor(
-    private val prayerUseCases: PrayerUseCases
+    private val prayerUseCases: PrayerUseCases,
+    private val telemetry: Telemetry
 ) : ViewModel() {
 
     private val _trackerState = MutableStateFlow(PrayerTrackerUiState())
@@ -95,13 +117,22 @@ class PrayerTrackerViewModel @Inject constructor(
     val historyState: StateFlow<PrayerHistoryUiState> = _historyState.asStateFlow()
 
     private var currentLocation: Location? = null
-    private var dateRecordsJob: kotlinx.coroutines.Job? = null
+    private var dateRecordsJob: Job? = null
 
     // The history range is re-requested every time the user changes period. Like
     // `dateRecordsJob` above, this collects a Room flow that never completes, so without a
     // handle each range left a collector alive on `_historyState` and an earlier range could
     // redraw the chart under a later one. (AP-7.1b.)
-    private var historyJob: kotlinx.coroutines.Job? = null
+    private var historyJob: Job? = null
+
+    // The same hazard twice more, both missed when the two above were fixed — because neither
+    // takes a parameter, so the sweep that found those read them as one-shot observers.
+    // `loadStats` is re-entered from `init`, `SetStatsPeriod` and `LoadStats` (it takes its
+    // period from `_statsState`), and `loadQadaPrayers` from `init` and `LoadQadaPrayers`.
+    // Un-handled, `loadQadaPrayers` left a collector per call and `loadStats` a read in
+    // flight per call, the slowest of which won.
+    private var statsJob: Job? = null
+    private var qadaJob: Job? = null
 
     init {
         loadCurrentLocation()
@@ -113,20 +144,20 @@ class PrayerTrackerViewModel @Inject constructor(
     fun onEvent(event: PrayerTrackerEvent) {
         when (event) {
             is PrayerTrackerEvent.MarkPrayerPrayed ->
-                AppAnalytics.logPrayerTracked(event.prayerName.name, "prayed", event.isJamaah)
+                telemetry.prayerTracked(event.prayerName.name, "prayed", event.isJamaah)
 
             is PrayerTrackerEvent.MarkPrayerMissed ->
-                AppAnalytics.logPrayerTracked(event.prayerName.name, "missed")
+                telemetry.prayerTracked(event.prayerName.name, "missed")
 
             is PrayerTrackerEvent.UpdatePrayerStatus ->
-                AppAnalytics.logPrayerTracked(
+                telemetry.prayerTracked(
                     event.prayerName.name,
                     event.status.name,
                     event.isJamaah
                 )
 
             is PrayerTrackerEvent.MarkQadaCompleted ->
-                AppAnalytics.logFeatureUsed("prayer_tracker", "qada_completed")
+                telemetry.featureUsed(DOMAIN, "qada_completed")
 
             else -> {}
         }
@@ -156,7 +187,8 @@ class PrayerTrackerViewModel @Inject constructor(
     }
 
     private fun loadCurrentLocation() {
-        viewModelScope.launch {
+        // Started once from `init`, so it needs no handle (§4.1).
+        launchSafely(telemetry, DOMAIN, "observe_location") {
             prayerUseCases.getCurrentLocation().collect { location ->
                 currentLocation = location
                 // Reload prayer times if we have a location
@@ -178,7 +210,12 @@ class PrayerTrackerViewModel @Inject constructor(
 
         // Cancel previous date's Flow collection before starting new one
         dateRecordsJob?.cancel()
-        dateRecordsJob = viewModelScope.launch {
+        dateRecordsJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_date_records",
+            onFailure = { _trackerState.update { it.copy(isLoading = false) } }
+        ) {
             // Room's reactive Flow ensures cross-screen sync: when HomeScreen or
             // PrayerTracker updates a prayer status via the repository, Room emits
             // the change to all active Flow collectors automatically.
@@ -211,10 +248,11 @@ class PrayerTrackerViewModel @Inject constructor(
             System.currentTimeMillis()
         } else null
 
-        viewModelScope.launch {
+        launchSafely(telemetry, DOMAIN, "update_status") {
             prayerUseCases.updatePrayerStatus(dateEpoch, prayerName, status, prayedAt, isJamaah)
-            // Refresh stats after update
-            loadStats()
+            // No `loadStats()` here. The stats collector observes the same table, so Room
+            // re-emits to it on this write. Re-reading imperatively is what put a second
+            // load in flight and let a period change race it.
         }
     }
 
@@ -227,7 +265,7 @@ class PrayerTrackerViewModel @Inject constructor(
     }
 
     private fun markQadaCompleted(record: PrayerRecord) {
-        viewModelScope.launch {
+        launchSafely(telemetry, DOMAIN, "complete_qada") {
             prayerUseCases.updatePrayerStatus(
                 record.date,
                 record.prayerName,
@@ -235,8 +273,9 @@ class PrayerTrackerViewModel @Inject constructor(
                 System.currentTimeMillis(),
                 false
             )
-            loadQadaPrayers()
-            loadStats()
+            // The qada list and the stats are both Room-backed observers of this table;
+            // the write re-emits to both. Re-calling the loaders here is what left three
+            // live collectors on the missed-prayer list after two completions.
         }
     }
 
@@ -249,42 +288,65 @@ class PrayerTrackerViewModel @Inject constructor(
         val period = _statsState.value.period
         val now = LocalDate.now()
 
-        val (startDate, endDate) = when (period) {
-            StatsPeriod.WEEK -> now.minusDays(7) to now
-            StatsPeriod.MONTH -> now.minusMonths(1) to now
-            StatsPeriod.YEAR -> now.minusYears(1) to now
-            StatsPeriod.ALL_TIME -> now.minusYears(10) to now
-        }
-
+        val (startDate, endDate) = statsWindow(period, now)
         val startEpoch = startDate.toUtcMidnightMillis()
         val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
         val currentEpoch = now.toUtcMidnightMillis()
 
-        // Always load monthly stats
-        val monthStart = now.minusMonths(1)
+        // The month summary is shown alongside every period, so it is always read.
+        val (monthStart, monthEnd) = statsWindow(StatsPeriod.MONTH, now)
         val monthStartEpoch = monthStart.toUtcMidnightMillis()
-        val monthEndEpoch = now.plusDays(1).toUtcMidnightMillis()
+        val monthEndEpoch = monthEnd.plusDays(1).toUtcMidnightMillis()
 
-        viewModelScope.launch {
-            val stats = prayerUseCases.getPrayerStats(startEpoch, endEpoch)
-            val monthlyStats = prayerUseCases.getPrayerStats(monthStartEpoch, monthEndEpoch)
-            val currentStreak = prayerUseCases.getCurrentStreak(currentEpoch)
-            val longestStreak = prayerUseCases.getLongestStreak()
+        statsJob?.cancel()
+        statsJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_stats",
+            onFailure = { _statsState.update { it.copy(isLoading = false) } }
+        ) {
+            // The four reads below are one-shot, but every number they produce is a view of
+            // `prayer_records` — a table Home, the widget and this screen all write. Read
+            // once and they freeze: marking Fajr on the Home card while the tracker sat in
+            // the back stack left the streak card showing the streak from before the tap.
+            // Collecting the records for the same window turns them into a subscription;
+            // Room re-emits on any write to the table, so the numbers follow it.
+            //
+            // `collectLatest` cancels a recompute a newer emission has overtaken, so a burst
+            // of writes costs one set of reads rather than one per emission.
+            prayerUseCases.getPrayerRecordsInRange(startEpoch, endEpoch).collectLatest {
+                val stats = prayerUseCases.getPrayerStats(startEpoch, endEpoch)
+                val monthlyStats = prayerUseCases.getPrayerStats(monthStartEpoch, monthEndEpoch)
+                val currentStreak = prayerUseCases.getCurrentStreak(currentEpoch)
+                val longestStreak = prayerUseCases.getLongestStreak()
 
-            _statsState.update {
-                it.copy(
-                    stats = stats,
-                    monthlyStats = monthlyStats,
-                    currentStreak = currentStreak,
-                    longestStreak = longestStreak,
-                    isLoading = false
-                )
+                // Cancelling the previous job stops an abandoned period at its next
+                // suspension point — and after the last read there isn't one, so a load
+                // that finished just as the period changed could still write. The captured
+                // period is checked against the live one so it cannot.
+                if (_statsState.value.period != period) return@collectLatest
+
+                _statsState.update {
+                    it.copy(
+                        stats = stats,
+                        monthlyStats = monthlyStats,
+                        currentStreak = currentStreak,
+                        longestStreak = longestStreak,
+                        isLoading = false
+                    )
+                }
             }
         }
     }
 
     private fun loadQadaPrayers() {
-        viewModelScope.launch {
+        qadaJob?.cancel()
+        qadaJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_qada",
+            onFailure = { _qadaState.update { it.copy(isLoading = false) } }
+        ) {
             prayerUseCases.getMissedPrayersRequiringQada().collect { missedPrayers ->
                 val grouped = missedPrayers.groupBy { record ->
                     val date = LocalDate.ofEpochDay(record.date / (24 * 60 * 60 * 1000))
@@ -310,7 +372,12 @@ class PrayerTrackerViewModel @Inject constructor(
         val endEpoch = endDate.plusDays(1).toUtcMidnightMillis()
 
         historyJob?.cancel()
-        historyJob = viewModelScope.launch {
+        historyJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_history",
+            onFailure = { _historyState.update { it.copy(isLoading = false) } }
+        ) {
             prayerUseCases.getPrayerRecordsInRange(startEpoch, endEpoch).collect { records ->
                 _historyState.update { it.copy(records = records, isLoading = false) }
             }
@@ -326,5 +393,9 @@ class PrayerTrackerViewModel @Inject constructor(
         if (!nextDay.isAfter(LocalDate.now())) {
             selectDate(nextDay)
         }
+    }
+
+    private companion object {
+        private const val DOMAIN = "prayer_tracker"
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerStatsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerStatsTest.kt
@@ -1,0 +1,215 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStats
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The statistics half of [PrayerTrackerViewModel].
+ *
+ * Two defects meet here. `loadStats()` was the **third** un-cancelled re-invocable load in
+ * this file — `dateRecordsJob` and `historyJob` were given handles and this one was missed —
+ * so a period change racing an in-flight read left the earlier period's numbers under the
+ * later chip. And every window was one day too wide: the range ran `[today-7, tomorrow)`,
+ * eight days, so "Week" scored eight days of prayers out of seven days' worth of chips.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrayerTrackerStatsTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var prayerUseCases: PrayerUseCases
+    private val telemetry = RecordingTelemetry()
+
+    /** Every `(start, end)` pair asked of `getPrayerStats`, in order. */
+    private val statsRanges = mutableListOf<Pair<Long, Long>>()
+
+    /** The records Room hands back for whatever range the stats load is watching. */
+    private val rangeRecords = MutableStateFlow(listOf(record(id = 1)))
+    private val missedPrayers = MutableStateFlow(listOf(record(id = 9)))
+
+    private var currentStreak = 3
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        prayerUseCases = mockk(relaxed = true)
+
+        every { prayerUseCases.getPrayerRecordsForDate(any()) } returns flowOf(emptyList())
+        every { prayerUseCases.getPrayerRecordsInRange(any(), any()) } returns rangeRecords
+        every { prayerUseCases.getMissedPrayersRequiringQada() } returns missedPrayers
+        every { prayerUseCases.getCurrentLocation() } returns flowOf(null)
+        coEvery { prayerUseCases.getCurrentStreak(any()) } answers { currentStreak }
+        coEvery { prayerUseCases.getLongestStreak() } returns 12
+        coEvery { prayerUseCases.getPrayerStats(any(), any()) } answers {
+            statsRanges += firstArg<Long>() to secondArg<Long>()
+            stats(totalPrayed = 0)
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = PrayerTrackerViewModel(prayerUseCases, telemetry)
+
+    // -- The window (D8) ---------------------------------------------------
+
+    @Test
+    fun `the week window spans seven days, not eight`() = runTest {
+        viewModel()
+        advanceUntilIdle()
+
+        val today = LocalDate.now()
+        val (start, end) = statsRanges.first()
+
+        // Exclusive end, so a seven-day window is exactly seven days wide.
+        assertThat(end - start).isEqualTo(7 * MILLIS_PER_DAY)
+        assertThat(start).isEqualTo(today.minusDays(6).toUtcMidnightMillis())
+        assertThat(end).isEqualTo(today.plusDays(1).toUtcMidnightMillis())
+    }
+
+    @Test
+    fun `the month window ends today and starts a month back, not a month and a day`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        statsRanges.clear()
+
+        vm.onEvent(PrayerTrackerEvent.SetStatsPeriod(StatsPeriod.MONTH))
+        advanceUntilIdle()
+
+        val today = LocalDate.now()
+        val (start, end) = statsRanges.first()
+
+        assertThat(start).isEqualTo(today.minusMonths(1).plusDays(1).toUtcMidnightMillis())
+        assertThat(end).isEqualTo(today.plusDays(1).toUtcMidnightMillis())
+    }
+
+    // -- The race (T18) ----------------------------------------------------
+
+    @Test
+    fun `an earlier period cannot leave its numbers under a later chip`() = runTest {
+        // The slow query is the one the user moves away from — the shape that loses the race.
+        coEvery { prayerUseCases.getPrayerStats(any(), any()) } coAnswers {
+            val start = firstArg<Long>()
+            val end = secondArg<Long>()
+            statsRanges += start to end
+            if (end - start > 8 * MILLIS_PER_DAY) {
+                delay(500)
+                stats(totalPrayed = 150)   // MONTH
+            } else {
+                delay(10)
+                stats(totalPrayed = 35)    // WEEK
+            }
+        }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.SetStatsPeriod(StatsPeriod.MONTH))
+        advanceTimeBy(20)                  // the month read is still in flight
+        vm.onEvent(PrayerTrackerEvent.SetStatsPeriod(StatsPeriod.WEEK))
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.period).isEqualTo(StatsPeriod.WEEK)
+        assertThat(vm.statsState.value.stats?.totalPrayed).isEqualTo(35)
+    }
+
+    // -- Reactivity (T18) --------------------------------------------------
+
+    @Test
+    fun `the streak follows the prayer table instead of freezing at the last load`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.currentStreak).isEqualTo(3)
+
+        // The Home card marks Fajr while the tracker sits in the back stack: Room
+        // re-emits to every observer of `prayer_records`.
+        currentStreak = 4
+        rangeRecords.value = listOf(record(id = 1), record(id = 2))
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.currentStreak).isEqualTo(4)
+    }
+
+    // -- Instrumentation ---------------------------------------------------
+
+    @Test
+    fun `a failing stats read is reported and does not leave the card spinning`() = runTest {
+        coEvery { prayerUseCases.getPrayerStats(any(), any()) } throws IllegalStateException("db locked")
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_stats")
+        assertThat(telemetry.exceptions.map { it.message }).contains("db locked")
+    }
+
+    // -- The fourth un-cancelled collector ---------------------------------
+
+    @Test
+    fun `completing a qada prayer leaves one collector on the missed list`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.MarkQadaCompleted(record(id = 9)))
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.MarkQadaCompleted(record(id = 9)))
+        advanceUntilIdle()
+
+        assertThat(missedPrayers.subscriptionCount.value).isEqualTo(1)
+    }
+}
+
+private const val MILLIS_PER_DAY = 86_400_000L
+
+private fun stats(totalPrayed: Int) = PrayerStats(
+    totalPrayed = totalPrayed,
+    totalMissed = 0,
+    totalJamaah = 0,
+    prayedByPrayer = emptyMap(),
+    missedByPrayer = emptyMap(),
+    currentStreak = 0,
+    longestStreak = 0,
+    perfectDays = 0,
+    startDate = 0L,
+    endDate = 0L
+)
+
+private fun record(id: Long) = PrayerRecord(
+    id = id,
+    date = 0L,
+    prayerName = PrayerName.FAJR,
+    status = PrayerStatus.PRAYED,
+    prayedAt = null,
+    scheduledTime = 0L,
+    isJamaah = false,
+    isQadaFor = null,
+    note = null,
+    createdAt = 0L,
+    updatedAt = 0L
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModelHistoryScopeTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModelHistoryScopeTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerRecord
 import com.arshadshah.nimaz.domain.model.PrayerStatus
@@ -60,7 +61,7 @@ class PrayerTrackerViewModelHistoryScopeTest {
 
     @Test
     fun `an earlier history range cannot redraw over the range on screen`() = runTest {
-        val vm = PrayerTrackerViewModel(prayerUseCases)
+        val vm = PrayerTrackerViewModel(prayerUseCases, RecordingTelemetry())
 
         vm.onEvent(PrayerTrackerEvent.LoadHistory(weekStart, end))
         advanceUntilIdle()
@@ -78,7 +79,7 @@ class PrayerTrackerViewModelHistoryScopeTest {
 
     @Test
     fun `returning to a range re-subscribes to it`() = runTest {
-        val vm = PrayerTrackerViewModel(prayerUseCases)
+        val vm = PrayerTrackerViewModel(prayerUseCases, RecordingTelemetry())
 
         vm.onEvent(PrayerTrackerEvent.LoadHistory(weekStart, end))
         advanceUntilIdle()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -310,6 +310,28 @@ Clearing a query counts as a change of request: cancel there too, or the last co
 emission repopulates the results the user just cleared. See AP-7.1b in
 [`CLEAN_ARCHITECTURE_CHECKLIST.md`](CLEAN_ARCHITECTURE_CHECKLIST.md).
 
+**A one-shot suspend read is the same hazard.** It is easy to read the rule above as being about
+`collect`, but nothing in it depends on the flow: two `launch`es that `await` a query and then
+write the same state race exactly as two collectors do, and the slower one wins. That is how
+`PrayerTrackerViewModel.loadStats` shipped — a period switch racing a stats read left week
+numbers under a MONTH chip. Cancellation alone does not close it, either: a coroutine cancelled
+after its **last** suspension point still runs to the end of the block, so the write needs a
+guard as well as a handle.
+
+```kotlin
+statsJob?.cancel()
+statsJob = launchSafely(telemetry, DOMAIN, "load_stats", …) {
+    val stats = useCases.getStats(startEpoch, endEpoch)   // last suspension point
+    if (_state.value.period != period) return@launchSafely // …so check before writing
+    _state.update { it.copy(stats = stats) }
+}
+```
+
+**Prefer removing the trigger to guarding the race.** A number derived from a Room table does not
+need re-reading after a write to that table — subscribe to it instead, and Room re-emits. Calling
+a loader imperatively after every write is what puts the second read in flight in the first
+place, and it also freezes the value when the write comes from *another* screen.
+
 #### Derived state is computed on the UI-state class, never stored
 
 A filtered list, a resolved language, a total — anything that is a pure function of other state

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -292,6 +292,22 @@ rg -U --multiline-dotall -n '\.collect\s*\{(?:[^}]|
     `loadForDate` that has always had `dateRecordsJob`. (`PrayerTrackerViewModelHistoryScopeTest`)
   - `HadithViewModel` — `search` / `searchInBook` / `loadBook` / `loadChapter` /
     `loadHadithById` / `filterByGrade` (fixed earlier, see above).
+- [x] ~~**`PrayerTrackerViewModel.loadStats` / `loadQadaPrayers` — the two the sweep's own
+  heuristic could not see.**~~ **Resolved.** The sweep above split hits by *"takes a parameter,
+  so it is re-invoked per value"* versus *"takes none, so it is a one-shot lifetime observer"*.
+  These two take no parameter and are re-invoked anyway: `loadStats` reads its input from
+  `_statsState.value.period` and runs from `init`, `SetStatsPeriod`, `LoadStats`,
+  `updatePrayerStatus` and `markQadaCompleted`; `loadQadaPrayers` from `init`,
+  `LoadQadaPrayers` and `markQadaCompleted`. Two completed qada prayers left **three** live
+  collectors on the missed-prayer list (asserted directly, via `subscriptionCount`), and a
+  period switch racing an in-flight stats read left week numbers under a MONTH chip.
+
+  **The heuristic to use instead: re-invocability is about the call graph, not the signature.**
+  A function whose input comes from `_state.value` is parameterised — the parameter is just
+  implicit — and a private loader called from a sibling handler is re-invoked even if no event
+  reaches it directly. Both handles are now cancel-and-replace, and the loaders are no longer
+  called imperatively after a write: the collector observes the same table, so Room re-emits.
+  (`PrayerTrackerStatsTest`)
 - [x] ~~**`SyncViewModel` — untriaged.**~~ **Not a defect.** Its single `collect` is a lifetime
   observer started once from `init`, which is exactly what the detect command cannot distinguish
   and what the parameterised/not split above is for. Left as-is.


### PR DESCRIPTION
Layer 10 of the #352 stack, on top of #378. Closes T18 of #366 and D8 of #363.

## What was broken

### 1. A period switch could leave the previous period's numbers on screen (#366 T18)

`loadStats()` launched with **no job handle**, and it is re-entered from five places — `init`, `SetStatsPeriod`, `LoadStats`, and (until this PR) `updatePrayerStatus` and `markQadaCompleted`. This is the third un-cancelled re-invocable load in this file: `dateRecordsJob` and `historyJob` were given handles and this one was missed.

**Input → wrong output:** tap "prayed" on Fajr, then within a few hundred ms switch the stats period from WEEK to MONTH. Two `getPrayerStats` reads in flight; the slower one writes last.

Asserted before the fix, with the slow query being the one the user moves away from:

```
an earlier period cannot leave its numbers under a later chip
expected: 35        // the WEEK numbers, under the WEEK chip
but was : 150       // the MONTH numbers
```

`PrayerStatsScreen` derives the chart subtitle from `stats.startDate`, so the mismatched period also mislabels its own chart.

**Cancelling is necessary but not sufficient.** A coroutine cancelled after its *last* suspension point still runs to the end of the block, and the `_statsState.update` is the last statement. So the captured period is also checked against the live one before the write.

### 2. Stats never refreshed reactively (#366 T18, second half)

`prayerRecords` came from a Room flow, but `stats` / `currentStreak` / `longestStreak` were imperative one-shot reads.

**Input → wrong output:** mark a prayer from the Home card while the tracker sits in the back stack. The record list updates via Room; the streak card at `PrayerTrackerScreen.kt:192` keeps showing the streak from before the tap.

The four reads are now driven by a collector on the same window of `prayer_records`, so Room re-emits and the numbers follow. `collectLatest` drops a recompute a newer emission has overtaken, so a burst of writes costs one set of reads rather than one per emission.

That also **removes the race's trigger rather than guarding it**: `updatePrayerStatus` and `markQadaCompleted` no longer re-read imperatively after a write, because the collector observes the table they just wrote to.

### 3. Every stats window was one day too wide (#363 D8)

`WEEK` asked for `[today-7, tomorrow)` — eight days.

**Input → wrong output:** a user who prayed all five prayers for the last seven days but missed three eight days ago reads **"37/40"** under a chip labelled *Week*, instead of 35/35. Measured before the fix:

```
the week window spans seven days, not eight
expected: 604800000   // 7 days
but was : 691200000   // 8
```

`MONTH` and `YEAR` had the same off-by-one, including the month summary that is read alongside *every* period. `statsWindow(period, today)` now returns the inclusive window and documents why the start is `n - 1` days back. `ALL_TIME` keeps its ten-year reach — it is a floor, not a window.

## Two corrections to the issue

Verified against the current code rather than taken on trust:

- **#366 calls this "the third instance of AP-7.1b in this file". There is a fourth.** `loadQadaPrayers()` has exactly the same shape and is reachable from `init`, `LoadQadaPrayers` and `markQadaCompleted`. Two completed qada prayers left **three** live collectors on the missed-prayer list — asserted directly via `subscriptionCount`, not inferred. Fixed here with `qadaJob`.
- **#366 lists three call sites for `loadStats()`; there are five**, counting `init` and the `LoadStats` event.

Both were invisible to the AP-7.1b sweep because it split its hits by *"takes a parameter, so it is re-invoked per value"* vs *"takes none, so it is a one-shot lifetime observer"* — and neither of these takes a parameter. `loadStats` reads its period from `_statsState.value`. The checklist now records the sharper rule: **re-invocability is a property of the call graph, not the signature.**

## Also in this layer

- **`Telemetry`.** The ViewModel used `AppAnalytics` directly and had no failure reporting at all — every load was a bare `viewModelScope.launch`, one Room error away from an uncaught crash on `viewModelScope`'s supervisor. All six now go through `launchSafely`, and the analytics calls through `telemetry`. `FirebaseTelemetry` is a pass-through, so no event payload changes.
- **No new error field.** `PrayerStatsUiState` deliberately does not gain one: nothing renders it, and this epic is already full of `error` fields written and never read. A failed load reports and clears `isLoading`.

## Not fixed here

`loadPrayerTimes` is called synchronously from `selectDate`, outside any coroutine, so a throw from the calculator still propagates to the caller. Pre-existing, unrelated to T18, left for the instrumentation pass.

## Tests

`PrayerTrackerStatsTest` — six tests, **all six failing before the fix**, each on the documented defect rather than a compilation accident:

| test | before |
|---|---|
| the week window spans seven days, not eight | 8 days |
| the month window ends today and starts a month back | off by one day |
| an earlier period cannot leave its numbers under a later chip | MONTH numbers under the WEEK chip |
| the streak follows the prayer table instead of freezing | streak frozen at 3 |
| a failing stats read is reported and does not leave the card spinning | `isLoading` stuck true |
| completing a qada prayer leaves one collector on the missed list | 3 collectors |

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1466/1467
python3 scripts/check_docs.py                              23/23
```

The one failure is `DeviceStateCorpusTest`, which needs the content artifact from the private `nimaz-data` repo (`Unable to copy database file`). This session's token gets 403 on that repo's releases API, so the run used `-x :app:fetchNimazData`. **Confirmed environmental**: the same test fails identically on `epic/vm-09-tasbih` with the same flag, and every other test in the suite passes.

## Docs

- `ARCHITECTURE.md` §4.1 — the case this file was missing: a one-shot suspend read races exactly as a collector does, cancellation does not close the window after the last suspension point, and preferring to remove the trigger over guarding the race.
- `CLEAN_ARCHITECTURE_CHECKLIST.md` AP-7.1b — the two new instances and the corrected detection heuristic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_