### PR TITLE
fix(ai): one worker call per question, and consent enforced below the UI

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
@@ -106,5 +106,16 @@ sealed interface AiError {
     data object Network : AiError
     data class Invalid(val message: String) : AiError
     data object Unverified : AiError
+
+    /**
+     * The question was not sent because the user has not opted in.
+     *
+     * Consent used to be checked in one place — a visibility condition in `SearchScreen` —
+     * so nothing below the UI enforced it. `AskWithProofUseCase` now refuses first, and
+     * this is what it refuses with: a state the UI can explain rather than a generic
+     * failure the user would read as the feature being broken.
+     */
+    data object ConsentRequired : AiError
+
     data object Unknown : AiError
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCase.kt
@@ -8,6 +8,7 @@ import com.arshadshah.nimaz.domain.model.HadithRef
 import com.arshadshah.nimaz.domain.model.Proof
 import com.arshadshah.nimaz.domain.repository.AiRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase
@@ -39,6 +40,7 @@ class AskWithProofUseCase @Inject constructor(
     private val aiRepository: AiRepository,
     private val quranUseCases: QuranUseCases,
     private val hadithUseCases: HadithUseCases,
+    private val settingsRepository: SettingsRepository,
 ) {
     sealed interface Outcome {
         data class Answered(
@@ -54,6 +56,13 @@ class AskWithProofUseCase @Inject constructor(
     }
 
     suspend operator fun invoke(question: String): Outcome {
+        // The consent gate lives here, below every caller, rather than in the one screen
+        // that happens to hide the entry point today. Nothing sends a question off the
+        // device without this check passing first.
+        if (!settingsRepository.aiAskEnabled.first()) {
+            return Outcome.Failed(AiError.ConsentRequired)
+        }
+
         val assist = aiRepository.assist(question).getOrElse { throwable ->
             val error = (throwable as? AiRequestException)?.error ?: AiError.Unknown
             return Outcome.Failed(error)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/AskComponents.kt
@@ -373,6 +373,12 @@ internal fun AskErrorCard(error: AiError, onRetry: () -> Unit) {
             body = stringResource(R.string.ai_error_invalid)
         }
 
+        AiError.ConsentRequired -> {
+            icon = Icons.Outlined.Shield
+            title = stringResource(R.string.ai_error_consent_title)
+            body = stringResource(R.string.ai_error_consent)
+        }
+
         AiError.Unknown -> {
             icon = Icons.Outlined.Info
             title = stringResource(R.string.ai_error_unknown_title)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
@@ -188,6 +188,15 @@ fun SearchSettingsScreen(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (state.consentFailed) {
+                    // The write did not commit. Saying so beats the sheet closing over a
+                    // switch that has quietly stayed off.
+                    Text(
+                        text = stringResource(R.string.ai_consent_save_failed),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
                 NimazButton(
                     text = stringResource(R.string.ai_consent_enable),
                     onClick = { viewModel.onEvent(SearchSettingsEvent.ConsentAccepted) },

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModel.kt
@@ -2,7 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
 import com.arshadshah.nimaz.domain.model.Proof
@@ -15,8 +16,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -60,6 +61,7 @@ sealed interface AskEvent {
 class AskViewModel @Inject constructor(
     private val askWithProof: AskWithProofUseCase,
     private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -67,29 +69,44 @@ class AskViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(AskUiState())
     val uiState: StateFlow<AskUiState> = _uiState.asStateFlow()
 
-    // Recent AI questions kept in memory for the session; also persisted only
-    // when history is enabled (mirrors SearchViewModel's recent-searches idiom).
-    private val recentQuestions = mutableListOf<String>()
-
     init {
+        // A pure transform: the previous version mutated a shared `mutableListOf` and
+        // called `_uiState.update` from inside `combine`, which is a side effect in a
+        // place that reads as a mapping — and that list was also mutated from `addRecent`
+        // on a different coroutine, with no synchronisation.
         combine(
             settingsRepository.aiAskEnabled,
             settingsRepository.aiAskHintDismissed,
             settingsRepository.aiHistoryEnabled,
             settingsRepository.aiQuestionHistory,
         ) { enabled, hintDismissed, historyEnabled, historyJson ->
-            if (historyEnabled && recentQuestions.isEmpty() && historyJson.isNotBlank()) {
-                recentQuestions.addAll(decodeHistory(historyJson))
+            // The stored history is the single source of truth, re-read on every change
+            // rather than loaded once "if the in-memory list happens to be empty". That
+            // condition is why switching "remember my questions" off left the questions
+            // it had already loaded on screen for the rest of the session.
+            Snapshot(
+                aiEnabled = enabled,
+                hintDismissed = hintDismissed,
+                recentQuestions = if (historyEnabled) decodeHistory(historyJson) else emptyList(),
+            )
+        }
+            .onEach { snapshot ->
+                _uiState.update {
+                    it.copy(
+                        aiEnabled = snapshot.aiEnabled,
+                        hintDismissed = snapshot.hintDismissed,
+                        recentQuestions = snapshot.recentQuestions,
+                    )
+                }
             }
-            _uiState.update {
-                it.copy(
-                    aiEnabled = enabled,
-                    hintDismissed = hintDismissed,
-                    recentQuestions = recentQuestions.toList(),
-                )
-            }
-        }.launchIn(viewModelScope)
+            .launchIn(viewModelScope)
     }
+
+    private data class Snapshot(
+        val aiEnabled: Boolean,
+        val hintDismissed: Boolean,
+        val recentQuestions: List<String>,
+    )
 
     fun onEvent(event: AskEvent) {
         when (event) {
@@ -108,7 +125,9 @@ class AskViewModel @Inject constructor(
                 }
 
             AskEvent.DismissHint ->
-                viewModelScope.launch { settingsRepository.setAiAskHintDismissed(true) }
+                launchSafely(telemetry, DOMAIN, "dismiss_hint") {
+                    settingsRepository.setAiAskHintDismissed(true)
+                }
         }
     }
 
@@ -116,15 +135,32 @@ class AskViewModel @Inject constructor(
         val question = rawQuestion.trim()
         if (question.length < MIN_QUESTION_LENGTH) return
 
-        AppAnalytics.logEvent(EVENT_SUBMITTED, null) // event name only — never the question text
+        // Every submit is one billed Worker invocation. Two guards, both checked
+        // synchronously before anything is launched:
+        //
+        //  - In flight already. Tapping "Ask" twice is the normal reaction to a slow
+        //    network, and the error card's retry button makes it one tap away. Without
+        //    this, that is two Worker calls for one question.
+        //  - Feature off. The use case refuses too — that is where the guarantee lives —
+        //    but returning here keeps the UI out of a Loading phase it would never leave
+        //    on its own.
+        if (_uiState.value.phase == AskPhase.Loading) return
+        if (!_uiState.value.aiEnabled) return
+
+        telemetry.featureUsed(DOMAIN, "submitted") // action only — never the question text
         // Reset the terms so a stale set can't drive the list if this ask fails;
         // only a fresh answer sets relatedTerms again.
         _uiState.update { it.copy(phase = AskPhase.Loading, relatedTerms = emptyList()) }
 
-        viewModelScope.launch {
+        launchSafely(
+            telemetry,
+            DOMAIN,
+            "ask",
+            onFailure = { _uiState.update { it.copy(phase = AskPhase.Error(AiError.Unknown)) } },
+        ) {
             when (val outcome = askWithProof(question)) {
                 is AskWithProofUseCase.Outcome.Answered -> {
-                    AppAnalytics.logEvent(EVENT_ANSWERED, null)
+                    telemetry.featureUsed(DOMAIN, "answered")
                     addRecent(question)
                     _uiState.update {
                         it.copy(
@@ -139,24 +175,21 @@ class AskViewModel @Inject constructor(
                 }
 
                 is AskWithProofUseCase.Outcome.Failed -> {
-                    AppAnalytics.logEvent(EVENT_ERROR_PREFIX + errorSlug(outcome.error), null)
+                    telemetry.error(DOMAIN, "ask_" + errorSlug(outcome.error))
                     _uiState.update { it.copy(phase = AskPhase.Error(outcome.error)) }
                 }
             }
         }
     }
 
-    private fun addRecent(question: String) {
-        recentQuestions.remove(question)
-        recentQuestions.add(0, question)
-        if (recentQuestions.size > MAX_RECENT) {
-            recentQuestions.removeAt(recentQuestions.lastIndex)
-        }
-        _uiState.update { it.copy(recentQuestions = recentQuestions.toList()) }
-        viewModelScope.launch {
-            if (settingsRepository.aiHistoryEnabled.first()) {
-                settingsRepository.setAiQuestionHistory(encodeHistory(recentQuestions))
-            }
+    private suspend fun addRecent(question: String) {
+        val updated = (listOf(question) + _uiState.value.recentQuestions.filterNot { it == question })
+            .take(MAX_RECENT)
+        _uiState.update { it.copy(recentQuestions = updated) }
+        // Persisting re-emits `aiQuestionHistory`, which flows back through the combine
+        // above — so the stored list stays the source of truth and the two cannot drift.
+        if (settingsRepository.aiHistoryEnabled.first()) {
+            settingsRepository.setAiQuestionHistory(encodeHistory(updated))
         }
     }
 
@@ -174,14 +207,13 @@ class AskViewModel @Inject constructor(
         AiError.Network -> "network"
         is AiError.Invalid -> "invalid"
         AiError.Unverified -> "unverified"
+        AiError.ConsentRequired -> "consent_required"
         AiError.Unknown -> "unknown"
     }
 
     companion object {
         const val MIN_QUESTION_LENGTH = 3
         private const val MAX_RECENT = 10
-        private const val EVENT_SUBMITTED = "ai_ask_submitted"
-        private const val EVENT_ANSWERED = "ai_ask_answered"
-        private const val EVENT_ERROR_PREFIX = "ai_ask_error_"
+        private const val DOMAIN = "ai_ask"
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModel.kt
@@ -2,7 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,7 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -23,6 +23,11 @@ data class SearchSettingsUiState(
     /** Persisted recent questions — shown in the clear-history confirm dialog. */
     val savedQuestions: List<String> = emptyList(),
     val showConsentSheet: Boolean = false,
+    /**
+     * The consent write failed. The sheet stays up and says so, because the alternative —
+     * what shipped — is a switch the user just turned on quietly turning itself back off.
+     */
+    val consentFailed: Boolean = false,
 )
 
 sealed interface SearchSettingsEvent {
@@ -37,6 +42,7 @@ sealed interface SearchSettingsEvent {
 @HiltViewModel
 class SearchSettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -75,22 +81,22 @@ class SearchSettingsViewModel @Inject constructor(
             SearchSettingsEvent.ToggleAiRequested -> onToggleRequested()
             SearchSettingsEvent.ConsentAccepted -> onConsentAccepted()
             SearchSettingsEvent.ConsentDismissed ->
-                _uiState.update { it.copy(showConsentSheet = false) }
+                _uiState.update { it.copy(showConsentSheet = false, consentFailed = false) }
 
             is SearchSettingsEvent.SetHistoryEnabled ->
-                viewModelScope.launch {
+                launchSafely(telemetry, DOMAIN, "set_history") {
                     settingsRepository.setAiHistoryEnabled(event.enabled)
                     if (!event.enabled) settingsRepository.setAiQuestionHistory("")
-                    AppAnalytics.logFeatureUsed(
-                        "ai_ask",
-                        if (event.enabled) "history_on" else "history_off",
+                    telemetry.settingChanged(
+                        "ai_ask_history",
+                        if (event.enabled) "on" else "off",
                     )
                 }
 
             SearchSettingsEvent.ClearHistory ->
-                viewModelScope.launch {
+                launchSafely(telemetry, DOMAIN, "clear_history") {
                     settingsRepository.setAiQuestionHistory("")
-                    AppAnalytics.logFeatureUsed("ai_ask", "history_cleared")
+                    telemetry.featureUsed(DOMAIN, "history_cleared")
                 }
         }
     }
@@ -98,22 +104,40 @@ class SearchSettingsViewModel @Inject constructor(
     private fun onToggleRequested() {
         if (_uiState.value.aiEnabled) {
             // Turning OFF is instant — no consent required.
-            viewModelScope.launch {
+            launchSafely(telemetry, DOMAIN, "disable") {
                 settingsRepository.setAiAskEnabled(false)
-                AppAnalytics.logFeatureUsed("ai_ask", "disabled")
+                telemetry.settingChanged("ai_ask", "off")
             }
         } else {
             // Turning ON requires explicit consent first.
-            _uiState.update { it.copy(showConsentSheet = true) }
+            _uiState.update { it.copy(showConsentSheet = true, consentFailed = false) }
         }
     }
 
+    /**
+     * Closes the sheet **after** the writes commit, not before.
+     *
+     * The previous order closed it synchronously while the DataStore write was still
+     * queued in a `launch`. If that write failed, the user had consented, the sheet was
+     * gone, and the `combine` above re-emitted `aiEnabled = false` — a switch that flipped
+     * itself back with no explanation, on the one control that governs whether anything
+     * leaves the device.
+     */
     private fun onConsentAccepted() {
-        viewModelScope.launch {
+        launchSafely(
+            telemetry,
+            DOMAIN,
+            "consent",
+            onFailure = { _uiState.update { it.copy(consentFailed = true) } },
+        ) {
             settingsRepository.setAiAskEnabled(true)
             settingsRepository.setAiConsentTimestamp(System.currentTimeMillis())
-            AppAnalytics.logFeatureUsed("ai_ask", "enabled")
+            telemetry.settingChanged("ai_ask", "on")
+            _uiState.update { it.copy(showConsentSheet = false, consentFailed = false) }
         }
-        _uiState.update { it.copy(showConsentSheet = false) }
+    }
+
+    private companion object {
+        private const val DOMAIN = "ai_ask"
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1763,4 +1763,7 @@
     <string name="bookmarks_clear_all_title">Alle Lesezeichen löschen?</string>
     <string name="bookmarks_clear_all_confirm">Alle löschen</string>
     <string name="bookmarks_clear_all_body">Damit werden alle %1$d Lesezeichen entfernt — Koran, Hadith und Bittgebete. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="ai_error_consent_title">Mit Beleg fragen ist aus</string>
+    <string name="ai_error_consent">Aktiviere es in den Sucheinstellungen, um eine Frage zu stellen. Die Stichwortsuche in Koran, Hadith und Bittgebeten funktioniert ohnehin offline.</string>
+    <string name="ai_consent_save_failed">Diese Einstellung konnte nicht gespeichert werden. Bitte versuche es erneut.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1798,4 +1798,7 @@
     <string name="bookmarks_clear_all_title">Effacer tous les favoris ?</string>
     <string name="bookmarks_clear_all_confirm">Tout effacer</string>
     <string name="bookmarks_clear_all_body">Cela supprime les %1$d favoris — Coran, Hadith et invocations. Action irréversible.</string>
+    <string name="ai_error_consent_title">Demander avec preuve est désactivé</string>
+    <string name="ai_error_consent">Activez-le dans les paramètres de recherche pour poser une question. La recherche par mot-clé dans le Coran, les hadiths et les invocations fonctionne hors ligne dans tous les cas.</string>
+    <string name="ai_consent_save_failed">Ce réglage n\'a pas pu être enregistré. Veuillez réessayer.</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1732,4 +1732,7 @@
     <string name="bookmarks_clear_all_title">Hapus semua markah?</string>
     <string name="bookmarks_clear_all_confirm">Hapus semua</string>
     <string name="bookmarks_clear_all_body">Ini menghapus semua %1$d markah — Al-Qur\'an, Hadis, dan Doa. Tindakan ini tidak dapat dibatalkan.</string>
+    <string name="ai_error_consent_title">Tanya dengan Dalil nonaktif</string>
+    <string name="ai_error_consent">Aktifkan di pengaturan pencarian untuk mengajukan pertanyaan. Pencarian kata kunci di Al-Qur\'an, hadis, dan doa tetap berfungsi offline.</string>
+    <string name="ai_consent_save_failed">Pengaturan itu tidak dapat disimpan. Silakan coba lagi.</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1733,4 +1733,7 @@
     <string name="bookmarks_clear_all_title">Kosongkan semua penanda buku?</string>
     <string name="bookmarks_clear_all_confirm">Kosongkan semua</string>
     <string name="bookmarks_clear_all_body">Ini membuang kesemua %1$d penanda buku — Al-Quran, Hadis dan Doa. Ia tidak boleh dibatalkan.</string>
+    <string name="ai_error_consent_title">Tanya dengan Dalil dimatikan</string>
+    <string name="ai_error_consent">Hidupkan dalam tetapan carian untuk bertanya. Carian kata kunci dalam al-Quran, hadis dan doa tetap berfungsi di luar talian.</string>
+    <string name="ai_consent_save_failed">Tetapan itu tidak dapat disimpan. Sila cuba lagi.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1769,4 +1769,7 @@
     <string name="bookmarks_clear_all_title">Tüm yer imleri silinsin mi?</string>
     <string name="bookmarks_clear_all_confirm">Tümünü sil</string>
     <string name="bookmarks_clear_all_body">Bu, %1$d yer iminin tamamını siler — Kur\'an, Hadis ve Dua. Geri alınamaz.</string>
+    <string name="ai_error_consent_title">Delille Sor kapalı</string>
+    <string name="ai_error_consent">Soru sormak için Arama ayarlarından açın. Kur\'an, hadis ve dualarda anahtar kelime araması her durumda çevrimdışı çalışır.</string>
+    <string name="ai_consent_save_failed">Bu ayar kaydedilemedi. Lütfen tekrar deneyin.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1934,4 +1934,7 @@
     <string name="bookmarks_clear_all_title">Clear all bookmarks?</string>
     <string name="bookmarks_clear_all_confirm">Clear all</string>
     <string name="bookmarks_clear_all_body">This removes all %1$d bookmarks — Qur\'an, Hadith and Dua. It cannot be undone.</string>
+    <string name="ai_error_consent_title">Ask with Proof is off</string>
+    <string name="ai_error_consent">Turn it on in Search settings to ask a question. Keyword search across the Qur\'an, Hadith and duas works offline either way.</string>
+    <string name="ai_consent_save_failed">That setting couldn\'t be saved. Please try again.</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofConsentTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofConsentTest.kt
@@ -1,0 +1,60 @@
+package com.arshadshah.nimaz.domain.usecase.ai
+
+import com.arshadshah.nimaz.domain.model.AiError
+import com.arshadshah.nimaz.domain.repository.AiRepository
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Consent for "Ask with Proof" is enforced below the UI layer.
+ *
+ * `aiAskEnabled` used to be checked in exactly one place — a visibility condition in
+ * `SearchScreen`. Nothing in `AskViewModel`, this use case, `AiRepository` or the Worker
+ * client re-checked it, so any future caller of `AskEvent.Submit` would have sent the
+ * question off the device with the feature switched off. For an opt-in privacy control,
+ * one UI site is not where the guarantee belongs.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AskWithProofConsentTest {
+
+    private val aiRepository = mockk<AiRepository>(relaxed = true)
+    private val quranUseCases = mockk<QuranUseCases>(relaxed = true)
+    private val hadithUseCases = mockk<HadithUseCases>(relaxed = true)
+    private val settings = mockk<SettingsRepository>(relaxed = true)
+
+    private fun useCase() =
+        AskWithProofUseCase(aiRepository, quranUseCases, hadithUseCases, settings)
+
+    @Test
+    fun `the question never leaves the device when the feature is off`() = runTest {
+        every { settings.aiAskEnabled } returns flowOf(false)
+
+        val outcome = useCase().invoke("What does the Quran say about patience?")
+
+        coVerify(exactly = 0) { aiRepository.assist(any()) }
+        assertThat(outcome)
+            .isEqualTo(AskWithProofUseCase.Outcome.Failed(AiError.ConsentRequired))
+    }
+
+    @Test
+    fun `with consent given the question reaches the worker`() = runTest {
+        every { settings.aiAskEnabled } returns flowOf(true)
+        // What the Worker answers is AskWithProofUseCaseTest's subject; here the only
+        // question is whether the call was made at all.
+        coEvery { aiRepository.assist(any()) } returns Result.failure(RuntimeException("boom"))
+
+        useCase().invoke("What does the Quran say about patience?")
+
+        coVerify(exactly = 1) { aiRepository.assist(any()) }
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ai/AskWithProofUseCaseTest.kt
@@ -15,6 +15,7 @@ import com.arshadshah.nimaz.domain.model.SearchAssist
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.model.SurahWithAyahs
 import com.arshadshah.nimaz.domain.repository.AiRepository
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.repository.AiRequestException
 import com.arshadshah.nimaz.domain.usecase.GetBookByIdUseCase
 import com.arshadshah.nimaz.domain.usecase.GetHadithByReferenceUseCase
@@ -38,6 +39,7 @@ class AskWithProofUseCaseTest {
     private val getHadithByReferenceUC = mockk<GetHadithByReferenceUseCase>()
     private val getBookByIdUC = mockk<GetBookByIdUseCase>()
     private val hadithUseCases = mockk<HadithUseCases>()
+    private val settingsRepository = mockk<SettingsRepository>(relaxed = true)
 
     private lateinit var useCase: AskWithProofUseCase
 
@@ -46,7 +48,9 @@ class AskWithProofUseCaseTest {
         every { quranUseCases.getSurahWithAyahs } returns getSurahWithAyahsUC
         every { hadithUseCases.getHadithByReference } returns getHadithByReferenceUC
         every { hadithUseCases.getBookById } returns getBookByIdUC
-        useCase = AskWithProofUseCase(aiRepository, quranUseCases, hadithUseCases)
+        // Consent is granted throughout: the refusal path is AskWithProofConsentTest.
+        every { settingsRepository.aiAskEnabled } returns flowOf(true)
+        useCase = AskWithProofUseCase(aiRepository, quranUseCases, hadithUseCases, settingsRepository)
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModelGuardTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModelGuardTest.kt
@@ -1,0 +1,146 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.AnswerConfidence
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.ai.AskWithProofUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What it costs to tap "Ask" twice.
+ *
+ * Every submit is one Cloudflare Worker invocation, billed. `submit()` validated only the
+ * question's length: no in-flight guard, and no check that the feature the user has to opt
+ * into is actually on. `docs/ai-ask-with-proof.md` states the design as "one Worker call per
+ * question"; the ViewModel did not enforce it, and the retry button made a second tap the
+ * natural reaction to a slow network.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AskViewModelGuardTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val askWithProof = mockk<AskWithProofUseCase>()
+    private val settings = mockk<SettingsRepository>(relaxed = true)
+    private val telemetry = RecordingTelemetry()
+
+    private val aiEnabled = MutableStateFlow(true)
+    private val historyEnabled = MutableStateFlow(true)
+    private val questionHistory = MutableStateFlow("""["an older question"]""")
+
+    private val question = "What does the Quran say about patience?"
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { settings.aiAskEnabled } returns aiEnabled
+        every { settings.aiAskHintDismissed } returns flowOf(false)
+        every { settings.aiHistoryEnabled } returns historyEnabled
+        every { settings.aiQuestionHistory } returns questionHistory
+
+        coEvery { askWithProof.invoke(any()) } coAnswers {
+            delay(500)
+            AskWithProofUseCase.Outcome.Answered(
+                answer = "Patience is virtuous.",
+                confidence = AnswerConfidence.HIGH,
+                proofs = emptyList(),
+                relatedTerms = emptyList(),
+            )
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = AskViewModel(askWithProof, settings, telemetry)
+
+    @Test
+    fun `a second tap while the first is in flight does not bill a second worker call`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion(question))
+        vm.onEvent(AskEvent.Submit)
+        advanceTimeBy(50)          // the first call is still in flight
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { askWithProof.invoke(question) }
+    }
+
+    @Test
+    fun `retrying a recent question while one is in flight does not bill twice either`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion(question))
+        vm.onEvent(AskEvent.Submit)
+        advanceTimeBy(50)
+        vm.onEvent(AskEvent.SelectRecent("an older question"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { askWithProof.invoke(any()) }
+    }
+
+    @Test
+    fun `a question is never sent while the feature is switched off`() = runTest {
+        aiEnabled.value = false
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion(question))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { askWithProof.invoke(any()) }
+        assertThat(vm.uiState.value.phase).isEqualTo(AskPhase.Idle)
+    }
+
+    @Test
+    fun `turning history off takes the loaded questions off the screen`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertThat(vm.uiState.value.recentQuestions).containsExactly("an older question")
+
+        // "Remember my questions" switched off in Search settings: the stored history is
+        // cleared there, and what is already on screen must go with it.
+        historyEnabled.value = false
+        questionHistory.value = ""
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.recentQuestions).isEmpty()
+    }
+
+    @Test
+    fun `turning history back on restores what was persisted`() = runTest {
+        historyEnabled.value = false
+        questionHistory.value = ""
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertThat(vm.uiState.value.recentQuestions).isEmpty()
+
+        historyEnabled.value = true
+        questionHistory.value = """["restored question"]"""
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.recentQuestions).containsExactly("restored question")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AskViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.AiError
 import com.arshadshah.nimaz.domain.model.AnswerConfidence
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -38,7 +39,7 @@ class AskViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = AskViewModel(askWithProof, settings)
+    private fun viewModel() = AskViewModel(askWithProof, settings, RecordingTelemetry())
 
     @Test
     fun `reflects enabled state from settings`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/SearchSettingsViewModelTest.kt
@@ -1,0 +1,157 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The consent gate for "Ask with Proof" — the whole privacy control for the one feature
+ * that sends anything off the device, and until now the ViewModel with zero tests.
+ *
+ * `onConsentAccepted` closed the sheet with a synchronous `_uiState.update` and wrote the
+ * flag in a `launch`, so the sheet was already gone before the write had a chance to fail.
+ * When it did fail the user had consented, the sheet was closed, and `aiEnabled` stayed
+ * false — a switch that flips itself back with no explanation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchSettingsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val settings = mockk<SettingsRepository>(relaxed = true)
+    private val telemetry = RecordingTelemetry()
+
+    private val aiEnabled = MutableStateFlow(false)
+    private val historyEnabled = MutableStateFlow(true)
+    private val questionHistory = MutableStateFlow("""["what is zakat"]""")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { settings.aiAskEnabled } returns aiEnabled
+        every { settings.aiHistoryEnabled } returns historyEnabled
+        every { settings.aiQuestionHistory } returns questionHistory
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = SearchSettingsViewModel(settings, telemetry)
+
+    @Test
+    fun `asking to enable opens the consent sheet rather than enabling anything`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.showConsentSheet).isTrue()
+        coVerify(exactly = 0) { settings.setAiAskEnabled(true) }
+    }
+
+    @Test
+    fun `the sheet stays up until the consent write has actually committed`() = runTest {
+        coEvery { settings.setAiAskEnabled(true) } coAnswers { delay(500) }
+
+        val vm = viewModel()
+        vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ConsentAccepted)
+        advanceTimeBy(50)
+        assertThat(vm.uiState.value.showConsentSheet).isTrue()
+
+        advanceUntilIdle()
+        assertThat(vm.uiState.value.showConsentSheet).isFalse()
+    }
+
+    @Test
+    fun `a consent write that fails leaves the sheet open instead of silently reverting`() =
+        runTest {
+            coEvery { settings.setAiAskEnabled(true) } throws IllegalStateException("disk full")
+
+            val vm = viewModel()
+            vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+            advanceUntilIdle()
+            vm.onEvent(SearchSettingsEvent.ConsentAccepted)
+            advanceUntilIdle()
+
+            // The alternative is what shipped: sheet closed, switch off, nothing said.
+            assertThat(vm.uiState.value.showConsentSheet).isTrue()
+            assertThat(vm.uiState.value.consentFailed).isTrue()
+            assertThat(telemetry.errors.map { it.type }).contains("consent")
+        }
+
+    @Test
+    fun `accepting consent records the flag and when it was given`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+        advanceUntilIdle()
+        vm.onEvent(SearchSettingsEvent.ConsentAccepted)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { settings.setAiAskEnabled(true) }
+        coVerify(exactly = 1) { settings.setAiConsentTimestamp(any()) }
+    }
+
+    @Test
+    fun `turning the feature off is instant and asks for nothing`() = runTest {
+        aiEnabled.value = true
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.showConsentSheet).isFalse()
+        coVerify(exactly = 1) { settings.setAiAskEnabled(false) }
+    }
+
+    @Test
+    fun `turning history off also throws away what was already stored`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.SetHistoryEnabled(false))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { settings.setAiHistoryEnabled(false) }
+        coVerify(exactly = 1) { settings.setAiQuestionHistory("") }
+    }
+
+    @Test
+    fun `dismissing the sheet clears a previous failure so the next attempt starts clean`() =
+        runTest {
+            coEvery { settings.setAiAskEnabled(true) } throws IllegalStateException("disk full")
+
+            val vm = viewModel()
+            vm.onEvent(SearchSettingsEvent.ToggleAiRequested)
+            advanceUntilIdle()
+            vm.onEvent(SearchSettingsEvent.ConsentAccepted)
+            advanceUntilIdle()
+            assertThat(vm.uiState.value.consentFailed).isTrue()
+
+            vm.onEvent(SearchSettingsEvent.ConsentDismissed)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.showConsentSheet).isFalse()
+            assertThat(vm.uiState.value.consentFailed).isFalse()
+        }
+}

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -247,9 +247,33 @@ action and the Settings hub):
   that answers can be wrong and must be verified against the cited sources,
   and that it is not a fatwa. "Enable" sets `aiAskEnabled=true` +
   `aiConsentTimestamp`. Turning it **off** is instant, no sheet.
+
+  The sheet closes **after** those two writes commit, not before. Closing it first —
+  which is what shipped — meant a failed write left the user having consented, the sheet
+  gone, and the toggle re-emitting `false`: a switch that flips itself back with no
+  explanation. A write that fails now keeps the sheet up and says so
+  (`SearchSettingsUiState.consentFailed`).
 - **Privacy** — an expandable "What gets shared" repeating the disclosure; an
   "AI question history" toggle (off = recent questions kept in memory only;
   on = persisted to DataStore as a JSON list); and "Clear AI history".
+
+### Where consent is enforced
+
+**In `AskWithProofUseCase`, before anything is sent.** It reads
+`settingsRepository.aiAskEnabled.first()` and returns
+`Outcome.Failed(AiError.ConsentRequired)` if the feature is off, so no caller can reach the
+Worker without consent. `AskViewModel.submit()` also returns early when `aiEnabled` is
+false, but only to keep the UI out of a `Loading` phase it would never leave — the
+guarantee lives in the use case.
+
+Before that, `aiAskEnabled` was checked in exactly one place: a visibility condition in
+`SearchScreen`. Nothing in the ViewModel, the use case, `AiRepository` or the Worker client
+re-checked it, so any second caller of `AskEvent.Submit` would have sent the question off
+the device with the feature switched off.
+
+**One Worker call per question is enforced too.** `submit()` returns early while
+`phase == AskPhase.Loading`. Without that guard, tapping "Ask" twice on a slow network —
+or tapping the error card's retry twice — billed two Worker invocations for one question.
 
 DataStore keys (in `PreferencesDataStore`, declared on `SettingsRepository`):
 `aiAskEnabled` (false), `aiConsentTimestamp` (0), `aiHistoryEnabled` (false),
@@ -260,9 +284,15 @@ rebuild — sources are no longer uploaded, so there is nothing to configure.)
 ### Privacy / analytics
 
 Only the question text ever leaves the device. It is **never** sent to
-Firebase. `AskViewModel` logs only event names via `AppAnalytics.logEvent`:
-`ai_ask_submitted`, `ai_ask_answered`, `ai_ask_error_{slug}` — no content
-payloads. The Worker stores nothing.
+Firebase. `AskViewModel` reports through the injected `Telemetry` seam and logs only
+actions, never content: `featureUsed("ai_ask", "submitted")`,
+`featureUsed("ai_ask", "answered")` and `error("ai_ask", "ask_{slug}")`. The Worker stores
+nothing.
+
+Turning "AI question history" **off** clears the stored list *and* what is on screen. The
+recent questions are derived from `aiQuestionHistory` on every emission rather than loaded
+once into a mutable list, so the two cannot drift — previously the loaded questions stayed
+visible for the rest of the session after the toggle went off.
 
 ## Cost model
 


### PR DESCRIPTION
Layer 12 of the #352 stack, on top of #380. Closes T6 and T7 of #366.

## What was broken

### 1. Two Worker calls billed for one question (T6)

`submit()` validated only `question.length < MIN_QUESTION_LENGTH`. No in-flight guard.

**Input → wrong output (cost):** tap "Ask", the network is slow, tap again. Two `viewModelScope.launch` blocks, **two Cloudflare Worker invocations billed for one question**. `AskErrorCard`'s retry button (`SearchScreen.kt:255`) makes it one tap away — tap retry twice, pay twice. `docs/ai-ask-with-proof.md` states the design as "one Worker call per question"; nothing enforced it.

Guarded synchronously before anything launches, so two taps in the same frame cannot both pass.

### 2. Consent was enforced at exactly one UI site (T6)

`aiAskEnabled` was checked in `SearchScreen.kt:192` — a visibility condition. Not in `AskViewModel`, not in `AskWithProofUseCase`, not in `AiRepository`, not in the Worker client.

**Input → wrong output (privacy):** any future caller of `AskViewModel.onEvent(AskEvent.Submit)` sends the question off the device with the feature switched off. For an opt-in privacy control, one screen's `if` is not where the guarantee belongs.

The gate now lives in **`AskWithProofUseCase`**, which reads `settingsRepository.aiAskEnabled.first()` before anything is sent and refuses with a new `AiError.ConsentRequired`. `AskViewModel` also returns early when disabled — but only to keep the UI out of a `Loading` phase it would never leave. The guarantee is in the use case, where no caller can route around it.

`ConsentRequired` is a real error state with its own card and copy rather than a generic failure, so if it ever does surface the user learns why nothing happened instead of reading it as a broken feature.

### 3. The consent sheet closed before the write committed (T7)

```kotlin
private fun onConsentAccepted() {
    viewModelScope.launch { settingsRepository.setAiAskEnabled(true); … }   // async
    _uiState.update { it.copy(showConsentSheet = false) }                    // sync, runs FIRST
}
```

**Input → wrong output:** the sheet closes while the DataStore write is queued. If it fails, the user has consented, the sheet is gone, and the `combine` re-emits `aiEnabled = false` — **a switch that flips itself back with no explanation**, on the one control that governs whether anything leaves the device.

The sheet now closes *after* both writes commit. A failure keeps it open and says so (`consentFailed`), and reports.

### 4. Two more in `AskViewModel`

- **The `combine` transform performed side effects** — mutating a shared `mutableListOf` and calling `_uiState.update` from inside what reads as a mapping. That list was also mutated from `addRecent` on a different coroutine, with no synchronisation. The transform is pure now.
- **History was loaded "only if the in-memory list is empty" and never cleared.** Turning "remember my questions" off left the already-loaded questions visible for the rest of the session. Recent questions are derived from `aiQuestionHistory` on every emission, so the stored list is the single source of truth and the two cannot drift.

## Tests

`SearchSettingsViewModel` gated the entire AI feature and had **zero tests** — #366 calls it the riskiest untested surface in the epic. It now has seven, covering the whole consent flow:

| test |
|---|
| asking to enable opens the consent sheet rather than enabling anything |
| the sheet stays up until the consent write has actually committed |
| a consent write that fails leaves the sheet open instead of silently reverting |
| accepting consent records the flag and when it was given |
| turning the feature off is instant and asks for nothing |
| turning history off also throws away what was already stored |
| dismissing the sheet clears a previous failure so the next attempt starts clean |

`AskViewModelGuardTest` (5) — double-submit, retry-while-in-flight, submit-with-feature-off, and history clearing in both directions. `AskWithProofConsentTest` (2) — the question does not reach `AiRepository.assist` when the feature is off.

The double-submit tests use `StandardTestDispatcher` with a 500 ms mocked Worker call and `coVerify(exactly = 1)`, so they fail against the old code by counting two invocations rather than by an indirect symptom.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1487/1488
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the layers below (`DeviceStateCorpusTest` needs the private `nimaz-data` artifact; this session 403s on it, so the run used `-x :app:fetchNimazData`).

## Docs & strings

`docs/ai-ask-with-proof.md` — a new **"Where consent is enforced"** subsection (use case first, ViewModel second, and why), the sheet's close-after-commit ordering, the one-call-per-question guard, and the corrected privacy/analytics paragraph now that both ViewModels report through `Telemetry`.

Three new strings (`ai_error_consent_title`, `ai_error_consent`, `ai_consent_save_failed`) translated into `de`, `fr`, `id`, `ms`, `tr`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_