### PR TITLE
feat(calendar): a today that can be faked and moved, and events that survive the Hijri year end

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -60,6 +60,12 @@ import com.arshadshah.nimaz.domain.usecase.GetAllBooksUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllCategoriesUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllHistoryUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllIslamicEventsUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildCalendarMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildHijriMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.CalendarUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetUpcomingEventsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllLocationsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllMakeupFastsUseCase
 import com.arshadshah.nimaz.domain.usecase.GetAllProphetsUseCase
@@ -678,6 +684,21 @@ object UseCaseModule {
     ): IslamicEventUseCases {
         return IslamicEventUseCases(
             getAllEvents = GetAllIslamicEventsUseCase(repository)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideCalendarUseCases(): CalendarUseCases {
+        // No repository: these are the calendar's arithmetic, taking the events and the
+        // date as parameters so they can be tested without a ViewModel or a clock.
+        val eventsForDate = GetEventsForDateUseCase()
+        return CalendarUseCases(
+            buildGregorianMonth = BuildCalendarMonthUseCase(eventsForDate),
+            buildHijriMonth = BuildHijriMonthUseCase(eventsForDate),
+            eventsForMonth = GetEventsForMonthUseCase(),
+            upcomingEvents = GetUpcomingEventsUseCase(),
+            eventsForDate = eventsForDate,
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/TimeModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/TimeModule.kt
@@ -1,0 +1,46 @@
+package com.arshadshah.nimaz.core.di
+
+import com.arshadshah.nimaz.core.time.SystemTodayProvider
+import com.arshadshah.nimaz.core.time.TodayProvider
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/**
+ * The dispatcher for work that is CPU-bound rather than blocking on I/O.
+ *
+ * Injected rather than referenced as `Dispatchers.Default` so a test can substitute its own
+ * scheduler and stay deterministic — without that, a `withContext(Dispatchers.Default)` runs
+ * on real threads and `advanceUntilIdle()` has nothing to wait for.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TimeModule {
+
+    @Provides
+    @Singleton
+    fun provideClock(): java.time.Clock = java.time.Clock.systemDefaultZone()
+
+    @Provides
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TimeBindingsModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTodayProvider(impl: SystemTodayProvider): TodayProvider
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/time/TodayProvider.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/time/TodayProvider.kt
@@ -1,0 +1,76 @@
+package com.arshadshah.nimaz.core.time
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * What day it is, and when that changes.
+ *
+ * `LocalDate.now()` was called directly at 39 sites across 12 ViewModels, always at `init` or
+ * collection time, and nothing re-evaluated it. There was no seam to fake in a test and no
+ * notion of "the day changed" anywhere in the ViewModel layer, so a whole family of defects
+ * shipped together: Home's "fasting today" bound a Room query to a fixed day range forever,
+ * the daily hadith and the time-of-day dua froze at whatever they were when the app started,
+ * and a month grid generated at 23:59 kept highlighting yesterday.
+ *
+ * Two things are needed to fix those, and this provides both:
+ *
+ *  - [today], so a test can decide what day it is. `Clock.fixed(...)` in production terms.
+ *  - [todayChanges], so a screen that stays open across midnight is told. It emits the
+ *    current date immediately and again at each local midnight, which makes "re-arm
+ *    everything that is scoped to today" an ordinary flow collection rather than a
+ *    hand-rolled check nobody remembers to write.
+ */
+interface TodayProvider {
+
+    /** The current local date. */
+    fun today(): LocalDate
+
+    /**
+     * The current local date, re-emitted at every local midnight.
+     *
+     * Emits immediately on collection, so a collector never has to seed itself separately.
+     */
+    val todayChanges: Flow<LocalDate>
+}
+
+@Singleton
+class SystemTodayProvider @Inject constructor(
+    private val clock: Clock,
+) : TodayProvider {
+
+    override fun today(): LocalDate = LocalDate.now(clock)
+
+    override val todayChanges: Flow<LocalDate> = flow {
+        while (true) {
+            val date = today()
+            emit(date)
+            // Sleep to the next local midnight rather than polling. Re-read the date after
+            // waking instead of assuming `date + 1`: a long doze, a timezone change or a
+            // clock correction can land the wake-up on a different day than arithmetic
+            // would predict, and the loop re-emits whatever is actually true.
+            delay(millisUntilNextMidnight())
+        }
+    }
+
+    private fun millisUntilNextMidnight(): Long {
+        val now = LocalDate.now(clock).atTime(LocalTime.now(clock))
+        val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay()
+        return Duration.between(now, nextMidnight).toMillis().coerceAtLeast(MIN_TICK_MILLIS)
+    }
+
+    private companion object {
+        /**
+         * Never schedule a zero-length wait: at exactly midnight the computed delay can round
+         * to 0 and spin the loop. A second is far below any resolution a date needs.
+         */
+        const val MIN_TICK_MILLIS = 1_000L
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/calendar/CalendarUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/calendar/CalendarUseCases.kt
@@ -1,0 +1,181 @@
+package com.arshadshah.nimaz.domain.usecase.calendar
+
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.CalendarDay
+import com.arshadshah.nimaz.domain.model.CalendarMonth
+import com.arshadshah.nimaz.domain.model.HijriDate
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import java.time.LocalDate
+import javax.inject.Inject
+
+/**
+ * The calendar's arithmetic, extracted from `CalendarViewModel`.
+ *
+ * These were 75 lines of pure functions over domain models, `private` inside the ViewModel and
+ * reachable only through it with mocked use cases. That is why two of the sharpest bugs in the
+ * app shipped and stayed: every Islamic event was projected into the **current** Hijri year
+ * only, so during the last weeks of a Hijri year the "upcoming events" list silently dropped
+ * Islamic New Year and Ashura — precisely the events that were upcoming — and the month grid
+ * dropped every Muharram event from the Gregorian month that straddles the year boundary.
+ *
+ * Nothing here reads a repository: the events are passed in, and so is today. That is the
+ * point — each function is a value in, a value out, testable without a ViewModel or a clock.
+ */
+data class CalendarUseCases(
+    val buildGregorianMonth: BuildCalendarMonthUseCase,
+    val buildHijriMonth: BuildHijriMonthUseCase,
+    val eventsForMonth: GetEventsForMonthUseCase,
+    val upcomingEvents: GetUpcomingEventsUseCase,
+    val eventsForDate: GetEventsForDateUseCase,
+)
+
+/**
+ * Projects a recurring Islamic event onto the Gregorian calendar.
+ *
+ * An [IslamicEvent] carries only a Hijri month and day — it recurs every Hijri year — so
+ * turning it into a date always means choosing a year. Choosing *this* Hijri year and
+ * stopping is the bug both D4 and D5 describe, and the reason this lives in one object is
+ * that two implementations of one projection drift apart silently.
+ */
+internal object IslamicEventProjection {
+
+    /** The event's date in [hijriYear], or null if the event is malformed. */
+    fun inYear(event: IslamicEvent, hijriYear: Int): LocalDate? {
+        if (event.hijriMonth !in 1..12 || event.hijriDay < 1) return null
+        return runCatching {
+            HijriDateCalculator.toGregorian(event.hijriDay, event.hijriMonth, hijriYear)
+        }.getOrNull()
+    }
+
+    /**
+     * The event's next occurrence on or after [onOrAfter].
+     *
+     * Tries the Hijri year containing [onOrAfter] and then the one after it, and takes the
+     * first projection that has not already passed. Without the second attempt, an event in
+     * Muharram looks ~355 days *behind* a today in Dhul-Hijjah and is filtered out as past.
+     */
+    fun nextOccurrence(event: IslamicEvent, onOrAfter: LocalDate): LocalDate? {
+        val hijriYear = HijriDateCalculator.toHijri(onOrAfter).year
+        return (hijriYear..hijriYear + 1)
+            .mapNotNull { year -> inYear(event, year) }
+            .firstOrNull { !it.isBefore(onOrAfter) }
+    }
+
+    /**
+     * The event's occurrence inside the Gregorian window `[from, to]`, or null.
+     *
+     * A Gregorian month can span two Hijri years, so both are tried — taking the year from
+     * the first day alone is what dropped every Muharram event from the month that contains
+     * 1 Muharram.
+     */
+    fun within(event: IslamicEvent, from: LocalDate, to: LocalDate): LocalDate? {
+        val firstHijriYear = HijriDateCalculator.toHijri(from).year
+        val lastHijriYear = HijriDateCalculator.toHijri(to).year
+        return (firstHijriYear..lastHijriYear)
+            .mapNotNull { year -> inYear(event, year) }
+            .firstOrNull { !it.isBefore(from) && !it.isAfter(to) }
+    }
+}
+
+/** The events that fall on a given Hijri day, in any year — the grid's per-day markers. */
+class GetEventsForDateUseCase @Inject constructor() {
+    operator fun invoke(events: List<IslamicEvent>, hijriDate: HijriDate): List<IslamicEvent> =
+        events.filter { it.hijriMonth == hijriDate.month && it.hijriDay == hijriDate.day }
+}
+
+/** Builds one Gregorian month's grid, with each day's Hijri date and events. */
+class BuildCalendarMonthUseCase @Inject constructor(
+    private val eventsForDate: GetEventsForDateUseCase,
+) {
+    operator fun invoke(
+        month: Int,
+        year: Int,
+        events: List<IslamicEvent>,
+        today: LocalDate,
+    ): CalendarMonth {
+        val firstDay = LocalDate.of(year, month, 1)
+        val lastDay = firstDay.plusMonths(1).minusDays(1)
+
+        val days = generateSequence(firstDay) { it.plusDays(1) }
+            .takeWhile { !it.isAfter(lastDay) }
+            .map { date ->
+                val hijriDate = HijriDateCalculator.toHijri(date).let {
+                    HijriDate(day = it.day, month = it.month, year = it.year)
+                }
+                CalendarDay(
+                    gregorianDate = date,
+                    hijriDate = hijriDate,
+                    // Passed in rather than read from the system clock, so a grid built at
+                    // 23:59 can be rebuilt for the new day instead of highlighting yesterday
+                    // until the user navigates away and back.
+                    isToday = date == today,
+                    isCurrentMonth = true,
+                    events = eventsForDate(events, hijriDate),
+                )
+            }
+            .toList()
+
+        val firstHijri = days.firstOrNull()?.hijriDate
+        return CalendarMonth(
+            hijriMonth = firstHijri?.month ?: 1,
+            hijriYear = firstHijri?.year ?: HijriDateCalculator.toHijri(firstDay).year,
+            days = days,
+            events = days.flatMap { it.events }.distinctBy { it.id },
+        )
+    }
+}
+
+/** Builds one Hijri month's days. */
+class BuildHijriMonthUseCase @Inject constructor(
+    private val eventsForDate: GetEventsForDateUseCase,
+) {
+    operator fun invoke(
+        month: Int,
+        year: Int,
+        events: List<IslamicEvent>,
+        today: LocalDate,
+    ): List<CalendarDay> =
+        (1..HijriDateCalculator.getDaysInHijriMonth(year, month)).map { day ->
+            val hijriDate = HijriDate(day = day, month = month, year = year)
+            val gregorianDate = HijriDateCalculator.toGregorian(day, month, year)
+            CalendarDay(
+                gregorianDate = gregorianDate,
+                hijriDate = hijriDate,
+                isToday = gregorianDate == today,
+                isCurrentMonth = true,
+                events = eventsForDate(events, hijriDate),
+            )
+        }
+}
+
+/** The events landing inside a Gregorian month, projected into whichever Hijri year fits. */
+class GetEventsForMonthUseCase @Inject constructor() {
+    operator fun invoke(month: Int, year: Int, events: List<IslamicEvent>): List<IslamicEvent> {
+        val firstDay = LocalDate.of(year, month, 1)
+        val lastDay = firstDay.plusMonths(1).minusDays(1)
+        return events.mapNotNull { event ->
+            IslamicEventProjection.within(event, firstDay, lastDay)
+                ?.let { event.copy(gregorianDate = it) }
+        }.sortedBy { it.gregorianDate }
+    }
+}
+
+/** The events occurring in the [window] starting today, soonest first. */
+class GetUpcomingEventsUseCase @Inject constructor() {
+    operator fun invoke(
+        events: List<IslamicEvent>,
+        today: LocalDate,
+        window: java.time.Period = DEFAULT_WINDOW,
+    ): List<IslamicEvent> {
+        val until = today.plus(window)
+        return events.mapNotNull { event ->
+            IslamicEventProjection.nextOccurrence(event, today)
+                ?.takeIf { !it.isAfter(until) }
+                ?.let { event.copy(gregorianDate = it) }
+        }.sortedBy { it.gregorianDate }
+    }
+
+    private companion object {
+        val DEFAULT_WINDOW: java.time.Period = java.time.Period.ofMonths(3)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
@@ -220,6 +220,18 @@ private fun CalendarSection(
     state: com.arshadshah.nimaz.presentation.viewmodel.CalendarUiState,
     viewModel: CalendarViewModel
 ) {
+    // The grid draws with or without events, so a content-database fault costs the event
+    // markers and nothing else. Before, it cost the whole screen: `loadToday()` ran inside
+    // the events `try`, so a throw left `currentMonth` null and this rendered nothing at all.
+    state.error?.let { error ->
+        Text(
+            text = stringResource(error),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+        )
+    }
+
     state.currentMonth?.let { month ->
         val eventMap = remember(month.days) {
             month.days.associate { day -> day.gregorianDate to day.events }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
@@ -1,22 +1,28 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.di.DefaultDispatcher
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.catchAndReport
+import com.arshadshah.nimaz.core.monitoring.launchSafely
+import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.domain.model.CalendarDay
 import com.arshadshah.nimaz.domain.model.CalendarMonth
 import com.arshadshah.nimaz.domain.model.HijriDate
 import com.arshadshah.nimaz.domain.model.IslamicEvent
 import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.CalendarUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -26,7 +32,8 @@ data class CalendarUiState(
     val selectedHijriDate: HijriDate? = null,
     val viewMode: CalendarViewMode = CalendarViewMode.GREGORIAN,
     val isLoading: Boolean = true,
-    val error: String? = null
+    /** A string resource, resolved by the screen — see ARCHITECTURE §6.1. */
+    @StringRes val error: Int? = null
 )
 
 data class HijriCalendarUiState(
@@ -70,10 +77,24 @@ sealed interface CalendarEvent {
 
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
-    private val islamicEventUseCases: IslamicEventUseCases
+    private val islamicEventUseCases: IslamicEventUseCases,
+    private val calendarUseCases: CalendarUseCases,
+    private val todayProvider: TodayProvider,
+    private val telemetry: Telemetry,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private var cachedEvents: List<IslamicEvent> = emptyList()
+
+    /** The date every grid was last built for — the guard that makes rollover detectable. */
+    private var renderedFor: LocalDate = todayProvider.today()
+
+    // One handle per surface, per ARCHITECTURE §4.1: each of these is re-invoked as the user
+    // navigates, and each writes one state.
+    private var monthJob: Job? = null
+    private var hijriJob: Job? = null
+    private var yearJob: Job? = null
+    private var upcomingJob: Job? = null
 
     private val _calendarState = MutableStateFlow(CalendarUiState())
     val calendarState: StateFlow<CalendarUiState> = _calendarState.asStateFlow()
@@ -88,36 +109,70 @@ class CalendarViewModel @Inject constructor(
     val yearState: StateFlow<YearOverviewUiState> = _yearState.asStateFlow()
 
     init {
-        loadEventsFromDatabase()
+        // Drawn first, and unconditionally. These need no events — a month grid is dates —
+        // so running them inside the events `try` meant one content-database fault left the
+        // whole screen blank: no grid, no message, no retry.
+        loadToday()
+        observeEvents()
+        observeDateRollover()
     }
 
-    private fun loadEventsFromDatabase() {
-        viewModelScope.launch {
-            try {
-                cachedEvents = islamicEventUseCases.getAllEvents().first()
-                loadToday()
-                loadUpcomingEvents()
-            } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError("calendar", "load_events", e.message)
-                _calendarState.update {
-                    it.copy(
-                        error = "Failed to load events: ${e.message}",
-                        isLoading = false
-                    )
+    /**
+     * Collects the events instead of reading them once.
+     *
+     * `getAllEvents().first()` was a one-shot read of a reactive source, cached forever. After
+     * `ContentArtifactInstaller` replaces the content database mid-session — explicitly
+     * supported, see `SUBSYSTEMS.md` §5 — the calendar served the *old* event set until the
+     * ViewModel was recreated.
+     */
+    private fun observeEvents() {
+        launchSafely(telemetry, DOMAIN, "load_events") {
+            islamicEventUseCases.getAllEvents()
+                .catchAndReport(telemetry, DOMAIN, "load_events") {
+                    // Deliberately no fallback emission: there are no events to report, and
+                    // emitting an empty list here would run the collector below and clear
+                    // the very error just set.
+                    _calendarState.update { it.copy(error = R.string.error_generic) }
                 }
+                .collect { events ->
+                    cachedEvents = events
+                    _calendarState.update { it.copy(error = null) }
+                    redrawForDate(renderedFor)
+                }
+        }
+    }
+
+    /**
+     * Re-draws when the day changes underneath an open screen.
+     *
+     * `isToday` is baked into each `CalendarDay` when its month is generated, so a grid built
+     * at 23:59 kept highlighting yesterday until the user navigated away and back.
+     */
+    private fun observeDateRollover() {
+        launchSafely(telemetry, DOMAIN, "observe_today") {
+            todayProvider.todayChanges.collect { today ->
+                if (today == renderedFor && _calendarState.value.currentMonth != null) return@collect
+                renderedFor = today
+                redrawForDate(today)
             }
         }
     }
 
+    /** Re-issues everything scoped to "today" or to the current event set, as one unit. */
+    private fun redrawForDate(today: LocalDate) {
+        val month = _calendarState.value.currentMonth
+            ?.days?.firstOrNull()?.gregorianDate
+            ?: today
+        navigateToMonth(month.monthValue, month.year)
+        selectDate(_calendarState.value.selectedDate)
+        loadUpcomingEvents()
+    }
+
     fun onEvent(event: CalendarEvent) {
         when (event) {
-            is CalendarEvent.SelectDate -> AppAnalytics.logFeatureUsed("calendar", "select_date")
-            is CalendarEvent.SetViewMode -> AppAnalytics.logFeatureUsed("calendar", "set_view_mode")
-            is CalendarEvent.NavigateToYear -> AppAnalytics.logFeatureUsed(
-                "calendar",
-                "navigate_year"
-            )
+            is CalendarEvent.SelectDate -> telemetry.featureUsed(DOMAIN, "select_date")
+            is CalendarEvent.SetViewMode -> telemetry.featureUsed(DOMAIN, "set_view_mode")
+            is CalendarEvent.NavigateToYear -> telemetry.featureUsed(DOMAIN, "navigate_year")
 
             else -> {}
         }
@@ -137,7 +192,8 @@ class CalendarViewModel @Inject constructor(
     }
 
     private fun loadToday() {
-        val today = LocalDate.now()
+        val today = todayProvider.today()
+        renderedFor = today
         selectDate(today)
         navigateToMonth(today.monthValue, today.year)
     }
@@ -149,7 +205,7 @@ class CalendarViewModel @Inject constructor(
             month = calculatorHijriDate.month,
             year = calculatorHijriDate.year
         )
-        val eventsForDate = getEventsForDate(hijriDate)
+        val eventsForDate = calendarUseCases.eventsForDate(cachedEvents, hijriDate)
 
         _calendarState.update {
             it.copy(
@@ -166,9 +222,19 @@ class CalendarViewModel @Inject constructor(
     private fun navigateToMonth(month: Int, year: Int) {
         _calendarState.update { it.copy(isLoading = true) }
 
-        viewModelScope.launch {
-            val calendarMonth = generateGregorianMonth(month, year)
-            val eventsThisMonth = getEventsForMonth(month, year)
+        monthJob?.cancel()
+        monthJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "navigate_month",
+            onFailure = { _calendarState.update { it.copy(isLoading = false) } },
+        ) {
+            // Off the main thread: a month is ~30 Hijri conversions, and the year view below
+            // is ~365 of them plus a filter per day.
+            val (calendarMonth, eventsThisMonth) = withContext(defaultDispatcher) {
+                calendarUseCases.buildGregorianMonth(month, year, cachedEvents, renderedFor) to
+                    calendarUseCases.eventsForMonth(month, year, cachedEvents)
+            }
 
             _calendarState.update {
                 it.copy(
@@ -186,8 +252,16 @@ class CalendarViewModel @Inject constructor(
     private fun navigateToHijriMonth(month: Int, year: Int) {
         _hijriState.update { it.copy(isLoading = true) }
 
-        viewModelScope.launch {
-            val days = generateHijriMonthDays(month, year)
+        hijriJob?.cancel()
+        hijriJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "navigate_hijri_month",
+            onFailure = { _hijriState.update { it.copy(isLoading = false) } },
+        ) {
+            val days = withContext(defaultDispatcher) {
+                calendarUseCases.buildHijriMonth(month, year, cachedEvents, renderedFor)
+            }
 
             _hijriState.update {
                 it.copy(
@@ -207,11 +281,21 @@ class CalendarViewModel @Inject constructor(
     private fun navigateToYear(year: Int, isHijri: Boolean) {
         _yearState.update { it.copy(isLoading = true, year = year, isHijriYear = isHijri) }
 
-        viewModelScope.launch {
-            val months = if (isHijri) {
-                generateHijriYearMonths(year)
-            } else {
-                generateGregorianYearMonths(year)
+        yearJob?.cancel()
+        yearJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "navigate_year",
+            onFailure = { _yearState.update { it.copy(isLoading = false) } },
+        ) {
+            val months = withContext(defaultDispatcher) {
+                if (isHijri) {
+                    generateHijriYearMonths(year)
+                } else {
+                    (1..12).map { month ->
+                        calendarUseCases.buildGregorianMonth(month, year, cachedEvents, renderedFor)
+                    }
+                }
             }
 
             _yearState.update {
@@ -221,8 +305,16 @@ class CalendarViewModel @Inject constructor(
     }
 
     private fun loadUpcomingEvents() {
-        viewModelScope.launch {
-            val events = getUpcomingIslamicEvents()
+        upcomingJob?.cancel()
+        upcomingJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_upcoming",
+            onFailure = { _eventsState.update { it.copy(isLoading = false) } },
+        ) {
+            val events = withContext(defaultDispatcher) {
+                calendarUseCases.upcomingEvents(cachedEvents, renderedFor)
+            }
 
             _eventsState.update {
                 it.copy(upcomingEvents = events, isLoading = false)
@@ -255,131 +347,15 @@ class CalendarViewModel @Inject constructor(
         navigateToYear(current.year + 1, current.isHijriYear)
     }
 
-    private fun generateGregorianMonth(month: Int, year: Int): CalendarMonth {
-        val firstDay = LocalDate.of(year, month, 1)
-        val lastDay = firstDay.plusMonths(1).minusDays(1)
-        val days = mutableListOf<CalendarDay>()
-
-        var currentDate = firstDay
-        while (!currentDate.isAfter(lastDay)) {
-            val calculatorHijriDate = HijriDateCalculator.toHijri(currentDate)
-            val hijriDate = HijriDate(
-                day = calculatorHijriDate.day,
-                month = calculatorHijriDate.month,
-                year = calculatorHijriDate.year
-            )
-            val events = getEventsForDate(hijriDate)
-
-            days.add(
-                CalendarDay(
-                    gregorianDate = currentDate,
-                    hijriDate = hijriDate,
-                    isToday = currentDate == LocalDate.now(),
-                    isCurrentMonth = true,
-                    events = events
-                )
-            )
-            currentDate = currentDate.plusDays(1)
-        }
-
-        val firstHijri = days.firstOrNull()?.hijriDate
-        days.lastOrNull()?.hijriDate
-
-        return CalendarMonth(
-            hijriMonth = firstHijri?.month ?: 1,
-            hijriYear = firstHijri?.year ?: 1446,
-            days = days,
-            events = days.flatMap { it.events }.distinctBy { it.id }
-        )
-    }
-
-    private fun generateHijriMonthDays(month: Int, year: Int): List<CalendarDay> {
-        val days = mutableListOf<CalendarDay>()
-        val daysInMonth = HijriDateCalculator.getDaysInHijriMonth(year, month)
-
-        for (day in 1..daysInMonth) {
-            val hijriDate = HijriDate(
-                day = day,
-                month = month,
-                year = year
-            )
-            val gregorianDate = HijriDateCalculator.toGregorian(day, month, year)
-            val events = getEventsForDate(hijriDate)
-
-            days.add(
-                CalendarDay(
-                    gregorianDate = gregorianDate,
-                    hijriDate = hijriDate,
-                    isToday = gregorianDate == LocalDate.now(),
-                    isCurrentMonth = true,
-                    events = events
-                )
-            )
-        }
-
-        return days
-    }
-
-    private fun generateGregorianYearMonths(year: Int): List<CalendarMonth> {
-        return (1..12).map { month ->
-            generateGregorianMonth(month, year)
-        }
-    }
-
     private fun generateHijriYearMonths(year: Int): List<CalendarMonth> {
-        // Would generate Hijri year months
+        // Still unimplemented, and still reachable only from a year view that no screen
+        // wires up (#357). Left as-is rather than quietly deleted: whether the year view
+        // ships at all is that issue's call, not this one's.
         return emptyList()
     }
 
-    private fun getEventsForDate(hijriDate: HijriDate): List<IslamicEvent> {
-        return cachedEvents.filter { event ->
-            event.hijriMonth == hijriDate.month && event.hijriDay == hijriDate.day
-        }
-    }
-
-    private fun getEventsForMonth(month: Int, year: Int): List<IslamicEvent> {
-        // Get all events that fall within this Gregorian month
-        val firstDay = LocalDate.of(year, month, 1)
-        val lastDay = firstDay.plusMonths(1).minusDays(1)
-        // Get the Hijri year for the first day of the month
-        val hijriYear = HijriDateCalculator.toHijri(firstDay).year
-
-        return cachedEvents.filter { event ->
-            val eventGregorian = getApproximateGregorianDate(event, hijriYear)
-            eventGregorian != null && !eventGregorian.isBefore(firstDay) && !eventGregorian.isAfter(
-                lastDay
-            )
-        }
-    }
-
-    private fun getUpcomingIslamicEvents(): List<IslamicEvent> {
-        val today = LocalDate.now()
-        val threeMonthsLater = today.plusMonths(3)
-        // Get the current Hijri year
-        val currentHijriYear = HijriDateCalculator.toHijri(today).year
-
-        return cachedEvents.mapNotNull { event ->
-            val eventDate = getApproximateGregorianDate(event, currentHijriYear)
-            if (eventDate != null && !eventDate.isBefore(today) && !eventDate.isAfter(
-                    threeMonthsLater
-                )
-            ) {
-                event.copy(gregorianDate = eventDate)
-            } else null
-        }.sortedBy { getApproximateGregorianDate(it, currentHijriYear) }
-    }
-
-    private fun getApproximateGregorianDate(event: IslamicEvent, hijriYear: Int): LocalDate? {
-        if (event.hijriMonth !in 1..12 || event.hijriDay < 1) return null
-        return try {
-            HijriDateCalculator.toGregorian(
-                event.hijriDay,
-                event.hijriMonth,
-                hijriYear
-            )
-        } catch (_: Exception) {
-            null
-        }
+    private companion object {
+        private const val DOMAIN = "calendar"
     }
 }
 

--- a/app/src/test/java/com/arshadshah/nimaz/core/time/FakeTodayProvider.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/time/FakeTodayProvider.kt
@@ -1,0 +1,26 @@
+package com.arshadshah.nimaz.core.time
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.LocalDate
+
+/**
+ * A [TodayProvider] whose "today" a test decides, and can move.
+ *
+ * Set [now] to roll the date over: everything collecting [todayChanges] is told, exactly as it
+ * would be at a real midnight, without waiting for one.
+ */
+class FakeTodayProvider(initial: LocalDate) : TodayProvider {
+
+    private val state = MutableStateFlow(initial)
+
+    var now: LocalDate
+        get() = state.value
+        set(value) {
+            state.value = value
+        }
+
+    override fun today(): LocalDate = state.value
+
+    override val todayChanges: Flow<LocalDate> = state
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/calendar/CalendarUseCasesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/calendar/CalendarUseCasesTest.kt
@@ -1,0 +1,119 @@
+package com.arshadshah.nimaz.domain.usecase.calendar
+
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import com.arshadshah.nimaz.domain.model.IslamicEventType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The Hijri projection, at the level where it can actually be tested.
+ *
+ * An [IslamicEvent] carries a Hijri month and day and recurs every Hijri year, so projecting
+ * it onto the Gregorian calendar always means choosing a year. The ViewModel chose the
+ * *current* one and stopped, which is right for eleven months of the year and wrong for the
+ * twelfth — and being wrong in the twelfth month means losing exactly the events people look
+ * for at the turn of the year.
+ */
+class CalendarUseCasesTest {
+
+    private val upcoming = GetUpcomingEventsUseCase()
+    private val eventsForMonth = GetEventsForMonthUseCase()
+    private val buildMonth = BuildCalendarMonthUseCase(GetEventsForDateUseCase())
+
+    private val newYear = event(id = "new-year", hijriMonth = 1, hijriDay = 1)
+    private val ashura = event(id = "ashura", hijriMonth = 1, hijriDay = 10)
+    private val ramadanStart = event(id = "ramadan", hijriMonth = 9, hijriDay = 1)
+
+    private val events = listOf(newYear, ashura, ramadanStart)
+
+    @Test
+    fun `Muharram events are upcoming when today is late Dhul-Hijjah`() {
+        // 25 Dhul-Hijjah: Islamic New Year and Ashura are days away, in the *next* Hijri year.
+        val today = HijriDateCalculator.toGregorian(25, 12, 1446)
+
+        val result = upcoming(events, today).map { it.id }
+
+        // Projected into the current Hijri year alone, both land ~355 days in the past and
+        // are filtered out as already gone — the list silently loses them.
+        assertThat(result).containsAtLeast("new-year", "ashura")
+    }
+
+    @Test
+    fun `an upcoming event is dated in the year it will actually happen`() {
+        val today = HijriDateCalculator.toGregorian(25, 12, 1446)
+
+        val ashuraDate = upcoming(events, today).first { it.id == "ashura" }.gregorianDate
+
+        assertThat(ashuraDate).isNotNull()
+        assertThat(ashuraDate!!).isAtLeast(today)
+        assertThat(HijriDateCalculator.toHijri(ashuraDate).year).isEqualTo(1447)
+    }
+
+    @Test
+    fun `events outside the window are left out`() {
+        val today = HijriDateCalculator.toGregorian(1, 1, 1447)
+
+        // Ramadan is eight Hijri months away — well outside the three-month window.
+        assertThat(upcoming(events, today).map { it.id }).doesNotContain("ramadan")
+    }
+
+    @Test
+    fun `the month that contains 1 Muharram lists its Muharram events`() {
+        // The Gregorian month straddling the Hijri year boundary: its first day is in 1446,
+        // its later days in 1447. Taking the Hijri year from the first day alone projects
+        // every Muharram event ~11 months earlier and drops all of them.
+        val firstMuharram = HijriDateCalculator.toGregorian(1, 1, 1447)
+
+        val result = eventsForMonth(firstMuharram.monthValue, firstMuharram.year, events)
+
+        assertThat(result.map { it.id }).contains("new-year")
+    }
+
+    @Test
+    fun `an ordinary month is unaffected by trying the next year too`() {
+        val ramadanDay = HijriDateCalculator.toGregorian(1, 9, 1447)
+
+        val result = eventsForMonth(ramadanDay.monthValue, ramadanDay.year, events)
+
+        // Exactly one projection may land in the window — never a duplicate from both years.
+        assertThat(result.filter { it.id == "ramadan" }).hasSize(1)
+    }
+
+    @Test
+    fun `today is whatever the caller says it is, not what the system clock says`() {
+        val someMonth = LocalDate.of(2026, 3, 1)
+        val chosenToday = LocalDate.of(2026, 3, 14)
+
+        val month = buildMonth(3, 2026, events, chosenToday)
+
+        assertThat(month.days.filter { it.isToday }.map { it.gregorianDate })
+            .containsExactly(chosenToday)
+        assertThat(month.days.first().gregorianDate).isEqualTo(someMonth)
+    }
+
+    @Test
+    fun `a month built for a day outside it highlights nothing`() {
+        val month = buildMonth(3, 2026, events, LocalDate.of(2026, 5, 2))
+
+        assertThat(month.days.none { it.isToday }).isTrue()
+    }
+}
+
+private fun event(id: String, hijriMonth: Int, hijriDay: Int) = IslamicEvent(
+    id = id,
+    nameArabic = "",
+    nameEnglish = id,
+    description = null,
+    hijriMonth = hijriMonth,
+    hijriDay = hijriDay,
+    eventType = IslamicEventType.HISTORICAL,
+    isHoliday = false,
+    isFastingDay = false,
+    isNightOfPower = false,
+    gregorianDate = null,
+    year = null,
+    notes = null,
+    priority = 0,
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModelRolloverTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModelRolloverTest.kt
@@ -1,0 +1,149 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.IslamicEvent
+import com.arshadshah.nimaz.domain.model.IslamicEventType
+import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildCalendarMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildHijriMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.CalendarUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetUpcomingEventsUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The calendar's relationship with "today" and with the content database.
+ *
+ * Three defects meet here. The month grid needs no events to draw, but `loadToday()` ran
+ * *inside* the `try` that read them, so one content-database fault left the screen with no
+ * grid, no message and no retry. The events themselves came from a `.first()` — a one-shot
+ * read of a reactive source — so a content-database replacement mid-session served the old
+ * set until the ViewModel died. And `isToday` was baked in at generation, so a grid built at
+ * 23:59 kept highlighting yesterday.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CalendarViewModelRolloverTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    // Anchored on the Hijri calendar: 20 Dhul-Hijjah, so Muharram's events are genuinely
+    // upcoming and the three-month window is not the thing under test.
+    private val today: LocalDate = HijriDateCalculator.toGregorian(20, 12, 1446)
+    private val todayProvider = FakeTodayProvider(today)
+    private val telemetry = RecordingTelemetry()
+
+    private lateinit var eventUseCases: IslamicEventUseCases
+    private val events = MutableStateFlow(listOf(event("ashura", hijriMonth = 1, hijriDay = 10)))
+
+    private val calendarUseCases = GetEventsForDateUseCase().let { forDate ->
+        CalendarUseCases(
+            buildGregorianMonth = BuildCalendarMonthUseCase(forDate),
+            buildHijriMonth = BuildHijriMonthUseCase(forDate),
+            eventsForMonth = GetEventsForMonthUseCase(),
+            upcomingEvents = GetUpcomingEventsUseCase(),
+            eventsForDate = forDate,
+        )
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        eventUseCases = mockk(relaxed = true)
+        every { eventUseCases.getAllEvents() } returns events
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = CalendarViewModel(
+        eventUseCases,
+        calendarUseCases,
+        todayProvider,
+        telemetry,
+        dispatcher,
+    )
+
+    @Test
+    fun `a failing event read still leaves a month grid on screen`() = runTest {
+        every { eventUseCases.getAllEvents() } returns
+            flow { throw IllegalStateException("no such table: islamic_events") }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // The grid is dates; it never needed the events.
+        assertThat(vm.calendarState.value.currentMonth).isNotNull()
+        assertThat(vm.calendarState.value.currentMonth!!.days).hasSize(today.lengthOfMonth())
+        // …and the failure is said out loud rather than swallowed into a blank screen.
+        assertThat(vm.calendarState.value.error).isEqualTo(R.string.error_generic)
+        assertThat(telemetry.errors.map { it.type }).contains("load_events")
+    }
+
+    @Test
+    fun `a replaced content database is picked up without recreating the ViewModel`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // ContentArtifactInstaller swaps the database under a running app.
+        events.value = listOf(
+            event("ashura", hijriMonth = 1, hijriDay = 10),
+            event("new-year", hijriMonth = 1, hijriDay = 1),
+        )
+        advanceUntilIdle()
+
+        assertThat(vm.eventsState.value.upcomingEvents.map { it.id })
+            .containsAtLeast("ashura", "new-year")
+    }
+
+    @Test
+    fun `the grid stops highlighting yesterday once the day changes`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.calendarState.value.currentMonth!!.days.filter { it.isToday }
+            .map { it.gregorianDate }).containsExactly(today)
+
+        // Midnight, with the screen still open.
+        todayProvider.now = today.plusDays(1)
+        advanceUntilIdle()
+
+        assertThat(vm.calendarState.value.currentMonth!!.days.filter { it.isToday }
+            .map { it.gregorianDate }).containsExactly(today.plusDays(1))
+    }
+}
+
+private fun event(id: String, hijriMonth: Int, hijriDay: Int) = IslamicEvent(
+    id = id,
+    nameArabic = "",
+    nameEnglish = id,
+    description = null,
+    hijriMonth = hijriMonth,
+    hijriDay = hijriDay,
+    eventType = IslamicEventType.HISTORICAL,
+    isHoliday = false,
+    isFastingDay = false,
+    isNightOfPower = false,
+    gregorianDate = null,
+    year = null,
+    notes = null,
+    priority = 0,
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModelTest.kt
@@ -1,7 +1,15 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
 import com.arshadshah.nimaz.domain.model.IslamicEvent
 import com.arshadshah.nimaz.domain.usecase.IslamicEventUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildCalendarMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.BuildHijriMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.CalendarUseCases
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForDateUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetEventsForMonthUseCase
+import com.arshadshah.nimaz.domain.usecase.calendar.GetUpcomingEventsUseCase
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -39,7 +47,20 @@ class CalendarViewModelTest {
         Dispatchers.setMain(dispatcher)
         useCases = mockk(relaxed = true)
         coEvery { useCases.getAllEvents() } returns flowOf(emptyList<IslamicEvent>())
-        viewModel = CalendarViewModel(useCases)
+        val forDate = GetEventsForDateUseCase()
+        viewModel = CalendarViewModel(
+            useCases,
+            CalendarUseCases(
+                buildGregorianMonth = BuildCalendarMonthUseCase(forDate),
+                buildHijriMonth = BuildHijriMonthUseCase(forDate),
+                eventsForMonth = GetEventsForMonthUseCase(),
+                upcomingEvents = GetUpcomingEventsUseCase(),
+                eventsForDate = forDate,
+            ),
+            FakeTodayProvider(LocalDate.now()),
+            RecordingTelemetry(),
+            dispatcher,
+        )
     }
 
     @After

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -512,6 +512,39 @@ channels — the stack trace to Crashlytics, the frequency to analytics — and 
 only as the production binding and for callers with no injection point (`NimazApp`, `BootReceiver`,
 workers).
 
+#### "Today" comes from `TodayProvider`, never `LocalDate.now()`
+
+`LocalDate.now()` was called directly at **39 sites across 12 ViewModels**, always at `init`
+or collection time, and nothing re-evaluated it. There was no seam to fake in a test and no
+notion of "the day changed" anywhere in the layer, so a whole family of defects shipped
+together — a Room query bound to a fixed day range forever, a "daily" hadith frozen at the
+day it loaded, a month grid built at 23:59 still highlighting yesterday.
+
+Inject **`TodayProvider`** (`core/time/TodayProvider.kt`) and use whichever half fits:
+
+```kotlin
+todayProvider.today()                       // what day is it — fakeable
+todayProvider.todayChanges.collect { … }    // …and tell me when that changes
+```
+
+`todayChanges` emits immediately and again at each local midnight, so re-arming everything
+scoped to today is an ordinary flow collection rather than a check each feature has to
+remember to write. Tests use `FakeTodayProvider`, whose `now` a test can move to roll the
+date over without waiting for one. The backing `java.time.Clock` is provided by `TimeModule`.
+
+Anything scoped to a day takes the date as a **parameter** rather than reading the clock
+inside itself — see `domain/usecase/calendar/`, where the grid builders take `today` — so the
+same call can be re-issued for the new day.
+
+#### CPU-bound work goes on the injected `@DefaultDispatcher`
+
+`viewModelScope.launch` is `Dispatchers.Main`. `CalendarViewModel.navigateToYear` did ~365
+Hijri conversions plus a filter per day there. Inject
+`@DefaultDispatcher CoroutineDispatcher` (`core/di/TimeModule.kt`) and `withContext` it —
+injected rather than `Dispatchers.Default` directly, because a test that substitutes its own
+scheduler stays deterministic, and one that does not has nothing for `advanceUntilIdle()` to
+wait on.
+
 #### A throwable's `message` is a diagnostic, never UI copy
 
 `_state.copy(error = e.message)` is the shortest thing to write and it puts SQLite's own words on

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -327,6 +327,31 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.4 · Pure domain logic held hostage inside a ViewModel
+
+- [x] ~~**`CalendarViewModel`'s seven generators.**~~ **Resolved.** 75 lines of pure functions
+  over domain models — `generateGregorianMonth`, `generateHijriMonthDays`,
+  `generateGregorianYearMonths`, `getEventsForDate`, `getEventsForMonth`,
+  `getUpcomingIslamicEvents`, `getApproximateGregorianDate` — all `private`, all reachable only
+  through a ViewModel with mocked use cases. Nothing in them needed a ViewModel: they took
+  values and returned values.
+
+  That is why two of the app's sharpest bugs shipped and stayed. Every Islamic event was
+  projected into the **current** Hijri year only, so in the last weeks of a Hijri year the
+  "upcoming events" list dropped Islamic New Year and Ashura — precisely the events that were
+  upcoming — and the month grid dropped every Muharram event from the Gregorian month that
+  straddles the boundary. Both are three-line tests once the code is reachable, and neither
+  had one.
+
+  Moved to `domain/usecase/calendar/`, with the projection in **one** `IslamicEventProjection`
+  so the two callers cannot drift apart. `today` is a parameter, not a clock read, so a grid
+  can be rebuilt for a new day. (`CalendarUseCasesTest` — three of its tests fail against the
+  single-year projection, verified by restoring it.)
+
+  Rule of thumb: **if a private ViewModel function neither reads state nor writes it, it does
+  not belong to the ViewModel.** It is domain logic that happens to live in the wrong file,
+  and it is untested for exactly that reason.
+
 ### AP-7.2 · `Get*` and `Observe*` variants of the same read
 
 - [x] ~~**Khatam had both `GetActiveKhatamUseCase` and `ObserveActiveKhatamUseCase`**~~ (also


### PR DESCRIPTION
Layer 13 of the #352 stack, on top of #381. Closes D4, D5, D6, D7, D9 and D10 of #363, and builds the `TodayProvider` seam the rest of that issue needs.

## The seam

`LocalDate.now()` was called directly at **39 sites across 12 ViewModels**, always at `init` or collection time, and nothing re-evaluated it. No seam to fake in a test, and no notion of "the day changed" anywhere in the layer — which is why a whole family of defects shipped together.

`core/time/TodayProvider.kt`:

```kotlin
todayProvider.today()                       // what day is it — fakeable
todayProvider.todayChanges.collect { … }    // …and tell me when that changes
```

`todayChanges` emits immediately and again at each local midnight, so "re-arm everything scoped to today" becomes an ordinary flow collection instead of a check each feature has to remember. `FakeTodayProvider` (test source set) lets a test move `now` and roll the date over without waiting for one.

It re-reads the date after waking rather than assuming `date + 1`: a doze, a timezone change or a clock correction can land the wake-up on a different day than arithmetic predicts.

## The two shipped bugs (D4, D5)

An `IslamicEvent` carries only a Hijri month and day — it recurs every Hijri year — so projecting it onto the Gregorian calendar always means picking a year. The ViewModel picked *this* one and stopped.

**D4 — input → wrong output:** today is 25 Dhul-Hijjah 1446. Ashura is `hijriMonth=1, hijriDay=10`, so it projects to 10 Muharram **1446** — about **355 days in the past** — and `!eventDate.isBefore(today)` drops it. For the last weeks of every Hijri year the "Upcoming events" list **silently loses Islamic New Year and Ashura**, precisely the events that are upcoming.

**D5 — input → wrong output:** `getEventsForMonth` took its Hijri year from the **first day** of the Gregorian month. The month containing both 29 Dhul-Hijjah 1446 and 1 Muharram 1447 projected every Muharram event ~11 months earlier and filtered them all out.

Both now try the containing Hijri year **and** the next, through a single `IslamicEventProjection` — one implementation, because two implementations of one projection drift apart silently.

## Why it took an extraction to fix

`CalendarViewModel.kt:258-332` was **75 lines of pure functions over domain models** — `generateGregorianMonth`, `generateHijriMonthDays`, `getEventsForDate`, `getEventsForMonth`, `getUpcomingIslamicEvents`, `getApproximateGregorianDate` — all `private`, reachable only through a ViewModel with mocked use cases. Nothing in them needed a ViewModel: values in, values out.

They now live in `domain/usecase/calendar/`, taking the events **and `today`** as parameters. #363 calls this "the single highest-leverage move in this issue" and it is: D4 and D5 are three-line tests once the code is reachable.

**These tests were verified red.** I restored the single-year projection and re-ran:

```
CalendarUseCasesTest > Muharram events are upcoming when today is late Dhul-Hijjah FAILED
CalendarUseCasesTest > an upcoming event is dated in the year it will actually happen FAILED
CalendarUseCasesTest > the month that contains 1 Muharram lists its Muharram events FAILED
7 tests completed, 3 failed
```

## Also fixed in `CalendarViewModel`

- **D6 — a blank calendar with no message.** `loadToday()` and `loadUpcomingEvents()` ran *inside* the `try` that read the events, so one content-DB fault left `currentMonth` null and `IslamicCalendarScreen.kt:223` rendered nothing — no grid, no message, no retry — while the `error` it set was read by no screen. The grid is dates and never needed the events: it draws first now, and the error is a `@StringRes` the screen renders.
- **D7 — a stale event set.** `getAllEvents().first()` was a one-shot read of a reactive source, cached forever. After `ContentArtifactInstaller` replaces the content database mid-session (explicitly supported, `SUBSYSTEMS.md` §5), the calendar served the **old** events until the ViewModel was recreated. Collected now.
- **D10 — a grid that highlights yesterday.** `isToday` was baked into each `CalendarDay` at generation, so a month generated at 23:59 kept highlighting yesterday until the user navigated away and back. Rebuilt on `todayChanges`.
- **D9 — Hijri conversions on the main thread.** `navigateToYear` did ~365 `toHijri` calls plus a per-day filter inside a bare `viewModelScope.launch` (= `Main`). Moved to an injected `@DefaultDispatcher` — injected rather than `Dispatchers.Default` directly, because a test that substitutes its own scheduler stays deterministic and one that does not gives `advanceUntilIdle()` nothing to wait on.
- Four re-invocable loads gained `Job` handles; the ViewModel routes through `Telemetry`.

## Deliberately not in this layer

- **D1–D3 (Home's rollover) and the `QuranViewModel` verse-of-the-day sibling.** They are the seam's next consumers and belong in their own layer — this one is already the largest in the stack.
- **`generateHijriYearMonths` still returns `emptyList()`.** It is reachable only from a year view no screen wires up. Whether that view ships at all is #357's call, not this one's — quietly implementing or deleting it here would pre-empt that decision.

## Tests

`CalendarUseCasesTest` (7) — the projection at both year boundaries, the window, and `today` as a parameter. `CalendarViewModelRolloverTest` (3) — a failing event read still draws a grid; a replaced content database is picked up live; the grid stops highlighting yesterday at midnight.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1497/1498
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the layers below (`DeviceStateCorpusTest`; private `nimaz-data` artifact unreachable from this session, run used `-x :app:fetchNimazData`).

## Docs

- `ARCHITECTURE.md` — two new subsections: **"Today" comes from `TodayProvider`, never `LocalDate.now()`**, and **CPU-bound work goes on the injected `@DefaultDispatcher`**.
- `CLEAN_ARCHITECTURE_CHECKLIST.md` — new **AP-7.4 · Pure domain logic held hostage inside a ViewModel**, with the rule of thumb: *if a private ViewModel function neither reads state nor writes it, it does not belong to the ViewModel* — it is domain logic in the wrong file, and untested for exactly that reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_