### PR TITLE
fix(home): re-arm everything scoped to today when the day changes

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -57,6 +57,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import javax.inject.Inject
+import com.arshadshah.nimaz.core.time.TodayProvider
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
@@ -77,7 +78,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
 data class HomeUiState(
-    val currentDate: LocalDate = LocalDate.now(),
+    // `currentDate` used to live here, set once at construction and read by no screen
+    // (`grep state.currentDate` in `screens/` returned nothing). It was the field that was
+    // *supposed* to detect a date rollover, and being inert is why nothing did. The rollover
+    // now comes from `TodayProvider.todayChanges`, so the dead field is gone rather than
+    // quietly kept and still unread.
     val hijriDate: String = "",
     val prayerTimes: List<PrayerTimeDisplay> = emptyList(),
     // Tomorrow's Fajr, so the UI can wrap the "next prayer" countdown past Isha without the
@@ -205,6 +210,7 @@ class HomeViewModel @Inject constructor(
     private val announcementUseCases: AnnouncementUseCases,
     private val observeEventCards: ObserveEventCardsUseCase,
     private val nextWorshipResolver: NextWorshipResolver,
+    private val todayProvider: TodayProvider,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeUiState())
@@ -260,6 +266,13 @@ class HomeViewModel @Inject constructor(
     // after the init block it would still be null at that point, causing an NPE.
     private val _prayerRecords = MutableStateFlow<Map<PrayerName, PrayerStatus>>(emptyMap())
 
+    // Re-armable per rollover: each of these is scoped to a specific day, either because it
+    // collects a Room flow bound to a fixed epoch range or because it reads the date once.
+    private var fastingJob: Job? = null
+    private var prayerRecordsJob: Job? = null
+    private var dailyHadithJob: Job? = null
+    private var dailyDuaJob: Job? = null
+
     init {
         checkPermissions()
         // observeLocation() also observes the calculation settings and adjustments, and triggers
@@ -272,6 +285,37 @@ class HomeViewModel @Inject constructor(
         loadDailyDua()
         observeCelebrationCards()
         scheduleWorshipRefresh()
+        observeDateRollover()
+    }
+
+    /**
+     * One place where the day changing re-arms everything scoped to it.
+     *
+     * Each of these read the date once, at `init`, and never again: the fasting collector
+     * bound a Room query to a fixed `[startOfDay, endOfDay]` range, the prayer-record flow
+     * resolved "today" inside the repository at call time, and the daily hadith and dua were
+     * picked from a day number and an hour read at construction. Left open at 23:50 the app
+     * still said "fasting today" at 00:05 about yesterday's record — and marking the new day's
+     * fast could never light it up, because the collector's range did not include the new day.
+     *
+     * `HomeScreen` already dispatched `RefreshPrayerTimes` on rollover, but that reached only
+     * `calculatePrayerTimes()`. This re-issues the lot as one unit.
+     */
+    private fun observeDateRollover() {
+        viewModelScope.launch {
+            todayProvider.todayChanges.collect { today ->
+                // `dayTimesDate` is the record of which day the cached prayer instants were
+                // computed for. It was assigned and read nowhere, while the comment beside it
+                // claimed it guarded the rollover recompute. It does now.
+                if (dayTimesDate == today) return@collect
+
+                observeFastingStatus()
+                loadPrayerRecords()
+                loadDailyHadith()
+                loadDailyDua()
+                calculatePrayerTimes()
+            }
+        }
     }
 
     /** Local calendar occasions merged with any pushed CELEBRATION announcement. */
@@ -284,7 +328,11 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun loadPrayerRecords() {
-        viewModelScope.launch {
+        // `getTodayPrayerRecords()` resolves "today" once, at call time, and returns a Flow
+        // bound to that epoch — so this needs re-invoking at rollover exactly as the fasting
+        // collector does, or Home's prayer card stays bound to the day the app was opened.
+        prayerRecordsJob?.cancel()
+        prayerRecordsJob = viewModelScope.launch {
             prayerUseCases.getTodayPrayerRecords().collect { records ->
                 _prayerRecords.update { records }
             }
@@ -292,8 +340,9 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun observeFastingStatus() {
-        viewModelScope.launch {
-            val today = LocalDate.now()
+        fastingJob?.cancel()
+        fastingJob = viewModelScope.launch {
+            val today = todayProvider.today()
             val startOfDay = today.toUtcMidnightMillis()
             val endOfDay = startOfDay + MILLIS_PER_DAY - 1
 
@@ -305,13 +354,15 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun loadDailyHadith() {
-        viewModelScope.launch {
+        dailyHadithJob?.cancel()
+        dailyHadithJob = viewModelScope.launch {
             try {
                 // GetDailyHadithUseCase seeds the backfill and applies the Knuth
                 // multiplicative-hash scatter so consecutive days land on very
                 // different hadiths while staying deterministic per day.
                 val hadith =
-                    hadithUseCases.getDailyHadith(LocalDate.now().toEpochDay()) ?: return@launch
+                    hadithUseCases.getDailyHadith(todayProvider.today().toEpochDay())
+                        ?: return@launch
                 _state.update {
                     it.copy(
                         dailyHadith = hadith.textEnglish.let { text ->
@@ -350,9 +401,10 @@ class HomeViewModel @Inject constructor(
      * sleep adhkar) and rotates the specific dua daily within that category.
      */
     private fun loadDailyDua() {
-        viewModelScope.launch {
+        dailyDuaJob?.cancel()
+        dailyDuaJob = viewModelScope.launch {
             try {
-                val now = LocalDate.now()
+                val now = todayProvider.today()
                 val selection = duaUseCases.getDailyDua(
                     hourOfDay = LocalTime.now().hour,
                     dayOfYear = now.dayOfYear
@@ -456,7 +508,7 @@ class HomeViewModel @Inject constructor(
 
         viewModelScope.launch {
             val prayerName = PrayerName.valueOf(prayerType.name)
-            val todayEpoch = LocalDate.now().toUtcMidnightMillis()
+            val todayEpoch = todayProvider.today().toUtcMidnightMillis()
             val currentStatus = _prayerRecords.value[prayerName] ?: PrayerStatus.NOT_PRAYED
             val newStatus =
                 if (currentStatus == PrayerStatus.PRAYED) PrayerStatus.NOT_PRAYED else PrayerStatus.PRAYED
@@ -644,7 +696,7 @@ class HomeViewModel @Inject constructor(
                     _state.update { it.copy(isLoading = true) }
                 }
 
-                val today = LocalDate.now()
+                val today = todayProvider.today()
                 val prayerTimes = prayerTimeCalculator.getPrayerTimes(
                     latitude = latitude,
                     longitude = longitude,
@@ -726,7 +778,7 @@ class HomeViewModel @Inject constructor(
             ?.toLocalDateTime(timeZone)
             ?.let { (it.hour * 60 + it.minute) / 1440f } ?: 0.80f
 
-        val isFriday = LocalDate.now().dayOfWeek == DayOfWeek.FRIDAY
+        val isFriday = todayProvider.today().dayOfWeek == DayOfWeek.FRIDAY
         val dhuhrInstant = prayerTimes.find { it.type == PrayerType.DHUHR }?.time
 
         _state.update {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelRolloverTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelRolloverTest.kt
@@ -1,0 +1,169 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.core.util.NextWorshipResolver
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.domain.repository.AnnouncementRepository
+import com.arshadshah.nimaz.domain.repository.DuaRepository
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.repository.HadithRepository
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * Home across midnight.
+ *
+ * `observeFastingStatus()` computed `today`, `startOfDay` and `endOfDay` once, inside its
+ * coroutine, at init — then collected a Room flow bound to that fixed range forever. Open the
+ * app at 23:50 while fasting and leave it: at 00:05 Home still said "fasting today" about
+ * yesterday's record, and marking the new day's fast could never light it up, because the
+ * collector's range did not include the new day.
+ *
+ * `HomeScreen` did dispatch `RefreshPrayerTimes` on rollover — but that reached only
+ * `calculatePrayerTimes()`. Nothing restarted this collector.
+ */
+// No `runTest` here: HomeViewModel keeps an infinite `while (isActive) { delay(…) }` worship
+// refresh alive, and runTest's cleanup advances virtual time until the scheduler is idle —
+// which that loop never is. The unconfined dispatcher runs everything eagerly instead, which
+// is what the sibling HomeViewModelTest does for the same reason.
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class HomeViewModelRolloverTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val yesterday = LocalDate.of(2026, 3, 14)
+    private val today = yesterday.plusDays(1)
+    private val todayProvider = FakeTodayProvider(yesterday)
+
+    private lateinit var fastingRepository: FastingRepository
+    private lateinit var prayerRepository: PrayerRepository
+    private lateinit var hadithRepository: HadithRepository
+    private lateinit var duaRepository: DuaRepository
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var announcementRepository: AnnouncementRepository
+    private lateinit var prayerTimeCalculator: PrayerTimeCalculator
+    private lateinit var nextWorshipResolver: NextWorshipResolver
+
+    /** Which day's records each range query asked for, in order. */
+    private val requestedRanges = mutableListOf<Long>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        fastingRepository = mockk(relaxed = true)
+        prayerRepository = mockk(relaxed = true)
+        hadithRepository = mockk(relaxed = true)
+        duaRepository = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
+        announcementRepository = mockk(relaxed = true)
+        prayerTimeCalculator = mockk(relaxed = true)
+        nextWorshipResolver = mockk(relaxed = true)
+
+        // Only *yesterday* has a fast recorded. If the collector is still bound to
+        // yesterday's range after midnight, Home keeps claiming the user is fasting today.
+        every { fastingRepository.getFastRecordsInRange(any(), any()) } answers {
+            val start = firstArg<Long>()
+            requestedRanges += start
+            if (start == yesterday.toUtcMidnightMillis()) {
+                flowOf(listOf(fastRecord(start)))
+            } else {
+                flowOf(emptyList())
+            }
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(): HomeViewModel {
+        val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
+        return HomeViewModel(
+            context = context,
+            prayerTimeCalculator = prayerTimeCalculator,
+            prayerUseCases = buildPrayerUseCases(prayerRepository),
+            fastingUseCases = buildFastingUseCases(fastingRepository),
+            hadithUseCases = buildHadithUseCases(hadithRepository),
+            duaUseCases = buildDuaUseCases(duaRepository),
+            settingsRepository = settingsRepository,
+            announcementUseCases = announcementUseCases,
+            observeEventCards = buildObserveEventCardsUseCase(announcementUseCases),
+            nextWorshipResolver = nextWorshipResolver,
+            todayProvider = todayProvider,
+        )
+    }
+
+    @Test
+    fun `fasting today stops meaning yesterday once the day changes`() {
+        val vm = viewModel()
+        assertThat(vm.state.value.fastingToday).isTrue()
+
+        todayProvider.now = today
+
+        assertThat(vm.state.value.fastingToday).isFalse()
+    }
+
+    @Test
+    fun `the fasting collector re-arms on the new day's range`() {
+        viewModel()
+        requestedRanges.clear()
+
+        todayProvider.now = today
+
+        // Without a re-arm the new day is never queried at all, so marking today's fast
+        // cannot light the card up however many times Room re-emits.
+        assertThat(requestedRanges).contains(today.toUtcMidnightMillis())
+    }
+
+    @Test
+    fun `a day that has not changed does not re-issue everything`() {
+        viewModel()
+        requestedRanges.clear()
+
+        // The provider re-emitting the same date must not restart the collectors.
+        todayProvider.now = yesterday
+
+        assertThat(requestedRanges).isEmpty()
+    }
+}
+
+private fun fastRecord(dateEpoch: Long) = FastRecord(
+    id = 1L,
+    date = dateEpoch,
+    hijriDate = null,
+    hijriMonth = null,
+    hijriYear = null,
+    fastType = FastType.RAMADAN,
+    status = FastStatus.FASTED,
+    exemptionReason = null,
+    suhoorTime = null,
+    iftarTime = null,
+    note = null,
+    createdAt = 0L,
+    updatedAt = 0L,
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModelTest.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel
 import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
 import com.arshadshah.nimaz.core.util.NextWorshipResolver
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -88,6 +89,8 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private val todayProvider = FakeTodayProvider(java.time.LocalDate.now())
+
     private fun createViewModel(): HomeViewModel {
         val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
         return HomeViewModel(
@@ -101,6 +104,7 @@ class HomeViewModelTest {
             announcementUseCases = announcementUseCases,
             observeEventCards = buildObserveEventCardsUseCase(announcementUseCases),
             nextWorshipResolver = nextWorshipResolver,
+            todayProvider = todayProvider,
         )
     }
 


### PR DESCRIPTION
Layer 14 of the #352 stack, on top of #382. Closes D1, D2 and D3 of #363 — the first consumer of the `TodayProvider` seam that layer added.

## What was broken

### D1 — "fasting today" permanently means yesterday

`observeFastingStatus()` computed `today`, `startOfDay` and `endOfDay` **once**, inside its coroutine, at `init` — then collected a Room flow bound to that fixed range forever.

**Input → wrong output:** open the app at 23:50 while fasting and leave it open. At 00:05 Home still says "fasting today" — that is the 3rd's record — and **marking the 4th's fast in the Fast Tracker will never light it up**, because the collector's range does not include the 4th.

`HomeScreen.kt:168-173` *does* dispatch `HomeEvent.RefreshPrayerTimes` on rollover, but that reaches only `calculatePrayerTimes()`. Nothing restarted this collector.

### D2 — the daily hadith and dua freeze at the date they loaded

`LocalDate.now().toEpochDay()` and `LocalTime.now().hour` / `now.dayOfYear` were read once in `init`.

**Input → wrong output:** the app sits in the background for two days. On return at 21:00 the "Today" carousel shows **the hadith from two days ago** and the **morning** adhkar dua — a dua the code documents as "matching the current time of day".

### D3 — the two fields that would have caught this were inert

- `HomeUiState.currentDate` — set to `LocalDate.now()` at construction, never updated, and `grep state.currentDate` in `screens/` returns **zero** hits.
- `dayTimesDate` — assigned at `:669`, read **nowhere**, while the comment beside it claimed it guarded the rollover recompute.

## A fifth instance the issue does not list

#363 names four members of this family in `HomeViewModel`. There is a fifth, and it hides one layer down:

`loadPrayerRecords()` collects `prayerUseCases.getTodayPrayerRecords()`. That looks date-free — but `PrayerRepositoryImpl.kt:34` resolves `LocalDate.now().toUtcMidnightMillis()` **once, at call time**, and returns a Flow bound to that epoch:

```kotlin
override fun getTodayPrayerRecords(): Flow<Map<PrayerName, PrayerStatus>> {
    val todayEpoch = LocalDate.now().toUtcMidnightMillis()   // ← resolved once
    return prayerDao.getPrayerRecordsForDate(todayEpoch).map { … }
}
```

So Home's prayer card was pinned to the day the app was opened too, by a clock read the ViewModel could not see. It re-arms with the rest; the repository's own hidden clock read is left for the sweep that finishes `LocalDate.now()` off across the layer.

## The fix

One `observeDateRollover()` collecting `todayProvider.todayChanges` re-issues all five as a unit, each behind a cancel-and-replace `Job`. It skips the work when the date has not actually changed, so a re-emission of the same day costs nothing.

Both dead fields are resolved rather than left: `currentDate` is **deleted** (the rollover signal is the seam now — keeping an unread field that was meant to be the signal is how it went unnoticed), and `dayTimesDate` becomes the guard its comment always claimed it was.

## Tests

`HomeViewModelRolloverTest` (3), **verified red** by commenting out `observeDateRollover()`:

```
HomeViewModelRolloverTest > the fasting collector re-arms on the new day's range FAILED
HomeViewModelRolloverTest > fasting today stops meaning yesterday once the day changes FAILED
3 tests completed, 2 failed
```

The third pins the other direction — a provider re-emitting the same date must not restart anything.

These use a plain `@Test fun` rather than `runTest`, like the sibling `HomeViewModelTest`: `HomeViewModel` keeps an infinite `while (isActive) { delay(…) }` worship refresh alive, and `runTest`'s cleanup advances virtual time until the scheduler is idle — which that loop never is. The comment in the file says so, since it cost real time to work out.

## Known remaining

The dua's **intra-day** time-of-day transition (morning adhkar → evening adhkar without a date change) still needs an hour-bucket trigger. The date rollover re-reads the hour, so the two-days-in-background case in D2 is fixed; sitting on Home from 08:00 to 21:00 is not. That needs a second signal on `TodayProvider`, and it belongs with the rest of the `LocalDate.now()` sweep rather than bolted on here.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1500/1501
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the layers below (`DeviceStateCorpusTest`; the private `nimaz-data` artifact is unreachable from this session, so the run used `-x :app:fetchNimazData`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_