### PR TITLE
fix(settings): reschedule alarms from what is persisted, not from a stale snapshot

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/notification/RescheduleNotificationsUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/notification/RescheduleNotificationsUseCase.kt
@@ -1,0 +1,77 @@
+package com.arshadshah.nimaz.domain.usecase.notification
+
+import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
+import com.arshadshah.nimaz.core.util.enabledPrayerTypes
+import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+/**
+ * Re-arms today's prayer alarms from **what is persisted**, never from a ViewModel's state.
+ *
+ * This lived in `SettingsViewModel.rescheduleNotifications()` and built its alarm set from
+ * `_notificationState.value` and `_prayerState.value` — two one-shot snapshots taken by
+ * `loadSettings()` at construction. `hiltViewModel()` scopes to the nav back-stack entry, so
+ * Notification Settings, Prayer Settings and Appearance each run their **own** instance, and a
+ * snapshot taken by one goes stale the moment another writes.
+ *
+ * That produced an alarm the user had switched off:
+ *
+ *  1. Open Prayer Settings — instance B snapshots `ishaNotification = true`.
+ *  2. Go to Notification Settings — instance A. Turn Isha off. DataStore is now `false`.
+ *  3. Back to Prayer Settings, change the Asr juristic method. That calls reschedule on **B**,
+ *     whose snapshot still says `true` — and the Isha adhan is re-armed.
+ *
+ * There was a second way in with the same root cause. `loadSettings()` does ~40 sequential
+ * `.first()` reads, and until it finishes the state holds its **defaults** — notifications on,
+ * every prayer except sunrise on. A user with notifications globally off who tapped the
+ * calculation-method row on the frame the screen appeared scheduled a full day of alarms.
+ *
+ * Reading DataStore here closes both, and being a use case means no ViewModel can reintroduce
+ * either by passing its own state in — there is nothing to pass.
+ */
+class RescheduleNotificationsUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val scheduler: PrayerNotificationScheduler,
+) {
+
+    suspend operator fun invoke() {
+        val prefs = settingsRepository.userPreferences.first()
+
+        val adjustments = mapOf(
+            PrayerType.FAJR to settingsRepository.fajrAdjustment.first(),
+            PrayerType.SUNRISE to settingsRepository.sunriseAdjustment.first(),
+            PrayerType.DHUHR to settingsRepository.dhuhrAdjustment.first(),
+            PrayerType.ASR to settingsRepository.asrAdjustment.first(),
+            PrayerType.MAGHRIB to settingsRepository.maghribAdjustment.first(),
+            PrayerType.ISHA to settingsRepository.ishaAdjustment.first(),
+        )
+
+        scheduler.scheduleTodaysPrayerNotifications(
+            latitude = prefs.latitude,
+            longitude = prefs.longitude,
+            notificationsEnabled = settingsRepository.prayerNotificationsEnabled.first(),
+            // `enabledPrayerTypes()` already existed beside `preReminderMinutesByPrayer()` and
+            // reads the same six flags off the repository — BootReceiver has been using it all
+            // along. The ViewModel built its own set from state instead.
+            enabledPrayers = settingsRepository.enabledPrayerTypes(),
+            preReminders = settingsRepository.preReminderMinutesByPrayer(),
+            calculationMethod = CalculationMethod.fromString(prefs.calculationMethod),
+            asrCalculation = AsrCalculation.fromString(prefs.asrCalculation),
+            // The domain's own parser, which accepts both the "MIDDLE_OF_NIGHT" and
+            // "MIDDLE_OF_THE_NIGHT" spellings. It replaces a hand-rolled string remap wrapped
+            // in `catch (_: Exception) { null }` — so a persisted value the remap did not cover
+            // silently dropped the high-latitude correction the user had chosen. At 60°N that
+            // moves Fajr and Isha by hours, with no report and nothing on screen to explain it.
+            highLatitudeRule = HighLatitudeRule.fromString(settingsRepository.highLatitudeRule.first()),
+            adjustments = adjustments,
+            fridayReminderEnabled = settingsRepository.fridayReminderEnabled.first(),
+            fridayReminderMinutes = settingsRepository.fridayReminderMinutes.first(),
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
 import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
@@ -21,6 +23,7 @@ import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.notification.RescheduleNotificationsUseCase
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
@@ -316,6 +319,10 @@ class SettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val quranUseCases: QuranUseCases,
     private val prayerNotificationScheduler: PrayerNotificationScheduler,
+    private val rescheduleNotificationsUseCase: RescheduleNotificationsUseCase,
+    // Only the new failure paths report through this so far. The ~40 existing AppAnalytics
+    // calls in this file are the analytics catalog's job (#355), not this layer's.
+    private val telemetry: Telemetry,
     val adhanAudioManager: AdhanAudioManager,
     private val database: NimazDatabase,
     private val userDatabase: NimazUserDatabase,
@@ -499,6 +506,12 @@ class SettingsViewModel @Inject constructor(
             .distinctUntilChanged()
             .flatMapLatest { translatorId ->
                 flow { emit(quranUseCases.getAyahTranslation(PREVIEW_AYAH_ID, translatorId)) }
+                    // Inside the flatMapLatest, deliberately. Applied outside, the first
+                    // failed read would end the whole chain — `quranTranslatorId` never
+                    // completes on its own, but a caught upstream throw completes it anyway —
+                    // and the preview would be frozen on the previous translation for the
+                    // ViewModel's entire life, with every later change silently doing nothing.
+                    .catchAndReport(telemetry, "settings", "preview_translation") { emit(null) }
             }
             .onEach { text ->
                 // Keep the previous text on a null (missing/failed) result rather than
@@ -1259,64 +1272,17 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Delegates to [RescheduleNotificationsUseCase], which reads the persisted values.
+     *
+     * This used to build the alarm set from `_notificationState.value` and `_prayerState.value`
+     * — construction-time snapshots. Since `hiltViewModel()` gives each settings screen its own
+     * instance, one screen's snapshot went stale as soon as another wrote, and a prayer the
+     * user had switched off in Notification Settings was re-armed by an unrelated change in
+     * Prayer Settings. See the use case's KDoc.
+     */
     private suspend fun rescheduleNotifications() {
-        val prefs = settingsRepository.userPreferences.first()
-        val lat = prefs.latitude
-        val lng = prefs.longitude
-        val notifState = _notificationState.value
-        val prayerSettings = _prayerState.value
-
-        val enabledPrayers = buildSet {
-            if (notifState.fajrNotification) add(PrayerType.FAJR)
-            if (notifState.dhuhrNotification) add(PrayerType.DHUHR)
-            if (notifState.asrNotification) add(PrayerType.ASR)
-            if (notifState.maghribNotification) add(PrayerType.MAGHRIB)
-            if (notifState.ishaNotification) add(PrayerType.ISHA)
-            if (notifState.sunriseNotification) add(PrayerType.SUNRISE)
-        }
-
-        val calcMethod = prayerSettings.calculationMethod
-        val asrCalc = when (prayerSettings.asrMethod) {
-            AsrJuristicMethod.STANDARD -> AsrCalculation.STANDARD
-            AsrJuristicMethod.HANAFI -> AsrCalculation.HANAFI
-        }
-        val highLatRule = try {
-            com.arshadshah.nimaz.domain.model.HighLatitudeRule.valueOf(
-                prayerSettings.highLatitudeRule.name.let {
-                    // Map SettingsViewModel enum names to domain model enum names
-                    when (it) {
-                        "MIDDLE_OF_NIGHT" -> "MIDDLE_OF_THE_NIGHT"
-                        "SEVENTH_OF_NIGHT" -> "SEVENTH_OF_THE_NIGHT"
-                        else -> it
-                    }
-                }
-            )
-        } catch (_: Exception) {
-            null
-        }
-
-        val adjustments = mapOf(
-            PrayerType.FAJR to prayerSettings.fajrAdjustment,
-            PrayerType.SUNRISE to prayerSettings.sunriseAdjustment,
-            PrayerType.DHUHR to prayerSettings.dhuhrAdjustment,
-            PrayerType.ASR to prayerSettings.asrAdjustment,
-            PrayerType.MAGHRIB to prayerSettings.maghribAdjustment,
-            PrayerType.ISHA to prayerSettings.ishaAdjustment
-        )
-
-        prayerNotificationScheduler.scheduleTodaysPrayerNotifications(
-            latitude = lat,
-            longitude = lng,
-            notificationsEnabled = notifState.notificationsEnabled,
-            enabledPrayers = enabledPrayers,
-            preReminders = settingsRepository.preReminderMinutesByPrayer(),
-            calculationMethod = calcMethod,
-            asrCalculation = asrCalc,
-            highLatitudeRule = highLatRule,
-            adjustments = adjustments,
-            fridayReminderEnabled = notifState.fridayReminderEnabled,
-            fridayReminderMinutes = notifState.fridayReminderMinutes
-        )
+        rescheduleNotificationsUseCase()
     }
 
     private fun updatePrayerAdjustment(prayer: String, minutes: Int) {

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/notification/RescheduleNotificationsUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/notification/RescheduleNotificationsUseCaseTest.kt
@@ -1,0 +1,168 @@
+package com.arshadshah.nimaz.domain.usecase.notification
+
+import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The alarm set is built from what is persisted, and from nothing else.
+ *
+ * A prayer the user switched off in Notification Settings used to come back on, because the
+ * reschedule read a `SettingsViewModel` snapshot taken at construction — and `hiltViewModel()`
+ * gives each settings screen its own instance, so one screen's snapshot went stale the moment
+ * another wrote. Turning Isha off on one screen and changing the Asr method on another re-armed
+ * the Isha adhan.
+ *
+ * These tests exist to make that unrepresentable: there is no state to pass in any more.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RescheduleNotificationsUseCaseTest {
+
+    private lateinit var settings: SettingsRepository
+    private lateinit var scheduler: PrayerNotificationScheduler
+
+    private val ishaEnabled = MutableStateFlow(true)
+    private val notificationsEnabled = MutableStateFlow(true)
+    private val highLatitudeRule = MutableStateFlow("MIDDLE_OF_NIGHT")
+
+    @Before
+    fun setUp() {
+        settings = mockk(relaxed = true)
+        scheduler = mockk(relaxed = true)
+
+        every { settings.userPreferences } returns flowOf(preferences())
+        every { settings.prayerNotificationsEnabled } returns notificationsEnabled
+        every { settings.fajrNotificationEnabled } returns flowOf(true)
+        every { settings.sunriseNotificationEnabled } returns flowOf(false)
+        every { settings.dhuhrNotificationEnabled } returns flowOf(true)
+        every { settings.asrNotificationEnabled } returns flowOf(true)
+        every { settings.maghribNotificationEnabled } returns flowOf(true)
+        every { settings.ishaNotificationEnabled } returns ishaEnabled
+        every { settings.highLatitudeRule } returns highLatitudeRule
+        every { settings.fajrAdjustment } returns flowOf(-5)
+        every { settings.sunriseAdjustment } returns flowOf(0)
+        every { settings.dhuhrAdjustment } returns flowOf(0)
+        every { settings.asrAdjustment } returns flowOf(0)
+        every { settings.maghribAdjustment } returns flowOf(0)
+        every { settings.ishaAdjustment } returns flowOf(0)
+        every { settings.fridayReminderEnabled } returns flowOf(false)
+        every { settings.fridayReminderMinutes } returns flowOf(60)
+        // preReminderMinutesByPrayer() reads a pair of flows per prayer; a relaxed mock
+        // returns a Flow that emits nothing, and `.first()` on that throws.
+        every { settings.prayerReminderEnabled(any()) } returns flowOf(false)
+        every { settings.prayerReminderMinutes(any()) } returns flowOf(0)
+    }
+
+    private fun useCase() = RescheduleNotificationsUseCase(settings, scheduler)
+
+    @Test
+    fun `a prayer switched off is not re-armed`() = runTest {
+        // Switched off on another settings screen, after this one was constructed.
+        ishaEnabled.value = false
+
+        useCase().invoke()
+
+        assertThat(scheduledPrayers()).doesNotContain(PrayerType.ISHA)
+    }
+
+    @Test
+    fun `the prayers that are on are armed`() = runTest {
+        useCase().invoke()
+
+        assertThat(scheduledPrayers()).containsExactly(
+            PrayerType.FAJR,
+            PrayerType.DHUHR,
+            PrayerType.ASR,
+            PrayerType.MAGHRIB,
+            PrayerType.ISHA,
+        )
+    }
+
+    @Test
+    fun `notifications switched off globally schedule nothing`() = runTest {
+        // The defaults-window variant: state held `notificationsEnabled = true` until ~40
+        // sequential reads finished, so a tap on the first frame armed a full day of alarms
+        // for a user who had them off.
+        notificationsEnabled.value = false
+
+        useCase().invoke()
+
+        val enabled = slot<Boolean>()
+        verify {
+            scheduler.scheduleTodaysPrayerNotifications(
+                any(), any(), capture(enabled), any(), any(), any(), any(), any(), any(),
+                any(), any(),
+            )
+        }
+        assertThat(enabled.captured).isFalse()
+    }
+
+    @Test
+    fun `the persisted high-latitude rule survives its older spelling`() = runTest {
+        // The old code remapped these by hand inside `catch (_: Exception) { null }`, so a
+        // value it did not cover silently dropped the correction — hours of error at 60°N.
+        useCase().invoke()
+
+        assertThat(capturedRule()).isEqualTo(HighLatitudeRule.MIDDLE_OF_THE_NIGHT)
+    }
+
+    @Test
+    fun `the newer spelling is accepted too`() = runTest {
+        highLatitudeRule.value = "SEVENTH_OF_THE_NIGHT"
+
+        useCase().invoke()
+
+        assertThat(capturedRule()).isEqualTo(HighLatitudeRule.SEVENTH_OF_THE_NIGHT)
+    }
+
+    private fun scheduledPrayers(): Set<PrayerType> {
+        val captured = slot<Set<PrayerType>>()
+        verify {
+            scheduler.scheduleTodaysPrayerNotifications(
+                any(), any(), any(), capture(captured), any(), any(), any(), any(), any(),
+                any(), any(),
+            )
+        }
+        return captured.captured
+    }
+
+    private fun capturedRule(): HighLatitudeRule? {
+        val captured = mutableListOf<HighLatitudeRule?>()
+        verify {
+            scheduler.scheduleTodaysPrayerNotifications(
+                any(), any(), any(), any(), any(), any(), any(), captureNullable(captured), any(),
+                any(), any(),
+            )
+        }
+        return captured.last()
+    }
+}
+
+private fun preferences() = UserPreferences(
+    onboardingCompleted = true,
+    themeMode = "system",
+    dynamicColor = false,
+    appLanguage = "en",
+    calculationMethod = CalculationMethod.UMM_AL_QURA.name,
+    asrCalculation = "hanafi",
+    latitude = 53.35,
+    longitude = -6.26,
+    locationName = "Dublin",
+    prayerNotificationsEnabled = true,
+    quranTranslatorId = "en.sahih",
+    showTranslation = true,
+)

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -365,6 +365,16 @@ sequenceDiagram
     Note over BR,Sched: self-perpetuating daily chain —<br/>an alarm armed outside this call fires once and never again
 ```
 
+**Who calls it, and with what.** Every caller builds its arguments from **DataStore**, never from
+ViewModel state: `BootReceiver` reads `PreferencesDataStore` directly, and the settings screens go
+through `RescheduleNotificationsUseCase` (`domain/usecase/notification/`). That is a rule with a
+scar behind it — `SettingsViewModel` used to build the alarm set from `_notificationState.value`,
+a snapshot taken at construction, and since `hiltViewModel()` gives each settings screen its own
+instance, a prayer switched off on the Notification screen was re-armed by an unrelated change on
+the Prayer screen. The use case exists so there is no state to pass in. Reuse
+`settingsRepository.enabledPrayerTypes()` and `preReminderMinutesByPrayer()`
+(`core/util/PrayerNotificationPrefs.kt`) rather than re-deriving either.
+
 **Scheduling.** `scheduleTodaysPrayerNotifications(...)` cancels everything then re-arms enabled prayers, using `setExactAndAllowWhileIdle(RTC_WAKEUP, …)` with `PendingIntent.getBroadcast` targeting `BootReceiver` (explicit intent). Request codes: prayer `1000 + ordinal`, pre-reminder `2000 + ordinal`, midnight reschedule `9999` (00:01), daily summary `8889` (23:00), Friday reminder `8890`, Khatam reminder `8891`. Pre-reminders fire at `prayerTime − preReminders[type]` (skipped for Sunrise) — see **per-prayer alert style and reminder** below. The **Friday (Jummah) reminder** (`scheduleFridayReminder`, gated on `fridayReminderEnabled`) is a one-shot at the upcoming Friday's Dhuhr − `fridayReminderMinutes`, re-armed on every reschedule so it always targets the next Friday.
 
 **Firing.** `BootReceiver.onReceive` dispatches on action: boot → reschedule; `ACTION_MIDNIGHT_RESCHEDULE` → mark missed prayers + reschedule (self-perpetuating daily chain); `ACTION_PRAYER_NOTIFICATION` → post notification &/or play adhan; `ACTION_DAILY_SUMMARY` → summary; `ACTION_FRIDAY_REMINDER` → post the Jummah reminder; `ACTION_KHATAM_REMINDER` → post the Khatam nudge. If adhan should play and the file exists, it calls `AdhanPlaybackService.playAdhan(...)` and the service's foreground notification **doubles as** the prayer notification (shared id `prayerName.hashCode()`); if the file is missing it triggers a download for next time and falls back to beep. **Do Not Disturb:** when `adhanRespectDnd` is on and the system is in a DND mode, `dndBlocksAdhan` gates only the **adhan audio** (`shouldPlayAdhan`/`shouldPlayBeep`) — the visual prayer notification is still posted, and the OS silences its channel sound under DND. The `SILENT` alert style is different in kind: it is the user's own choice, so it silences the visual notification too. The Friday reminder (no adhan audio) always posts and is likewise silenced by the OS under DND.


### PR DESCRIPTION
Layer 15 of the #352 stack, on top of #383. Closes P1 (and its defaults-window variant), P4 and P12 of #362.

## P1 — a disabled prayer alarm re-arms itself

`rescheduleNotifications()` built its alarm set from `_notificationState.value` and `_prayerState.value` — two **one-shot snapshots** taken by `loadSettings()` at construction. `hiltViewModel()` scopes to the nav back-stack entry, so Notification Settings, Prayer Settings and Appearance each run their **own** `SettingsViewModel` instance, and one instance's snapshot goes stale the moment another writes.

**Input → wrong output:**

1. Open Prayer Settings — instance **B** is constructed, snapshotting `ishaNotification = true`.
2. Navigate to Notification Settings — instance **A**. Turn Isha off. DataStore is now `false`.
3. Back to Prayer Settings, change the Asr juristic method. `SetAsrMethod` calls reschedule on **B**, whose snapshot still says `true`.
4. `enabledPrayers` includes `ISHA` → **the Isha adhan is re-armed.**

The user gets a call to prayer they explicitly switched off. The file's own KDoc records this exact fix being made for the Quran block and the notification summary; the reschedule path was left on the old pattern.

**The same root cause has a second entrance.** `loadSettings()` does ~40 sequential `.first()` reads, and until it completes the state holds its **defaults** — `notificationsEnabled = true`, every prayer but sunrise on. A user with notifications globally off who taps the calculation-method row on the frame the screen appears schedules **a full day of alarms**.

Both close by reading DataStore — and the read moves into `RescheduleNotificationsUseCase` (`domain/usecase/notification/`), which is the shape #362 asks for. That matters beyond tidiness: with the logic in a use case there is **no state left to pass in**, so no future ViewModel can reintroduce either bug.

## Two things found while doing it

- **`enabledPrayerTypes()` already existed** in `core/util/PrayerNotificationPrefs.kt` — right beside the `preReminderMinutesByPrayer()` the old code *did* use, and `BootReceiver` has been calling it all along. The ViewModel hand-rolled the same six-flag set from its own state instead. The use case reuses it.
- **P4 was worse than stale state.** The high-latitude rule was remapped between two spellings by hand, inside `catch (_: Exception) { null }` — so a persisted value the remap did not cover **silently dropped the correction the user chose**. At 60°N that moves Fajr and Isha by hours, with no report and nothing on screen to explain it. The domain has shipped `HighLatitudeRule.fromString`, which accepts both spellings, the whole time. The block collapses to one call.

## P12 — the adhan preview freezes permanently on the first DB error

`observeQuranPreviewTranslation()` put no `catch` on the inner flow, so a throw propagated out of `flatMapLatest` → `onEach` → `launchIn`, cancelling the collector for the ViewModel's whole lifetime.

**Input → wrong output:** the first translation whose read hits a `SQLiteException` freezes the preview card on the **previous** translation forever, and every later translation change silently fails to update it. No crash report either.

Same shape as the Help bug fixed in #374, and fixed the same way — `catchAndReport` **inside** the `flatMapLatest`.

## Tests

`SettingsViewModel` has **zero** tests, and #362 flags the reschedule as the highest-value one to write. It is now pinned at the use-case level, where it needs no ViewModel at all:

| test |
|---|
| a prayer switched off is not re-armed |
| the prayers that are on are armed |
| notifications switched off globally schedule nothing |
| the persisted high-latitude rule survives its older spelling |
| the newer spelling is accepted too |

## Scope

Deliberately P1 + P4 + P12 only. #362 carries 16 bugs across five ViewModels; the rest (P2 Fast Tracker's calculation params, P5/P6 the midnight and settings staleness in Prayer Times and Night Worship, P8 prayer maths on the main thread, P9/P10/P11) need the `PrayerTimeCalculator`-behind-a-use-case seam from #360 or belong to other files, and each would make this diff harder to review rather than easier.

One thing I did **not** do: `SettingsViewModel` still calls `AppAnalytics` directly at ~40 sites. `Telemetry` is injected and used by the new failure path, but converting the rest belongs to the analytics catalog (#355), which is the next layer. The constructor comment says so, so it does not read as an oversight.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1505/1506
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the layers below (`DeviceStateCorpusTest`; the private `nimaz-data` artifact is unreachable from this session, so the run used `-x :app:fetchNimazData`).

## Docs

`SUBSYSTEMS.md` §4 gains **"Who calls it, and with what"**: every caller of `scheduleTodaysPrayerNotifications` builds its arguments from DataStore, never from ViewModel state — with the scar that rule came from, and a pointer to reuse `enabledPrayerTypes()` / `preReminderMinutesByPrayer()` rather than re-deriving either.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_