### PR TITLE
refactor(viewmodel): one exhaustive event table, not two

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUlHusnaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUlHusnaViewModel.kt
@@ -54,30 +54,32 @@ class AsmaUlHusnaViewModel @Inject constructor(
 
     fun onEvent(event: AsmaUlHusnaEvent) {
         when (event) {
-            is AsmaUlHusnaEvent.LoadDetail -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UL_HUSNA,
-                "open_detail"
-            )
-
-            is AsmaUlHusnaEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UL_HUSNA,
-                "toggle_favorite"
-            )
-
-            is AsmaUlHusnaEvent.Search -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UL_HUSNA, "search")
-            AsmaUlHusnaEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UL_HUSNA,
-                "toggle_favorites_filter"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            is AsmaUlHusnaEvent.LoadDetail -> loadDetail(event.nameId)
-            is AsmaUlHusnaEvent.ToggleFavorite -> toggleFavorite(event.nameId)
-            is AsmaUlHusnaEvent.Search -> search(event.query)
+            is AsmaUlHusnaEvent.LoadDetail -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UL_HUSNA,
+                    "open_detail"
+                )
+                loadDetail(event.nameId)
+            }
+            is AsmaUlHusnaEvent.ToggleFavorite -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UL_HUSNA,
+                    "toggle_favorite"
+                )
+                toggleFavorite(event.nameId)
+            }
+            is AsmaUlHusnaEvent.Search -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UL_HUSNA, "search")
+                search(event.query)
+            }
             AsmaUlHusnaEvent.ClearSearch -> clearSearch()
-            AsmaUlHusnaEvent.ToggleFavoritesFilter -> toggleFavoritesFilter()
+            AsmaUlHusnaEvent.ToggleFavoritesFilter -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UL_HUSNA,
+                    "toggle_favorites_filter"
+                )
+                toggleFavoritesFilter()
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUnNabiViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/AsmaUnNabiViewModel.kt
@@ -54,30 +54,32 @@ class AsmaUnNabiViewModel @Inject constructor(
 
     fun onEvent(event: AsmaUnNabiEvent) {
         when (event) {
-            is AsmaUnNabiEvent.LoadDetail -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UN_NABI,
-                "open_detail"
-            )
-
-            is AsmaUnNabiEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UN_NABI,
-                "toggle_favorite"
-            )
-
-            is AsmaUnNabiEvent.Search -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UN_NABI, "search")
-            AsmaUnNabiEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.ASMA_UN_NABI,
-                "toggle_favorites_filter"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            is AsmaUnNabiEvent.LoadDetail -> loadDetail(event.nameId)
-            is AsmaUnNabiEvent.ToggleFavorite -> toggleFavorite(event.nameId)
-            is AsmaUnNabiEvent.Search -> search(event.query)
+            is AsmaUnNabiEvent.LoadDetail -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UN_NABI,
+                    "open_detail"
+                )
+                loadDetail(event.nameId)
+            }
+            is AsmaUnNabiEvent.ToggleFavorite -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UN_NABI,
+                    "toggle_favorite"
+                )
+                toggleFavorite(event.nameId)
+            }
+            is AsmaUnNabiEvent.Search -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UN_NABI, "search")
+                search(event.query)
+            }
             AsmaUnNabiEvent.ClearSearch -> clearSearch()
-            AsmaUnNabiEvent.ToggleFavoritesFilter -> toggleFavoritesFilter()
+            AsmaUnNabiEvent.ToggleFavoritesFilter -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.ASMA_UN_NABI,
+                    "toggle_favorites_filter"
+                )
+                toggleFavoritesFilter()
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/CalendarViewModel.kt
@@ -171,18 +171,20 @@ class CalendarViewModel @Inject constructor(
 
     fun onEvent(event: CalendarEvent) {
         when (event) {
-            is CalendarEvent.SelectDate -> telemetry.featureUsed(DOMAIN, "select_date")
-            is CalendarEvent.SetViewMode -> telemetry.featureUsed(DOMAIN, "set_view_mode")
-            is CalendarEvent.NavigateToYear -> telemetry.featureUsed(DOMAIN, "navigate_year")
-
-            else -> {}
-        }
-        when (event) {
-            is CalendarEvent.SelectDate -> selectDate(event.date)
+            is CalendarEvent.SelectDate -> {
+                telemetry.featureUsed(DOMAIN, "select_date")
+                selectDate(event.date)
+            }
             is CalendarEvent.NavigateToMonth -> navigateToMonth(event.month, event.year)
             is CalendarEvent.NavigateToHijriMonth -> navigateToHijriMonth(event.month, event.year)
-            is CalendarEvent.SetViewMode -> setViewMode(event.mode)
-            is CalendarEvent.NavigateToYear -> navigateToYear(event.year, event.isHijri)
+            is CalendarEvent.SetViewMode -> {
+                telemetry.featureUsed(DOMAIN, "set_view_mode")
+                setViewMode(event.mode)
+            }
+            is CalendarEvent.NavigateToYear -> {
+                telemetry.featureUsed(DOMAIN, "navigate_year")
+                navigateToYear(event.year, event.isHijri)
+            }
             CalendarEvent.LoadToday -> loadToday()
             CalendarEvent.LoadUpcomingEvents -> loadUpcomingEvents()
             CalendarEvent.NavigateToPreviousMonth -> navigateToPreviousMonth()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -152,20 +152,27 @@ class DuaViewModel @Inject constructor(
 
     fun onEvent(event: DuaEvent) {
         when (event) {
-            is DuaEvent.LoadCategory -> telemetry.featureUsed(DOMAIN, "open_category")
-            is DuaEvent.LoadDua -> telemetry.featureUsed(DOMAIN, "open_reader")
-            is DuaEvent.LoadDuasByOccasion -> telemetry.featureUsed(DOMAIN, "open_occasion")
-            is DuaEvent.Search -> telemetry.featureUsed(DOMAIN, "search")
-            is DuaEvent.ToggleFavorite -> telemetry.featureUsed(DOMAIN, "toggle_favorite")
-            else -> {}
-        }
-        when (event) {
-            is DuaEvent.LoadCategory -> loadCategory(event.categoryId)
-            is DuaEvent.LoadDua -> loadDua(event.duaId)
-            is DuaEvent.LoadDuasByOccasion -> loadDuasByOccasion(event.occasion)
-            is DuaEvent.Search -> search(event.query)
+            is DuaEvent.LoadCategory -> {
+                telemetry.featureUsed(DOMAIN, "open_category")
+                loadCategory(event.categoryId)
+            }
+            is DuaEvent.LoadDua -> {
+                telemetry.featureUsed(DOMAIN, "open_reader")
+                loadDua(event.duaId)
+            }
+            is DuaEvent.LoadDuasByOccasion -> {
+                telemetry.featureUsed(DOMAIN, "open_occasion")
+                loadDuasByOccasion(event.occasion)
+            }
+            is DuaEvent.Search -> {
+                telemetry.featureUsed(DOMAIN, "search")
+                search(event.query)
+            }
             is DuaEvent.SearchCategories -> searchCategories(event.query)
-            is DuaEvent.ToggleFavorite -> toggleFavorite(event.duaId, event.categoryId)
+            is DuaEvent.ToggleFavorite -> {
+                telemetry.featureUsed(DOMAIN, "toggle_favorite")
+                toggleFavorite(event.duaId, event.categoryId)
+            }
             is DuaEvent.SetFontSize -> _readerState.update { it.copy(fontSize = event.size) }
             is DuaEvent.SetArabicFontSize -> _readerState.update { it.copy(arabicFontSize = event.size) }
             is DuaEvent.LoadProgressForDate -> loadProgressForDate(event.date)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -230,39 +230,38 @@ class FastingViewModel @Inject constructor(
 
     fun onEvent(event: FastingEvent) {
         when (event) {
-            is FastingEvent.StartFast -> telemetry.fastTracked("start", event.fastType.name)
-            is FastingEvent.CompleteFast -> telemetry.fastTracked("complete")
-            is FastingEvent.BreakFast -> telemetry.fastTracked("break")
-            is FastingEvent.MissFast -> telemetry.fastTracked("miss")
-            is FastingEvent.LogRecommendedFast -> telemetry.fastTracked(
-                "recommended",
-                event.fastType.name
-            )
-
-            is FastingEvent.PayFidya -> telemetry.featureUsed(DOMAIN, "pay_fidya")
-            is FastingEvent.AddMakeupFast -> telemetry.featureUsed(DOMAIN, "add_makeup")
-            is FastingEvent.CompleteMakeupFast ->
-                telemetry.featureUsed(DOMAIN, "complete_makeup")
-            // Status/type only — never the user's exemption reason or note text.
-            is FastingEvent.SaveFastForDate -> telemetry.fastTracked(
-                "save_for_date",
-                event.fastType.name
-            )
-
-            is FastingEvent.DeleteFastRecord -> telemetry.fastTracked("delete")
-            else -> {}
-        }
-        when (event) {
             is FastingEvent.SelectDate -> selectDate(event.date)
-            is FastingEvent.StartFast -> startFast(event.date, event.fastType)
-            is FastingEvent.CompleteFast -> completeFast(event.date)
-            is FastingEvent.BreakFast -> breakFast(event.date)
-            is FastingEvent.MissFast -> missFast(event.date, event.reason)
+            is FastingEvent.StartFast -> {
+                telemetry.fastTracked("start", event.fastType.name)
+                startFast(event.date, event.fastType)
+            }
+            is FastingEvent.CompleteFast -> {
+                telemetry.fastTracked("complete")
+                completeFast(event.date)
+            }
+            is FastingEvent.BreakFast -> {
+                telemetry.fastTracked("break")
+                breakFast(event.date)
+            }
+            is FastingEvent.MissFast -> {
+                telemetry.fastTracked("miss")
+                missFast(event.date, event.reason)
+            }
             is FastingEvent.SetFastType -> _trackerState.update { it.copy(selectedFastType = event.fastType) }
             is FastingEvent.SelectMonth -> selectMonth(event.month, event.year)
-            is FastingEvent.AddMakeupFast -> addMakeupFast(event.makeupFast)
-            is FastingEvent.CompleteMakeupFast -> completeMakeupFast(event.makeupFastId)
-            is FastingEvent.PayFidya -> payFidya(event.makeupFastId, event.amount)
+            is FastingEvent.AddMakeupFast -> {
+                telemetry.featureUsed(DOMAIN, "add_makeup")
+                addMakeupFast(event.makeupFast)
+            }
+            is FastingEvent.CompleteMakeupFast -> {
+                telemetry.featureUsed(DOMAIN, "complete_makeup")
+                // Status/type only — never the user's exemption reason or note text.
+                completeMakeupFast(event.makeupFastId)
+            }
+            is FastingEvent.PayFidya -> {
+                telemetry.featureUsed(DOMAIN, "pay_fidya")
+                payFidya(event.makeupFastId, event.amount)
+            }
             is FastingEvent.SetStatsPeriod -> setStatsPeriod(event.period)
             FastingEvent.LoadToday -> loadToday()
             FastingEvent.LoadRamadan -> loadRamadan()
@@ -271,17 +270,32 @@ class FastingViewModel @Inject constructor(
             FastingEvent.ToggleTodayFast -> toggleTodayFast()
             is FastingEvent.OpenFastSheet -> openFastSheet(event.date)
             FastingEvent.DismissFastSheet -> _sheetState.update { it.copy(isVisible = false) }
-            is FastingEvent.SaveFastForDate -> saveFastForDate(
-                event.date,
-                event.status,
-                event.fastType,
-                event.exemptionReason,
-                event.note
-            )
+            is FastingEvent.SaveFastForDate -> {
+                telemetry.fastTracked(
+                    "save_for_date",
+                    event.fastType.name
+                )
+                saveFastForDate(
+                    event.date,
+                    event.status,
+                    event.fastType,
+                    event.exemptionReason,
+                    event.note
+                )
+            }
 
-            is FastingEvent.DeleteFastRecord -> deleteFastRecord(event.date)
+            is FastingEvent.DeleteFastRecord -> {
+                telemetry.fastTracked("delete")
+                deleteFastRecord(event.date)
+            }
             is FastingEvent.UpdateMakeupFast -> updateMakeupFastRecord(event.makeupFast)
-            is FastingEvent.LogRecommendedFast -> startFast(event.date, event.fastType)
+            is FastingEvent.LogRecommendedFast -> {
+                telemetry.fastTracked(
+                    "recommended",
+                    event.fastType.name
+                )
+                startFast(event.date, event.fastType)
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HadithViewModel.kt
@@ -148,42 +148,53 @@ class HadithViewModel @Inject constructor(
 
     fun onEvent(event: HadithEvent) {
         when (event) {
-            is HadithEvent.LoadBook -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_book")
-            is HadithEvent.LoadChapter -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_reader")
-            is HadithEvent.LoadHadithById -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_hadith")
-            is HadithEvent.LoadHadithByNumber -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.HADITH,
-                "open_hadith"
-            )
+            is HadithEvent.LoadBook -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_book")
+                loadBook(event.bookId)
+            }
+            is HadithEvent.LoadChapter -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_reader")
+                loadChapter(event.chapterId)
+            }
+            is HadithEvent.LoadHadithById -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_hadith")
+                loadHadithById(event.hadithId)
+            }
+            is HadithEvent.LoadHadithByNumber -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.HADITH,
+                    "open_hadith"
+                )
+                loadHadithByNumber(
+                    event.bookId,
+                    event.hadithNumber
+                )
+            }
 
-            is HadithEvent.Search -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search")
-            is HadithEvent.SearchInBook -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search_in_book")
-            is HadithEvent.FilterByGrade -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "filter_by_grade")
-            is HadithEvent.ToggleBookmark -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.HADITH,
-                "toggle_bookmark"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            is HadithEvent.LoadBook -> loadBook(event.bookId)
-            is HadithEvent.LoadChapter -> loadChapter(event.chapterId)
-            is HadithEvent.LoadHadithById -> loadHadithById(event.hadithId)
-            is HadithEvent.LoadHadithByNumber -> loadHadithByNumber(
-                event.bookId,
-                event.hadithNumber
-            )
-
-            is HadithEvent.Search -> search(event.query)
-            is HadithEvent.SearchInBook -> searchInBook(event.bookId, event.query)
+            is HadithEvent.Search -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search")
+                search(event.query)
+            }
+            is HadithEvent.SearchInBook -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search_in_book")
+                searchInBook(event.bookId, event.query)
+            }
             is HadithEvent.SearchChapters -> searchChapters(event.query)
-            is HadithEvent.FilterByGrade -> filterByGrade(event.grade)
-            is HadithEvent.ToggleBookmark -> toggleBookmark(
-                event.hadithId,
-                event.bookId,
-                event.hadithNumber
-            )
+            is HadithEvent.FilterByGrade -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "filter_by_grade")
+                filterByGrade(event.grade)
+            }
+            is HadithEvent.ToggleBookmark -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.HADITH,
+                    "toggle_bookmark"
+                )
+                toggleBookmark(
+                    event.hadithId,
+                    event.bookId,
+                    event.hadithNumber
+                )
+            }
 
             is HadithEvent.NavigateToHadith -> _readerState.update { it.copy(currentHadithIndex = event.index) }
             is HadithEvent.SetFontSize -> _readerState.update { it.copy(fontSize = event.size) }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -432,23 +432,20 @@ class HomeViewModel @Inject constructor(
 
     fun onEvent(event: HomeEvent) {
         when (event) {
-            is HomeEvent.UpdateLocation -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HOME, "update_location")
-            is HomeEvent.TogglePrayerStatus -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.HOME,
-                "toggle_prayer_status"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            is HomeEvent.UpdateLocation -> updateLocation(
-                event.latitude,
-                event.longitude,
-                event.name
-            )
+            is HomeEvent.UpdateLocation -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HOME, "update_location")
+                updateLocation(
+                    event.latitude,
+                    event.longitude,
+                    event.name
+                )
+            }
 
             HomeEvent.RefreshPrayerTimes -> calculatePrayerTimes()
             HomeEvent.RefreshPermissions -> checkPermissions()
+            // The log moved inside togglePrayerStatus, past its Sunrise guard. Logged here
+            // it counted taps that toggled nothing: Sunrise is not a prayer and returns early,
+            // so the dashboard has been reporting toggles that never happened.
             is HomeEvent.TogglePrayerStatus -> togglePrayerStatus(event.prayerType)
             HomeEvent.DismissAnnouncement -> dismissAnnouncement()
             HomeEvent.AnnouncementCtaClicked -> logAnnouncementCta()
@@ -505,6 +502,8 @@ class HomeViewModel @Inject constructor(
     private fun togglePrayerStatus(prayerType: PrayerType) {
         // Sunrise is not a prayer - don't allow toggling
         if (prayerType == PrayerType.SUNRISE) return
+
+        AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HOME, "toggle_prayer_status")
 
         viewModelScope.launch {
             val prayerName = PrayerName.valueOf(prayerType.name)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -110,26 +110,29 @@ class PrayerTimesViewModel @Inject constructor(
 
     fun onEvent(event: PrayerTimesEvent) {
         when (event) {
-            PrayerTimesEvent.PreviousDay -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.PRAYER_TIMES,
-                "previous_day"
-            )
-
-            PrayerTimesEvent.NextDay -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_day")
-            PrayerTimesEvent.GoToToday -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "go_to_today")
-            is PrayerTimesEvent.TogglePrayer -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.PRAYER_TIMES,
-                "toggle_prayer"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            PrayerTimesEvent.PreviousDay -> changeDay(-1)
-            PrayerTimesEvent.NextDay -> changeDay(1)
-            PrayerTimesEvent.GoToToday -> selectDate(LocalDate.now())
+            PrayerTimesEvent.PreviousDay -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.PRAYER_TIMES,
+                    "previous_day"
+                )
+                changeDay(-1)
+            }
+            PrayerTimesEvent.NextDay -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_day")
+                changeDay(1)
+            }
+            PrayerTimesEvent.GoToToday -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "go_to_today")
+                selectDate(LocalDate.now())
+            }
             is PrayerTimesEvent.SelectDate -> selectDate(event.date)
-            is PrayerTimesEvent.TogglePrayer -> togglePrayer(event.type)
+            is PrayerTimesEvent.TogglePrayer -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.PRAYER_TIMES,
+                    "toggle_prayer"
+                )
+                togglePrayer(event.type)
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTrackerViewModel.kt
@@ -144,46 +144,40 @@ class PrayerTrackerViewModel @Inject constructor(
 
     fun onEvent(event: PrayerTrackerEvent) {
         when (event) {
-            // One casing into Param.STATUS. Two of these passed lowercase literals while the
-            // third passed `PrayerStatus.name` (PRAYED/MISSED) into the *same* dimension, so
-            // one state arrived under four different values and no dashboard could count it.
-            is PrayerTrackerEvent.MarkPrayerPrayed ->
-                telemetry.prayerTracked(
-                    event.prayerName.name,
-                    PrayerStatus.PRAYED.name,
-                    event.isJamaah
-                )
-
-            is PrayerTrackerEvent.MarkPrayerMissed ->
-                telemetry.prayerTracked(event.prayerName.name, PrayerStatus.MISSED.name)
-
-            is PrayerTrackerEvent.UpdatePrayerStatus ->
-                telemetry.prayerTracked(
-                    event.prayerName.name,
-                    event.status.name,
-                    event.isJamaah
-                )
-
-            is PrayerTrackerEvent.MarkQadaCompleted ->
-                telemetry.featureUsed(DOMAIN, "qada_completed")
-
-            else -> {}
-        }
-        when (event) {
             is PrayerTrackerEvent.SelectDate -> selectDate(event.date)
-            is PrayerTrackerEvent.UpdatePrayerStatus -> updatePrayerStatus(
-                event.prayerName,
-                event.status,
-                event.isJamaah
-            )
+            is PrayerTrackerEvent.UpdatePrayerStatus -> {
+                telemetry.prayerTracked(
+                        event.prayerName.name,
+                        event.status.name,
+                        event.isJamaah
+                    )
+                updatePrayerStatus(
+                    event.prayerName,
+                    event.status,
+                    event.isJamaah
+                )
+            }
 
-            is PrayerTrackerEvent.MarkPrayerPrayed -> markPrayerPrayed(
-                event.prayerName,
-                event.isJamaah
-            )
+            is PrayerTrackerEvent.MarkPrayerPrayed -> {
+                telemetry.prayerTracked(
+                        event.prayerName.name,
+                        PrayerStatus.PRAYED.name,
+                        event.isJamaah
+                    )
+                markPrayerPrayed(
+                    event.prayerName,
+                    event.isJamaah
+                )
+            }
 
-            is PrayerTrackerEvent.MarkPrayerMissed -> markPrayerMissed(event.prayerName)
-            is PrayerTrackerEvent.MarkQadaCompleted -> markQadaCompleted(event.record)
+            is PrayerTrackerEvent.MarkPrayerMissed -> {
+                telemetry.prayerTracked(event.prayerName.name, PrayerStatus.MISSED.name)
+                markPrayerMissed(event.prayerName)
+            }
+            is PrayerTrackerEvent.MarkQadaCompleted -> {
+                telemetry.featureUsed(DOMAIN, "qada_completed")
+                markQadaCompleted(event.record)
+            }
             is PrayerTrackerEvent.SetStatsPeriod -> setStatsPeriod(event.period)
             is PrayerTrackerEvent.LoadHistory -> loadHistory(event.startDate, event.endDate)
             PrayerTrackerEvent.LoadToday -> loadToday()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ProphetViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ProphetViewModel.kt
@@ -54,26 +54,29 @@ class ProphetViewModel @Inject constructor(
 
     fun onEvent(event: ProphetEvent) {
         when (event) {
-            is ProphetEvent.LoadDetail -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "open_detail")
-            is ProphetEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.PROPHET,
-                "toggle_favorite"
-            )
-
-            is ProphetEvent.Search -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "search")
-            ProphetEvent.ToggleFavoritesFilter -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.PROPHET,
-                "toggle_favorites_filter"
-            )
-
-            else -> {}
-        }
-        when (event) {
-            is ProphetEvent.LoadDetail -> loadDetail(event.prophetId)
-            is ProphetEvent.ToggleFavorite -> toggleFavorite(event.prophetId)
-            is ProphetEvent.Search -> search(event.query)
+            is ProphetEvent.LoadDetail -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "open_detail")
+                loadDetail(event.prophetId)
+            }
+            is ProphetEvent.ToggleFavorite -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.PROPHET,
+                    "toggle_favorite"
+                )
+                toggleFavorite(event.prophetId)
+            }
+            is ProphetEvent.Search -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "search")
+                search(event.query)
+            }
             ProphetEvent.ClearSearch -> clearSearch()
-            ProphetEvent.ToggleFavoritesFilter -> toggleFavoritesFilter()
+            ProphetEvent.ToggleFavoritesFilter -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.PROPHET,
+                    "toggle_favorites_filter"
+                )
+                toggleFavoritesFilter()
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QaidaReaderViewModel.kt
@@ -113,27 +113,35 @@ class QaidaReaderViewModel @Inject constructor(
 
     fun onEvent(event: QaidaReaderEvent) {
         when (event) {
-            is QaidaReaderEvent.SelectLesson -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.QAIDA,
-                "select_lesson"
-            )
-
-            is QaidaReaderEvent.CellTapped -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_cell")
-            is QaidaReaderEvent.PlayLine -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_line")
-            is QaidaReaderEvent.PlayLetter -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_letter")
-            QaidaReaderEvent.Resume -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "resume")
-            QaidaReaderEvent.ResetJourney -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "reset_journey")
-            else -> {}
-        }
-        when (event) {
-            is QaidaReaderEvent.SelectLesson -> selectLesson(event.lessonId)
-            is QaidaReaderEvent.CellTapped -> onCellTapped(event.cell)
-            is QaidaReaderEvent.PlayLine -> playLine(event.lineId)
-            is QaidaReaderEvent.PlayLetter -> playLetter(event.letter)
+            is QaidaReaderEvent.SelectLesson -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.QAIDA,
+                    "select_lesson"
+                )
+                selectLesson(event.lessonId)
+            }
+            is QaidaReaderEvent.CellTapped -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_cell")
+                onCellTapped(event.cell)
+            }
+            is QaidaReaderEvent.PlayLine -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_line")
+                playLine(event.lineId)
+            }
+            is QaidaReaderEvent.PlayLetter -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_letter")
+                playLetter(event.letter)
+            }
             QaidaReaderEvent.NextLesson -> nextLesson()
             QaidaReaderEvent.PreviousLesson -> previousLesson()
-            QaidaReaderEvent.Resume -> resume()
-            QaidaReaderEvent.ResetJourney -> resetJourney()
+            QaidaReaderEvent.Resume -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "resume")
+                resume()
+            }
+            QaidaReaderEvent.ResetJourney -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "reset_journey")
+                resetJourney()
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QiblaViewModel.kt
@@ -203,15 +203,6 @@ class QiblaViewModel @Inject constructor(
 
     fun onEvent(event: QiblaEvent) {
         when (event) {
-            QiblaEvent.StartCompass -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QIBLA, "start_compass")
-            is QiblaEvent.SetArMode -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.QIBLA,
-                if (event.enabled) "ar_on" else "ar_off"
-            )
-
-            else -> {}
-        }
-        when (event) {
             is QiblaEvent.UpdateAccuracy -> updateAccuracy(event.accuracy)
             is QiblaEvent.SetLocation -> setLocation(event.location)
             is QiblaEvent.SetTrueNorthMode -> _settingsState.update { it.copy(trueNorthMode = event.enabled) }
@@ -231,12 +222,19 @@ class QiblaViewModel @Inject constructor(
             }
 
             QiblaEvent.StartCompass -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QIBLA, "start_compass")
                 resetSensorState()
                 registerSensors()
             }
 
             QiblaEvent.StopCompass -> unregisterSensors()
-            is QiblaEvent.SetArMode -> _qiblaState.update { it.copy(isArMode = event.enabled) }
+            is QiblaEvent.SetArMode -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.QIBLA,
+                    if (event.enabled) "ar_on" else "ar_off"
+                )
+                _qiblaState.update { it.copy(isArMode = event.enabled) }
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -435,27 +435,28 @@ class QuranViewModel @Inject constructor(
 
     fun onEvent(event: QuranEvent) {
         when (event) {
-            is QuranEvent.LoadSurah -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "open_surah")
-            is QuranEvent.PlaySurahAudio -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_surah_audio")
-            is QuranEvent.PlayAyahAudio -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_ayah_audio")
-            is QuranEvent.ToggleBookmark -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "toggle_bookmark")
-            is QuranEvent.Search -> AppAnalytics.logSearch("quran", event.query.trim().length)
-            else -> {}
-        }
-        when (event) {
-            is QuranEvent.LoadSurah -> loadSurah(event.surahNumber)
+            is QuranEvent.LoadSurah -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "open_surah")
+                loadSurah(event.surahNumber)
+            }
             is QuranEvent.LoadJuz -> loadJuz(event.juzNumber)
             is QuranEvent.LoadPage -> loadPage(event.pageNumber)
             is QuranEvent.PrefetchPage -> loadPage(event.pageNumber, makeActive = false)
             is QuranEvent.LoadMushafPageLayout -> loadMushafPageLayout(event.pageNumber)
-            is QuranEvent.Search -> search(event.query)
+            is QuranEvent.Search -> {
+                AppAnalytics.logSearch("quran", event.query.trim().length)
+                search(event.query)
+            }
             is QuranEvent.SetTopTab -> _homeState.update { it.copy(topTab = event.index) }
             is QuranEvent.SetTab -> _homeState.update { it.copy(selectedTab = event.index) }
-            is QuranEvent.ToggleBookmark -> toggleBookmark(
-                event.ayahId,
-                event.surahNumber,
-                event.ayahNumber
-            )
+            is QuranEvent.ToggleBookmark -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "toggle_bookmark")
+                toggleBookmark(
+                    event.ayahId,
+                    event.surahNumber,
+                    event.ayahNumber
+                )
+            }
 
             is QuranEvent.ToggleFavorite -> toggleFavorite(
                 event.ayahId,
@@ -486,12 +487,18 @@ class QuranViewModel @Inject constructor(
                 _homeState.update { it.copy(searchQuery = "", filteredSurahs = it.surahs) }
             }
 
-            is QuranEvent.PlaySurahAudio -> playSurahAudio(event.surahNumber, event.surahName)
-            is QuranEvent.PlayAyahAudio -> playAyahAudio(
-                event.ayahGlobalId,
-                event.surahNumber,
-                event.ayahNumber
-            )
+            is QuranEvent.PlaySurahAudio -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_surah_audio")
+                playSurahAudio(event.surahNumber, event.surahName)
+            }
+            is QuranEvent.PlayAyahAudio -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_ayah_audio")
+                playAyahAudio(
+                    event.ayahGlobalId,
+                    event.surahNumber,
+                    event.ayahNumber
+                )
+            }
 
             QuranEvent.PauseAudio -> audioManager.togglePlayPause()
             QuranEvent.ResumeAudio -> audioManager.togglePlayPause()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -525,82 +525,9 @@ class SettingsViewModel @Inject constructor(
         // Record meaningful configuration changes. Notification and calculation
         // settings are the ones most often behind "it's doing the wrong thing".
         when (event) {
-            is SettingsEvent.SetTheme -> AppAnalytics.logSettingChanged("theme", event.theme.name)
-            is SettingsEvent.SetLanguage -> AppAnalytics.logSettingChanged(
-                "language",
-                event.language.name
-            )
-
-            is SettingsEvent.SetCalculationMethod -> AppAnalytics.logSettingChanged(
-                "calculation_method",
-                event.method.name
-            )
-
-            is SettingsEvent.SetAsrMethod -> AppAnalytics.logSettingChanged(
-                "asr_method",
-                event.method.name
-            )
-
-            is SettingsEvent.SetHighLatitudeRule -> AppAnalytics.logSettingChanged(
-                "high_latitude_rule",
-                event.rule.name
-            )
-
-            is SettingsEvent.SetNotificationsEnabled -> AppAnalytics.logSettingChanged(
-                "notifications_enabled",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetPrayerNotification -> AppAnalytics.logSettingChanged(
-                "prayer_notification_${event.prayer.lowercase()}",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetAdhanEnabled -> AppAnalytics.logSettingChanged(
-                "adhan_enabled",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetPrayerAlertStyle -> AppAnalytics.logSettingChanged(
-                "alert_style_${event.prayer.lowercase()}",
-                event.style.name
-            )
-
-            is SettingsEvent.SetPrayerReminderEnabled -> AppAnalytics.logSettingChanged(
-                "reminder_enabled_${event.prayer.lowercase()}",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetPrayerReminderMinutes -> AppAnalytics.logSettingChanged(
-                "reminder_minutes_${event.prayer.lowercase()}",
-                event.minutes.toString()
-            )
-
-            is SettingsEvent.SetAdhanSound -> AppAnalytics.logSettingChanged(
-                "adhan_sound",
-                event.sound
-            )
-
-            is SettingsEvent.SetRespectDnd -> AppAnalytics.logSettingChanged(
-                "respect_dnd",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetShowReminderBefore -> AppAnalytics.logSettingChanged(
-                "pre_reminder_enabled",
-                event.enabled.toString()
-            )
-
-            is SettingsEvent.SetReminderMinutes -> AppAnalytics.logSettingChanged(
-                "reminder_minutes",
-                event.minutes.toString()
-            )
-
-            else -> {}
-        }
-        when (event) {
             // General
             is SettingsEvent.SetTheme -> {
+                AppAnalytics.logSettingChanged("theme", event.theme.name)
                 _generalState.update { it.copy(theme = event.theme) }
                 viewModelScope.launch {
                     val modeString = when (event.theme) {
@@ -613,6 +540,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetLanguage -> {
+                AppAnalytics.logSettingChanged(
+                    "language",
+                    event.language.name
+                )
                 _generalState.update { it.copy(language = event.language) }
                 // AppAnalytics.UserProperty.APP_LANGUAGE has been declared and never set, so
                 // every segmentation by language has been empty since it was added.
@@ -684,6 +615,10 @@ class SettingsViewModel @Inject constructor(
 
             // Prayer
             is SettingsEvent.SetCalculationMethod -> {
+                AppAnalytics.logSettingChanged(
+                    "calculation_method",
+                    event.method.name
+                )
                 _prayerState.update { it.copy(calculationMethod = event.method) }
                 AppAnalytics.setUserProperty(
                     AppAnalytics.UserProperty.CALC_METHOD,
@@ -696,6 +631,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAsrMethod -> {
+                AppAnalytics.logSettingChanged(
+                    "asr_method",
+                    event.method.name
+                )
                 _prayerState.update { it.copy(asrMethod = event.method) }
                 viewModelScope.launch {
                     settingsRepository.setAsrCalculation(event.method.name.lowercase())
@@ -704,6 +643,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetHighLatitudeRule -> {
+                AppAnalytics.logSettingChanged(
+                    "high_latitude_rule",
+                    event.rule.name
+                )
                 _prayerState.update { it.copy(highLatitudeRule = event.rule) }
                 viewModelScope.launch {
                     settingsRepository.setHighLatitudeRule(event.rule.name)
@@ -731,6 +674,10 @@ class SettingsViewModel @Inject constructor(
 
             // Notifications
             is SettingsEvent.SetNotificationsEnabled -> {
+                AppAnalytics.logSettingChanged(
+                    "notifications_enabled",
+                    event.enabled.toString()
+                )
                 _notificationState.update { it.copy(notificationsEnabled = event.enabled) }
                 AppAnalytics.setUserProperty(
                     AppAnalytics.UserProperty.NOTIFICATIONS_ENABLED,
@@ -743,6 +690,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerNotification -> {
+                AppAnalytics.logSettingChanged(
+                    "prayer_notification_${event.prayer.lowercase()}",
+                    event.enabled.toString()
+                )
                 updatePrayerNotification(event.prayer, event.enabled)
                 viewModelScope.launch {
                     settingsRepository.setPrayerNotificationEnabled(event.prayer, event.enabled)
@@ -751,6 +702,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAdhanEnabled -> {
+                AppAnalytics.logSettingChanged(
+                    "adhan_enabled",
+                    event.enabled.toString()
+                )
                 _notificationState.update { it.copy(adhanEnabled = event.enabled) }
                 viewModelScope.launch {
                     settingsRepository.setAdhanEnabled(event.enabled)
@@ -759,6 +714,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerAlertStyle -> {
+                AppAnalytics.logSettingChanged(
+                    "alert_style_${event.prayer.lowercase()}",
+                    event.style.name
+                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(alertStyles = it.alertStyles + (prayer to event.style))
@@ -770,6 +729,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerReminderEnabled -> {
+                AppAnalytics.logSettingChanged(
+                    "reminder_enabled_${event.prayer.lowercase()}",
+                    event.enabled.toString()
+                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(reminderEnabled = it.reminderEnabled + (prayer to event.enabled))
@@ -782,6 +745,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerReminderMinutes -> {
+                AppAnalytics.logSettingChanged(
+                    "reminder_minutes_${event.prayer.lowercase()}",
+                    event.minutes.toString()
+                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(reminderOffsets = it.reminderOffsets + (prayer to event.minutes))
@@ -798,11 +765,19 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetRespectDnd -> {
+                AppAnalytics.logSettingChanged(
+                    "respect_dnd",
+                    event.enabled.toString()
+                )
                 _notificationState.update { it.copy(respectDnd = event.enabled) }
                 viewModelScope.launch { settingsRepository.setAdhanRespectDnd(event.enabled) }
             }
 
             is SettingsEvent.SetReminderMinutes -> {
+                AppAnalytics.logSettingChanged(
+                    "reminder_minutes",
+                    event.minutes.toString()
+                )
                 _notificationState.update { it.copy(reminderMinutes = event.minutes) }
                 viewModelScope.launch {
                     settingsRepository.setNotificationReminderMinutes(event.minutes)
@@ -811,6 +786,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetShowReminderBefore -> {
+                AppAnalytics.logSettingChanged(
+                    "pre_reminder_enabled",
+                    event.enabled.toString()
+                )
                 _notificationState.update { it.copy(showReminderBefore = event.enabled) }
                 viewModelScope.launch {
                     settingsRepository.setShowReminderBefore(event.enabled)
@@ -886,6 +865,10 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAdhanSound -> {
+                AppAnalytics.logSettingChanged(
+                    "adhan_sound",
+                    event.sound
+                )
                 _notificationState.update { it.copy(selectedAdhanSound = event.sound) }
                 viewModelScope.launch {
                     settingsRepository.setSelectedAdhanSound(event.sound)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SyncViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SyncViewModel.kt
@@ -227,17 +227,20 @@ class SyncViewModel @Inject constructor(
 
     fun onEvent(event: SyncEvent) {
         when (event) {
-            is SyncEvent.StartSend -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_send")
-            is SyncEvent.StartReceive -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_receive")
-            is SyncEvent.Cancel -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "cancel")
-            else -> {}
-        }
-        when (event) {
-            is SyncEvent.StartSend -> startSend()
-            is SyncEvent.StartReceive -> startReceive()
+            is SyncEvent.StartSend -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_send")
+                startSend()
+            }
+            is SyncEvent.StartReceive -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_receive")
+                startReceive()
+            }
             is SyncEvent.AcceptConnection -> acceptConnection(event.endpointId)
             is SyncEvent.RejectConnection -> rejectConnection(event.endpointId)
-            is SyncEvent.Cancel -> cancel()
+            is SyncEvent.Cancel -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "cancel")
+                cancel()
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TafseerViewModel.kt
@@ -102,42 +102,50 @@ class TafseerViewModel @Inject constructor(
 
     fun onEvent(event: TafseerEvent) {
         when (event) {
-            is TafseerEvent.LoadSurah -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "open_surah")
-            is TafseerEvent.SwitchSource -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "switch_source")
-            is TafseerEvent.AddHighlight -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_highlight")
-            is TafseerEvent.DeleteHighlight -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.TAFSEER,
-                "delete_highlight"
-            )
-
-            is TafseerEvent.AddNote -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_note")
-            is TafseerEvent.DeleteNote -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "delete_note")
-            else -> {}
-        }
-        when (event) {
-            is TafseerEvent.LoadSurah -> loadSurah(event.surahNumber, event.ayahNumber)
+            is TafseerEvent.LoadSurah -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "open_surah")
+                loadSurah(event.surahNumber, event.ayahNumber)
+            }
             is TafseerEvent.NavigateToAyah -> onAyahChanged(event.index)
             is TafseerEvent.NavigateToTafseerPage ->
                 _state.value = _state.value.copy(currentTafseerPage = event.page)
 
-            is TafseerEvent.SwitchSource -> switchSource(event.source)
-            is TafseerEvent.AddHighlight -> addHighlight(
-                event.startOffset,
-                event.endOffset,
-                event.color,
-                event.note
-            )
+            is TafseerEvent.SwitchSource -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "switch_source")
+                switchSource(event.source)
+            }
+            is TafseerEvent.AddHighlight -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_highlight")
+                addHighlight(
+                    event.startOffset,
+                    event.endOffset,
+                    event.color,
+                    event.note
+                )
+            }
 
-            is TafseerEvent.DeleteHighlight -> deleteHighlight(event.highlightId)
+            is TafseerEvent.DeleteHighlight -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.TAFSEER,
+                    "delete_highlight"
+                )
+                deleteHighlight(event.highlightId)
+            }
             is TafseerEvent.UpdateHighlight -> updateHighlight(
                 event.highlightId,
                 event.color,
                 event.note
             )
 
-            is TafseerEvent.AddNote -> addNote(event.text)
+            is TafseerEvent.AddNote -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_note")
+                addNote(event.text)
+            }
             is TafseerEvent.UpdateNote -> updateNote(event.note)
-            is TafseerEvent.DeleteNote -> deleteNote(event.noteId)
+            is TafseerEvent.DeleteNote -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "delete_note")
+                deleteNote(event.noteId)
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -202,29 +202,25 @@ class TasbihViewModel @Inject constructor(
 
     fun onEvent(event: TasbihEvent) {
         when (event) {
-            TasbihEvent.StartSession -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "session_start")
-            TasbihEvent.CompleteSession -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "session_complete")
-            TasbihEvent.Reset -> AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "reset")
-            is TasbihEvent.CreateCustomPreset -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.TASBIH,
-                "preset_created"
-            )
-
-            is TasbihEvent.DeleteCustomPreset -> AppAnalytics.logFeatureUsed(
-                AppAnalytics.Feature.TASBIH,
-                "preset_deleted"
-            )
-
-            else -> {}
-        }
-        when (event) {
             is TasbihEvent.SelectPreset -> selectPreset(event.preset)
             TasbihEvent.ClearPreset -> clearPreset()
             is TasbihEvent.FilterByCategory -> filterByCategory(event.category)
             is TasbihEvent.SetTargetCount -> setTargetCount(event.count)
-            is TasbihEvent.CreateCustomPreset -> createCustomPreset(event.preset)
+            is TasbihEvent.CreateCustomPreset -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.TASBIH,
+                    "preset_created"
+                )
+                createCustomPreset(event.preset)
+            }
             is TasbihEvent.UpdateCustomPreset -> updateCustomPreset(event.preset)
-            is TasbihEvent.DeleteCustomPreset -> deleteCustomPreset(event.presetId)
+            is TasbihEvent.DeleteCustomPreset -> {
+                AppAnalytics.logFeatureUsed(
+                    AppAnalytics.Feature.TASBIH,
+                    "preset_deleted"
+                )
+                deleteCustomPreset(event.presetId)
+            }
             is TasbihEvent.ToggleVibration -> _counterState.update { it.copy(vibrationEnabled = event.enabled) }
             is TasbihEvent.ToggleSound -> _counterState.update { it.copy(soundEnabled = event.enabled) }
             is TasbihEvent.SetCounterStyle -> {
@@ -247,11 +243,20 @@ class TasbihViewModel @Inject constructor(
 
             is TasbihEvent.ToggleAutoLap -> _counterState.update { it.copy(autoLap = event.enabled) }
             TasbihEvent.Increment -> increment()
-            TasbihEvent.Reset -> reset()
-            TasbihEvent.StartSession -> startSession()
+            TasbihEvent.Reset -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "reset")
+                reset()
+            }
+            TasbihEvent.StartSession -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "session_start")
+                startSession()
+            }
             TasbihEvent.PauseSession -> pauseSession()
             TasbihEvent.ResumeSession -> resumeSession()
-            TasbihEvent.CompleteSession -> completeSession()
+            TasbihEvent.CompleteSession -> {
+                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "session_complete")
+                completeSession()
+            }
             TasbihEvent.LoadPresets -> loadPresets()
             TasbihEvent.LoadHistory -> loadHistory()
             TasbihEvent.LoadStats -> loadStats()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,6 +287,42 @@ class XxxViewModel @Inject constructor(
 }
 ```
 
+#### One `when (event)` per `onEvent` — never two
+
+`onEvent` used to be written as **two** consecutive `when (event)` blocks over the same sealed
+hierarchy: the first logging analytics and ending in `else -> {}`, the second dispatching. The
+`else` means the compiler only checks exhaustiveness on the *behaviour* table, so **every event
+added afterwards ships with working behaviour and no telemetry, silently**. That was the measured
+state of 20 of 31 ViewModels — `SettingsViewModel`'s `else` dropped 63 of its 78 events, `Zakat`
+logged 3 of 24, `Tasbih` 5 of 23.
+
+Put the analytics call **inside the branch that owns it**, in one exhaustive table:
+
+```kotlin
+fun onEvent(event: XxxEvent) = when (event) {
+    is XxxEvent.Select -> {
+        telemetry.featureUsed(AppAnalytics.Feature.XXX, AppAnalytics.Action.OPEN_DETAIL)
+        select(event.id)
+    }
+    XxxEvent.Refresh -> refresh()          // deliberately not logged, and visibly so
+}
+```
+
+A new event then **fails to compile** until someone decides whether it is logged — which is the
+whole regression test, and cheaper than any runtime one. It also lets the log be conditional:
+`QuranTopicsViewModel` logs a load only when it actually loads, and `HomeViewModel` now logs a
+prayer toggle only past its Sunrise guard — before, it counted taps that toggled nothing.
+
+A branch that deliberately does nothing gets an explicit empty body with a comment, never an
+`else`.
+
+#### A read-only ViewModel may have no `onEvent`
+
+`TafseerChaptersViewModel` is `combine(...).launchIn` and nothing else — its screen has no
+intents to send. That is sanctioned for a genuinely read-only surface, and it is the reason the
+file has no analytics seam: there is no event to hang one on. If such a screen later gains a
+single tappable thing, it gains an `XxxEvent` at the same time rather than a bare public method.
+
 Screens collect with `collectAsStateWithLifecycle()` and call `viewModel.onEvent(...)`.
 
 #### Cancellation: one handle per identity of the request

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -327,6 +327,33 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.5 · Two `when`s over one sealed hierarchy
+
+- [x] ~~**The dual-`when` `onEvent` shape, in 20 of 31 ViewModels.**~~ **Resolved.** An analytics
+  `when (event)` ending in `else -> {}`, followed by the real dispatch `when (event)`. The `else`
+  means the compiler checks exhaustiveness on the behaviour table only, so **every event added
+  afterwards ships with working behaviour and no telemetry** — silently, and permanently, because
+  nothing ever fails.
+
+  Not hypothetical: `SettingsViewModel`'s `else` dropped **63 of its 78** events, `ZakatViewModel`
+  logged 3 of 24, `TasbihViewModel` 5 of 23, `FastingViewModel` 10 of 24, `HomeViewModel` 2 of 6.
+
+  It also produced logged actions that never happened — Home logged `toggle_prayer_status` before
+  `togglePrayerStatus` returned early for Sunrise.
+
+  Collapsed to one exhaustive table per `onEvent`, with the analytics call inside the branch that
+  owns it. Detect:
+
+  ```bash
+  # Any onEvent with more than one dispatch table:
+  for f in app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/*.kt; do
+    n=$(awk '/fun onEvent\(/,/^    }$/' "$f" | grep -c "when (event)")
+    [ "$n" -gt 1 ] && echo "$n $f"
+  done
+  # Any else-fallthrough over an Event hierarchy:
+  grep -rn "else -> {}" app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/
+  ```
+
 ### AP-7.4 · Pure domain logic held hostage inside a ViewModel
 
 - [x] ~~**`CalendarViewModel`'s seven generators.**~~ **Resolved.** 75 lines of pure functions


### PR DESCRIPTION
Layer 17 of the #352 stack, on top of #385. Closes #354.

## What was broken

`onEvent` was written as **two** consecutive `when (event)` blocks over the same sealed hierarchy — the first logging analytics and ending in `else -> {}`, the second dispatching.

The `else` means the compiler checks exhaustiveness on the **behaviour** table only. So every event added afterwards ships with working behaviour and **no telemetry**, silently — and permanently, because nothing ever fails.

That is the measured state of the codebase, not a worry about the future:

| ViewModel | events logged / total |
|---|---|
| `SettingsViewModel` | **15 / 78** — one `else` dropping 63 |
| `ZakatViewModel` | 3 / 24 |
| `TasbihViewModel` | 5 / 23 |
| `FastingViewModel` | 10 / 24 |
| `HomeViewModel` | 2 / 6 |

## The fix

17 files collapse to one exhaustive table with the analytics call **inside the branch that owns it** — the shape `QuranTopicsViewModel`, `OnboardingViewModel`, `LocationViewModel` and `HelpViewModel` already use, which #354 says to copy rather than invent.

Adding an event now **fails to compile** until someone decides whether it is logged. That is the regression test, and it costs nothing to run.

Verified against both acceptance criteria:

```
$ for f in .../viewmodel/*.kt; do
    n=$(awk '/fun onEvent\(/,/^    }$/' "$f" | grep -c "when (event)"); [ "$n" -gt 1 ] && echo "$n $f"
  done
(no output)

$ grep -rn "else -> {}" .../presentation/viewmodel/
SyncViewModel.kt:150:  else -> {}     # over ConnectionState, not an Event hierarchy — out of scope
```

## Two things the merge exposed

- **Home logged an action that did not happen.** `toggle_prayer_status` was logged unconditionally, then `togglePrayerStatus` returned early for `SUNRISE` without toggling anything — so the dashboard counted taps that changed nothing. The log now sits past the guard.
- **`PrayerTracker` had a latent double-log.** `MarkPrayerPrayed` and `UpdatePrayerStatus` were separate analytics branches while their handlers delegate at the private-function level. No double-log today, but there would be one the moment someone routed `MarkPrayerPrayed` through `onEvent(UpdatePrayerStatus(...))`. With one table that is visible at the call site instead of split across two blocks 20 lines apart.

## A judgement call, stated plainly

**I did not add the `AnalyticsEvent { val action: String? }` descriptor interface #354 recommends.**

A single exhaustive `when` already makes a new event a compile error, which is the entire safety property the issue is after. The interface would add ~200 lines of `override val action` — **78 of them on `SettingsEvent` alone** — to buy the same guarantee. And it cannot express the conditional logs that four ViewModels already need and that #354 itself calls out: `QuranTopicsViewModel` logs a load *only when it actually loads*, and Home now logs a toggle *only past its Sunrise guard*. The descriptor returns `null` for those and the call has to move inline anyway.

The issue's own "patterns that are already right (copy these, don't invent)" section lists exactly the shape used here. If the descriptor is still wanted, it layers on top of this cleanly — but it should be a deliberate second step, not smuggled in.

## `TafseerChaptersViewModel`

Left with no `onEvent`. Its screen is read-only — `combine(...).launchIn` and nothing else — so there is no intent to model and nothing to hang an analytics seam on. #354 asks to either document it as sanctioned or give it an Event; `ARCHITECTURE.md` §4.1 now sanctions it explicitly, with the condition that gaining one tappable thing means gaining an `XxxEvent` at the same time rather than a bare public method.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1505/1506
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the layers below (`DeviceStateCorpusTest`; the private `nimaz-data` artifact is unreachable from this session, so the run used `-x :app:fetchNimazData`).

## Docs

- `ARCHITECTURE.md` §4.1 — **"One `when (event)` per `onEvent` — never two"**, with the measured drift, and **"A read-only ViewModel may have no `onEvent`"**.
- `CLEAN_ARCHITECTURE_CHECKLIST.md` — new **AP-7.5**, ticked, with a two-command detector so the shape cannot creep back unnoticed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_