### PR TITLE
fix(sync): stop logging user data, and count the steps from one source

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/sync/NearbyConnectionsManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/sync/NearbyConnectionsManager.kt
@@ -534,13 +534,18 @@ class NearbyConnectionsManager @Inject constructor(
         return GZIPInputStream(ByteArrayInputStream(data)).use { it.readBytes() }
     }
 
-    fun setOnDataReceived(callback: (ByteArray) -> Unit) {
-        Log.d(TAG, "setOnDataReceived: callback set")
+    /**
+     * Nullable on purpose: this manager is a `@Singleton`, and the callback captures the
+     * ViewModel that set it. Without a way to clear it, a destroyed `SyncViewModel` — and its
+     * dead `viewModelScope` — stayed reachable from here for the process's life.
+     */
+    fun setOnDataReceived(callback: ((ByteArray) -> Unit)?) {
+        Log.d(TAG, "setOnDataReceived: callback ${if (callback == null) "cleared" else "set"}")
         onDataReceived = callback
     }
 
-    fun setOnSignalReceived(callback: (SyncSignal) -> Unit) {
-        Log.d(TAG, "setOnSignalReceived: callback set")
+    fun setOnSignalReceived(callback: ((SyncSignal) -> Unit)?) {
+        Log.d(TAG, "setOnSignalReceived: callback ${if (callback == null) "cleared" else "set"}")
         onSignalReceived = callback
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/data/sync/SyncDataExporter.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/sync/SyncDataExporter.kt
@@ -49,9 +49,20 @@ class SyncDataExporter @Inject constructor(
     private val locationDao: LocationDao,
     private val preferencesDataStore: PreferencesDataStore
 ) {
-    suspend fun export(onProgress: suspend (String) -> Unit = {}): SyncPayload {
+    /**
+     * Exports everything, reporting `(stepIndex, total, label)` as it goes.
+     *
+     * The total comes from [STEP_COUNT] rather than from the caller, because the caller cannot
+     * know it: `SyncViewModel` hard-coded `SEND_TOTAL_STEPS = 10` against **eleven** reports
+     * here, and then hand-numbered the encode and send steps as 8 and 9 — so the progress bar
+     * filled to 120%, captioned "Step 11 of 10", and then visibly rewound to 80%.
+     */
+    suspend fun export(onProgress: suspend (Int, Int, String) -> Unit = { _, _, _ -> }): SyncPayload {
+        var step = 0
+        suspend fun report(label: String) = onProgress(++step, STEP_COUNT, label)
+
         // Quran
-        onProgress("Exporting Quran data...")
+        report("Exporting Quran data...")
         // The wire format is unchanged on purpose — a phone on this version has to sync with
         // one that still keeps seven bookmark tables — so the consolidated rows are read back
         // out into the shapes the payload has always had. A verse that is both bookmarked and
@@ -85,7 +96,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Prayer & Fasting
-        onProgress("Exporting prayer records...")
+        report("Exporting prayer records...")
         val prayerRecords = prayerDao.getAllPrayerRecords().map {
             SyncPrayerRecord(
                 it.id,
@@ -102,7 +113,7 @@ class SyncDataExporter @Inject constructor(
             )
         }
 
-        onProgress("Exporting fasting records...")
+        report("Exporting fasting records...")
         val fastRecords = fastingDao.getAllFastRecords().map {
             SyncFastRecord(
                 it.id,
@@ -136,7 +147,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Tasbih
-        onProgress("Exporting tasbih data...")
+        report("Exporting tasbih data...")
         val presets = tasbihDao.getAllPresetsSync().map {
             SyncTasbihPreset(
                 it.id,
@@ -169,7 +180,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Khatam
-        onProgress("Exporting khatam data...")
+        report("Exporting khatam data...")
         val khatams = khatamDao.getAllKhatamsSync().map {
             SyncKhatam(
                 it.id,
@@ -200,7 +211,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Tafseer & Zakat
-        onProgress("Exporting tafseer & zakat data...")
+        report("Exporting tafseer & zakat data...")
         val highlights = tafseerUserDao.getAllHighlightsSync().map {
             SyncTafseerHighlight(
                 it.id,
@@ -235,7 +246,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Names & Prophets favorites
-        onProgress("Exporting saved names & prophets...")
+        report("Exporting saved names & prophets...")
         val asmaUlHusnaBookmarks = marks.filter { it.kind == BookmarkKind.ASMA_UL_HUSNA }.map {
             SyncNameBookmark(0, it.targetId, it.favourite, it.createdAt)
         }
@@ -247,7 +258,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Hadith & Dua bookmarks
-        onProgress("Exporting hadith & dua bookmarks...")
+        report("Exporting hadith & dua bookmarks...")
         // The payload shape is unchanged on purpose: a phone on this version has to be able
         // to sync with one that still has seven bookmark tables, so the wire format keeps the
         // old field names and the consolidated row is mapped onto them.
@@ -290,7 +301,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Qaida learning progress
-        onProgress("Exporting Qaida progress...")
+        report("Exporting Qaida progress...")
         val qaidaLessonProgress = counts.filter { it.kind == ProgressKind.QAIDA_LESSON }.map {
             SyncQaidaLessonProgress(
                 it.targetId,
@@ -313,7 +324,7 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Saved (favorite) locations only — current-location flag is not carried.
-        onProgress("Exporting saved locations...")
+        report("Exporting saved locations...")
         val favoriteLocations = locationDao.getFavoriteLocationsSync().map {
             SyncLocation(
                 it.name,
@@ -333,8 +344,12 @@ class SyncDataExporter @Inject constructor(
         }
 
         // Preferences
-        onProgress("Exporting preferences...")
+        report("Exporting preferences...")
         val preferences = preferencesDataStore.exportAllPreferences()
+
+        // If someone adds a report() without updating STEP_COUNT, the bar silently goes wrong
+        // again. Fail loudly in debug instead.
+        check(step == STEP_COUNT) { "SyncDataExporter reported $step steps, STEP_COUNT is $STEP_COUNT" }
 
         return SyncPayload(
             exportedAt = System.currentTimeMillis(),
@@ -364,5 +379,10 @@ class SyncDataExporter @Inject constructor(
             favoriteLocations = favoriteLocations,
             preferences = preferences
         )
+    }
+
+    companion object {
+        /** How many times [export] calls its progress callback. Pinned by SyncDataExporterTest. */
+        const val STEP_COUNT = 11
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
@@ -1,9 +1,10 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
 import android.os.Build
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.util.Log
+import com.arshadshah.nimaz.BuildConfig
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.sync.CancelReason
@@ -54,12 +55,12 @@ class SyncViewModel @Inject constructor(
     private val json = Json { ignoreUnknownKeys = true }
 
     init {
-        Log.d(TAG, "SyncViewModel init")
+        debugLog("SyncViewModel init")
         connectionsManager.setOnSignalReceived { signal -> handleSignal(signal) }
 
         viewModelScope.launch {
             connectionsManager.connectionState.collect { state ->
-                Log.d(TAG, "connectionState changed: $state (mode=${_uiState.value.mode})")
+                debugLog("connectionState changed: $state (mode=${_uiState.value.mode})")
                 _uiState.update { current ->
                     val newState = current.copy(connectionState = state)
                     when (state) {
@@ -82,12 +83,12 @@ class SyncViewModel @Inject constructor(
                     is ConnectionState.Connected -> {
                         addLogEntry("Connected to ${state.endpointName}")
                         if (_uiState.value.mode == SyncMode.SEND) {
-                            Log.d(TAG, "SEND mode: sending Ready signal and starting export")
+                            debugLog("SEND mode: sending Ready signal and starting export")
                             connectionsManager.sendSignal(SyncSignal.Ready)
                             addLogEntry("Preparing data for export...")
                             sendData()
                         } else {
-                            Log.d(TAG, "RECEIVE mode: waiting for data")
+                            debugLog("RECEIVE mode: waiting for data")
                             _uiState.update {
                                 it.copy(
                                     currentStep = "Connected — waiting for data...",
@@ -98,7 +99,7 @@ class SyncViewModel @Inject constructor(
                     }
 
                     is ConnectionState.Completed -> {
-                        Log.d(TAG, "Completed state received (mode=${_uiState.value.mode})")
+                        debugLog("Completed state received (mode=${_uiState.value.mode})")
                         if (_uiState.value.mode == SyncMode.SEND) {
                             addLogEntry("Data sent — waiting for partner to import...")
                             _uiState.update {
@@ -111,7 +112,7 @@ class SyncViewModel @Inject constructor(
                     }
 
                     is ConnectionState.Error -> {
-                        Log.e(TAG, "Error state: ${state.message}")
+                        debugLog("Error state: ${state.message}")
                         addLogEntry("Error: ${state.message}")
                         _uiState.update { it.copy(error = state.message) }
                     }
@@ -122,7 +123,7 @@ class SyncViewModel @Inject constructor(
                             CancelReason.BY_PARTNER -> "Cancelled by partner"
                             CancelReason.CONNECTION_LOST -> "Connection lost"
                         }
-                        Log.d(TAG, "Cancelled: $reason")
+                        debugLog("Cancelled: $reason")
                         addLogEntry(reason)
                     }
 
@@ -133,7 +134,7 @@ class SyncViewModel @Inject constructor(
     }
 
     private fun handleSignal(signal: SyncSignal) {
-        Log.d(TAG, "handleSignal: $signal")
+        debugLog("handleSignal: $signal")
         when (signal) {
             is SyncSignal.Cancel -> {
                 addLogEntry("Partner cancelled the sync")
@@ -250,31 +251,28 @@ class SyncViewModel @Inject constructor(
         }
 
         connectionsManager.setOnDataReceived { bytes ->
-            Log.d(TAG, "onDataReceived callback invoked: ${bytes.size} bytes")
+            debugLog("onDataReceived callback invoked: ${bytes.size} bytes")
             addLogEntry("Received ${formatBytes(bytes.size.toLong())} of data")
             viewModelScope.launch {
                 try {
                     updateStep("Reading received data...", 1)
-                    Log.d(TAG, "Decoding JSON payload (${bytes.size} bytes)...")
+                    debugLog("Decoding JSON payload (${bytes.size} bytes)...")
                     val jsonString = String(bytes)
-                    Log.d(
-                        TAG,
-                        "JSON string length: ${jsonString.length}, first 200 chars: ${
-                            jsonString.take(200)
-                        }"
-                    )
+                    // The log that used to sit here printed the first 200 characters of the
+                    // payload — real bookmark ids and prayer records — with no DEBUG guard.
+                    // Deleted rather than guarded: payload content has no business in a log.
                     val payload = json.decodeFromString<SyncPayload>(jsonString)
-                    Log.d(
-                        TAG, "JSON decoded successfully: bookmarks=${payload.bookmarks.size}, " +
+                    debugLog(
+                        "JSON decoded successfully: bookmarks=${payload.bookmarks.size}, " +
                                 "favorites=${payload.favorites.size}, prayers=${payload.prayerRecords.size}"
                     )
                     val summary = buildSummaryFromPayload(payload, bytes.size.toLong())
                     _uiState.update { it.copy(dataSummary = summary) }
 
-                    Log.d(TAG, "Starting import with progress...")
+                    debugLog("Starting import with progress...")
                     importWithProgress(payload)
 
-                    Log.d(TAG, "Import complete! Setting Completed state.")
+                    debugLog("Import complete! Setting Completed state.")
                     _uiState.update {
                         it.copy(
                             connectionState = ConnectionState.Completed(bytes.size.toLong()),
@@ -286,7 +284,7 @@ class SyncViewModel @Inject constructor(
                 } catch (e: Exception) {
                     CrashReporter.recordException(e)
                     AppAnalytics.logError(AppAnalytics.Feature.SYNC, "import", e.message)
-                    Log.e(TAG, "Import failed!", e)
+                    debugLog("Import failed: ${e.message}")
                     addLogEntry("Import failed: ${e.message}")
                     _uiState.update { it.copy(error = "Import failed: ${e.message}") }
                 }
@@ -297,33 +295,30 @@ class SyncViewModel @Inject constructor(
     }
 
     private fun sendData() {
-        Log.d(TAG, "sendData: starting export")
+        debugLog("sendData: starting export")
         viewModelScope.launch {
             try {
-                var exportStep = 0
-                val payload = exporter.export { step ->
-                    exportStep++
-                    Log.d(TAG, "Export step $exportStep: $step")
+                val payload = exporter.export { completed, _, step ->
                     addLogEntry(step)
-                    _uiState.update { it.copy(currentStep = step, stepsCompleted = exportStep) }
+                    _uiState.update { it.copy(currentStep = step, stepsCompleted = completed) }
                     yield()
                 }
 
-                Log.d(
-                    TAG, "Export returned: bookmarks=${payload.bookmarks.size}, " +
+                debugLog(
+                    "Export returned: bookmarks=${payload.bookmarks.size}, " +
                             "favorites=${payload.favorites.size}, prayers=${payload.prayerRecords.size}, " +
                             "khatamAyahs=${payload.khatamAyahs.size}, prefs=${payload.preferences.size}"
                 )
                 val summary = buildSummaryFromPayload(payload, 0)
                 _uiState.update { it.copy(dataSummary = summary) }
 
-                updateStep("Encoding data...", 8)
+                updateStep("Encoding data...", SyncDataExporter.STEP_COUNT + 1)
                 addLogEntry("Encoding data...")
-                Log.d(TAG, "Starting JSON encode...")
+                debugLog("Starting JSON encode...")
                 val startEncode = System.currentTimeMillis()
                 val jsonBytes = json.encodeToString(SyncPayload.serializer(), payload).toByteArray()
                 val encodeMs = System.currentTimeMillis() - startEncode
-                Log.d(TAG, "JSON encoded: ${jsonBytes.size} bytes in ${encodeMs}ms")
+                debugLog("JSON encoded: ${jsonBytes.size} bytes in ${encodeMs}ms")
 
                 _uiState.update {
                     it.copy(
@@ -332,15 +327,15 @@ class SyncViewModel @Inject constructor(
                 }
 
                 val sizeText = formatBytes(jsonBytes.size.toLong())
-                updateStep("Sending $sizeText...", 9)
+                updateStep("Sending $sizeText...", SyncDataExporter.STEP_COUNT + 2)
                 addLogEntry("Sending $sizeText to partner...")
-                Log.d(TAG, "Calling connectionsManager.sendData(${jsonBytes.size} bytes)")
+                debugLog("Calling connectionsManager.sendData(${jsonBytes.size} bytes)")
                 connectionsManager.sendData(jsonBytes)
-                Log.d(TAG, "sendData returned — transfer queued")
+                debugLog("sendData returned — transfer queued")
             } catch (e: Exception) {
                 CrashReporter.recordException(e)
                 AppAnalytics.logError(AppAnalytics.Feature.SYNC, "export", e.message)
-                Log.e(TAG, "Export/send failed!", e)
+                debugLog("Export/send failed: ${e.message}")
                 addLogEntry("Export failed: ${e.message}")
                 _uiState.update { it.copy(error = "Export failed: ${e.message}") }
             }
@@ -348,8 +343,7 @@ class SyncViewModel @Inject constructor(
     }
 
     private suspend fun importWithProgress(payload: SyncPayload) {
-        val totalImportSteps = 8
-        Log.d(TAG, "importWithProgress: starting $totalImportSteps steps")
+
         connectionsManager.sendSignal(SyncSignal.ImportStarted)
 
         val steps: List<Pair<String, suspend () -> Unit>> = listOf(
@@ -367,19 +361,25 @@ class SyncViewModel @Inject constructor(
             "Importing preferences..." to { importer.importPreferencesData(payload) },
         )
 
+        // Both totals come from `steps` itself. They used to be two hand-maintained numbers
+        // against a list of twelve: the wire signal said "12 of 8" on the partner's screen, and
+        // the local caption reached "Step 13 of 10".
+        val totalImportSteps = steps.size
+        check(totalImportSteps == IMPORT_STEP_COUNT) {
+            "import steps ($totalImportSteps) disagree with IMPORT_STEP_COUNT ($IMPORT_STEP_COUNT)"
+        }
         steps.forEachIndexed { index, (label, action) ->
             val step = index + 2 // step 1 is "Reading received data..."
-            Log.d(TAG, "Import step ${index + 1}/$totalImportSteps: $label")
             connectionsManager.sendSignal(
                 SyncSignal.ImportProgress(step = index + 1, total = totalImportSteps, label = label)
             )
             updateStep(label, step)
             addLogEntry(label)
             action()
-            Log.d(TAG, "Import step ${index + 1} completed")
+            debugLog("Import step ${index + 1} completed")
         }
 
-        Log.d(TAG, "All import steps complete, sending ImportComplete signal")
+        debugLog("All import steps complete, sending ImportComplete signal")
         connectionsManager.sendSignal(SyncSignal.ImportComplete)
         addLogEntry("Import complete — waiting for confirmation...")
     }
@@ -406,7 +406,7 @@ class SyncViewModel @Inject constructor(
         val current = _uiState.value.connectionState
         val isTerminal =
             current is ConnectionState.Completed || current is ConnectionState.Cancelled
-        Log.d(TAG, "cancel: currentState=$current, isTerminal=$isTerminal")
+        debugLog("cancel: currentState=$current, isTerminal=$isTerminal")
 
         if (!isTerminal) {
             if (current is ConnectionState.Connected ||
@@ -414,7 +414,7 @@ class SyncViewModel @Inject constructor(
                 current is ConnectionState.WaitingForPartnerAccept ||
                 current is ConnectionState.PartnerImporting
             ) {
-                Log.d(TAG, "cancel: sending cancel signal to partner")
+                debugLog("cancel: sending cancel signal to partner")
                 connectionsManager.cancelWithSignal()
             }
         }
@@ -442,17 +442,37 @@ class SyncViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        // `connectionsManager` is a @Singleton, and both callbacks capture this ViewModel. Only
+        // stopping the transport left the singleton holding a destroyed ViewModel and its dead
+        // `viewModelScope` — so the receive handler stayed armed and its `launch` was a silent
+        // no-op. Clearing them is the half that was missing.
+        connectionsManager.setOnSignalReceived(null)
+        connectionsManager.setOnDataReceived(null)
         connectionsManager.stopAll()
     }
 
     companion object {
         private const val TAG = "SyncVM"
 
-        // 7 export callbacks + packaging + sending + complete
-        private const val SEND_TOTAL_STEPS = 10
+        /**
+         * Every step the send flow reports: the exporter's own, then encoding, then sending.
+         *
+         * Derived rather than counted by hand. The comment that used to sit here said
+         * "7 export callbacks" against an exporter that made **eleven** calls, which is how
+         * the bar reached 120% and then rewound.
+         */
+        private val SEND_TOTAL_STEPS = SyncDataExporter.STEP_COUNT + 2
 
-        // reading + 8 import categories + complete
-        private const val RECEIVE_TOTAL_STEPS = 10
+        /** Reading the received bytes, then one step per import category. */
+        internal val RECEIVE_TOTAL_STEPS = IMPORT_STEP_COUNT + 1
+
+        /**
+         * The number of categories [importWithProgress] imports.
+         *
+         * Kept beside the totals so the two cannot drift the way `8` did against a list of
+         * twelve; `importWithProgress` asserts the list still matches.
+         */
+        internal const val IMPORT_STEP_COUNT = 12
 
         fun formatBytes(bytes: Long): String = when {
             bytes < 1024 -> "$bytes B"
@@ -466,4 +486,17 @@ class SyncViewModel @Inject constructor(
             )
         }
     }
+}
+
+/**
+ * Sync's verbose tracing, compiled out of release builds.
+ *
+ * This ViewModel is the only one in the app that uses `android.util.Log` — 29 calls — and the
+ * app ships no proguard rule stripping it, so all of it reached release logcat. One of those
+ * calls printed the first 200 characters of the decoded `SyncPayload`: real bookmark ids and
+ * prayer records, readable by any app holding READ_LOGS on an older device or by anyone with
+ * adb. That call is deleted rather than guarded; the rest are behind this.
+ */
+private fun debugLog(message: String) {
+    if (BuildConfig.DEBUG) Log.d("SyncVM", message)
 }

--- a/app/src/test/java/com/arshadshah/nimaz/data/sync/SyncDataExporterStepsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/sync/SyncDataExporterStepsTest.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * The send progress bar's arithmetic.
+ *
+ * `SyncViewModel` hard-coded `SEND_TOTAL_STEPS = 10` — with a comment claiming "7 export
+ * callbacks" — against an exporter that reports **eleven** times, and then hand-numbered the
+ * encoding and sending steps as 8 and 9. So tapping Send filled the bar to 120%, captioned it
+ * "Step 11 of 10", and then visibly **rewound it to 80%**.
+ *
+ * The count now comes from [SyncDataExporter.STEP_COUNT], and this is what stops that constant
+ * drifting away from the calls again: it counts the real callbacks of a real export.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncDataExporterStepsTest {
+
+    private fun exporter() = SyncDataExporter(
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+    )
+
+    @Test
+    fun `the exporter reports exactly STEP_COUNT steps`() = runTest {
+        val reported = mutableListOf<Triple<Int, Int, String>>()
+
+        exporter().export { completed, total, label ->
+            reported += Triple(completed, total, label)
+        }
+
+        assertThat(reported).hasSize(SyncDataExporter.STEP_COUNT)
+    }
+
+    @Test
+    fun `progress is monotonic and never exceeds the total`() = runTest {
+        val completedValues = mutableListOf<Int>()
+
+        exporter().export { completed, total, _ ->
+            completedValues += completed
+            // The defect in one assertion: a step number larger than the total is a bar
+            // past 100%, which is what shipped.
+            assertThat(completed).isAtMost(total)
+        }
+
+        assertThat(completedValues).isInOrder()
+        assertThat(completedValues.first()).isEqualTo(1)
+        assertThat(completedValues.last()).isEqualTo(SyncDataExporter.STEP_COUNT)
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -1115,6 +1115,21 @@ formatted strings.
 over Google's **Nearby Connections** API. No server, no account: one device sends, the other
 receives.
 
+**Progress totals come from one source each, and logging carries no payload.**
+`SyncDataExporter.export` reports `(step, total, label)` with the total from
+`SyncDataExporter.STEP_COUNT`, which `SyncDataExporterStepsTest` pins by counting the real
+callbacks; the import side derives its total from the step list it iterates. Both used to be
+hand-maintained constants that had drifted — the send bar filled to 120% and rewound to 80%, and
+the receive caption read "Step 13 of 10".
+
+`SyncViewModel` is the only ViewModel using `android.util.Log`, and the app ships **no proguard
+rule stripping it**, so anything logged there reaches release logcat. Its verbose tracing is
+therefore behind a `BuildConfig.DEBUG` helper, and **payload content is never logged at all** —
+a call printing the first 200 characters of a decoded `SyncPayload` (bookmark ids, prayer
+records) was deleted rather than guarded. `NearbyConnectionsManager` is a `@Singleton`, so its
+two callbacks are nullable and cleared in `SyncViewModel.onCleared()`; leaving them set kept a
+destroyed ViewModel and its dead scope reachable for the life of the process.
+
 | File | Role |
 |---|---|
 | `data/sync/NearbyConnectionsManager.kt` | `@Singleton`; transport (advertise/discover/connect/payload) |


### PR DESCRIPTION
**Layer 25 of 25** · epic #352 · on top of #419 (vm-24). Closes S1–S4 of #365.

## S3 — user data in release logcat

`onDataReceived` logged the **first 200 characters of the decoded `SyncPayload`**:

```kotlin
Log.d(TAG, "JSON string length: ${jsonString.length}, first 200 chars: ${jsonString.take(200)}")
```

That is real user content — bookmark ids, prayer records — with **no `BuildConfig.DEBUG` guard**. I checked the proguard question the issue raises: `app/proguard-rules.pro` has **no `assumenosideeffects` rule for `android.util.Log`**, so this reaches release logcat verbatim.

**Deleted, not guarded.** Payload content has no business in a log at any build type. The other 28 calls in the file — it is the only ViewModel in the app using `android.util.Log` at all — now go through a `debugLog` helper that compiles out of release.

## S1 and S2 — the same arithmetic bug twice

Numbers maintained by hand next to the thing they were meant to describe:

| | Reality | Constant | What the user saw |
|---|---|---|---|
| Send | exporter reports **11** times | `SEND_TOTAL_STEPS = 10`, comment says *"7 export callbacks"* | bar fills to **120%**, caption "Step 11 of 10", then **rewinds to 80%** when encode is hand-numbered 8 |
| Receive | **12** import steps | `totalImportSteps = 8`, `RECEIVE_TOTAL_STEPS = 10` | partner's screen reads **"12 of 8"**; local caption reaches **"Step 13 of 10"** |

`export()` now reports `(step, total, label)` with the total from `SyncDataExporter.STEP_COUNT`, so the ViewModel never hand-numbers anything — encode and send are `STEP_COUNT + 1` and `+ 2`. The import totals derive from the step list itself, with a `check()` that fails loudly if list and count ever disagree.

## S4 — a singleton holding a destroyed ViewModel

`NearbyConnectionsManager` is `@Singleton` and both callbacks capture the ViewModel. `onCleared()` called `stopAll()` but never cleared them, so leaving the sync screen left the singleton holding a dead `SyncViewModel` and its dead `viewModelScope` — which also made the still-armed receive handler's `launch` a silent no-op.

The setters take a nullable now and `onCleared()` clears both.

## Tests

`SyncDataExporterStepsTest` — the exporter is constructible on the JVM (20 DAO/DataStore params, all mockable), so this counts the **real callbacks of a real export**:

- `the exporter reports exactly STEP_COUNT steps` — stops the constant drifting from the calls again, which is how it got to 11-vs-10.
- `progress is monotonic and never exceeds the total` — the defect stated as an invariant: `isAtMost(total)` is precisely the 120% bar, `isInOrder()` precisely the rewind.

## Not in this layer

S5–S7 (Location) and S8–S10 (Qibla, Onboarding) come next. S6 carries a schema change and a `SUBSYSTEMS.md` §5 obligation, so it wants its own PR.

The issue's acceptance also asks that `SyncViewModel` and `QiblaViewModel` be **instantiable in a JVM test** — that needs the seam extractions in #360 and is not attempted here. What this PR proves is testable at the layer below, in the exporter, which is where the arithmetic actually lives.

## Gates

```
./gradlew :app:compileDebugKotlin :app:testDebugUnitTest   1526/1527
python3 scripts/check_docs.py                              23/23
```

Same single environmental failure as the rest of the stack (`DeviceStateCorpusTest`; private `nimaz-data` artifact unreachable from this session, run used `-x :app:fetchNimazData`).

## Docs

`SUBSYSTEMS.md` §10 — progress totals come from one source each and are pinned by a test; the logging rule, including that no proguard rule strips `Log` so release logcat is a real destination; and the singleton-callback lifecycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_