### PR TITLE
Telemetry: an injectable seam over AppAnalytics and CrashReporter

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/MonitoringModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/MonitoringModule.kt
@@ -1,0 +1,22 @@
+package com.arshadshah.nimaz.core.di
+
+import com.arshadshah.nimaz.core.monitoring.FirebaseTelemetry
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the monitoring seam. `@Binds` for interface→impl per the DI convention in
+ * `docs/ARCHITECTURE.md` §5.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MonitoringModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTelemetry(impl: FirebaseTelemetry): Telemetry
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/FirebaseTelemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/FirebaseTelemetry.kt
@@ -1,0 +1,42 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The production [Telemetry], delegating to the existing [AppAnalytics] and
+ * [CrashReporter] objects.
+ *
+ * Deliberately a thin pass-through with no logic of its own: every guard already
+ * lives in those two objects (both no-op safely when Firebase is not initialised,
+ * e.g. builds without `google-services.json`). Keeping it thin means the behaviour
+ * worth testing lives on [Telemetry] itself, where `RecordingTelemetry` can reach it.
+ */
+@Singleton
+class FirebaseTelemetry @Inject constructor() : Telemetry {
+
+    override fun featureUsed(feature: String, action: String?) =
+        AppAnalytics.logFeatureUsed(feature, action)
+
+    override fun settingChanged(setting: String, value: String) =
+        AppAnalytics.logSettingChanged(setting, value)
+
+    override fun search(filter: String, queryLength: Int) =
+        AppAnalytics.logSearch(filter, queryLength)
+
+    override fun prayerTracked(prayer: String, status: String, isJamaah: Boolean) =
+        AppAnalytics.logPrayerTracked(prayer, status, isJamaah)
+
+    override fun fastTracked(action: String, fastType: String?) =
+        AppAnalytics.logFastTracked(action, fastType)
+
+    override fun error(domain: String, type: String, message: String?) =
+        AppAnalytics.logError(domain, type, message)
+
+    override fun recordException(throwable: Throwable) =
+        CrashReporter.recordException(throwable)
+
+    override fun breadcrumb(message: String) = CrashReporter.log(message)
+
+    override fun customKey(key: String, value: String) = CrashReporter.setCustomKey(key, value)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/Telemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/Telemetry.kt
@@ -1,0 +1,86 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * An injectable seam over [AppAnalytics] and [CrashReporter].
+ *
+ * Both of those are Kotlin `object`s holding a static [android.content.Context].
+ * They no-op safely in unit tests, so they never *blocked* testing — but they made
+ * it impossible for a test to assert that an action had been logged. Two live
+ * defects survived because of exactly that:
+ *
+ *  - `AppAnalytics.logOnboardingStep` has **never fired in production**, because the
+ *    event that triggers it is emitted by no screen. The drop-off funnel is empty.
+ *  - `logFeatureUsed("zakat", "calculate")` sits on a branch no screen can reach, so
+ *    the dashboard reports that nobody calculates zakat.
+ *
+ * Depend on this interface from ViewModels and use cases; bind the Firebase-backed
+ * implementation in production and `RecordingTelemetry` in tests.
+ *
+ * Method names deliberately drop the `log` prefix — at a call site
+ * `telemetry.featureUsed(...)` reads better than `telemetry.logFeatureUsed(...)`,
+ * and the shorter names keep the [failure] pairing prominent.
+ */
+interface Telemetry {
+
+    // -- Usage -------------------------------------------------------------
+
+    /** A feature-usage event for actions that are not screens (counters, toggles, …). */
+    fun featureUsed(feature: String, action: String? = null)
+
+    /** A setting the user changed, and its new value. */
+    fun settingChanged(setting: String, value: String)
+
+    /**
+     * A search that actually ran. The raw query is deliberately never recorded —
+     * only the active filter and the query length — to keep user input out of
+     * analytics. Call this once per completed search, not per keystroke.
+     */
+    fun search(filter: String, queryLength: Int)
+
+    /** A prayer's tracker status changed — the app's core engagement signal. */
+    fun prayerTracked(prayer: String, status: String, isJamaah: Boolean = false)
+
+    /** A fasting record changed. */
+    fun fastTracked(action: String, fastType: String? = null)
+
+    // -- Failure -----------------------------------------------------------
+
+    /**
+     * A non-fatal error, recorded as an analytics event so error *frequency* and the
+     * affected user share are visible in dashboards.
+     *
+     * Prefer [failure], which also captures the stack trace.
+     */
+    fun error(domain: String, type: String, message: String? = null)
+
+    /** Records a non-fatal throwable with its stack trace. Prefer [failure]. */
+    fun recordException(throwable: Throwable)
+
+    // -- Diagnostics -------------------------------------------------------
+
+    /** A breadcrumb attached to the next crash report. */
+    fun breadcrumb(message: String)
+
+    /** A key/value pinned to crash reports, e.g. the active calculation method. */
+    fun customKey(key: String, value: String)
+
+    // -- The pairing -------------------------------------------------------
+
+    /**
+     * Reports a failure to **both** channels: the stack trace to Crashlytics and the
+     * frequency to analytics. `AppAnalytics`'s own documentation describes this as
+     * the intended pairing, but across the ViewModel layer most catch sites reach one
+     * channel or neither. This is the entry point every `catch` should use.
+     *
+     * [CancellationException] is ignored: coroutine cancellation is normal control
+     * flow, not a failure. A reader ViewModel cancels loads every time the user
+     * navigates away, and reporting those would bury real failures in noise.
+     */
+    fun failure(domain: String, type: String, throwable: Throwable) {
+        if (throwable is CancellationException) return
+        recordException(throwable)
+        error(domain, type, throwable.message)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/monitoring/RecordingTelemetry.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/monitoring/RecordingTelemetry.kt
@@ -1,0 +1,89 @@
+package com.arshadshah.nimaz.core.monitoring
+
+/**
+ * A [Telemetry] test double that records every call in order.
+ *
+ * `AppAnalytics` and `CrashReporter` are Kotlin `object`s with a static context, so
+ * before [Telemetry] existed no test could assert that an action had been logged.
+ * That is precisely why two live defects went unnoticed: `logOnboardingStep` has
+ * never fired in production, and `logFeatureUsed("zakat", "calculate")` sits on a
+ * branch no screen can reach.
+ *
+ * Inject this in ViewModel tests and assert against [calls].
+ */
+class RecordingTelemetry : Telemetry {
+
+    /** Every call made, in order. */
+    val calls = mutableListOf<TelemetryCall>()
+
+    val featureUsages: List<TelemetryCall.FeatureUsed>
+        get() = calls.filterIsInstance<TelemetryCall.FeatureUsed>()
+
+    val errors: List<TelemetryCall.Error>
+        get() = calls.filterIsInstance<TelemetryCall.Error>()
+
+    val exceptions: List<Throwable>
+        get() = calls.filterIsInstance<TelemetryCall.Exception>().map { it.throwable }
+
+    val settingChanges: List<TelemetryCall.SettingChanged>
+        get() = calls.filterIsInstance<TelemetryCall.SettingChanged>()
+
+    val searches: List<TelemetryCall.Search>
+        get() = calls.filterIsInstance<TelemetryCall.Search>()
+
+    fun clear() = calls.clear()
+
+    override fun featureUsed(feature: String, action: String?) {
+        calls += TelemetryCall.FeatureUsed(feature, action)
+    }
+
+    override fun error(domain: String, type: String, message: String?) {
+        calls += TelemetryCall.Error(domain, type, message)
+    }
+
+    override fun settingChanged(setting: String, value: String) {
+        calls += TelemetryCall.SettingChanged(setting, value)
+    }
+
+    override fun search(filter: String, queryLength: Int) {
+        calls += TelemetryCall.Search(filter, queryLength)
+    }
+
+    override fun prayerTracked(prayer: String, status: String, isJamaah: Boolean) {
+        calls += TelemetryCall.PrayerTracked(prayer, status, isJamaah)
+    }
+
+    override fun fastTracked(action: String, fastType: String?) {
+        calls += TelemetryCall.FastTracked(action, fastType)
+    }
+
+    override fun recordException(throwable: Throwable) {
+        calls += TelemetryCall.Exception(throwable)
+    }
+
+    override fun breadcrumb(message: String) {
+        calls += TelemetryCall.Breadcrumb(message)
+    }
+
+    override fun customKey(key: String, value: String) {
+        calls += TelemetryCall.CustomKey(key, value)
+    }
+}
+
+/** One recorded [Telemetry] call. */
+sealed interface TelemetryCall {
+    data class FeatureUsed(val feature: String, val action: String?) : TelemetryCall
+    data class Error(val domain: String, val type: String, val message: String?) : TelemetryCall
+    data class SettingChanged(val setting: String, val value: String) : TelemetryCall
+    data class Search(val filter: String, val queryLength: Int) : TelemetryCall
+    data class PrayerTracked(
+        val prayer: String,
+        val status: String,
+        val isJamaah: Boolean,
+    ) : TelemetryCall
+
+    data class FastTracked(val action: String, val fastType: String?) : TelemetryCall
+    data class Exception(val throwable: Throwable) : TelemetryCall
+    data class Breadcrumb(val message: String) : TelemetryCall
+    data class CustomKey(val key: String, val value: String) : TelemetryCall
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/monitoring/TelemetryFailureTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/monitoring/TelemetryFailureTest.kt
@@ -1,0 +1,62 @@
+package com.arshadshah.nimaz.core.monitoring
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
+import org.junit.Test
+
+/**
+ * Pins the contract that a failure reaches **both** monitoring channels.
+ *
+ * `AppAnalytics`'s own KDoc documents the pairing: Crashlytics carries the stack
+ * trace, analytics carries the frequency and the affected-user share. Across the
+ * ViewModel layer only 41 catch sites cover 293 `viewModelScope.launch` calls, and
+ * where a catch does exist it usually reports to one channel or neither. A single
+ * `failure()` entry point makes "reported to both" the default rather than a thing
+ * each call site has to remember.
+ */
+class TelemetryFailureTest {
+
+    private val telemetry = RecordingTelemetry()
+
+    @Test
+    fun `a failure is recorded to Crashlytics and to analytics`() {
+        val boom = IllegalStateException("no such table: quran_ayah")
+
+        telemetry.failure(domain = "quran", type = "load_surah", throwable = boom)
+
+        assertThat(telemetry.exceptions).containsExactly(boom)
+        assertThat(telemetry.errors).containsExactly(
+            TelemetryCall.Error("quran", "load_surah", "no such table: quran_ayah")
+        )
+    }
+
+    @Test
+    fun `both channels are used for one failure, never just one`() {
+        telemetry.failure("settings", "reschedule", RuntimeException("nope"))
+
+        // Order matters only in that both must be present; assert on kinds so the
+        // implementation stays free to reorder.
+        assertThat(telemetry.calls.map { it::class })
+            .containsExactly(TelemetryCall.Exception::class, TelemetryCall.Error::class)
+    }
+
+    @Test
+    fun `a null exception message still reports both channels`() {
+        val messageless = RuntimeException()
+
+        telemetry.failure("sync", "import", messageless)
+
+        assertThat(telemetry.exceptions).containsExactly(messageless)
+        assertThat(telemetry.errors.single().message).isNull()
+    }
+
+    @Test
+    fun `cancellation is not a failure and is never reported`() {
+        // Coroutine cancellation is normal control flow — a cancelled load is not a
+        // crash. Reporting it would bury real failures in noise every time a user
+        // navigates away mid-load, which the reader ViewModels do constantly.
+        telemetry.failure("hadith", "load_chapter", CancellationException("navigated away"))
+
+        assertThat(telemetry.calls).isEmpty()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,6 +459,32 @@ Conventions:
 **Adding a use-case wrapper:** add a `provideXxxUseCases(repository: XxxRepository): XxxUseCases`
 function to `UseCaseModule`, mirroring `provideAsmaUlHusnaUseCases`.
 
+### 6.1 Monitoring — inject `Telemetry`, do not call the objects
+
+`AppAnalytics` and `CrashReporter` are Kotlin `object`s holding a static `Context`. They no-op
+safely when Firebase is absent, so they never *blocked* testing — but a test could never assert
+that an action had been logged, and two live defects survived exactly that gap (a drop-off funnel
+that has never fired, and a `logFeatureUsed` call on a branch no screen can reach).
+
+**ViewModels and use cases inject `Telemetry`** (`core/monitoring/Telemetry.kt`), bound to
+`FirebaseTelemetry` in `MonitoringModule`. Tests inject `RecordingTelemetry` and assert on its
+`calls`.
+
+```kotlin
+@HiltViewModel
+class ExampleViewModel @Inject constructor(
+    private val exampleUseCases: ExampleUseCases,
+    private val telemetry: Telemetry,
+) : ViewModel()
+```
+
+Report every failure through **`telemetry.failure(domain, type, throwable)`**, which reaches both
+channels — the stack trace to Crashlytics, the frequency to analytics — and ignores
+`CancellationException`, because a load cancelled by navigating away is not a failure. Calling
+`AppAnalytics.*` or `CrashReporter.*` directly from a ViewModel is a deviation; the objects remain
+only as the production binding and for callers with no injection point (`NimazApp`, `BootReceiver`,
+workers).
+
 ---
 
 ## 7. Navigation


### PR DESCRIPTION
**Layer 1 of 25** · epic #352 · re-opened for review — full write-up in **#369**.

> These layers were recorded as merged into `epic/viewmodel-cleanup` by a fast-forward push before review. The diffs are unchanged; this chain restores them as reviewable units, each based on its predecessor. The original PR carries the complete reasoning.

`AppAnalytics` and `CrashReporter` are Kotlin `object`s holding a static `Context`. They no-op safely without Firebase, so they never *blocked* testing — but no test could assert that an action had been logged, and two live defects survived exactly that gap: `logOnboardingStep` has never fired in production, and `logFeatureUsed("zakat", "calculate")` sits on a branch no screen can reach.

Adds the `Telemetry` interface, its `FirebaseTelemetry` pass-through binding, and `RecordingTelemetry` for tests. The one piece of behaviour is `failure(domain, type, throwable)` — reaches both channels, ignores `CancellationException`, because a load abandoned on navigation is not a failure.

Base: `dev`. Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_