### PR TITLE
fix(dua): guard every loader, and stop showing SQLite's words to users

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
@@ -93,7 +93,7 @@ fun DuaCategoryScreen(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = state.error ?: stringResource(R.string.error_generic),
+                    text = stringResource(state.error ?: R.string.error_generic),
                     color = MaterialTheme.colorScheme.error
                 )
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
@@ -142,8 +142,10 @@ fun DuaReaderScreen(
                 }
 
                 duas.isEmpty() -> {
+                    // A load that failed says so; an id that resolved to nothing keeps the
+                    // "not found" wording. Both come from the ViewModel as a resource id.
                     Text(
-                        text = stringResource(R.string.dua_reader_not_found),
+                        text = stringResource(state.error ?: R.string.dua_reader_not_found),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.align(Alignment.Center)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
@@ -155,8 +155,23 @@ fun DuasCollectionScreen(
             )
         }
     ) { paddingValues ->
+        val errorRes = state.error
         if (state.isLoading) {
             NimazLoadingState(modifier = Modifier.padding(paddingValues))
+        } else if (errorRes != null) {
+            // Before the collection load was guarded, a content-database fault killed the
+            // collector and left the spinner up for good. It now resolves to this.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(errorRes),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
         } else {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModel.kt
@@ -1,10 +1,11 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import androidx.annotation.StringRes
 import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaBookmark
@@ -23,7 +24,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -33,21 +33,29 @@ data class DuaCollectionUiState(
     val searchQuery: String = "",
     val sortAlphabetical: Boolean = false,
     val isLoading: Boolean = true,
-    val error: String? = null
+    /**
+     * What to tell the user, as a string resource the screen resolves in their language.
+     *
+     * Deliberately not the exception's `message`: this state used to carry `e.message`
+     * straight to a `Text`, so a content-database fault reached the user as
+     * `SQLiteException: no such table: duas`. The throwable still goes to the crash
+     * report, which is the only place its wording is any use.
+     */
+    @StringRes val error: Int? = null
 )
 
 data class DuaCategoryUiState(
     val category: DuaCategory? = null,
     val duas: List<Dua> = emptyList(),
     val isLoading: Boolean = true,
-    val error: String? = null
+    @StringRes val error: Int? = null
 )
 
 data class DuaReaderUiState(
     val duas: List<Dua> = emptyList(),
     val initialIndex: Int = 0,
     val isLoading: Boolean = true,
-    val error: String? = null,
+    @StringRes val error: Int? = null,
     val showArabic: Boolean = true,
     val showTransliteration: Boolean = true,
     val showTranslation: Boolean = true,
@@ -97,7 +105,8 @@ sealed interface DuaEvent {
 @HiltViewModel
 class DuaViewModel @Inject constructor(
     private val duaUseCases: DuaUseCases,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry
 ) : ViewModel() {
 
     private val _collectionState = MutableStateFlow(DuaCollectionUiState())
@@ -142,11 +151,11 @@ class DuaViewModel @Inject constructor(
 
     fun onEvent(event: DuaEvent) {
         when (event) {
-            is DuaEvent.LoadCategory -> AppAnalytics.logFeatureUsed("dua", "open_category")
-            is DuaEvent.LoadDua -> AppAnalytics.logFeatureUsed("dua", "open_reader")
-            is DuaEvent.LoadDuasByOccasion -> AppAnalytics.logFeatureUsed("dua", "open_occasion")
-            is DuaEvent.Search -> AppAnalytics.logFeatureUsed("dua", "search")
-            is DuaEvent.ToggleFavorite -> AppAnalytics.logFeatureUsed("dua", "toggle_favorite")
+            is DuaEvent.LoadCategory -> telemetry.featureUsed(DOMAIN, "open_category")
+            is DuaEvent.LoadDua -> telemetry.featureUsed(DOMAIN, "open_reader")
+            is DuaEvent.LoadDuasByOccasion -> telemetry.featureUsed(DOMAIN, "open_occasion")
+            is DuaEvent.Search -> telemetry.featureUsed(DOMAIN, "search")
+            is DuaEvent.ToggleFavorite -> telemetry.featureUsed(DOMAIN, "toggle_favorite")
             else -> {}
         }
         when (event) {
@@ -185,7 +194,12 @@ class DuaViewModel @Inject constructor(
     }
 
     private fun loadAllCategories() {
-        viewModelScope.launch {
+        launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_categories",
+            onFailure = { _collectionState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+        ) {
             combine(
                 duaUseCases.getAllCategories(),
                 settingsRepository.duaCategoriesSortAlphabetical
@@ -208,8 +222,8 @@ class DuaViewModel @Inject constructor(
     }
 
     private fun toggleCategoriesSort() {
-        AppAnalytics.logFeatureUsed("dua", "toggle_category_sort")
-        viewModelScope.launch {
+        telemetry.featureUsed(DOMAIN, "toggle_category_sort")
+        launchSafely(telemetry, DOMAIN, "toggle_category_sort") {
             settingsRepository.setDuaCategoriesSortAlphabetical(
                 !_collectionState.value.sortAlphabetical
             )
@@ -244,20 +258,19 @@ class DuaViewModel @Inject constructor(
     private fun loadCategory(categoryId: String) {
         _categoryState.update { it.copy(isLoading = true, error = null) }
         categoryJob?.cancel()
-        categoryJob = viewModelScope.launch {
-            try {
-                val category = duaUseCases.getCategoryById(categoryId)
-                _categoryState.update { it.copy(category = category) }
+        categoryJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_category",
+            onFailure = { _categoryState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+        ) {
+            val category = duaUseCases.getCategoryById(categoryId)
+            _categoryState.update { it.copy(category = category) }
 
-                duaUseCases.getDuasByCategory(categoryId).collect { duas ->
-                    _categoryState.update {
-                        it.copy(duas = duas, isLoading = false)
-                    }
+            duaUseCases.getDuasByCategory(categoryId).collect { duas ->
+                _categoryState.update {
+                    it.copy(duas = duas, isLoading = false)
                 }
-            } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError("dua", "load_category", e.message)
-                _categoryState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
     }
@@ -265,27 +278,36 @@ class DuaViewModel @Inject constructor(
     private fun loadDua(duaId: String) {
         _readerState.update { it.copy(isLoading = true, error = null) }
         readerJob?.cancel()
-        readerJob = viewModelScope.launch {
-            try {
-                val dua = duaUseCases.getDuaById(duaId)
-                if (dua == null) {
-                    _readerState.update { it.copy(isLoading = false, error = "Dua not found") }
-                    return@launch
-                }
-                // Load the sibling duas in this collection so the reader can page
-                // through them with a HorizontalPager.
-                duaUseCases.getDuasByCategory(dua.categoryId).collect { categoryDuas ->
-                    val list = categoryDuas.ifEmpty { listOf(dua) }
-                    val index = list.indexOfFirst { it.id == duaId }.coerceAtLeast(0)
-                    _readerState.update {
-                        it.copy(duas = list, initialIndex = index, isLoading = false)
-                    }
-                }
-            } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError("dua", "load_dua", e.message)
-                _readerState.update { it.copy(error = e.message, isLoading = false) }
+        readerJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_dua",
+            onFailure = { failReader(R.string.error_generic) }
+        ) {
+            val dua = duaUseCases.getDuaById(duaId)
+            if (dua == null) {
+                // Clearing the list matters as much as setting the message: leaving the
+                // previous dua's pages loaded meant a reader asked for a dua that does not
+                // exist kept paging through the one before it, while its state said "not
+                // found". The screen keys its not-found message off an empty list.
+                failReader(R.string.dua_reader_not_found)
+                return@launchSafely
             }
+            // Load the sibling duas in this collection so the reader can page
+            // through them with a HorizontalPager.
+            duaUseCases.getDuasByCategory(dua.categoryId).collect { categoryDuas ->
+                val list = categoryDuas.ifEmpty { listOf(dua) }
+                val index = list.indexOfFirst { it.id == duaId }.coerceAtLeast(0)
+                _readerState.update {
+                    it.copy(duas = list, initialIndex = index, isLoading = false)
+                }
+            }
+        }
+    }
+
+    private fun failReader(@StringRes error: Int) {
+        _readerState.update {
+            it.copy(duas = emptyList(), initialIndex = 0, isLoading = false, error = error)
         }
     }
 
@@ -295,7 +317,7 @@ class DuaViewModel @Inject constructor(
      * groups of three because [combine] only has typed overloads up to five flows.
      */
     private fun observeDuaSettings() {
-        viewModelScope.launch {
+        launchSafely(telemetry, DOMAIN, "observe_settings") {
             val displayFlow = combine(
                 settingsRepository.duaArabicFont,
                 settingsRepository.duaArabicFontSize,
@@ -330,7 +352,12 @@ class DuaViewModel @Inject constructor(
     private fun loadDuasByOccasion(occasion: DuaOccasion) {
         _categoryState.update { it.copy(isLoading = true, error = null) }
         categoryJob?.cancel()
-        categoryJob = viewModelScope.launch {
+        categoryJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_occasion",
+            onFailure = { _categoryState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+        ) {
             duaUseCases.getDuasByOccasion(occasion).collect { duas ->
                 _categoryState.update {
                     it.copy(duas = duas, isLoading = false)
@@ -350,7 +377,12 @@ class DuaViewModel @Inject constructor(
 
         _searchState.update { it.copy(query = query, isSearching = true) }
         searchJob?.cancel()
-        searchJob = viewModelScope.launch {
+        searchJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "search",
+            onFailure = { _searchState.update { it.copy(isSearching = false) } }
+        ) {
             duaUseCases.searchDuas(query).collect { results ->
                 _searchState.update { it.copy(results = results, isSearching = false) }
             }
@@ -371,13 +403,18 @@ class DuaViewModel @Inject constructor(
     }
 
     private fun toggleFavorite(duaId: String, categoryId: String) {
-        viewModelScope.launch {
+        launchSafely(telemetry, DOMAIN, "toggle_favorite") {
             duaUseCases.toggleFavorite(duaId, categoryId)
         }
     }
 
     private fun loadFavorites() {
-        viewModelScope.launch {
+        launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_favorites",
+            onFailure = { _favoritesState.update { it.copy(isLoading = false) } }
+        ) {
             duaUseCases.getFavoriteDuas().collect { favorites ->
                 _favoritesState.update { it.copy(favorites = favorites, isLoading = false) }
             }
@@ -392,7 +429,12 @@ class DuaViewModel @Inject constructor(
     private fun loadProgressForDate(date: Long) {
         _dailyProgressState.update { it.copy(isLoading = true, date = date) }
         progressJob?.cancel()
-        progressJob = viewModelScope.launch {
+        progressJob = launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_progress",
+            onFailure = { _dailyProgressState.update { it.copy(isLoading = false) } }
+        ) {
             duaUseCases.getProgressForDate(date).collect { progressList ->
                 _dailyProgressState.update {
                     it.copy(progressList = progressList, isLoading = false)
@@ -406,4 +448,8 @@ class DuaViewModel @Inject constructor(
     }
 
     fun isDuaFavorite(duaId: String) = duaUseCases.isDuaFavorite(duaId)
+
+    private companion object {
+        private const val DOMAIN = "dua"
+    }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModelErrorPathTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModelErrorPathTest.kt
@@ -1,0 +1,183 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaBookmark
+import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.domain.model.DuaProgress
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What [DuaViewModel] does when the content database does not cooperate.
+ *
+ * Four of its loaders collected Room flows with no `try`/`catch` at all, while two others in
+ * the same file had one — so it read as oversight rather than decision. A throw killed the
+ * collector silently and pinned `isLoading` to `true`: a spinner that never resolves and no
+ * report anywhere.
+ *
+ * The other half is what the user is shown when something does go wrong. The category screen
+ * rendered `e.message` verbatim, so a content-database fault surfaced as
+ * `SQLiteException: no such table: duas` in whatever language SQLite writes in.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DuaViewModelErrorPathTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var duaUseCases: DuaUseCases
+    private lateinit var settingsRepository: SettingsRepository
+    private val telemetry = RecordingTelemetry()
+
+    private val morningDuas = MutableStateFlow(listOf(dua("m1", "morning")))
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        duaUseCases = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
+
+        every { duaUseCases.getAllCategories() } returns flowOf(emptyList())
+        every { duaUseCases.getFavoriteDuas() } returns flowOf(emptyList<DuaBookmark>())
+        every { duaUseCases.getProgressForDate(any()) } returns flowOf(emptyList<DuaProgress>())
+        every { duaUseCases.getDuasByCategory(any()) } returns morningDuas
+        every { settingsRepository.duaCategoriesSortAlphabetical } returns flowOf(false)
+        coEvery { duaUseCases.getCategoryById(any()) } answers { category(firstArg()) }
+        coEvery { duaUseCases.getDuaById(any()) } answers {
+            if (firstArg<String>() == "m1") dua("m1", "morning") else null
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = DuaViewModel(duaUseCases, settingsRepository, telemetry)
+
+    @Test
+    fun `a failing category list clears the spinner instead of hanging on it`() = runTest {
+        every { duaUseCases.getAllCategories() } returns
+            flow { throw IllegalStateException("no such table: dua_categories") }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.collectionState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_categories")
+    }
+
+    @Test
+    fun `a failing favourites load clears the spinner instead of hanging on it`() = runTest {
+        every { duaUseCases.getFavoriteDuas() } returns
+            flow { throw IllegalStateException("no such table: dua_bookmarks") }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.favoritesState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_favorites")
+    }
+
+    @Test
+    fun `a failing progress load clears the spinner instead of hanging on it`() = runTest {
+        every { duaUseCases.getProgressForDate(any()) } returns
+            flow { throw IllegalStateException("no such table: dua_progress") }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.dailyProgressState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_progress")
+    }
+
+    @Test
+    fun `a failing occasion list clears the spinner instead of hanging on it`() = runTest {
+        every { duaUseCases.getDuasByOccasion(any()) } returns
+            flow { throw IllegalStateException("no such table: duas") }
+
+        val vm = viewModel()
+        vm.onEvent(DuaEvent.LoadDuasByOccasion(com.arshadshah.nimaz.domain.model.DuaOccasion.TRAVELING))
+        advanceUntilIdle()
+
+        assertThat(vm.categoryState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_occasion")
+    }
+
+    @Test
+    fun `what the user is shown is translated copy, never the database's own words`() = runTest {
+        every { duaUseCases.getDuasByCategory(any()) } returns
+            flow { throw IllegalStateException("no such table: duas") }
+
+        val vm = viewModel()
+        vm.onEvent(DuaEvent.LoadCategory("morning"))
+        advanceUntilIdle()
+
+        // A string resource, resolved by the screen in the user's language — not `e.message`.
+        assertThat(vm.categoryState.value.error).isEqualTo(R.string.error_generic)
+        // The exception itself still reaches the crash report, where it belongs.
+        assertThat(telemetry.exceptions.map { it.message })
+            .contains("no such table: duas")
+    }
+
+    @Test
+    fun `a dua that does not exist replaces the one on screen rather than sitting under it`() =
+        runTest {
+            val vm = viewModel()
+
+            vm.onEvent(DuaEvent.LoadDua("m1"))
+            advanceUntilIdle()
+            assertThat(vm.readerState.value.duas.map { it.id }).containsExactly("m1")
+
+            vm.onEvent(DuaEvent.LoadDua("gone"))
+            advanceUntilIdle()
+
+            // Otherwise the reader keeps paging through the previous dua while its state
+            // says the requested one was not found.
+            assertThat(vm.readerState.value.duas).isEmpty()
+            assertThat(vm.readerState.value.error).isEqualTo(R.string.dua_reader_not_found)
+            assertThat(vm.readerState.value.isLoading).isFalse()
+        }
+}
+
+private fun category(id: String) = DuaCategory(
+    id = id,
+    nameArabic = "",
+    nameEnglish = id,
+    description = null,
+    iconName = null,
+    displayOrder = 0,
+    duaCount = 1
+)
+
+private fun dua(id: String, categoryId: String) = Dua(
+    id = id,
+    categoryId = categoryId,
+    titleArabic = "",
+    titleEnglish = id,
+    textArabic = "",
+    textTransliteration = null,
+    textEnglish = "",
+    reference = null,
+    occasion = null,
+    benefits = null,
+    repeatCount = null,
+    audioUrl = null,
+    displayOrder = 0
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModelLoadScopeTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/DuaViewModelLoadScopeTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaCategory
 import com.arshadshah.nimaz.domain.model.DuaOccasion
@@ -86,7 +87,7 @@ class DuaViewModelLoadScopeTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = DuaViewModel(duaUseCases, settingsRepository)
+    private fun viewModel() = DuaViewModel(duaUseCases, settingsRepository, RecordingTelemetry())
 
     @Test
     fun `a previously opened category cannot overwrite the category on screen`() = runTest {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -512,6 +512,27 @@ channels — the stack trace to Crashlytics, the frequency to analytics — and 
 only as the production binding and for callers with no injection point (`NimazApp`, `BootReceiver`,
 workers).
 
+#### A throwable's `message` is a diagnostic, never UI copy
+
+`_state.copy(error = e.message)` is the shortest thing to write and it puts SQLite's own words on
+the user's screen: `DuaCategoryScreen` rendered `state.error` directly, so a fault in the content
+database surfaced as `SQLiteException: no such table: duas` — in English, whatever the app's
+language.
+
+User-facing error text is a **string resource id** on the UI state, resolved by the screen:
+
+```kotlin
+data class XxxUiState(
+    val isLoading: Boolean = true,
+    @StringRes val error: Int? = null,
+)
+// screen: Text(stringResource(state.error ?: R.string.error_generic))
+```
+
+The throwable still goes to `telemetry.failure(...)`, which is the one place its wording earns
+its keep. An `error` field that no screen renders is worse than none — see the several this epic
+found written and never read — so add the field and the rendering together.
+
 ---
 
 ## 7. Navigation


### PR DESCRIPTION
**Layer 11 of 25** · epic #352 · re-opened for review — full write-up in **#380**. Closes T19 of #366.

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

**1. Four loaders with no error handling at all.** `loadAllCategories`, `loadDuasByOccasion`, `loadFavorites` and `loadProgressForDate` each collected a Room flow with no `try`/`catch` — while `loadCategory` and `loadDua` in the same file *did*. That asymmetry is what makes it oversight rather than a decision. The content database being momentarily unavailable is an explicitly supported scenario (`ContentArtifactInstaller` replaces it in place); the collector dies, `isLoading` stays `true` forever, and nothing is reported. Eight call sites now go through `launchSafely` with an `onFailure` that resolves the spinner.

**2. The user was shown SQLite's error text.** `DuaCategoryScreen` rendered `state.error` straight into a `Text` and the ViewModel set it to `e.message`, so a content-DB fault put **`SQLiteException: no such table: duas`** on screen, in English, whatever language the app runs in. The three `error` fields are now `@StringRes Int?`; the throwable still reaches telemetry, which is the one place its wording is any use.

**Correction to the issue.** #366 T19 says `DuaReaderScreen` never reads `state.error`, so a bad `duaId` deep link yields a blank reader. That is wrong — the screen keys its not-found message off an empty dua list and already renders the localized string. The real defect is narrower and worse: `loadDua` set a hardcoded English `"Dua not found"` that nothing read, and left `duas` untouched — so **the reader kept paging through the previous dua** while its own state said the requested one was not found.

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_