### PR TITLE
chore(viewmodel): delete the code that is provably unreachable

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -207,13 +207,10 @@ import com.arshadshah.nimaz.domain.usecase.QaidaUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.arshadshah.nimaz.domain.usecase.ReactivateKhatamUseCase
 import com.arshadshah.nimaz.domain.usecase.ResetQaidaProgressUseCase
-import com.arshadshah.nimaz.domain.usecase.SearchAsmaUlHusnaUseCase
-import com.arshadshah.nimaz.domain.usecase.SearchAsmaUnNabiUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchDuasUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchHadithsInBookUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchHadithsUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchHelpUseCase
-import com.arshadshah.nimaz.domain.usecase.SearchProphetsUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchQuranUseCase
 import com.arshadshah.nimaz.domain.usecase.SeedMissingDefaultsUseCase
 import com.arshadshah.nimaz.domain.usecase.SetActiveKhatamUseCase
@@ -447,7 +444,6 @@ object UseCaseModule {
         return AsmaUlHusnaUseCases(
             getAllNames = GetAllAsmaUlHusnaUseCase(repository),
             getNameById = GetAsmaUlHusnaByIdUseCase(repository),
-            searchNames = SearchAsmaUlHusnaUseCase(repository),
             toggleFavorite = ToggleAsmaUlHusnaFavoriteUseCase(repository),
             getFavorites = GetFavoriteAsmaUlHusnaUseCase(repository)
         )
@@ -461,7 +457,6 @@ object UseCaseModule {
         return AsmaUnNabiUseCases(
             getAllNames = GetAllAsmaUnNabiUseCase(repository),
             getNameById = GetAsmaUnNabiByIdUseCase(repository),
-            searchNames = SearchAsmaUnNabiUseCase(repository),
             toggleFavorite = ToggleAsmaUnNabiFavoriteUseCase(repository),
             getFavorites = GetFavoriteAsmaUnNabiUseCase(repository)
         )
@@ -475,7 +470,6 @@ object UseCaseModule {
         return ProphetUseCases(
             getAllProphets = GetAllProphetsUseCase(repository),
             getProphetById = GetProphetByIdUseCase(repository),
-            searchProphets = SearchProphetsUseCase(repository),
             toggleFavorite = ToggleProphetFavoriteUseCase(repository),
             getFavorites = GetFavoriteProphetsUseCase(repository)
         )

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/AsmaUlHusnaDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/AsmaUlHusnaDao.kt
@@ -13,9 +13,6 @@ interface AsmaUlHusnaDao {
     @Query("SELECT * FROM asma_ul_husna WHERE id = :id")
     suspend fun getNameById(id: Int): AsmaUlHusnaEntity?
 
-    @Query("SELECT * FROM asma_ul_husna WHERE name_english LIKE '%' || :query || '%' OR name_transliteration LIKE '%' || :query || '%' OR meaning LIKE '%' || :query || '%' ORDER BY display_order ASC")
-    fun searchNames(query: String): Flow<List<AsmaUlHusnaEntity>>
-
     /**
      * The favourited entries, from ids the user's database supplied.
      *

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/AsmaUnNabiDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/AsmaUnNabiDao.kt
@@ -13,9 +13,6 @@ interface AsmaUnNabiDao {
     @Query("SELECT * FROM asma_un_nabi WHERE id = :id")
     suspend fun getNameById(id: Int): AsmaUnNabiEntity?
 
-    @Query("SELECT * FROM asma_un_nabi WHERE name_english LIKE '%' || :query || '%' OR name_transliteration LIKE '%' || :query || '%' OR meaning LIKE '%' || :query || '%' ORDER BY display_order ASC")
-    fun searchNames(query: String): Flow<List<AsmaUnNabiEntity>>
-
     /**
      * The favourited entries, from ids the user's database supplied.
      *

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/ProphetDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/ProphetDao.kt
@@ -13,9 +13,6 @@ interface ProphetDao {
     @Query("SELECT * FROM prophets WHERE id = :id")
     suspend fun getProphetById(id: Int): ProphetEntity?
 
-    @Query("SELECT * FROM prophets WHERE name_english LIKE '%' || :query || '%' OR name_transliteration LIKE '%' || :query || '%' OR title_english LIKE '%' || :query || '%' ORDER BY display_order ASC")
-    fun searchProphets(query: String): Flow<List<ProphetEntity>>
-
     /**
      * The favourited entries, from ids the user's database supplied.
      *

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUlHusnaRepositoryImpl.kt
@@ -37,13 +37,6 @@ class AsmaUlHusnaRepositoryImpl @Inject constructor(
         return entity.toDomain(isFavorite = isFav)
     }
 
-    override fun searchNames(query: String): Flow<List<AsmaUlHusna>> {
-        return combine(dao.searchNames(query), bookmarkDao.favourites(BookmarkKind.ASMA_UL_HUSNA)) { names, bookmarks ->
-            val bookmarkedIds = bookmarks.map { it.targetId }.toSet()
-            names.map { it.toDomain(isFavorite = it.id in bookmarkedIds) }
-        }
-    }
-
     override fun getFavoriteNames(): Flow<List<AsmaUlHusna>> {
         // Ids from the user's database, then the names from the content one.
         return bookmarkDao.favourites(BookmarkKind.ASMA_UL_HUSNA)

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUnNabiRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/AsmaUnNabiRepositoryImpl.kt
@@ -35,13 +35,6 @@ class AsmaUnNabiRepositoryImpl @Inject constructor(
         return entity.toDomain(isFavorite = isFav)
     }
 
-    override fun searchNames(query: String): Flow<List<AsmaUnNabi>> {
-        return combine(dao.searchNames(query), bookmarkDao.favourites(BookmarkKind.ASMA_UN_NABI)) { names, bookmarks ->
-            val bookmarkedIds = bookmarks.map { it.targetId }.toSet()
-            names.map { it.toDomain(isFavorite = it.id in bookmarkedIds) }
-        }
-    }
-
     override fun getFavoriteNames(): Flow<List<AsmaUnNabi>> {
         return bookmarkDao.favourites(BookmarkKind.ASMA_UN_NABI)
             .flatMapLatest { marks ->

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/ProphetRepositoryImpl.kt
@@ -37,13 +37,6 @@ class ProphetRepositoryImpl @Inject constructor(
         return entity.toDomain(isFavorite = isFav)
     }
 
-    override fun searchProphets(query: String): Flow<List<Prophet>> {
-        return combine(dao.searchProphets(query), bookmarkDao.favourites(BookmarkKind.PROPHET)) { prophets, bookmarks ->
-            val bookmarkedIds = bookmarks.map { it.targetId }.toSet()
-            prophets.map { it.toDomain(isFavorite = it.id in bookmarkedIds) }
-        }
-    }
-
     override fun getFavoriteProphets(): Flow<List<Prophet>> {
         return bookmarkDao.favourites(BookmarkKind.PROPHET)
             .flatMapLatest { marks ->

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/AsmaUlHusnaRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/AsmaUlHusnaRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface AsmaUlHusnaRepository {
     fun getAllNames(): Flow<List<AsmaUlHusna>>
     suspend fun getNameById(id: Int): AsmaUlHusna?
-    fun searchNames(query: String): Flow<List<AsmaUlHusna>>
     fun getFavoriteNames(): Flow<List<AsmaUlHusna>>
     suspend fun toggleFavorite(nameId: Int)
     suspend fun isFavorite(nameId: Int): Boolean

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/AsmaUnNabiRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/AsmaUnNabiRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface AsmaUnNabiRepository {
     fun getAllNames(): Flow<List<AsmaUnNabi>>
     suspend fun getNameById(id: Int): AsmaUnNabi?
-    fun searchNames(query: String): Flow<List<AsmaUnNabi>>
     fun getFavoriteNames(): Flow<List<AsmaUnNabi>>
     suspend fun toggleFavorite(nameId: Int)
     suspend fun isFavorite(nameId: Int): Boolean

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/ProphetRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/ProphetRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface ProphetRepository {
     fun getAllProphets(): Flow<List<Prophet>>
     suspend fun getProphetById(id: Int): Prophet?
-    fun searchProphets(query: String): Flow<List<Prophet>>
     fun getFavoriteProphets(): Flow<List<Prophet>>
     suspend fun toggleFavorite(prophetId: Int)
     suspend fun isFavorite(prophetId: Int): Boolean

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AsmaUlHusnaUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AsmaUlHusnaUseCases.kt
@@ -8,7 +8,6 @@ import javax.inject.Inject
 data class AsmaUlHusnaUseCases(
     val getAllNames: GetAllAsmaUlHusnaUseCase,
     val getNameById: GetAsmaUlHusnaByIdUseCase,
-    val searchNames: SearchAsmaUlHusnaUseCase,
     val toggleFavorite: ToggleAsmaUlHusnaFavoriteUseCase,
     val getFavorites: GetFavoriteAsmaUlHusnaUseCase
 )
@@ -19,10 +18,6 @@ class GetAllAsmaUlHusnaUseCase @Inject constructor(private val repository: AsmaU
 
 class GetAsmaUlHusnaByIdUseCase @Inject constructor(private val repository: AsmaUlHusnaRepository) {
     suspend operator fun invoke(id: Int): AsmaUlHusna? = repository.getNameById(id)
-}
-
-class SearchAsmaUlHusnaUseCase @Inject constructor(private val repository: AsmaUlHusnaRepository) {
-    operator fun invoke(query: String): Flow<List<AsmaUlHusna>> = repository.searchNames(query)
 }
 
 class ToggleAsmaUlHusnaFavoriteUseCase @Inject constructor(private val repository: AsmaUlHusnaRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AsmaUnNabiUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/AsmaUnNabiUseCases.kt
@@ -8,7 +8,6 @@ import javax.inject.Inject
 data class AsmaUnNabiUseCases(
     val getAllNames: GetAllAsmaUnNabiUseCase,
     val getNameById: GetAsmaUnNabiByIdUseCase,
-    val searchNames: SearchAsmaUnNabiUseCase,
     val toggleFavorite: ToggleAsmaUnNabiFavoriteUseCase,
     val getFavorites: GetFavoriteAsmaUnNabiUseCase
 )
@@ -19,10 +18,6 @@ class GetAllAsmaUnNabiUseCase @Inject constructor(private val repository: AsmaUn
 
 class GetAsmaUnNabiByIdUseCase @Inject constructor(private val repository: AsmaUnNabiRepository) {
     suspend operator fun invoke(id: Int): AsmaUnNabi? = repository.getNameById(id)
-}
-
-class SearchAsmaUnNabiUseCase @Inject constructor(private val repository: AsmaUnNabiRepository) {
-    operator fun invoke(query: String): Flow<List<AsmaUnNabi>> = repository.searchNames(query)
 }
 
 class ToggleAsmaUnNabiFavoriteUseCase @Inject constructor(private val repository: AsmaUnNabiRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ProphetUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ProphetUseCases.kt
@@ -8,7 +8,6 @@ import javax.inject.Inject
 data class ProphetUseCases(
     val getAllProphets: GetAllProphetsUseCase,
     val getProphetById: GetProphetByIdUseCase,
-    val searchProphets: SearchProphetsUseCase,
     val toggleFavorite: ToggleProphetFavoriteUseCase,
     val getFavorites: GetFavoriteProphetsUseCase
 )
@@ -19,10 +18,6 @@ class GetAllProphetsUseCase @Inject constructor(private val repository: ProphetR
 
 class GetProphetByIdUseCase @Inject constructor(private val repository: ProphetRepository) {
     suspend operator fun invoke(id: Int): Prophet? = repository.getProphetById(id)
-}
-
-class SearchProphetsUseCase @Inject constructor(private val repository: ProphetRepository) {
-    operator fun invoke(query: String): Flow<List<Prophet>> = repository.searchProphets(query)
 }
 
 class ToggleProphetFavoriteUseCase @Inject constructor(private val repository: ProphetRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/FastingViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.core.util.formatClockTime
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.ExemptionReason
 import com.arshadshah.nimaz.domain.model.FastRecord
@@ -18,9 +17,7 @@ import com.arshadshah.nimaz.domain.model.resolveLocation
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.FastingUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.time.Duration
 import java.time.LocalDate
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/HomeViewModel.kt
@@ -20,7 +20,6 @@ import com.arshadshah.nimaz.core.util.NextWorshipResolver
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.core.util.WorshipReminderContent
 import com.arshadshah.nimaz.core.util.currentPrayerIndexAt
-import com.arshadshah.nimaz.core.util.formatClockTime
 import com.arshadshah.nimaz.core.util.nextPrayerIndexAt
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.Announcement
@@ -38,7 +37,6 @@ import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerTime
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.model.WorshipReminderOccurrence
-import com.arshadshah.nimaz.domain.model.WorshipReminderType
 import com.arshadshah.nimaz.domain.model.resolveLocation
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.AnnouncementUseCases
@@ -58,7 +56,6 @@ import java.time.LocalTime
 import java.time.ZoneId
 import javax.inject.Inject
 import com.arshadshah.nimaz.core.time.TodayProvider
-import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
 import kotlinx.coroutines.Job

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/MonthlyPrayerTimesViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.core.util.formatClockTime
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerTimesViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.core.util.formatClockTime
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
@@ -20,18 +19,14 @@ import com.arshadshah.nimaz.presentation.components.organisms.MoonPhase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import javax.inject.Inject
-import kotlin.math.abs
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -67,7 +62,6 @@ data class PrayerTimesUiState(
     val daylight: String = "",
     val methodLabel: String = "",
     // +1 when moving to a later day, -1 to an earlier day (drives slide direction)
-    val navDirection: Int = 0,
 )
 
 sealed interface PrayerTimesEvent {
@@ -144,8 +138,7 @@ class PrayerTimesViewModel @Inject constructor(
     private fun selectDate(date: LocalDate) {
         val current = _state.value.selectedDate
         if (date == current) return
-        val dir = if (date.isAfter(current)) 1 else -1
-        _state.update { it.copy(selectedDate = date, navDirection = dir) }
+        _state.update { it.copy(selectedDate = date) }
         recomputeDay()
     }
 
@@ -336,24 +329,5 @@ class PrayerTimesViewModel @Inject constructor(
 
     // No `use24HourFormat` mirror: times are formatted at the leaf from LocalUse24HourFormat, so
     // toggling the preference no longer forces a full day recompute.
-
-    private fun formatCountdown(totalSeconds: Long): String {
-        val s = if (totalSeconds < 0) 0 else totalSeconds
-        val hours = s / 3600
-        val minutes = (s % 3600) / 60
-        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
-    }
-
-    private fun daysFromToday(date: LocalDate, today: LocalDate): String {
-        val diff = date.toEpochDay() - today.toEpochDay()
-        return when {
-            diff == 0L -> "Today"
-            diff == 1L -> "Tomorrow"
-            diff == -1L -> "Yesterday"
-            diff > 0 -> "in ${diff} days"
-            else -> "${abs(diff)} days ago"
-        }
-    }
-
 
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/QuranViewModel.kt
@@ -677,15 +677,6 @@ class QuranViewModel @Inject constructor(
         val mushafScript: MushafScript
     )
 
-    fun refreshSettings() {
-        // Settings are now observed reactively; just reload current surah if needed
-        _readerState.value.surahWithAyahs?.let { current ->
-            if (_readerState.value.readingMode == ReadingMode.SURAH) {
-                loadSurah(current.surah.number)
-            }
-        }
-    }
-
     private fun loadSurahInfo(surahNumber: Int) {
         viewModelScope.launch {
             _surahInfo.value = quranUseCases.getSurahInfo(surahNumber)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SearchViewModel.kt
@@ -54,7 +54,6 @@ data class SearchUiState(
     val duaResults: List<DuaSearchResult> = emptyList(),
     val surahResults: List<Surah> = emptyList(),
     val recentSearches: List<String> = emptyList(),
-    val suggestions: List<String> = emptyList(),
     val error: String? = null
 )
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/SettingsViewModel.kt
@@ -9,11 +9,9 @@ import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.LocaleHelper
 import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
-import com.arshadshah.nimaz.core.util.preReminderMinutesByPrayer
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
-import com.arshadshah.nimaz.data.local.database.NimazDatabase
 import com.arshadshah.nimaz.data.local.user.NimazUserDatabase
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -21,7 +19,6 @@ import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.MushafScript
 import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.PrayerTimes
-import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.notification.RescheduleNotificationsUseCase
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
@@ -304,8 +301,6 @@ sealed interface SettingsEvent {
     // Actions
     data object LoadSettings : SettingsEvent
     data object ResetToDefaults : SettingsEvent
-    data object ExportSettings : SettingsEvent
-    data object ImportSettings : SettingsEvent
     data object TestNotification : SettingsEvent
     data object TestAllNotifications : SettingsEvent
     data object ResetNotifications : SettingsEvent
@@ -324,7 +319,6 @@ class SettingsViewModel @Inject constructor(
     // calls in this file are the analytics catalog's job (#355), not this layer's.
     private val telemetry: Telemetry,
     val adhanAudioManager: AdhanAudioManager,
-    private val database: NimazDatabase,
     private val userDatabase: NimazUserDatabase,
 ) : ViewModel() {
 
@@ -1049,8 +1043,6 @@ class SettingsViewModel @Inject constructor(
             // Actions
             SettingsEvent.LoadSettings -> loadSettings()
             SettingsEvent.ResetToDefaults -> resetToDefaults()
-            SettingsEvent.ExportSettings -> exportSettings()
-            SettingsEvent.ImportSettings -> importSettings()
             SettingsEvent.TestNotification -> {
                 // AppAnalytics.logTestNotification exists for exactly this and was never
                 // called, so "did the user try a test notification before reporting that
@@ -1350,18 +1342,6 @@ class SettingsViewModel @Inject constructor(
             _notificationState.update { NotificationSettingsUiState() }
             _quranState.update { QuranSettingsUiState() }
             _shouldRestart.value = true
-        }
-    }
-
-    private fun exportSettings() {
-        viewModelScope.launch {
-            // Implementation would export all settings to a shareable format
-        }
-    }
-
-    private fun importSettings() {
-        viewModelScope.launch {
-            // Implementation would import settings from a file
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/TasbihViewModel.kt
@@ -15,7 +15,6 @@ import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -327,6 +327,19 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.6 · A search path nobody can reach
+
+- [x] ~~**Three `search*` use cases, three repository methods, three DAO queries.**~~ **Resolved by
+  deletion.** `ProphetUseCases.searchProphets` and the `searchNames` pair on `AsmaUlHusnaUseCases`
+  / `AsmaUnNabiUseCases` were declared, constructed by Hilt on every ViewModel creation, backed by
+  a repository method and an indexed DAO query — and invoked by nothing. All three ViewModels
+  filter in memory instead.
+
+  #357 poses the choice as *delete the SQL path or use it*, and calls the middle state — built,
+  reachable by nothing, tested by nothing — the worst option. Deleted, because the corpora are 99
+  names, 99 names and 25 prophets: an index earns nothing over a `contains()` sweep at that size,
+  and the in-memory filter is the one that actually ships.
+
 ### AP-7.5 · Two `when`s over one sealed hierarchy
 
 - [x] ~~**The dual-`when` `onEvent` shape, in 20 of 31 ViewModels.**~~ **Resolved.** An analytics


### PR DESCRIPTION
**Layer 18 of 25** · epic #352 · re-opened for review — full write-up in **#387**. Partial for #357 — the decided deletions only.

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

**119 lines removed, 21 files, no behaviour change.**

**A whole search path, reachable by nothing.** `ProphetUseCases.searchProphets` and the `searchNames` pair on `AsmaUlHusnaUseCases` / `AsmaUnNabiUseCases` were each declared, **constructed by Hilt on every ViewModel creation**, backed by a repository method and an indexed DAO query — and invoked by nothing. All three ViewModels filter in memory instead. #357 poses this as *delete the SQL path or use it*, and calls the middle state the worst option. Deleted: the corpora are 99 names, 99 names and 25 prophets, so an index earns nothing over a `contains()` sweep, and the in-memory filter is the one that actually ships. Removed end to end — use case class, wrapper field, DI construction, repository interface method, impl, and the `@Query`.

| Also deleted | Why it is dead |
|---|---|
| `SettingsViewModel`'s `private val database: NimazDatabase` | A Room database injected into a ViewModel, appearing only in its own declaration and in prose comments |
| `exportSettings()` / `importSettings()` | Each launched a coroutine to run a comment; their events had no producer either |
| `QuranViewModel.refreshSettings()` | Public function, zero call sites |
| `PrayerTimesViewModel.formatCountdown` / `daysFromToday` | Both dead; the screen carries its own copy of the second |
| `PrayerTimesUiState.navDirection` | Written on every date selection, read nowhere |
| `SearchUiState.suggestions` | Never written *and* never read |
| 15 unused imports | Across 6 ViewModels |

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_