### PR TITLE
feat(tafseer): give notes a way in, and prove the loop that never ran

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
@@ -41,6 +41,23 @@ import com.arshadshah.nimaz.presentation.viewmodel.quran.TafseerViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.outlined.EditNote
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.arshadshah.nimaz.domain.model.TafseerNote
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
+import androidx.compose.foundation.layout.fillMaxWidth
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +69,7 @@ fun TafseerScreen(
     viewModel: TafseerViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    var showNotes by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -121,6 +139,18 @@ fun TafseerScreen(
                         NimazIcon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.cd_back)
+                        )
+                    }
+                },
+                actions = {
+                    // The affordance that makes AddNote/UpdateNote/DeleteNote reachable at
+                    // all. The handlers and the Room collector behind them have been in the
+                    // ViewModel the whole time; nothing emitted the events, so the notes list
+                    // on TafseerChaptersScreen was permanently empty.
+                    IconButton(onClick = { showNotes = true }) {
+                        NimazIcon(
+                            imageVector = Icons.Outlined.EditNote,
+                            contentDescription = stringResource(R.string.tafseer_notes)
                         )
                     }
                 },
@@ -207,6 +237,100 @@ fun TafseerScreen(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                }
+            }
+        }
+    }
+
+    if (showNotes) {
+        TafseerNotesDialog(
+            notes = state.notes,
+            onAdd = { viewModel.onEvent(TafseerEvent.AddNote(it)) },
+            onUpdate = { viewModel.onEvent(TafseerEvent.UpdateNote(it)) },
+            onDelete = { viewModel.onEvent(TafseerEvent.DeleteNote(it)) },
+            onDismiss = { showNotes = false },
+        )
+    }
+}
+
+/**
+ * The notes for the commentary block on screen: read them, write one, edit or delete one.
+ *
+ * `TafseerEvent.AddNote`, `UpdateNote` and `DeleteNote` had handlers, a use case, a repository
+ * method and a Room collector — and no producer, so none of them had ever run and the notes
+ * list on `TafseerChaptersScreen` was permanently empty. This is the missing producer.
+ */
+@Composable
+private fun TafseerNotesDialog(
+    notes: List<TafseerNote>,
+    onAdd: (String) -> Unit,
+    onUpdate: (TafseerNote) -> Unit,
+    onDelete: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Non-null while editing an existing note; null while composing a new one.
+    var editing by remember { mutableStateOf<TafseerNote?>(null) }
+    var draft by remember { mutableStateOf("") }
+
+    NimazDialog(
+        title = stringResource(R.string.tafseer_notes),
+        titleIcon = Icons.Outlined.EditNote,
+        onDismiss = onDismiss,
+        wrapContent = false,
+        actions = {
+            NimazDialogCancelButton(
+                text = stringResource(R.string.close),
+                onClick = onDismiss,
+            )
+            NimazButton(
+                text = stringResource(
+                    if (editing == null) R.string.tafseer_note_add else R.string.save
+                ),
+                onClick = {
+                    val current = editing
+                    if (current == null) onAdd(draft) else onUpdate(current.copy(text = draft))
+                    draft = ""
+                    editing = null
+                },
+                enabled = draft.isNotBlank(),
+                variant = NimazButtonVariant.FILLED,
+            )
+        },
+    ) {
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            label = { Text(stringResource(R.string.tafseer_note_hint)) },
+            minLines = 3,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        notes.forEach { note ->
+            NimazCard(
+                style = NimazCardStyle.FILLED,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 4.dp),
+            ) {
+                Column(modifier = Modifier.padding(12.dp)) {
+                    Text(text = note.text, style = MaterialTheme.typography.bodyMedium)
+                    Row {
+                        TextButton(onClick = {
+                            editing = note
+                            draft = note.text
+                        }) { Text(stringResource(R.string.tafseer_note_edit)) }
+                        TextButton(onClick = {
+                            if (editing?.id == note.id) {
+                                editing = null
+                                draft = ""
+                            }
+                            onDelete(note.id)
+                        }) { Text(stringResource(R.string.delete)) }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModel.kt
@@ -3,6 +3,8 @@ package com.arshadshah.nimaz.presentation.viewmodel.quran
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.TafseerHighlight
@@ -77,7 +79,8 @@ sealed interface TafseerEvent {
 @HiltViewModel
 class TafseerViewModel @Inject constructor(
     private val tafseerUseCases: TafseerUseCases,
-    private val quranUseCases: QuranUseCases
+    private val quranUseCases: QuranUseCases,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TafseerUiState())
@@ -272,30 +275,46 @@ class TafseerViewModel @Inject constructor(
     }
 
     private fun addNote(text: String) {
-        val currentState = _state.value
-        val ayahs = currentState.ayahs
-        if (ayahs.isEmpty()) return
+        val body = text.trim()
+        // A blank note is a mis-tap, not a thought. Storing it puts an empty row in the
+        // reader and on the notes screen, with nothing to read and nothing to explain it.
+        if (body.isEmpty()) return
 
-        val ayah = ayahs[currentState.currentAyahIndex]
-        viewModelScope.launch {
+        val currentState = _state.value
+        // `getOrNull`, not `[…]`. This ran outside the coroutine, so an index that had not
+        // caught up with the ayah list — before the first load, or straight after switching
+        // to a shorter surah — threw IndexOutOfBoundsException out of `onEvent`, on the UI
+        // thread, from a tap. None of these three handlers has ever executed in production,
+        // which is why nothing found it.
+        val ayah = currentState.ayahs.getOrNull(currentState.currentAyahIndex) ?: return
+
+        launchSafely(telemetry, DOMAIN, "add_note") {
             tafseerUseCases.addNote(
                 ayahId = ayah.id,
                 tafseerId = currentState.selectedSource.id,
-                text = text
+                text = body
             )
         }
     }
 
     private fun updateNote(note: TafseerNote) {
-        viewModelScope.launch {
-            tafseerUseCases.updateNote(note)
+        val body = note.text.trim()
+        if (body.isEmpty()) return
+        launchSafely(telemetry, DOMAIN, "update_note") {
+            // The id carries through unchanged, so the DAO's @Update targets this row rather
+            // than the insert-a-second-copy that an id of 0 would have produced.
+            tafseerUseCases.updateNote(note.copy(text = body))
         }
     }
 
     private fun deleteNote(noteId: Long) {
-        viewModelScope.launch {
+        launchSafely(telemetry, DOMAIN, "delete_note") {
             tafseerUseCases.deleteNote(noteId)
         }
     }
 
+
+    private companion object {
+        private const val DOMAIN = AppAnalytics.Feature.TAFSEER
+    }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1766,4 +1766,8 @@
     <string name="ai_error_consent_title">Mit Beleg fragen ist aus</string>
     <string name="ai_error_consent">Aktiviere es in den Sucheinstellungen, um eine Frage zu stellen. Die Stichwortsuche in Koran, Hadith und Bittgebeten funktioniert ohnehin offline.</string>
     <string name="ai_consent_save_failed">Diese Einstellung konnte nicht gespeichert werden. Bitte versuche es erneut.</string>
+    <string name="tafseer_notes">Notizen</string>
+    <string name="tafseer_note_add">Notiz hinzufügen</string>
+    <string name="tafseer_note_hint">Deine Gedanken zu diesem Abschnitt</string>
+    <string name="tafseer_note_edit">Bearbeiten</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1801,4 +1801,8 @@
     <string name="ai_error_consent_title">Demander avec preuve est désactivé</string>
     <string name="ai_error_consent">Activez-le dans les paramètres de recherche pour poser une question. La recherche par mot-clé dans le Coran, les hadiths et les invocations fonctionne hors ligne dans tous les cas.</string>
     <string name="ai_consent_save_failed">Ce réglage n\'a pas pu être enregistré. Veuillez réessayer.</string>
+    <string name="tafseer_notes">Notes</string>
+    <string name="tafseer_note_add">Ajouter une note</string>
+    <string name="tafseer_note_hint">Votre réflexion sur ce passage</string>
+    <string name="tafseer_note_edit">Modifier</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1735,4 +1735,8 @@
     <string name="ai_error_consent_title">Tanya dengan Dalil nonaktif</string>
     <string name="ai_error_consent">Aktifkan di pengaturan pencarian untuk mengajukan pertanyaan. Pencarian kata kunci di Al-Qur\'an, hadis, dan doa tetap berfungsi offline.</string>
     <string name="ai_consent_save_failed">Pengaturan itu tidak dapat disimpan. Silakan coba lagi.</string>
+    <string name="tafseer_notes">Catatan</string>
+    <string name="tafseer_note_add">Tambah catatan</string>
+    <string name="tafseer_note_hint">Renungan Anda tentang bagian ini</string>
+    <string name="tafseer_note_edit">Ubah</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1736,4 +1736,8 @@
     <string name="ai_error_consent_title">Tanya dengan Dalil dimatikan</string>
     <string name="ai_error_consent">Hidupkan dalam tetapan carian untuk bertanya. Carian kata kunci dalam al-Quran, hadis dan doa tetap berfungsi di luar talian.</string>
     <string name="ai_consent_save_failed">Tetapan itu tidak dapat disimpan. Sila cuba lagi.</string>
+    <string name="tafseer_notes">Nota</string>
+    <string name="tafseer_note_add">Tambah nota</string>
+    <string name="tafseer_note_hint">Renungan anda tentang petikan ini</string>
+    <string name="tafseer_note_edit">Sunting</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1772,4 +1772,8 @@
     <string name="ai_error_consent_title">Delille Sor kapalı</string>
     <string name="ai_error_consent">Soru sormak için Arama ayarlarından açın. Kur\'an, hadis ve dualarda anahtar kelime araması her durumda çevrimdışı çalışır.</string>
     <string name="ai_consent_save_failed">Bu ayar kaydedilemedi. Lütfen tekrar deneyin.</string>
+    <string name="tafseer_notes">Notlar</string>
+    <string name="tafseer_note_add">Not ekle</string>
+    <string name="tafseer_note_hint">Bu bölüm hakkındaki düşünceniz</string>
+    <string name="tafseer_note_edit">Düzenle</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1937,4 +1937,8 @@
     <string name="ai_error_consent_title">Ask with Proof is off</string>
     <string name="ai_error_consent">Turn it on in Search settings to ask a question. Keyword search across the Qur\'an, Hadith and duas works offline either way.</string>
     <string name="ai_consent_save_failed">That setting couldn\'t be saved. Please try again.</string>
+    <string name="tafseer_notes">Notes</string>
+    <string name="tafseer_note_add">Add note</string>
+    <string name="tafseer_note_hint">Your reflection on this passage</string>
+    <string name="tafseer_note_edit">Edit</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerNoteCrudTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerNoteCrudTest.kt
@@ -1,0 +1,218 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.TafseerNote
+import com.arshadshah.nimaz.domain.model.TafseerSource
+import com.arshadshah.nimaz.domain.model.TafseerText
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.TafseerUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The tafseer note loop, end to end at the ViewModel boundary.
+ *
+ * `AddNote`, `UpdateNote` and `DeleteNote` are declared, handled — and emitted by nothing, so
+ * **none of these three handlers has ever executed in production**, and no test covered them:
+ * the only Tafseer test pins collector cancellation. #357 says to treat them as unproven and
+ * to expect at least one to be wrong before wiring the UI. These are the tests that decide it.
+ *
+ * The notes themselves are stored against the *ayah*, while the reader collects them for the
+ * whole commentary **block** — so a note added on one ayah must show up while reading any ayah
+ * of the same block, and must survive the ayah-by-ayah swipe that re-arms the collector.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TafseerNoteCrudTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var tafseerUseCases: TafseerUseCases
+    private lateinit var quranUseCases: QuranUseCases
+    private val telemetry = RecordingTelemetry()
+
+    /** Stands in for the notes table: what the reader's collector sees. */
+    private val notes = MutableStateFlow(emptyList<TafseerNote>())
+    private var nextId = 1L
+
+    private val block = TafseerText(
+        id = 1L,
+        tafseerId = TafseerSource.IBN_KATHIR.id,
+        surahNumber = 2,
+        ayahStart = 1,
+        ayahEnd = 5,
+        text = "commentary",
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        tafseerUseCases = mockk(relaxed = true)
+        quranUseCases = mockk(relaxed = true)
+
+        every { quranUseCases.getAyahsBySurah(any()) } returns
+            flowOf(listOf(ayah(id = 101, number = 1), ayah(id = 102, number = 2)))
+        coEvery { tafseerUseCases.getTafseerForAyah(any(), any(), any()) } returns block
+        every { tafseerUseCases.getHighlightsForRange(any(), any(), any(), any()) } returns
+            flowOf(emptyList())
+        every { tafseerUseCases.getNotesForRange(any(), any(), any(), any()) } returns notes
+
+        // A fake store, so the round-trip is real rather than a verified call.
+        coEvery { tafseerUseCases.addNote(any(), any(), any()) } answers {
+            val id = nextId++
+            notes.value = notes.value + TafseerNote(
+                id = id,
+                ayahId = firstArg(),
+                tafseerId = secondArg(),
+                text = thirdArg(),
+                createdAt = 0L,
+                updatedAt = 0L,
+            )
+            id
+        }
+        coEvery { tafseerUseCases.updateNote(any()) } answers {
+            val updated = firstArg<TafseerNote>()
+            notes.value = notes.value.map { if (it.id == updated.id) updated else it }
+        }
+        coEvery { tafseerUseCases.deleteNote(any()) } answers {
+            val id = firstArg<Long>()
+            notes.value = notes.value.filterNot { it.id == id }
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = TafseerViewModel(tafseerUseCases, quranUseCases, telemetry)
+
+    private fun loadedViewModel() = viewModel().also {
+        it.onEvent(TafseerEvent.LoadSurah(surahNumber = 2, ayahNumber = 1))
+    }
+
+    @Test
+    fun `a note created on the ayah being read appears in the reader`() = runTest {
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TafseerEvent.AddNote("a reflection"))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes.map { it.text }).containsExactly("a reflection")
+        // Stored against the ayah on screen, not the block's first ayah.
+        assertThat(vm.state.value.notes.single().ayahId).isEqualTo(101)
+    }
+
+    @Test
+    fun `updating a note changes that row instead of adding a second`() = runTest {
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+        vm.onEvent(TafseerEvent.AddNote("first draft"))
+        advanceUntilIdle()
+
+        val existing = vm.state.value.notes.single()
+        vm.onEvent(TafseerEvent.UpdateNote(existing.copy(text = "second draft")))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes).hasSize(1)
+        assertThat(vm.state.value.notes.single().text).isEqualTo("second draft")
+        // The id has to round-trip, or the update targets nothing and the reader
+        // silently keeps the old text.
+        assertThat(vm.state.value.notes.single().id).isEqualTo(existing.id)
+    }
+
+    @Test
+    fun `deleting a note removes it from the reader`() = runTest {
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+        vm.onEvent(TafseerEvent.AddNote("to be deleted"))
+        advanceUntilIdle()
+        val existing = vm.state.value.notes.single()
+
+        vm.onEvent(TafseerEvent.DeleteNote(existing.id))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes).isEmpty()
+    }
+
+    @Test
+    fun `a note added on the second ayah is still there after swiping back`() = runTest {
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TafseerEvent.NavigateToAyah(1))
+        advanceUntilIdle()
+        vm.onEvent(TafseerEvent.AddNote("on the second ayah"))
+        advanceUntilIdle()
+
+        // Swiping re-arms the notes collector for the same commentary block.
+        vm.onEvent(TafseerEvent.NavigateToAyah(0))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes.map { it.text }).containsExactly("on the second ayah")
+        assertThat(vm.state.value.notes.single().ayahId).isEqualTo(102)
+    }
+
+    @Test
+    fun `a blank note is not stored`() = runTest {
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TafseerEvent.AddNote("   "))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes).isEmpty()
+    }
+
+    @Test
+    fun `adding a note before the ayahs load does not crash`() = runTest {
+        // The handler indexed `ayahs[currentAyahIndex]` outside its coroutine, so an
+        // out-of-range index threw straight out of onEvent — on the UI thread, from a tap.
+        val vm = viewModel()
+
+        vm.onEvent(TafseerEvent.AddNote("too early"))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.notes).isEmpty()
+    }
+
+    @Test
+    fun `a note write that fails is reported instead of vanishing`() = runTest {
+        coEvery { tafseerUseCases.addNote(any(), any(), any()) } throws
+            IllegalStateException("disk full")
+
+        val vm = loadedViewModel()
+        advanceUntilIdle()
+        vm.onEvent(TafseerEvent.AddNote("a reflection"))
+        advanceUntilIdle()
+
+        assertThat(telemetry.errors.map { it.type }).contains("add_note")
+    }
+}
+
+private fun ayah(id: Int, number: Int) = Ayah(
+    id = id,
+    surahNumber = 2,
+    ayahNumber = number,
+    textArabic = "",
+    textSimple = "",
+    juzNumber = 1,
+    hizbNumber = 1,
+    rubNumber = 1,
+    pageNumber = 1,
+    sajdaType = null,
+    sajdaNumber = null,
+)

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModelAnnotationScopeTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModelAnnotationScopeTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.SajdaType
 import com.arshadshah.nimaz.domain.model.TafseerHighlight
@@ -91,7 +92,7 @@ class TafseerViewModelAnnotationScopeTest {
 
     @Test
     fun `a previous ayah's highlights cannot overwrite the ayah on screen`() = runTest {
-        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases)
+        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases, RecordingTelemetry())
 
         viewModel.onEvent(TafseerEvent.LoadSurah(surahNumber = 1, ayahNumber = 1))
         advanceUntilIdle()
@@ -114,7 +115,7 @@ class TafseerViewModelAnnotationScopeTest {
 
     @Test
     fun `a previous ayah's notes cannot overwrite the ayah on screen`() = runTest {
-        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases)
+        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases, RecordingTelemetry())
 
         viewModel.onEvent(TafseerEvent.LoadSurah(surahNumber = 1, ayahNumber = 1))
         advanceUntilIdle()
@@ -135,7 +136,7 @@ class TafseerViewModelAnnotationScopeTest {
     fun `swiping back re-subscribes, so the earlier ayah's annotations return`() = runTest {
         // The cancellation must be scoped to "not the current ayah", not "load once" — a
         // reader swiping 1 -> 2 -> 1 has to see ayah 1's highlights again.
-        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases)
+        val viewModel = TafseerViewModel(tafseerUseCases, quranUseCases, RecordingTelemetry())
 
         viewModel.onEvent(TafseerEvent.LoadSurah(surahNumber = 1, ayahNumber = 1))
         advanceUntilIdle()


### PR DESCRIPTION
**Layer 20 of 25** · epic #352 · re-opened for review — full write-up in **#389**. Wires the second of #357's four "lost features".

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

`TafseerEvent.AddNote`, `UpdateNote` and `DeleteNote` had handlers, use cases, repository methods, DAO queries and a live Room collector populating `TafseerUiState.notes` on every ayah swipe — **and no producer**. None of the three had ever executed in production, and the only Tafseer test covers collector cancellation. Meanwhile `TafseerChaptersScreen.kt:133` *does* render notes, from the other ViewModel — so the list users can actually see was permanently empty, fed by a write path nobody could reach. #357 is explicit: treat those handlers as unproven, expect at least one to be wrong. Tests first, then the UI.

**What the tests found:**

1. **`addNote` could crash the UI from a tap.** The guard covered an empty list only, and the index was read outside the coroutine — an index that has not caught up with the ayah list (before the first load completes, or straight after switching to a shorter surah) threw `IndexOutOfBoundsException` **synchronously out of `onEvent`, on the UI thread**. `getOrNull` now.
2. **Nothing rejected a blank note** — a mis-tap stored an empty row that then appears in the reader and on the notes screen with nothing to read.
3. **All three writes were bare `viewModelScope.launch`** with no guard and no report — one Room error from an uncaught crash, and a failed write vanished silently. Now `launchSafely` + `Telemetry`.

The round-trip itself is sound, and the tests say so rather than assuming it.

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅ · new strings translated into all five shipped locales

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_