### PR TITLE
feat(quran): put the surah filter back on screen

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -113,6 +113,7 @@ import com.arshadshah.nimaz.presentation.viewmodel.quran.QuranViewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
 import kotlinx.coroutines.launch
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -261,6 +262,8 @@ fun QuranHomeScreen(
                         onNavigateToJuz = onNavigateToJuz,
                         onNavigateToPage = onNavigateToPage,
                         onTabSelect = { viewModel.onEvent(QuranEvent.SetTab(it)) },
+                        onSearchQueryChange = { viewModel.onEvent(QuranEvent.Search(it)) },
+                        onSearchCleared = { viewModel.onEvent(QuranEvent.ClearSearch) },
                         onNavigateToSurahInfo = onNavigateToSurahInfo,
                         selectedSurahNumber = selectedSurahNumber,
                         selectedJuzNumber = selectedJuzNumber,
@@ -487,6 +490,8 @@ private fun BrowseTabContent(
     onNavigateToJuz: (Int) -> Unit,
     onNavigateToPage: (Int) -> Unit,
     onTabSelect: (Int) -> Unit,
+    onSearchQueryChange: (String) -> Unit,
+    onSearchCleared: () -> Unit,
     onNavigateToSurahInfo: (Int) -> Unit = {},
     selectedSurahNumber: Int? = null,
     selectedJuzNumber: Int? = null,
@@ -640,8 +645,27 @@ private fun BrowseTabContent(
         }
 
         Box(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize()) {
+            // The surah filter. `filteredSurahs` and the whole debounced `Search`/`ClearSearch`
+            // path existed in the ViewModel with no producer, so the filter argument was
+            // permanently "" and `filteredSurahs` was permanently identical to `surahs`.
+            // Deliberately a *list filter*, not the global content search on SearchScreen —
+            // it narrows the 114 surahs in place rather than navigating away.
+            if (state.selectedTab == 0) {
+                NimazSearchBar(
+                    query = state.searchQuery,
+                    onQueryChange = onSearchQueryChange,
+                    onClear = onSearchCleared,
+                    placeholder = stringResource(R.string.quran_search_surahs),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
             LazyColumn(
-                modifier = Modifier.testTag(ScreenTags.QuranSurahList),
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(ScreenTags.QuranSurahList),
                 state = when (state.selectedTab) {
                     1 -> juzListState
                     2 -> pageListState
@@ -721,6 +745,7 @@ private fun BrowseTabContent(
                         }
                     }
                 }
+            }
             }
 
             // Juz scrollbar rail — only shown on Page tab

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1770,4 +1770,5 @@
     <string name="tafseer_note_add">Notiz hinzufügen</string>
     <string name="tafseer_note_hint">Deine Gedanken zu diesem Abschnitt</string>
     <string name="tafseer_note_edit">Bearbeiten</string>
+    <string name="quran_search_surahs">Suren suchen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1805,4 +1805,5 @@
     <string name="tafseer_note_add">Ajouter une note</string>
     <string name="tafseer_note_hint">Votre réflexion sur ce passage</string>
     <string name="tafseer_note_edit">Modifier</string>
+    <string name="quran_search_surahs">Rechercher des sourates</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1739,4 +1739,5 @@
     <string name="tafseer_note_add">Tambah catatan</string>
     <string name="tafseer_note_hint">Renungan Anda tentang bagian ini</string>
     <string name="tafseer_note_edit">Ubah</string>
+    <string name="quran_search_surahs">Cari surah</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1740,4 +1740,5 @@
     <string name="tafseer_note_add">Tambah nota</string>
     <string name="tafseer_note_hint">Renungan anda tentang petikan ini</string>
     <string name="tafseer_note_edit">Sunting</string>
+    <string name="quran_search_surahs">Cari surah</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1776,4 +1776,5 @@
     <string name="tafseer_note_add">Not ekle</string>
     <string name="tafseer_note_hint">Bu bölüm hakkındaki düşünceniz</string>
     <string name="tafseer_note_edit">Düzenle</string>
+    <string name="quran_search_surahs">Sure ara</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1941,4 +1941,5 @@
     <string name="tafseer_note_add">Add note</string>
     <string name="tafseer_note_hint">Your reflection on this passage</string>
     <string name="tafseer_note_edit">Edit</string>
+    <string name="quran_search_surahs">Search surahs</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
@@ -1,0 +1,158 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import android.content.Context
+import com.arshadshah.nimaz.data.audio.QuranAudioManager
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.KhatamUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The surah filter on Quran Home.
+ *
+ * `QuranEvent.Search` / `ClearSearch` were emitted by nobody — `SearchScreen` drives a
+ * different ViewModel entirely — so `filterSurahs` only ever ran with a blank query and
+ * `filteredSurahs` was **permanently identical to `surahs`**, while `QuranHomeScreen` rendered
+ * it as though it were filtered.
+ *
+ * This is deliberately a *list filter*, not the global content search: it narrows the 114
+ * surahs in place rather than navigating away.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuranSurahFilterTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: QuranUseCases
+    private lateinit var audioManager: QuranAudioManager
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var khatamUseCases: KhatamUseCases
+    private lateinit var context: Context
+
+    private val surahs = listOf(
+        surah(1, "The Opening", "Al-Fatihah", "الفاتحة"),
+        surah(2, "The Cow", "Al-Baqarah", "البقرة"),
+        surah(18, "The Cave", "Al-Kahf", "الكهف"),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        audioManager = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
+        khatamUseCases = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+        // The reader/home init combines a wall of settings flows, and a relaxed mock hands
+        // back a Flow that emits nothing — on which `.first()` throws. Only the ones the init
+        // path actually reads need real values.
+        every { settingsRepository.quranTranslatorId } returns MutableStateFlow("en.sahih")
+        every { settingsRepository.quranMushafScript } returns MutableStateFlow("madani")
+        every { settingsRepository.showTranslation } returns MutableStateFlow(true)
+        every { settingsRepository.showTransliteration } returns MutableStateFlow(false)
+        every { settingsRepository.quranArabicFontSize } returns MutableStateFlow(28f)
+        every { settingsRepository.quranArabicFont } returns MutableStateFlow("amiri")
+        every { settingsRepository.quranTranslationFontSize } returns MutableStateFlow(16f)
+        every { settingsRepository.continuousReading } returns MutableStateFlow(true)
+        every { settingsRepository.keepScreenOn } returns MutableStateFlow(true)
+        every { settingsRepository.selectedReciterId } returns MutableStateFlow(null)
+        every { settingsRepository.showTajweed } returns MutableStateFlow(false)
+        every { settingsRepository.tajweedUnderline } returns MutableStateFlow(false)
+        every { useCases.getSurahList() } returns flowOf(surahs)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() =
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, context)
+
+    @Test
+    fun `the list narrows to the transliterated name`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QuranEvent.Search("kahf"))
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.filteredSurahs.map { it.number }).containsExactly(18)
+        assertThat(vm.homeState.value.searchQuery).isEqualTo("kahf")
+    }
+
+    @Test
+    fun `the English name matches too, case-insensitively`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QuranEvent.Search("THE COW"))
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.filteredSurahs.map { it.number }).containsExactly(2)
+    }
+
+    @Test
+    fun `the Arabic name matches`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QuranEvent.Search("الكهف"))
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.filteredSurahs.map { it.number }).containsExactly(18)
+    }
+
+    @Test
+    fun `clearing restores the whole list`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(QuranEvent.Search("kahf"))
+        advanceUntilIdle()
+
+        vm.onEvent(QuranEvent.ClearSearch)
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.filteredSurahs.map { it.number })
+            .containsExactly(1, 2, 18)
+        assertThat(vm.homeState.value.searchQuery).isEmpty()
+    }
+
+    @Test
+    fun `a query matching nothing leaves an empty list, not the whole list`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QuranEvent.Search("zzzz"))
+        advanceUntilIdle()
+
+        // The failure mode this whole feature had: filteredSurahs == surahs regardless.
+        assertThat(vm.homeState.value.filteredSurahs).isEmpty()
+    }
+}
+
+private fun surah(number: Int, english: String, transliteration: String, arabic: String) = Surah(
+    number = number,
+    nameArabic = arabic,
+    nameEnglish = english,
+    nameTransliteration = transliteration,
+    revelationType = RevelationType.MECCAN,
+    ayahCount = 7,
+    juzStart = 1,
+    orderInMushaf = number,
+    startPage = number,
+)


### PR DESCRIPTION
**Layer 21 of 25** · epic #352 · re-opened for review — full write-up in **#390**. Wires the last of #357's four "lost features" — **all four are now done** (Zakat prices, Bookmarks search+sort, Tafseer notes, this).

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

`QuranEvent.Search` and `ClearSearch` were emitted by nobody — `SearchScreen` drives a different ViewModel entirely. So `filterSurahs`' query argument was **always `""`**, which means **`filteredSurahs` was permanently identical to `surahs`** — and `QuranHomeScreen.kt:661` rendered it as though it were filtered. Behind that unreachable event sat a complete implementation: `QuranSearchUiState`, `searchQueryFlow`, `searchJob`, `setupDebouncedSearch()` (called from `init`, debouncing nothing), `search()`, `performSearch()` and `filterSurahs()`.

The fix is a `NimazSearchBar` above the surah tab, wired to the existing events; the ViewModel side needed no changes at all. The callbacks are hoisted through `BrowseTabContent`'s signature rather than reaching for `viewModel` inside it — that composable takes state and lambdas, and it stays that way.

**A deliberate distinction:** this is a *list filter*, not the global content search. It narrows the 114 surahs in place — by English name, transliteration, or Arabic — rather than navigating to `SearchScreen`. #357 makes that distinction explicitly, and it is why both can exist without one being redundant.

`QuranSurahFilterTest` adds 5 tests; the one that proves the feature is real is "a query matching nothing leaves an empty list, not the whole list" — the exact failure mode of the shipped code.

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅ · new strings translated into all five shipped locales

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_