### PR TITLE
refactor(content): three copies of one ViewModel become one

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaDetailScreen.kt
@@ -37,7 +37,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionC
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -48,7 +48,7 @@ fun AsmaUlHusnaDetailScreen(
     viewModel: AsmaUlHusnaViewModel = hiltViewModel()
 ) {
     LaunchedEffect(nameId) {
-        viewModel.onEvent(AsmaUlHusnaEvent.LoadDetail(nameId))
+        viewModel.onEvent(CatalogEvent.LoadDetail(nameId))
     }
 
     val state by viewModel.detailState.collectAsStateWithLifecycle()
@@ -57,24 +57,24 @@ fun AsmaUlHusnaDetailScreen(
     NimazScreenScaffold(
         topBar = {
             NimazBackTopAppBar(
-                title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
+                title = state.item?.nameTransliteration ?: stringResource(R.string.name_detail),
                 onBackClick = onNavigateBack
             )
         },
         floatingActionButton = {
-            state.name?.let { name ->
+            state.item?.let { name ->
                 FavoriteFab(
                     isFavorite = name.isFavorite,
                     accent = accent,
-                    onClick = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(name.id)) }
+                    onClick = { viewModel.onEvent(CatalogEvent.ToggleFavorite(name.id)) }
                 )
             }
         }
     ) { paddingValues ->
-        if (state.isLoading || state.name == null) {
+        if (state.isLoading || state.item == null) {
             NimazLoadingState(modifier = Modifier.padding(paddingValues))
         } else {
-            val name = state.name!!
+            val name = state.item!!
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asma/AsmaUlHusnaListScreen.kt
@@ -28,7 +28,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,21 +57,21 @@ fun AsmaUlHusnaListScreen(
             // Search Bar
             NimazSearchBar(
                 query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(AsmaUlHusnaEvent.Search(it)) },
+                onQueryChange = { viewModel.onEvent(CatalogEvent.Search(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
                 placeholder = stringResource(R.string.asma_ul_husna_search_hint),
                 showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(AsmaUlHusnaEvent.ClearSearch) },
-                onSearch = { viewModel.onEvent(AsmaUlHusnaEvent.Search(it)) }
+                onClear = { viewModel.onEvent(CatalogEvent.ClearSearch) },
+                onSearch = { viewModel.onEvent(CatalogEvent.Search(it)) }
             )
 
             // Filter Chips
             NameFilterRow(
                 showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavoritesFilter) },
+                onShowAll = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
+                onShowFavorites = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
                 accent = accent,
                 allLabel = stringResource(R.string.all),
                 favoritesLabel = stringResource(R.string.favorites),
@@ -85,7 +85,7 @@ fun AsmaUlHusnaListScreen(
             if (state.isLoading) {
                 NimazLoadingState()
             } else {
-                val displayList = state.filteredNames
+                val displayList = state.filteredItems
 
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -108,7 +108,7 @@ fun AsmaUlHusnaListScreen(
                             accent = accent,
                             onClick = { onNavigateToDetail(name.id) },
                             onFavoriteClick = {
-                                viewModel.onEvent(AsmaUlHusnaEvent.ToggleFavorite(name.id))
+                                viewModel.onEvent(CatalogEvent.ToggleFavorite(name.id))
                             }
                         )
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiDetailScreen.kt
@@ -27,7 +27,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NameDetailSectionC
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,7 +38,7 @@ fun AsmaUnNabiDetailScreen(
     viewModel: AsmaUnNabiViewModel = hiltViewModel()
 ) {
     LaunchedEffect(nameId) {
-        viewModel.onEvent(AsmaUnNabiEvent.LoadDetail(nameId))
+        viewModel.onEvent(CatalogEvent.LoadDetail(nameId))
     }
 
     val state by viewModel.detailState.collectAsStateWithLifecycle()
@@ -47,21 +47,21 @@ fun AsmaUnNabiDetailScreen(
     NimazScreenScaffold(
         topBar = {
             NimazBackTopAppBar(
-                title = state.name?.nameTransliteration ?: stringResource(R.string.name_detail),
+                title = state.item?.nameTransliteration ?: stringResource(R.string.name_detail),
                 onBackClick = onNavigateBack
             )
         },
         floatingActionButton = {
-            state.name?.let { name ->
+            state.item?.let { name ->
                 FavoriteFab(
                     isFavorite = name.isFavorite,
                     accent = accent,
-                    onClick = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(name.id)) }
+                    onClick = { viewModel.onEvent(CatalogEvent.ToggleFavorite(name.id)) }
                 )
             }
         }
     ) { paddingValues ->
-        if (state.isLoading || state.name == null) {
+        if (state.isLoading || state.item == null) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -71,7 +71,7 @@ fun AsmaUnNabiDetailScreen(
                 CircularProgressIndicator()
             }
         } else {
-            val name = state.name!!
+            val name = state.item!!
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/asmaunnabi/AsmaUnNabiListScreen.kt
@@ -28,7 +28,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,21 +56,21 @@ fun AsmaUnNabiListScreen(
         ) {
             NimazSearchBar(
                 query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(AsmaUnNabiEvent.Search(it)) },
+                onQueryChange = { viewModel.onEvent(CatalogEvent.Search(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
                 placeholder = stringResource(R.string.asma_un_nabi_search_hint),
                 showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(AsmaUnNabiEvent.ClearSearch) },
-                onSearch = { viewModel.onEvent(AsmaUnNabiEvent.Search(it)) }
+                onClear = { viewModel.onEvent(CatalogEvent.ClearSearch) },
+                onSearch = { viewModel.onEvent(CatalogEvent.Search(it)) }
             )
 
             // Filter Chips
             NameFilterRow(
                 showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(AsmaUnNabiEvent.ToggleFavoritesFilter) },
+                onShowAll = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
+                onShowFavorites = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
                 accent = accent,
                 allLabel = stringResource(R.string.all),
                 favoritesLabel = stringResource(R.string.favorites),
@@ -84,7 +84,7 @@ fun AsmaUnNabiListScreen(
             if (state.isLoading) {
                 NimazLoadingState()
             } else {
-                val displayList = state.filteredNames
+                val displayList = state.filteredItems
 
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -107,7 +107,7 @@ fun AsmaUnNabiListScreen(
                             accent = accent,
                             onClick = { onNavigateToDetail(name.id) },
                             onFavoriteClick = {
-                                viewModel.onEvent(AsmaUnNabiEvent.ToggleFavorite(name.id))
+                                viewModel.onEvent(CatalogEvent.ToggleFavorite(name.id))
                             }
                         )
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreen.kt
@@ -44,7 +44,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NamesAccent
 import com.arshadshah.nimaz.presentation.components.molecules.NamesAccents
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -55,7 +55,7 @@ fun ProphetDetailScreen(
     viewModel: ProphetViewModel = hiltViewModel()
 ) {
     LaunchedEffect(prophetId) {
-        viewModel.onEvent(ProphetEvent.LoadDetail(prophetId))
+        viewModel.onEvent(CatalogEvent.LoadDetail(prophetId))
     }
 
     val state by viewModel.detailState.collectAsStateWithLifecycle()
@@ -64,24 +64,24 @@ fun ProphetDetailScreen(
     NimazScreenScaffold(
         topBar = {
             NimazBackTopAppBar(
-                title = state.prophet?.nameEnglish ?: stringResource(R.string.prophet_detail),
+                title = state.item?.nameEnglish ?: stringResource(R.string.prophet_detail),
                 onBackClick = onNavigateBack
             )
         },
         floatingActionButton = {
-            state.prophet?.let { prophet ->
+            state.item?.let { prophet ->
                 FavoriteFab(
                     isFavorite = prophet.isFavorite,
                     accent = accent,
-                    onClick = { viewModel.onEvent(ProphetEvent.ToggleFavorite(prophet.id)) }
+                    onClick = { viewModel.onEvent(CatalogEvent.ToggleFavorite(prophet.id)) }
                 )
             }
         }
     ) { paddingValues ->
-        if (state.isLoading || state.prophet == null) {
+        if (state.isLoading || state.item == null) {
             NimazLoadingState(modifier = Modifier.padding(paddingValues))
         } else {
-            val prophet = state.prophet!!
+            val prophet = state.item!!
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetsListScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prophets/ProphetsListScreen.kt
@@ -28,7 +28,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
 import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,20 +56,20 @@ fun ProphetsListScreen(
         ) {
             NimazSearchBar(
                 query = state.searchQuery,
-                onQueryChange = { viewModel.onEvent(ProphetEvent.Search(it)) },
+                onQueryChange = { viewModel.onEvent(CatalogEvent.Search(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = NimazSpacing.Large, vertical = NimazSpacing.Small),
                 placeholder = stringResource(R.string.prophets_search_hint),
                 showClearButton = state.searchQuery.isNotEmpty(),
-                onClear = { viewModel.onEvent(ProphetEvent.ClearSearch) }
+                onClear = { viewModel.onEvent(CatalogEvent.ClearSearch) }
             )
 
             // Filter Chips
             NameFilterRow(
                 showFavoritesOnly = state.showFavoritesOnly,
-                onShowAll = { viewModel.onEvent(ProphetEvent.ToggleFavoritesFilter) },
-                onShowFavorites = { viewModel.onEvent(ProphetEvent.ToggleFavoritesFilter) },
+                onShowAll = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
+                onShowFavorites = { viewModel.onEvent(CatalogEvent.ToggleFavoritesFilter) },
                 accent = accent,
                 allLabel = stringResource(R.string.all),
                 favoritesLabel = stringResource(R.string.favorites),
@@ -82,7 +82,7 @@ fun ProphetsListScreen(
             if (state.isLoading) {
                 NimazLoadingState()
             } else {
-                val displayList = state.filteredProphets
+                val displayList = state.filteredItems
 
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -105,7 +105,7 @@ fun ProphetsListScreen(
                             accent = accent,
                             onClick = { onNavigateToDetail(prophet.id) },
                             onFavoriteClick = {
-                                viewModel.onEvent(ProphetEvent.ToggleFavorite(prophet.id))
+                                viewModel.onEvent(CatalogEvent.ToggleFavorite(prophet.id))
                             },
                             titleLabel = prophet.titleEnglish,
                             eraChip = prophet.era

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/AsmaUlHusnaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/AsmaUlHusnaViewModel.kt
@@ -1,171 +1,37 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.AsmaUlHusna
 import com.arshadshah.nimaz.domain.usecase.AsmaUlHusnaUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-data class AsmaUlHusnaListState(
-    val names: List<AsmaUlHusna> = emptyList(),
-    val favorites: List<AsmaUlHusna> = emptyList(),
-    val filteredNames: List<AsmaUlHusna> = emptyList(),
-    val isLoading: Boolean = true,
-    val searchQuery: String = "",
-    val showFavoritesOnly: Boolean = false
-)
-
-data class AsmaUlHusnaDetailState(
-    val name: AsmaUlHusna? = null,
-    val isFavorite: Boolean = false,
-    val isLoading: Boolean = true
-)
-
-sealed interface AsmaUlHusnaEvent {
-    data class LoadDetail(val nameId: Int) : AsmaUlHusnaEvent
-    data class ToggleFavorite(val nameId: Int) : AsmaUlHusnaEvent
-    data class Search(val query: String) : AsmaUlHusnaEvent
-    data object ClearSearch : AsmaUlHusnaEvent
-    data object ToggleFavoritesFilter : AsmaUlHusnaEvent
-}
+/** The ninety-nine names, as a catalogue. See CatalogViewModel for why this is four lines. */
+typealias AsmaUlHusnaListState = CatalogListState<AsmaUlHusna>
+typealias AsmaUlHusnaDetailState = CatalogDetailState<AsmaUlHusna>
 
 @HiltViewModel
 class AsmaUlHusnaViewModel @Inject constructor(
-    private val asmaUlHusnaUseCases: AsmaUlHusnaUseCases
-) : ViewModel() {
+    useCases: AsmaUlHusnaUseCases,
+    telemetry: Telemetry,
+) : CatalogViewModel<AsmaUlHusna>(
+    source = AsmaUlHusnaSource(useCases),
+    telemetry = telemetry,
+    feature = AppAnalytics.Feature.ASMA_UL_HUSNA,
+)
 
-    private val _listState = MutableStateFlow(AsmaUlHusnaListState())
-    val listState: StateFlow<AsmaUlHusnaListState> = _listState.asStateFlow()
+private class AsmaUlHusnaSource(private val useCases: AsmaUlHusnaUseCases) : CatalogSource<AsmaUlHusna> {
+    override fun all(): Flow<List<AsmaUlHusna>> = useCases.getAllNames()
+    override fun favourites(): Flow<List<AsmaUlHusna>> = useCases.getFavorites()
+    override suspend fun byId(id: Int): AsmaUlHusna? = useCases.getNameById(id)
+    override suspend fun toggleFavourite(id: Int) { useCases.toggleFavorite(id) }
+    override fun idOf(item: AsmaUlHusna): Int = item.id
 
-    private val _detailState = MutableStateFlow(AsmaUlHusnaDetailState())
-    val detailState: StateFlow<AsmaUlHusnaDetailState> = _detailState.asStateFlow()
-
-    init {
-        observeNames()
-        observeFavorites()
-    }
-
-    fun onEvent(event: AsmaUlHusnaEvent) {
-        when (event) {
-            is AsmaUlHusnaEvent.LoadDetail -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UL_HUSNA,
-                    "open_detail"
-                )
-                loadDetail(event.nameId)
-            }
-            is AsmaUlHusnaEvent.ToggleFavorite -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UL_HUSNA,
-                    "toggle_favorite"
-                )
-                toggleFavorite(event.nameId)
-            }
-            is AsmaUlHusnaEvent.Search -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UL_HUSNA, "search")
-                search(event.query)
-            }
-            AsmaUlHusnaEvent.ClearSearch -> clearSearch()
-            AsmaUlHusnaEvent.ToggleFavoritesFilter -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UL_HUSNA,
-                    "toggle_favorites_filter"
-                )
-                toggleFavoritesFilter()
-            }
-        }
-    }
-
-    private fun observeNames() {
-        viewModelScope.launch {
-            asmaUlHusnaUseCases.getAllNames().collect { names ->
-                _listState.update {
-                    it.copy(
-                        names = names,
-                        isLoading = false
-                    )
-                }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun observeFavorites() {
-        viewModelScope.launch {
-            asmaUlHusnaUseCases.getFavorites().collect { favorites ->
-                _listState.update { it.copy(favorites = favorites) }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun loadDetail(nameId: Int) {
-        _detailState.update { it.copy(isLoading = true) }
-
-        viewModelScope.launch {
-            val name = asmaUlHusnaUseCases.getNameById(nameId)
-            _detailState.update {
-                it.copy(
-                    name = name,
-                    isFavorite = name?.isFavorite ?: false,
-                    isLoading = false
-                )
-            }
-        }
-    }
-
-    private fun toggleFavorite(nameId: Int) {
-        viewModelScope.launch {
-            asmaUlHusnaUseCases.toggleFavorite(nameId)
-            // Refresh detail if currently viewing this name
-            val currentDetail = _detailState.value
-            if (currentDetail.name?.id == nameId) {
-                val updatedName = asmaUlHusnaUseCases.getNameById(nameId)
-                _detailState.update {
-                    it.copy(
-                        name = updatedName,
-                        isFavorite = updatedName?.isFavorite ?: false
-                    )
-                }
-            }
-        }
-    }
-
-    private fun search(query: String) {
-        _listState.update { it.copy(searchQuery = query) }
-        applyFilters()
-    }
-
-    private fun clearSearch() {
-        _listState.update { it.copy(searchQuery = "") }
-        applyFilters()
-    }
-
-    private fun toggleFavoritesFilter() {
-        _listState.update { it.copy(showFavoritesOnly = !it.showFavoritesOnly) }
-        applyFilters()
-    }
-
-    private fun applyFilters() {
-        val state = _listState.value
-        val source = if (state.showFavoritesOnly) state.favorites else state.names
-        val filtered = if (state.searchQuery.isBlank()) {
-            source
-        } else {
-            source.filter { name ->
-                name.nameArabic.contains(state.searchQuery, ignoreCase = true) ||
-                        name.nameTransliteration.contains(state.searchQuery, ignoreCase = true) ||
-                        name.nameEnglish.contains(state.searchQuery, ignoreCase = true) ||
-                        name.meaning.contains(state.searchQuery, ignoreCase = true)
-            }
-        }
-        _listState.update { it.copy(filteredNames = filtered) }
-    }
+    override fun matches(item: AsmaUlHusna, query: String): Boolean =
+        item.nameArabic.contains(query, ignoreCase = true) ||
+            item.nameTransliteration.contains(query, ignoreCase = true) ||
+            item.nameEnglish.contains(query, ignoreCase = true) ||
+            item.meaning.contains(query, ignoreCase = true)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/AsmaUnNabiViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/AsmaUnNabiViewModel.kt
@@ -1,171 +1,37 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.AsmaUnNabi
 import com.arshadshah.nimaz.domain.usecase.AsmaUnNabiUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-data class AsmaUnNabiListState(
-    val names: List<AsmaUnNabi> = emptyList(),
-    val favorites: List<AsmaUnNabi> = emptyList(),
-    val filteredNames: List<AsmaUnNabi> = emptyList(),
-    val isLoading: Boolean = true,
-    val searchQuery: String = "",
-    val showFavoritesOnly: Boolean = false
-)
-
-data class AsmaUnNabiDetailState(
-    val name: AsmaUnNabi? = null,
-    val isFavorite: Boolean = false,
-    val isLoading: Boolean = true
-)
-
-sealed interface AsmaUnNabiEvent {
-    data class LoadDetail(val nameId: Int) : AsmaUnNabiEvent
-    data class ToggleFavorite(val nameId: Int) : AsmaUnNabiEvent
-    data class Search(val query: String) : AsmaUnNabiEvent
-    data object ClearSearch : AsmaUnNabiEvent
-    data object ToggleFavoritesFilter : AsmaUnNabiEvent
-}
+/** The names of the Prophet ﷺ, as a catalogue. */
+typealias AsmaUnNabiListState = CatalogListState<AsmaUnNabi>
+typealias AsmaUnNabiDetailState = CatalogDetailState<AsmaUnNabi>
 
 @HiltViewModel
 class AsmaUnNabiViewModel @Inject constructor(
-    private val asmaUnNabiUseCases: AsmaUnNabiUseCases
-) : ViewModel() {
+    useCases: AsmaUnNabiUseCases,
+    telemetry: Telemetry,
+) : CatalogViewModel<AsmaUnNabi>(
+    source = AsmaUnNabiSource(useCases),
+    telemetry = telemetry,
+    feature = AppAnalytics.Feature.ASMA_UN_NABI,
+)
 
-    private val _listState = MutableStateFlow(AsmaUnNabiListState())
-    val listState: StateFlow<AsmaUnNabiListState> = _listState.asStateFlow()
+private class AsmaUnNabiSource(private val useCases: AsmaUnNabiUseCases) : CatalogSource<AsmaUnNabi> {
+    override fun all(): Flow<List<AsmaUnNabi>> = useCases.getAllNames()
+    override fun favourites(): Flow<List<AsmaUnNabi>> = useCases.getFavorites()
+    override suspend fun byId(id: Int): AsmaUnNabi? = useCases.getNameById(id)
+    override suspend fun toggleFavourite(id: Int) { useCases.toggleFavorite(id) }
+    override fun idOf(item: AsmaUnNabi): Int = item.id
 
-    private val _detailState = MutableStateFlow(AsmaUnNabiDetailState())
-    val detailState: StateFlow<AsmaUnNabiDetailState> = _detailState.asStateFlow()
-
-    init {
-        observeNames()
-        observeFavorites()
-    }
-
-    fun onEvent(event: AsmaUnNabiEvent) {
-        when (event) {
-            is AsmaUnNabiEvent.LoadDetail -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UN_NABI,
-                    "open_detail"
-                )
-                loadDetail(event.nameId)
-            }
-            is AsmaUnNabiEvent.ToggleFavorite -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UN_NABI,
-                    "toggle_favorite"
-                )
-                toggleFavorite(event.nameId)
-            }
-            is AsmaUnNabiEvent.Search -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.ASMA_UN_NABI, "search")
-                search(event.query)
-            }
-            AsmaUnNabiEvent.ClearSearch -> clearSearch()
-            AsmaUnNabiEvent.ToggleFavoritesFilter -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.ASMA_UN_NABI,
-                    "toggle_favorites_filter"
-                )
-                toggleFavoritesFilter()
-            }
-        }
-    }
-
-    private fun observeNames() {
-        viewModelScope.launch {
-            asmaUnNabiUseCases.getAllNames().collect { names ->
-                _listState.update {
-                    it.copy(
-                        names = names,
-                        isLoading = false
-                    )
-                }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun observeFavorites() {
-        viewModelScope.launch {
-            asmaUnNabiUseCases.getFavorites().collect { favorites ->
-                _listState.update { it.copy(favorites = favorites) }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun loadDetail(nameId: Int) {
-        _detailState.update { it.copy(isLoading = true) }
-
-        viewModelScope.launch {
-            val name = asmaUnNabiUseCases.getNameById(nameId)
-            _detailState.update {
-                it.copy(
-                    name = name,
-                    isFavorite = name?.isFavorite ?: false,
-                    isLoading = false
-                )
-            }
-        }
-    }
-
-    private fun toggleFavorite(nameId: Int) {
-        viewModelScope.launch {
-            asmaUnNabiUseCases.toggleFavorite(nameId)
-            // Refresh detail if currently viewing this name
-            val currentDetail = _detailState.value
-            if (currentDetail.name?.id == nameId) {
-                val updatedName = asmaUnNabiUseCases.getNameById(nameId)
-                _detailState.update {
-                    it.copy(
-                        name = updatedName,
-                        isFavorite = updatedName?.isFavorite ?: false
-                    )
-                }
-            }
-        }
-    }
-
-    private fun search(query: String) {
-        _listState.update { it.copy(searchQuery = query) }
-        applyFilters()
-    }
-
-    private fun clearSearch() {
-        _listState.update { it.copy(searchQuery = "") }
-        applyFilters()
-    }
-
-    private fun toggleFavoritesFilter() {
-        _listState.update { it.copy(showFavoritesOnly = !it.showFavoritesOnly) }
-        applyFilters()
-    }
-
-    private fun applyFilters() {
-        val state = _listState.value
-        val source = if (state.showFavoritesOnly) state.favorites else state.names
-        val filtered = if (state.searchQuery.isBlank()) {
-            source
-        } else {
-            source.filter { name ->
-                name.nameArabic.contains(state.searchQuery, ignoreCase = true) ||
-                        name.nameTransliteration.contains(state.searchQuery, ignoreCase = true) ||
-                        name.nameEnglish.contains(state.searchQuery, ignoreCase = true) ||
-                        name.meaning.contains(state.searchQuery, ignoreCase = true)
-            }
-        }
-        _listState.update { it.copy(filteredNames = filtered) }
-    }
+    override fun matches(item: AsmaUnNabi, query: String): Boolean =
+        item.nameArabic.contains(query, ignoreCase = true) ||
+            item.nameTransliteration.contains(query, ignoreCase = true) ||
+            item.nameEnglish.contains(query, ignoreCase = true) ||
+            item.meaning.contains(query, ignoreCase = true)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
@@ -1,0 +1,174 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import androidx.lifecycle.ViewModel
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.monitoring.launchSafely
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * The browse-a-catalogue-of-things feature, once.
+ *
+ * `AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel` and `ProphetViewModel` were **byte-identical
+ * after identifier substitution** — 171, 171 and 172 lines of the same two states, the same
+ * five events, the same six handlers and the same filter, differing only in what the thing is
+ * called. Three copies means a fix lands in one and rots in the other two, and it already had:
+ * the search use case each of them injects was invoked by none of them, and the `isFavorite`
+ * field each of them maintains at four sites is read by no screen (the screens read
+ * `item.isFavorite` off the domain model).
+ *
+ * What genuinely differs per feature is small enough to be a parameter: where the rows come
+ * from, and which of their fields a search should look at. That is [CatalogSource].
+ */
+interface CatalogSource<T : Any> {
+    fun all(): Flow<List<T>>
+    fun favourites(): Flow<List<T>>
+    suspend fun byId(id: Int): T?
+    suspend fun toggleFavourite(id: Int)
+    fun idOf(item: T): Int
+
+    /** Whether [item] matches [query] — the only per-feature part of the filter. */
+    fun matches(item: T, query: String): Boolean
+}
+
+data class CatalogListState<T>(
+    val items: List<T> = emptyList(),
+    val favorites: List<T> = emptyList(),
+    val filteredItems: List<T> = emptyList(),
+    val isLoading: Boolean = true,
+    val searchQuery: String = "",
+    val showFavoritesOnly: Boolean = false,
+)
+
+data class CatalogDetailState<T>(
+    val item: T? = null,
+    val isLoading: Boolean = true,
+)
+
+/**
+ * Shared by all three catalogues. Ids are plain `Int`s, so this needs no type parameter and
+ * the three features keep distinct `typealias`es without three copies of the hierarchy.
+ */
+sealed interface CatalogEvent {
+    data class LoadDetail(val itemId: Int) : CatalogEvent
+    data class ToggleFavorite(val itemId: Int) : CatalogEvent
+    data class Search(val query: String) : CatalogEvent
+    data object ClearSearch : CatalogEvent
+    data object ToggleFavoritesFilter : CatalogEvent
+}
+
+abstract class CatalogViewModel<T : Any>(
+    private val source: CatalogSource<T>,
+    private val telemetry: Telemetry,
+    private val feature: String,
+) : ViewModel() {
+
+    private val _listState = MutableStateFlow(CatalogListState<T>())
+    val listState: StateFlow<CatalogListState<T>> = _listState.asStateFlow()
+
+    private val _detailState = MutableStateFlow(CatalogDetailState<T>())
+    val detailState: StateFlow<CatalogDetailState<T>> = _detailState.asStateFlow()
+
+    private var detailJob: Job? = null
+
+    init {
+        observeItems()
+        observeFavourites()
+    }
+
+    fun onEvent(event: CatalogEvent) = when (event) {
+        is CatalogEvent.LoadDetail -> {
+            telemetry.featureUsed(feature, AppAnalytics.Action.OPEN_DETAIL)
+            loadDetail(event.itemId)
+        }
+
+        is CatalogEvent.ToggleFavorite -> {
+            telemetry.featureUsed(feature, AppAnalytics.Action.TOGGLE_FAVORITE)
+            toggleFavourite(event.itemId)
+        }
+
+        is CatalogEvent.Search -> {
+            telemetry.featureUsed(feature, AppAnalytics.Action.SEARCH)
+            updateList { it.copy(searchQuery = event.query) }
+        }
+
+        CatalogEvent.ClearSearch -> updateList { it.copy(searchQuery = "") }
+
+        CatalogEvent.ToggleFavoritesFilter -> {
+            telemetry.featureUsed(feature, AppAnalytics.Action.TOGGLE_FAVORITES_FILTER)
+            updateList { it.copy(showFavoritesOnly = !it.showFavoritesOnly) }
+        }
+    }
+
+    private fun observeItems() {
+        launchSafely(
+            telemetry,
+            feature,
+            "load_items",
+            onFailure = { _listState.update { it.copy(isLoading = false) } },
+        ) {
+            source.all().collect { items ->
+                updateList { it.copy(items = items, isLoading = false) }
+            }
+        }
+    }
+
+    private fun observeFavourites() {
+        launchSafely(telemetry, feature, "load_favourites") {
+            source.favourites().collect { favourites ->
+                updateList { it.copy(favorites = favourites) }
+            }
+        }
+    }
+
+    private fun loadDetail(itemId: Int) {
+        _detailState.update { it.copy(isLoading = true) }
+        detailJob?.cancel()
+        detailJob = launchSafely(
+            telemetry,
+            feature,
+            "load_detail",
+            onFailure = { _detailState.update { it.copy(isLoading = false) } },
+        ) {
+            _detailState.update { it.copy(item = source.byId(itemId), isLoading = false) }
+        }
+    }
+
+    private fun toggleFavourite(itemId: Int) {
+        launchSafely(telemetry, feature, "toggle_favourite") {
+            source.toggleFavourite(itemId)
+            // Re-read only when the detail screen is showing this very item; the list is
+            // driven by the two flows above and needs no help.
+            val open = _detailState.value.item
+            if (open != null && source.idOf(open) == itemId) {
+                _detailState.update { it.copy(item = source.byId(itemId)) }
+            }
+        }
+    }
+
+    /**
+     * The single place the filter is applied.
+     *
+     * Every mutation of the list state goes through here, so the filtered view can never fall
+     * out of step with its inputs — which is what happened when each copy had to remember to
+     * call `applyFilters()` after every `update`.
+     */
+    private fun updateList(mutate: (CatalogListState<T>) -> CatalogListState<T>) {
+        _listState.update { current ->
+            val next = mutate(current)
+            val pool = if (next.showFavoritesOnly) next.favorites else next.items
+            next.copy(
+                filteredItems = if (next.searchQuery.isBlank()) {
+                    pool
+                } else {
+                    pool.filter { source.matches(it, next.searchQuery) }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/ProphetViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/ProphetViewModel.kt
@@ -1,172 +1,38 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.Prophet
 import com.arshadshah.nimaz.domain.usecase.ProphetUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-data class ProphetListState(
-    val prophets: List<Prophet> = emptyList(),
-    val favorites: List<Prophet> = emptyList(),
-    val filteredProphets: List<Prophet> = emptyList(),
-    val isLoading: Boolean = true,
-    val searchQuery: String = "",
-    val showFavoritesOnly: Boolean = false
-)
-
-data class ProphetDetailState(
-    val prophet: Prophet? = null,
-    val isFavorite: Boolean = false,
-    val isLoading: Boolean = true
-)
-
-sealed interface ProphetEvent {
-    data class LoadDetail(val prophetId: Int) : ProphetEvent
-    data class ToggleFavorite(val prophetId: Int) : ProphetEvent
-    data class Search(val query: String) : ProphetEvent
-    data object ClearSearch : ProphetEvent
-    data object ToggleFavoritesFilter : ProphetEvent
-}
+/** The prophets, as a catalogue. Its search also covers the title and the era. */
+typealias ProphetListState = CatalogListState<Prophet>
+typealias ProphetDetailState = CatalogDetailState<Prophet>
 
 @HiltViewModel
 class ProphetViewModel @Inject constructor(
-    private val prophetUseCases: ProphetUseCases
-) : ViewModel() {
+    useCases: ProphetUseCases,
+    telemetry: Telemetry,
+) : CatalogViewModel<Prophet>(
+    source = ProphetSource(useCases),
+    telemetry = telemetry,
+    feature = AppAnalytics.Feature.PROPHET,
+)
 
-    private val _listState = MutableStateFlow(ProphetListState())
-    val listState: StateFlow<ProphetListState> = _listState.asStateFlow()
+private class ProphetSource(private val useCases: ProphetUseCases) : CatalogSource<Prophet> {
+    override fun all(): Flow<List<Prophet>> = useCases.getAllProphets()
+    override fun favourites(): Flow<List<Prophet>> = useCases.getFavorites()
+    override suspend fun byId(id: Int): Prophet? = useCases.getProphetById(id)
+    override suspend fun toggleFavourite(id: Int) { useCases.toggleFavorite(id) }
+    override fun idOf(item: Prophet): Int = item.id
 
-    private val _detailState = MutableStateFlow(ProphetDetailState())
-    val detailState: StateFlow<ProphetDetailState> = _detailState.asStateFlow()
-
-    init {
-        observeProphets()
-        observeFavorites()
-    }
-
-    fun onEvent(event: ProphetEvent) {
-        when (event) {
-            is ProphetEvent.LoadDetail -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "open_detail")
-                loadDetail(event.prophetId)
-            }
-            is ProphetEvent.ToggleFavorite -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.PROPHET,
-                    "toggle_favorite"
-                )
-                toggleFavorite(event.prophetId)
-            }
-            is ProphetEvent.Search -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PROPHET, "search")
-                search(event.query)
-            }
-            ProphetEvent.ClearSearch -> clearSearch()
-            ProphetEvent.ToggleFavoritesFilter -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.PROPHET,
-                    "toggle_favorites_filter"
-                )
-                toggleFavoritesFilter()
-            }
-        }
-    }
-
-    private fun observeProphets() {
-        viewModelScope.launch {
-            prophetUseCases.getAllProphets().collect { prophets ->
-                _listState.update {
-                    it.copy(
-                        prophets = prophets,
-                        isLoading = false
-                    )
-                }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun observeFavorites() {
-        viewModelScope.launch {
-            prophetUseCases.getFavorites().collect { favorites ->
-                _listState.update { it.copy(favorites = favorites) }
-                applyFilters()
-            }
-        }
-    }
-
-    private fun loadDetail(prophetId: Int) {
-        _detailState.update { it.copy(isLoading = true) }
-
-        viewModelScope.launch {
-            val prophet = prophetUseCases.getProphetById(prophetId)
-            _detailState.update {
-                it.copy(
-                    prophet = prophet,
-                    isFavorite = prophet?.isFavorite ?: false,
-                    isLoading = false
-                )
-            }
-        }
-    }
-
-    private fun toggleFavorite(prophetId: Int) {
-        viewModelScope.launch {
-            prophetUseCases.toggleFavorite(prophetId)
-            // Refresh detail if currently viewing this prophet
-            val currentDetail = _detailState.value
-            if (currentDetail.prophet?.id == prophetId) {
-                val updatedProphet = prophetUseCases.getProphetById(prophetId)
-                _detailState.update {
-                    it.copy(
-                        prophet = updatedProphet,
-                        isFavorite = updatedProphet?.isFavorite ?: false
-                    )
-                }
-            }
-        }
-    }
-
-    private fun search(query: String) {
-        _listState.update { it.copy(searchQuery = query) }
-        applyFilters()
-    }
-
-    private fun clearSearch() {
-        _listState.update { it.copy(searchQuery = "") }
-        applyFilters()
-    }
-
-    private fun toggleFavoritesFilter() {
-        _listState.update { it.copy(showFavoritesOnly = !it.showFavoritesOnly) }
-        applyFilters()
-    }
-
-    private fun applyFilters() {
-        val state = _listState.value
-        val source = if (state.showFavoritesOnly) state.favorites else state.prophets
-        val filtered = if (state.searchQuery.isBlank()) {
-            source
-        } else {
-            source.filter { prophet ->
-                prophet.nameArabic.contains(state.searchQuery, ignoreCase = true) ||
-                        prophet.nameEnglish.contains(state.searchQuery, ignoreCase = true) ||
-                        prophet.nameTransliteration.contains(
-                            state.searchQuery,
-                            ignoreCase = true
-                        ) ||
-                        prophet.titleEnglish.contains(state.searchQuery, ignoreCase = true) ||
-                        prophet.era.contains(state.searchQuery, ignoreCase = true)
-            }
-        }
-        _listState.update { it.copy(filteredProphets = filtered) }
-    }
+    override fun matches(item: Prophet, query: String): Boolean =
+        item.nameArabic.contains(query, ignoreCase = true) ||
+            item.nameEnglish.contains(query, ignoreCase = true) ||
+            item.nameTransliteration.contains(query, ignoreCase = true) ||
+            item.titleEnglish.contains(query, ignoreCase = true) ||
+            item.era.contains(query, ignoreCase = true)
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModelTest.kt
@@ -1,0 +1,146 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * One test suite for what used to be three copies of the same ViewModel.
+ *
+ * `AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel` and `ProphetViewModel` were byte-identical
+ * after identifier substitution, and between them had four tests — none of which touched the
+ * filter. That is the shape a triplicated file always ends up in: nobody writes the same test
+ * three times, so it gets written zero times.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CatalogViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private data class Row(val id: Int, val name: String)
+
+    private val all = MutableStateFlow(
+        listOf(Row(1, "Ar-Rahman"), Row(2, "Ar-Rahim"), Row(3, "Al-Malik")),
+    )
+    private val favourites = MutableStateFlow(listOf(Row(3, "Al-Malik")))
+    private var toggled = mutableListOf<Int>()
+    private var failing = false
+
+    private inner class Source : CatalogSource<Row> {
+        override fun all(): Flow<List<Row>> =
+            if (failing) flow { throw IllegalStateException("no such table") } else all
+
+        override fun favourites(): Flow<List<Row>> = favourites
+        override suspend fun byId(id: Int): Row? = all.value.firstOrNull { it.id == id }
+        override suspend fun toggleFavourite(id: Int) { toggled += id }
+        override fun idOf(item: Row): Int = item.id
+        override fun matches(item: Row, query: String): Boolean =
+            item.name.contains(query, ignoreCase = true)
+    }
+
+    private inner class TestCatalog : CatalogViewModel<Row>(Source(), telemetry, "test_catalog")
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `the filtered view starts as the whole list`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.filteredItems.map { it.id }).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `searching narrows the list`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("rahi"))
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.filteredItems.map { it.id }).containsExactly(2)
+    }
+
+    @Test
+    fun `the favourites filter and the query compose`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.ToggleFavoritesFilter)
+        advanceUntilIdle()
+        assertThat(vm.listState.value.filteredItems.map { it.id }).containsExactly(3)
+
+        vm.onEvent(CatalogEvent.Search("rahman"))
+        advanceUntilIdle()
+
+        // Ar-Rahman matches the query but is not a favourite, so nothing survives both.
+        assertThat(vm.listState.value.filteredItems).isEmpty()
+    }
+
+    @Test
+    fun `a new emission is filtered by the query already on screen`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        vm.onEvent(CatalogEvent.Search("malik"))
+        advanceUntilIdle()
+
+        // The bug the three copies were one forgotten `applyFilters()` away from: the list
+        // refreshes and quietly ignores the filter the user has set.
+        all.value = all.value + Row(4, "Al-Quddus")
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.filteredItems.map { it.id }).containsExactly(3)
+    }
+
+    @Test
+    fun `clearing the query restores the list`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        vm.onEvent(CatalogEvent.Search("malik"))
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.ClearSearch)
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.filteredItems.map { it.id }).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `opening a detail loads that item`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.LoadDetail(2))
+        advanceUntilIdle()
+
+        assertThat(vm.detailState.value.item?.id).isEqualTo(2)
+        assertThat(vm.detailState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a failing list load clears the spinner and is reported`() = runTest {
+        failing = true
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.type }).contains("load_items")
+    }
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -327,6 +327,24 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.7 · The same ViewModel written three times
+
+- [x] ~~**`AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel`, `ProphetViewModel`.**~~ **Resolved.**
+  171, 171 and 172 lines that were **byte-identical after identifier substitution** — same two
+  states, same five events, same six handlers, same filter, differing only in what the thing is
+  called.
+
+  Triplication does not merely cost lines, it costs correctness twice over. A fix lands in one
+  copy and rots in the other two — and nobody writes the same test three times, so between them
+  the three had four tests and **none touched the filter**, the one piece with any logic in it.
+
+  Collapsed onto `CatalogViewModel<T>` + a `CatalogSource<T>` per feature, which is the only
+  genuinely varying part (where the rows come from, and which fields a search reads). The
+  filter now applies inside the single state mutator, so a new emission cannot arrive
+  unfiltered — the bug all three were one forgotten `applyFilters()` call away from.
+
+  Detect: two ViewModels whose bodies match after substituting their feature nouns.
+
 ### AP-7.6 · A search path nobody can reach
 
 - [x] ~~**Three `search*` use cases, three repository methods, three DAO queries.**~~ **Resolved by


### PR DESCRIPTION
**Layer 22 of 25** · epic #352 · re-opened for review — full write-up in **#391**. Closes the ViewModel half of #361.

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

**514 lines → 286**, of which the 174 in `CatalogViewModel` are the only ones with behaviour.

`AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel` and `ProphetViewModel` were 171, 171 and 172 lines, byte-identical after identifier substitution — verified with `diff` over `sed` substitutions rather than eyeballed. Same two states, same five events, same six handlers, same filter.

**Why that costs correctness, not just lines.** A fix lands in one copy and rots in the other two — and **nobody writes the same test three times, so it gets written zero times.** Between them the three had four tests, and *none* touched the filter, the one part with any logic in it. Both symptoms were already present: the `searchNames`/`searchProphets` use case each injected was invoked by none of them (deleted two layers back), and the `isFavorite` field each maintains at four sites is read by no screen — the screens read `item.isFavorite` off the domain model all along.

What genuinely differs per feature is small enough to be a parameter: where the rows come from, and which fields a search should read. That is `CatalogSource`. Each ViewModel is now four lines of binding plus its source. `CatalogViewModelTest` covers the filter properly for the first time, including "a new emission is filtered by the query already on screen" — the forgotten-`applyFilters()` bug all three copies were one edit away from.

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_