### PR TITLE
refactor(viewmodel): move out the types that were in the wrong layer

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/CityCatalog.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/CityCatalog.kt
@@ -1,7 +1,20 @@
-package com.arshadshah.nimaz.presentation.viewmodel.location
+package com.arshadshah.nimaz.domain.model
 
-import java.util.Locale
-import kotlin.math.abs
+data class SearchLocation(
+    val name: String,
+    val country: String,
+    val latitude: Double,
+    val longitude: Double,
+    val region: CityRegion? = null,   // set for curated cities; null for Geocoder & recent results
+    val flag: String? = null,         // country-flag emoji for curated cities; null otherwise
+) {
+    /**
+     * Stable identity for a lazy-list `key`. Coordinates rather than the name: the same city
+     * name recurs across countries, and the Geocoder and the curated catalogue can both
+     * produce a row for one place with differently-cased names.
+     */
+    val key: String get() = "$latitude,$longitude"
+}
 
 /**
  * Geographic grouping for the curated city list shown on the Location screen.
@@ -78,8 +91,8 @@ val defaultPopularCities: List<SearchLocation> = listOf(
 
 /** Groups curated cities by region, preserving [CityRegion.order]; skips regions with no cities. */
 fun groupCitiesByRegion(cities: List<SearchLocation>): List<Pair<CityRegion, List<SearchLocation>>> =
-    cities.filter { it.region != null }
-        .groupBy { it.region!! }
+    cities.mapNotNull { city -> city.region?.let { it to city } }
+        .groupBy({ it.first }, { it.second })
         .toList()
         .sortedBy { it.first.order }
 
@@ -87,9 +100,3 @@ fun groupCitiesByRegion(cities: List<SearchLocation>): List<Pair<CityRegion, Lis
 fun citiesForRegion(cities: List<SearchLocation>, region: CityRegion?): List<SearchLocation> =
     if (region == null) cities else cities.filter { it.region == region }
 
-/** Formats a coordinate pair with sign-derived hemispheres, e.g. "21.4225° N, 39.8262° E". */
-fun formatCoordinates(latitude: Double, longitude: Double): String {
-    val ns = if (latitude >= 0) "N" else "S"
-    val ew = if (longitude >= 0) "E" else "W"
-    return String.format(Locale.US, "%.4f° %s, %.4f° %s", abs(latitude), ns, abs(longitude), ew)
-}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/DayPrayerTimes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/DayPrayerTimes.kt
@@ -1,0 +1,22 @@
+package com.arshadshah.nimaz.domain.model
+
+import kotlin.time.Instant
+import java.time.LocalDate
+
+/** One day's prayer instants — a fact about the day, not about the table that renders it. */
+/**
+ * One row of the month table. Times are **instants**; the clock format is applied at the leaf from
+ * `LocalUse24HourFormat`, so flipping the 12/24-hour toggle is a recomposition rather than a full
+ * month recompute.
+ */
+data class DayPrayerTimes(
+    val date: LocalDate,
+    val fajr: kotlin.time.Instant?,
+    val sunrise: kotlin.time.Instant?,
+    val dhuhr: kotlin.time.Instant?,
+    val asr: kotlin.time.Instant?,
+    val maghrib: kotlin.time.Instant?,
+    val isha: kotlin.time.Instant?,
+    /** Fasting length (Fajr → Maghrib) in minutes; null if unavailable. */
+    val fastMinutes: Int? = null
+)

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/UnifiedBookmark.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/UnifiedBookmark.kt
@@ -1,0 +1,48 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.arshadshah.nimaz.core.navigation.Route
+
+/**
+ * A Quran, Hadith or Dua bookmark under one type.
+ *
+ * Domain rather than presentation: it unifies three content kinds and carries the navigation
+ * target each resolves to, which is a fact about the content, not about how a screen draws it.
+ * It lived inside `BookmarksViewModel.kt`.
+ */
+data class UnifiedBookmark(
+    val id: String,
+    val type: BookmarkType,
+    val title: String,
+    val subtitle: String,
+    val arabicText: String?,
+    val createdAt: Long,
+    val note: String?,
+    val color: String?,
+    // Navigation data
+    val surahNumber: Int? = null,
+    val ayahNumber: Int? = null,
+    val hadithBookId: String? = null,
+    val hadithNumber: Int? = null,
+    val duaId: String? = null,
+    val categoryId: String? = null
+)
+
+enum class BookmarkType(val prefix: String) {
+    QURAN("quran_"),
+    HADITH("hadith_"),
+    DUA("dua_");
+
+    /** The unified id for a bookmark of this type. */
+    fun idFor(rawId: Any): String = "$prefix$rawId"
+
+    companion object {
+        /**
+         * The type a unified id belongs to, or null.
+         *
+         * The three prefixes used to be written out at nine separate call sites, split
+         * between construction and parsing — and a typo in one of them was a silent
+         * no-op rather than a compile error.
+         */
+        fun ofId(id: String): BookmarkType? = entries.firstOrNull { id.startsWith(it.prefix) }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/UnifiedSearchResult.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/UnifiedSearchResult.kt
@@ -1,0 +1,22 @@
+package com.arshadshah.nimaz.domain.model
+
+/** A search hit from any corpus — belongs beside `LibrarySearchResults`, not in a ViewModel. */
+sealed class UnifiedSearchResult {
+    data class QuranResult(val result: QuranSearchResult) : UnifiedSearchResult()
+    data class HadithResult(val result: HadithSearchResult) : UnifiedSearchResult()
+    data class DuaResult(val result: DuaSearchResult) : UnifiedSearchResult()
+    data class SurahResult(val surah: Surah) : UnifiedSearchResult()
+
+    /**
+     * Stable identity for a lazy-list `key`. Prefixed per variant because the underlying ids
+     * are only unique within their own corpus — ayah 12 and dua "12" must not collide in a
+     * mixed result list.
+     */
+    val key: String
+        get() = when (this) {
+            is QuranResult -> "quran:${result.ayah.id}"
+            is HadithResult -> "hadith:${result.hadith.id}"
+            is DuaResult -> "dua:${result.dua.id}"
+            is SurahResult -> "surah:${surah.number}"
+        }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
@@ -37,7 +37,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.getArabicPrayerName
 import com.arshadshah.nimaz.presentation.components.atoms.getPrayerColor
 import com.arshadshah.nimaz.presentation.components.atoms.getPrayerIcon
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import kotlin.time.Instant
 import com.arshadshah.nimaz.presentation.components.atoms.clockTimeText
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodayCarousel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodayCarousel.kt
@@ -16,8 +16,8 @@ import com.arshadshah.nimaz.presentation.components.molecules.DuaOfTheMomentCard
 import com.arshadshah.nimaz.presentation.components.molecules.FastingStatusCard
 import com.arshadshah.nimaz.presentation.components.molecules.HadithOfTheDayCard
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
-import com.arshadshah.nimaz.presentation.viewmodel.home.DailyDua
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.DailyDua
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import kotlin.time.Instant
 import androidx.compose.runtime.getValue
 import com.arshadshah.nimaz.core.util.prayerTimelineProgressAt

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodayInfoCards.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodayInfoCards.kt
@@ -12,7 +12,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.DuaOfTheMomentCard
 import com.arshadshah.nimaz.presentation.components.molecules.FastingStatusCard
 import com.arshadshah.nimaz.presentation.components.molecules.HadithOfTheDayCard
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
-import com.arshadshah.nimaz.presentation.viewmodel.home.DailyDua
+import com.arshadshah.nimaz.presentation.model.DailyDua
 
 /**
  * Stacked "Today" info cards (fasting status, optional hadith of the day, and

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodaysProgressCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TodaysProgressCard.kt
@@ -37,7 +37,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import kotlin.time.Instant
 import androidx.compose.runtime.getValue
 import com.arshadshah.nimaz.core.util.prayerTimelineProgressAt

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/model/PrayerTimeDisplay.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/model/PrayerTimeDisplay.kt
@@ -1,0 +1,70 @@
+package com.arshadshah.nimaz.presentation.model
+
+import com.arshadshah.nimaz.core.util.currentPrayerIndexAt
+import com.arshadshah.nimaz.core.util.nextPrayerIndexAt
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerType
+import kotlin.time.Instant
+
+/**
+ * Display models shared across the presentation layer.
+ *
+ * These lived in `HomeViewModel.kt`. `PrayerTimeDisplay` alone was imported by **eight** files —
+ * screens, components, and `PrayerTimesViewModel`, which reached into an unrelated feature's
+ * ViewModel file for a type it renders. A shared presentation model parked inside one feature is
+ * a layering leak rather than an organisation nit: every consumer ends up depending on Home.
+ */
+
+/**
+ * A single dua surfaced on the home screen's "Today" section, picked to match
+ * the current time of day (morning / evening / before sleep adhkar).
+ */
+data class DailyDua(
+    val title: String,
+    val arabic: String,
+    val translation: String,
+    val source: String,
+    val categoryLabel: String,
+    val categoryIcon: String,
+)
+
+/**
+ * One prayer row. Carries the prayer's **instant**, not a formatted string: the clock time is
+ * rendered at the leaf so it honours `LocalUse24HourFormat` in the same frame the toggle flips,
+ * and [isPassed]/[isCurrent]/[isNext] are re-derived at the leaf from the shared ticker via
+ * [withClockState] rather than pushed once a second by a ViewModel loop.
+ *
+ * The three booleans default to `false`: a ViewModel publishes the facts (type, instant, status)
+ * and the UI decides what they mean *now*.
+ */
+data class PrayerTimeDisplay(
+    val type: PrayerType,
+    val name: String,
+    val timeAt: Instant,
+    val isPassed: Boolean = false,
+    val isCurrent: Boolean = false,
+    val isNext: Boolean = false,
+    val prayerStatus: PrayerStatus = PrayerStatus.NOT_PRAYED
+)
+
+/**
+ * Re-derive the clock-dependent flags for [now]. Pure and cheap — call it from a composable that
+ * reads `rememberNow()` so the list re-derives at the caller's tick resolution.
+ *
+ * Comparison is by instant, which fixes the long-standing bug where after Isha nothing highlighted
+ * and before Fajr today's Isha rendered as "current" (see `core/util/PrayerClock.kt`).
+ */
+fun List<PrayerTimeDisplay>.withClockState(now: Instant): List<PrayerTimeDisplay> {
+    if (isEmpty()) return this
+    val sorted = sortedBy { it.timeAt }
+    val instants = sorted.map { it.timeAt }
+    val nextIndex = nextPrayerIndexAt(instants, now)
+    val currentIndex = currentPrayerIndexAt(instants, now)
+    return sorted.mapIndexed { index, display ->
+        display.copy(
+            isPassed = display.timeAt <= now,
+            isCurrent = index == currentIndex,
+            isNext = index == nextIndex
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/bookmarks/BookmarksScreen.kt
@@ -69,10 +69,10 @@ import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazMenuAction
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPillTabs
 import com.arshadshah.nimaz.presentation.components.organisms.SwipeableSavedCard
-import com.arshadshah.nimaz.presentation.viewmodel.quran.BookmarkType
+import com.arshadshah.nimaz.domain.model.BookmarkType
 import com.arshadshah.nimaz.presentation.viewmodel.quran.BookmarksEvent
 import com.arshadshah.nimaz.presentation.viewmodel.quran.BookmarksViewModel
-import com.arshadshah.nimaz.presentation.viewmodel.quran.UnifiedBookmark
+import com.arshadshah.nimaz.domain.model.UnifiedBookmark
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -77,8 +77,8 @@ import com.arshadshah.nimaz.presentation.viewmodel.home.AnnouncementUiState
 import com.arshadshah.nimaz.presentation.viewmodel.home.HomeEvent
 import com.arshadshah.nimaz.presentation.viewmodel.home.HomeUiState
 import com.arshadshah.nimaz.presentation.viewmodel.home.HomeViewModel
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
-import com.arshadshah.nimaz.presentation.viewmodel.home.withClockState
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.withClockState
 import kotlin.time.Instant
 
 /**

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
@@ -86,7 +86,7 @@ import com.arshadshah.nimaz.presentation.theme.LocalUse24HourFormat
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazCornerRadius
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
-import com.arshadshah.nimaz.presentation.viewmodel.prayer.DayPrayerTimes
+import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesEvent
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesViewModel
 import java.time.LocalDate

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
@@ -74,11 +74,11 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
 import com.arshadshah.nimaz.presentation.components.molecules.PrayerTimeCard
 import com.arshadshah.nimaz.presentation.components.molecules.calendar.NimazCalendar
 import com.arshadshah.nimaz.presentation.components.organisms.PrayerSkyScene
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesEvent
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesUiState
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesViewModel
-import com.arshadshah.nimaz.presentation.viewmodel.home.withClockState
+import com.arshadshah.nimaz.presentation.model.withClockState
 import java.time.LocalDate
 import java.time.YearMonth
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/search/SearchScreen.kt
@@ -89,7 +89,7 @@ import com.arshadshah.nimaz.presentation.viewmodel.ai.AskViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.search.SearchEvent
 import com.arshadshah.nimaz.presentation.viewmodel.search.SearchFilter
 import com.arshadshah.nimaz.presentation.viewmodel.search.SearchViewModel
-import com.arshadshah.nimaz.presentation.viewmodel.search.UnifiedSearchResult
+import com.arshadshah.nimaz.domain.model.UnifiedSearchResult
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/LocationFormat.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/LocationFormat.kt
@@ -1,0 +1,11 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import java.util.Locale
+import kotlin.math.abs
+
+/** Formats a coordinate pair with sign-derived hemispheres, e.g. "21.4225° N, 39.8262° E". */
+fun formatCoordinates(latitude: Double, longitude: Double): String {
+    val ns = if (latitude >= 0) "N" else "S"
+    val ew = if (longitude >= 0) "E" else "W"
+    return String.format(Locale.US, "%.4f° %s, %.4f° %s", abs(latitude), ns, abs(longitude), ew)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/LocationScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/LocationScreen.kt
@@ -63,14 +63,14 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionTitle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
-import com.arshadshah.nimaz.presentation.viewmodel.location.CityRegion
+import com.arshadshah.nimaz.domain.model.CityRegion
 import com.arshadshah.nimaz.presentation.viewmodel.location.CurrentLocationState
 import com.arshadshah.nimaz.presentation.viewmodel.location.LocationEvent
 import com.arshadshah.nimaz.presentation.viewmodel.location.LocationViewModel
-import com.arshadshah.nimaz.presentation.viewmodel.location.SearchLocation
-import com.arshadshah.nimaz.presentation.viewmodel.location.citiesForRegion
-import com.arshadshah.nimaz.presentation.viewmodel.location.formatCoordinates
-import com.arshadshah.nimaz.presentation.viewmodel.location.groupCitiesByRegion
+import com.arshadshah.nimaz.domain.model.SearchLocation
+import com.arshadshah.nimaz.domain.model.citiesForRegion
+import com.arshadshah.nimaz.presentation.screens.settings.formatCoordinates
+import com.arshadshah.nimaz.domain.model.groupCitiesByRegion
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeUiState.kt
@@ -6,6 +6,9 @@ import com.arshadshah.nimaz.domain.model.HomeEventCard
 import com.arshadshah.nimaz.presentation.components.organisms.WorshipCardUi
 import com.arshadshah.nimaz.core.time.TodayProvider
 import kotlin.time.Instant
+import com.arshadshah.nimaz.presentation.model.DailyDua
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.withClockState
 
 data class HomeUiState(
     // `currentDate` used to live here, set once at construction and read by no screen

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
@@ -73,60 +73,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-
-/**
- * A single dua surfaced on the home screen's "Today" section, picked to match
- * the current time of day (morning / evening / before sleep adhkar).
- */
-data class DailyDua(
-    val title: String,
-    val arabic: String,
-    val translation: String,
-    val source: String,
-    val categoryLabel: String,
-    val categoryIcon: String,
-)
-
-/**
- * One prayer row. Carries the prayer's **instant**, not a formatted string: the clock time is
- * rendered at the leaf so it honours `LocalUse24HourFormat` in the same frame the toggle flips,
- * and [isPassed]/[isCurrent]/[isNext] are re-derived at the leaf from the shared ticker via
- * [withClockState] rather than pushed once a second by a ViewModel loop.
- *
- * The three booleans default to `false`: a ViewModel publishes the facts (type, instant, status)
- * and the UI decides what they mean *now*.
- */
-data class PrayerTimeDisplay(
-    val type: PrayerType,
-    val name: String,
-    val timeAt: Instant,
-    val isPassed: Boolean = false,
-    val isCurrent: Boolean = false,
-    val isNext: Boolean = false,
-    val prayerStatus: PrayerStatus = PrayerStatus.NOT_PRAYED
-)
-
-/**
- * Re-derive the clock-dependent flags for [now]. Pure and cheap — call it from a composable that
- * reads `rememberNow()` so the list re-derives at the caller's tick resolution.
- *
- * Comparison is by instant, which fixes the long-standing bug where after Isha nothing highlighted
- * and before Fajr today's Isha rendered as "current" (see `core/util/PrayerClock.kt`).
- */
-fun List<PrayerTimeDisplay>.withClockState(now: Instant): List<PrayerTimeDisplay> {
-    if (isEmpty()) return this
-    val sorted = sortedBy { it.timeAt }
-    val instants = sorted.map { it.timeAt }
-    val nextIndex = nextPrayerIndexAt(instants, now)
-    val currentIndex = currentPrayerIndexAt(instants, now)
-    return sorted.mapIndexed { index, display ->
-        display.copy(
-            isPassed = display.timeAt <= now,
-            isCurrent = index == currentIndex,
-            isNext = index == nextIndex
-        )
-    }
-}
+import com.arshadshah.nimaz.presentation.model.DailyDua
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.withClockState
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationEvent.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.location
 
+import com.arshadshah.nimaz.domain.model.CityRegion
+import com.arshadshah.nimaz.domain.model.SearchLocation
 sealed interface LocationEvent {
     data class UpdateSearchQuery(val query: String) : LocationEvent
     data object Search : LocationEvent

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationUiState.kt
@@ -1,5 +1,8 @@
 package com.arshadshah.nimaz.presentation.viewmodel.location
 
+import com.arshadshah.nimaz.domain.model.CityRegion
+import com.arshadshah.nimaz.domain.model.SearchLocation
+import com.arshadshah.nimaz.domain.model.defaultPopularCities
 data class LocationUiState(
     val searchQuery: String = "",
     val searchResults: List<SearchLocation> = emptyList(),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModel.kt
@@ -37,22 +37,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-
-data class SearchLocation(
-    val name: String,
-    val country: String,
-    val latitude: Double,
-    val longitude: Double,
-    val region: CityRegion? = null,   // set for curated cities; null for Geocoder & recent results
-    val flag: String? = null,         // country-flag emoji for curated cities; null otherwise
-) {
-    /**
-     * Stable identity for a lazy-list `key`. Coordinates rather than the name: the same city
-     * name recurs across countries, and the Geocoder and the curated catalogue can both
-     * produce a row for one place with differently-cased names.
-     */
-    val key: String get() = "$latitude,$longitude"
-}
+import com.arshadshah.nimaz.domain.model.SearchLocation
 
 @HiltViewModel
 class LocationViewModel @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesUiState.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 
 import java.time.LocalDate
 import java.time.YearMonth
+import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 
 data class MonthlyPrayerTimesUiState(
     val currentMonth: YearMonth = YearMonth.now(),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
@@ -22,23 +22,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.toLocalDateTime
-
-/**
- * One row of the month table. Times are **instants**; the clock format is applied at the leaf from
- * `LocalUse24HourFormat`, so flipping the 12/24-hour toggle is a recomposition rather than a full
- * month recompute.
- */
-data class DayPrayerTimes(
-    val date: LocalDate,
-    val fajr: kotlin.time.Instant?,
-    val sunrise: kotlin.time.Instant?,
-    val dhuhr: kotlin.time.Instant?,
-    val asr: kotlin.time.Instant?,
-    val maghrib: kotlin.time.Instant?,
-    val isha: kotlin.time.Instant?,
-    /** Fasting length (Fajr → Maghrib) in minutes; null if unavailable. */
-    val fastMinutes: Int? = null
-)
+import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 
 @HiltViewModel
 class MonthlyPrayerTimesViewModel @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesUiState.kt
@@ -3,7 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 import com.arshadshah.nimaz.domain.model.FallbackLocation
 import java.time.Instant
 import java.time.LocalDate
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 
 /**
  * Drives the dedicated Prayer Times screen: a day pager over the prayer

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 
 @HiltViewModel
 class PrayerTimesViewModel @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksEvent.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.domain.model.BookmarkType
 sealed interface BookmarksEvent {
     data class SetFilter(val type: BookmarkType?) : BookmarksEvent
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksUiState.kt
@@ -3,6 +3,8 @@ package com.arshadshah.nimaz.presentation.viewmodel.quran
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.HadithBookmark
 import com.arshadshah.nimaz.domain.model.QuranBookmark
+import com.arshadshah.nimaz.domain.model.BookmarkType
+import com.arshadshah.nimaz.domain.model.UnifiedBookmark
 
 data class BookmarksUiState(
     val allBookmarks: List<UnifiedBookmark> = emptyList(),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
@@ -21,44 +21,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-data class UnifiedBookmark(
-    val id: String,
-    val type: BookmarkType,
-    val title: String,
-    val subtitle: String,
-    val arabicText: String?,
-    val createdAt: Long,
-    val note: String?,
-    val color: String?,
-    // Navigation data
-    val surahNumber: Int? = null,
-    val ayahNumber: Int? = null,
-    val hadithBookId: String? = null,
-    val hadithNumber: Int? = null,
-    val duaId: String? = null,
-    val categoryId: String? = null
-)
-
-enum class BookmarkType(val prefix: String) {
-    QURAN("quran_"),
-    HADITH("hadith_"),
-    DUA("dua_");
-
-    /** The unified id for a bookmark of this type. */
-    fun idFor(rawId: Any): String = "$prefix$rawId"
-
-    companion object {
-        /**
-         * The type a unified id belongs to, or null.
-         *
-         * The three prefixes used to be written out at nine separate call sites, split
-         * between construction and parsing — and a typo in one of them was a silent
-         * no-op rather than a compile error.
-         */
-        fun ofId(id: String): BookmarkType? = entries.firstOrNull { id.startsWith(it.prefix) }
-    }
-}
+import com.arshadshah.nimaz.domain.model.BookmarkType
+import com.arshadshah.nimaz.domain.model.UnifiedBookmark
 
 enum class BookmarkSortOrder {
     DATE_NEWEST, DATE_OLDEST, TYPE, ALPHABETICAL

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchUiState.kt
@@ -4,6 +4,7 @@ import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.UnifiedSearchResult
 
 data class SearchUiState(
     val query: String = "",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
@@ -18,26 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-sealed class UnifiedSearchResult {
-    data class QuranResult(val result: QuranSearchResult) : UnifiedSearchResult()
-    data class HadithResult(val result: HadithSearchResult) : UnifiedSearchResult()
-    data class DuaResult(val result: DuaSearchResult) : UnifiedSearchResult()
-    data class SurahResult(val surah: Surah) : UnifiedSearchResult()
-
-    /**
-     * Stable identity for a lazy-list `key`. Prefixed per variant because the underlying ids
-     * are only unique within their own corpus — ayah 12 and dua "12" must not collide in a
-     * mixed result list.
-     */
-    val key: String
-        get() = when (this) {
-            is QuranResult -> "quran:${result.ayah.id}"
-            is HadithResult -> "hadith:${result.hadith.id}"
-            is DuaResult -> "dua:${result.dua.id}"
-            is SurahResult -> "surah:${surah.number}"
-        }
-}
+import com.arshadshah.nimaz.domain.model.UnifiedSearchResult
 
 enum class SearchFilter {
     ALL, QURAN, HADITH, DUA

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationCatalogTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationCatalogTest.kt
@@ -2,6 +2,11 @@ package com.arshadshah.nimaz.presentation.viewmodel.location
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import com.arshadshah.nimaz.domain.model.CityRegion
+import com.arshadshah.nimaz.domain.model.citiesForRegion
+import com.arshadshah.nimaz.domain.model.defaultPopularCities
+import com.arshadshah.nimaz.domain.model.groupCitiesByRegion
+import com.arshadshah.nimaz.presentation.screens.settings.formatCoordinates
 
 class LocationCatalogTest {
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModelRegionTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModelRegionTest.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.location
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import com.arshadshah.nimaz.domain.model.CityRegion
 
 /**
  * Pure state-transition checks for the region filter. We assert the reducer contract via a

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCardTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCardTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TodayCarouselTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TodayCarouselTest.kt
@@ -3,7 +3,7 @@ package com.arshadshah.nimaz.presentation.components.organisms
 import androidx.compose.ui.test.onNodeWithText
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TodaysProgressCardTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/organisms/TodaysProgressCardTest.kt
@@ -3,7 +3,7 @@ package com.arshadshah.nimaz.presentation.components.organisms
 import androidx.compose.ui.test.onNodeWithText
 import com.arshadshah.nimaz.domain.model.PrayerStatus
 import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.presentation.viewmodel.home.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,6 +263,20 @@ The types stay in the **same package** as the ViewModel, so splitting them costs
 which is exactly why there is no excuse for a 1,400-line file that opens with 200 lines of
 `data class`.
 
+**What does *not* belong there: anything a screen, component or widget also imports.** A type
+in `viewmodel/<feature>/` is that feature's business. `PrayerTimeDisplay` lived in
+`HomeViewModel.kt` and was imported by eight files — including `PrayerTimesViewModel`, which
+reached into an unrelated feature's ViewModel for a type it renders. Shared display models go
+to **`presentation/model/`**; anything that is a fact about the content rather than about how
+it is drawn (`UnifiedBookmark`, `UnifiedSearchResult`, `DayPrayerTimes`, the city catalogue)
+goes to **`domain/model/`**. `widget/` and `components/` must import from neither
+`viewmodel/` — that is a layering leak, and it is currently at zero:
+
+```bash
+grep -rn "import com.arshadshah.nimaz.presentation.viewmodel" \
+  app/src/main/java/com/arshadshah/nimaz/{widget,presentation/components}/   # expect none
+```
+
 Rules:
 - Lives in `presentation/viewmodel/<feature>/`, with its `XxxUiState`s in `XxxUiState.kt` and
   its `XxxEvent` in `XxxEvent.kt` beside it. Pick the existing sub-package the feature belongs


### PR DESCRIPTION
**Layer 24 of 25** · epic #352 · re-opened for review — full write-up in **#393**. **Closes #353.**

> Recorded as merged into `epic/viewmodel-cleanup` by a fast-forward before review. Diff unchanged; based on its predecessor.

**Not the wrong file — the wrong layer.** The previous two layers moved ViewModels into sub-packages and split their states and events into sibling files. These types are different: they were imported by **screens, components and widgets**, so parking them in one feature's ViewModel made every consumer depend on that feature. `PrayerTimeDisplay` is the clearest symptom — it lived in `HomeViewModel.kt` and was imported by **eight** files, including `PrayerTimesViewModel`, a ViewModel reaching into an unrelated feature's ViewModel for a type it renders.

| Type | Was | Now |
|---|---|---|
| `PrayerTimeDisplay`, `DailyDua`, `List.withClockState` | `HomeViewModel.kt` | `presentation/model/` |
| `UnifiedBookmark`, `BookmarkType` | `BookmarksViewModel.kt` | `domain/model/` |
| `UnifiedSearchResult` | `SearchViewModel.kt` | `domain/model/` |
| `DayPrayerTimes` | `MonthlyPrayerTimesViewModel.kt` | `domain/model/` |
| `SearchLocation`, `CityRegion`, `defaultPopularCities`, the two transforms | `LocationCatalog.kt` | `domain/model/CityCatalog.kt` |
| `formatCoordinates` | `LocationCatalog.kt` | `screens/settings/LocationFormat.kt` |

The split between the two destinations is deliberate: **`presentation/model/` for shared display models**, **`domain/model/` for anything that is a fact about the content rather than about how it is drawn.** `UnifiedBookmark` unifies three content kinds and carries the navigation target each resolves to; that is content, not layout.

`LocationCatalog.kt` was never a ViewModel — 95 lines in `presentation/viewmodel/` holding an enum, a 40-entry curated dataset, two list transforms and a coordinate formatter. Split by responsibility, with the formatter following its only consumer.

Gates: compile ✅ · tests ✅ · `check_docs.py` 23/23 ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_