### PR TITLE
fix(quran): open the reader in the user's translation, once

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -318,6 +317,12 @@ class QuranViewModel @Inject constructor(
 
     private fun observeQuranSettings() {
         viewModelScope.launch {
+            // DataStore's first emission is hydration, not a change the user made — and the
+            // reader state it is compared against holds compiled-in defaults until it arrives.
+            // Treating it as a change re-issued a load the reader had already performed with
+            // the right values (see `translatorId`/`mushafScript`), and for a non-default
+            // edition it repaginated a page number *from* an edition the reader was never on.
+            var hydrated = false
             // Split into two groups of 4 to use typed combine overloads
             val displayFlow = combine(
                 settingsRepository.quranTranslatorId,
@@ -350,12 +355,13 @@ class QuranViewModel @Inject constructor(
             }.collect { settings ->
                 val (display, behavior, showTajweed, tajweedUnderline, mushafScript) = settings
                 // Captured before the state update below overwrites them.
-                val translationChanged =
+                val translationChanged = hydrated &&
                     _readerState.value.selectedTranslatorId != display.translatorId
                 // A different edition repaginates the Quran, so page N no longer holds the
                 // same ayahs.
                 val previousScript = _readerState.value.mushafScript
-                val scriptChanged = previousScript != mushafScript
+                val scriptChanged = hydrated && previousScript != mushafScript
+                hydrated = true
                 audioManager.setReciter(behavior.reciterId)
                 // Push continuous-reading reactively so toggling the setting while
                 // in the reader takes effect immediately, not on next play-start.
@@ -512,7 +518,7 @@ class QuranViewModel @Inject constructor(
 
     private fun playSurahFromInfo(surahNumber: Int) {
         viewModelScope.launch {
-            quranUseCases.getSurahWithAyahs(surahNumber, _readerState.value.selectedTranslatorId)
+            quranUseCases.getSurahWithAyahs(surahNumber, translatorId())
                 .first()?.let { surahWithAyahs ->
                     val audioItems = surahWithAyahs.ayahs.map { ayah ->
                         QuranAudioManager.AyahAudioItem(
@@ -577,8 +583,10 @@ class QuranViewModel @Inject constructor(
             _homeState.update { it.copy(hasThematicContent = thematic) }
         }
         viewModelScope.launch {
+            // Collected directly. Wrapping it in `stateIn(…, emptyList())` first published the
+            // seed — surahs = [], isLoading = false — before Room had produced a row, so the
+            // list rendered its "nothing here" state for a frame on every cold open.
             quranUseCases.getSurahList()
-                .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
                 .collect { surahs ->
                     _homeState.update { state ->
                         state.copy(
@@ -629,9 +637,30 @@ class QuranViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The translation content is fetched with, read from where it is persisted.
+     *
+     * [QuranReaderUiState.selectedTranslatorId] carries a compiled-in default —
+     * `sahih_international` — and is only replaced once [observeQuranSettings]' first emission
+     * lands, which is after DataStore's first read and so generally *after* the screen has
+     * already asked for a surah. Reading it off the state handed every non-default user English
+     * first, then `translationChanged` re-issued the entire query: a visible flash **and** a
+     * wasted full-surah read on every reader open. [loadVerseOfTheDay] already resolved the
+     * preference this way; the reader paths did not.
+     */
+    private suspend fun translatorId(): String = settingsRepository.quranTranslatorId.first()
+
+    /**
+     * The Mushaf edition content is fetched with, read from where it is persisted — the same
+     * pre-hydration hazard as [translatorId], and worse in page mode, because an edition
+     * decides which ayahs page N even holds.
+     */
+    private suspend fun mushafScript(): MushafScript =
+        MushafScript.fromName(settingsRepository.quranMushafScript.first())
+
     private fun loadVerseOfTheDay() {
         viewModelScope.launch {
-            val translatorId = settingsRepository.quranTranslatorId.first()
+            val translatorId = translatorId()
             val epochDay = java.time.LocalDate.now().toEpochDay()
             val verse = quranUseCases.getVerseOfTheDay(epochDay, translatorId)
             _homeState.update { it.copy(verseOfTheDay = verse) }
@@ -674,7 +703,7 @@ class QuranViewModel @Inject constructor(
         contentJob?.cancel()
         cancelPageJobs()
         contentJob = viewModelScope.launch {
-            quranUseCases.getSurahWithAyahs(surahNumber, _readerState.value.selectedTranslatorId)
+            quranUseCases.getSurahWithAyahs(surahNumber, translatorId())
                 .collect { surahWithAyahs ->
                     _readerState.update {
                         it.copy(
@@ -713,7 +742,7 @@ class QuranViewModel @Inject constructor(
         contentJob?.cancel()
         cancelPageJobs()
         contentJob = viewModelScope.launch {
-            quranUseCases.getAyahsByJuz(juzNumber, _readerState.value.selectedTranslatorId)
+            quranUseCases.getAyahsByJuz(juzNumber, translatorId())
                 .collect { ayahs ->
                     _readerState.update {
                         it.copy(
@@ -785,8 +814,8 @@ class QuranViewModel @Inject constructor(
             // info bar, "mark page read" for khatam and the ayah-action lookups (#325).
             quranUseCases.getAyahsByPage(
                 pageNumber = pageNumber,
-                translatorId = _readerState.value.selectedTranslatorId,
-                script = _readerState.value.mushafScript
+                translatorId = translatorId(),
+                script = mushafScript()
             )
                 .collect { ayahs ->
                     // Re-read at emission time: a prefetch started while the user was on this
@@ -841,10 +870,7 @@ class QuranViewModel @Inject constructor(
         // Already cached (e.g. a neighbouring pager page pre-loaded it) — nothing to do.
         if (_readerState.value.mushafPageLayoutCache.containsKey(pageNumber)) return
         viewModelScope.launch {
-            val layout = quranUseCases.getMushafPageLayout(
-                pageNumber,
-                _readerState.value.mushafScript
-            )
+            val layout = quranUseCases.getMushafPageLayout(pageNumber, mushafScript())
             _readerState.update {
                 it.copy(
                     mushafPageLayoutCache = it.mushafPageLayoutCache + (pageNumber to layout)
@@ -880,7 +906,7 @@ class QuranViewModel @Inject constructor(
 
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
-            quranUseCases.searchQuran(query, _readerState.value.selectedTranslatorId)
+            quranUseCases.searchQuran(query, translatorId())
                 .collect { results ->
                     // Populate surah names and limit results to 50 for performance
                     val surahs = _homeState.value.surahs

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
@@ -1,0 +1,185 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import android.content.Context
+import com.arshadshah.nimaz.data.audio.QuranAudioManager
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.GetSurahWithAyahsUseCase
+import com.arshadshah.nimaz.domain.usecase.KhatamUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What the Quran surfaces show *before* their data arrives.
+ *
+ * Both defects here are invisible in a test that hands the ViewModel data instantly, which is
+ * why neither was caught: they only exist in the window between construction and the first
+ * real emission. So the fakes below are deliberately slow, and the assertions are taken
+ * *inside* that window.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuranReaderHydrationTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: QuranUseCases
+    private lateinit var audioManager: QuranAudioManager
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var khatamUseCases: KhatamUseCases
+    private lateinit var context: Context
+    private lateinit var getSurahWithAyahs: GetSurahWithAyahsUseCase
+
+    /**
+     * The translator id every reader query was actually issued with, in order.
+     *
+     * Recorded rather than verified through mockk: `getSurahWithAyahs` is an `operator fun
+     * invoke` reached through a property of a mock, so a `verify` block records the property
+     * getter *and* the call and its counts do not mean what they look like.
+     */
+    private val requestedTranslators = mutableListOf<String?>()
+
+    private val surahs = listOf(
+        surah(1, "The Opening", "Al-Fatihah", "الفاتحة"),
+        surah(2, "The Cow", "Al-Baqarah", "البقرة"),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        audioManager = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
+        khatamUseCases = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+        every { settingsRepository.quranTranslatorId } returns MutableStateFlow("en.sahih")
+        every { settingsRepository.quranMushafScript } returns MutableStateFlow("madani")
+        every { settingsRepository.showTranslation } returns MutableStateFlow(true)
+        every { settingsRepository.showTransliteration } returns MutableStateFlow(false)
+        every { settingsRepository.quranArabicFontSize } returns MutableStateFlow(28f)
+        every { settingsRepository.quranArabicFont } returns MutableStateFlow("amiri")
+        every { settingsRepository.quranTranslationFontSize } returns MutableStateFlow(16f)
+        every { settingsRepository.continuousReading } returns MutableStateFlow(true)
+        every { settingsRepository.keepScreenOn } returns MutableStateFlow(true)
+        every { settingsRepository.selectedReciterId } returns MutableStateFlow(null)
+        every { settingsRepository.showTajweed } returns MutableStateFlow(false)
+        every { settingsRepository.tajweedUnderline } returns MutableStateFlow(false)
+        every { useCases.getSurahList() } returns flowOf(surahs)
+        getSurahWithAyahs = mockk()
+        every { useCases.getSurahWithAyahs } returns getSurahWithAyahs
+        every { getSurahWithAyahs(any(), any()) } answers {
+            requestedTranslators += secondArg<String?>()
+            flowOf(null)
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() =
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, context)
+
+    // R1 — the home list must stay on its skeleton until Room answers.
+
+    @Test
+    fun `the surah list is still loading before Room has emitted`() = runTest {
+        every { useCases.getSurahList() } returns flow {
+            delay(100)
+            emit(surahs)
+        }
+
+        val vm = viewModel()
+        advanceTimeBy(50)
+
+        // `stateIn(…, SharingStarted.Eagerly, emptyList())` published its seed here — an empty
+        // list with `isLoading = false`, which Quran Home renders as "nothing here" — one or
+        // more frames before the database produced a single row.
+        assertThat(vm.homeState.value.isLoading).isTrue()
+        assertThat(vm.homeState.value.surahs).isEmpty()
+    }
+
+    @Test
+    fun `the surah list resolves once Room emits`() = runTest {
+        every { useCases.getSurahList() } returns flow {
+            delay(100)
+            emit(surahs)
+        }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.isLoading).isFalse()
+        assertThat(vm.homeState.value.surahs.map { it.number }).containsExactly(1, 2)
+        assertThat(vm.homeState.value.filteredSurahs.map { it.number }).containsExactly(1, 2)
+    }
+
+    // R2 — the reader must open in the user's translation, once.
+
+    @Test
+    fun `the reader loads the persisted translation, never the compiled-in default`() = runTest {
+        // Slow enough that `LoadSurah` lands before the settings collector's first emission —
+        // which is the ordering on a real cold open, DataStore's first read being disk-bound.
+        every { settingsRepository.quranTranslatorId } returns flow {
+            delay(100)
+            emit("urdu_jalandhry")
+        }
+
+        val vm = viewModel()
+        vm.onEvent(QuranEvent.LoadSurah(2))
+        advanceUntilIdle()
+
+        // `QuranReaderUiState.selectedTranslatorId` defaults to `sahih_international`, so
+        // reading the translator off the state served English to every non-default user —
+        // and this is the whole list of queries, so it also pins the second half of the
+        // defect: the wrong-translation load landed first, then hydration looked like a
+        // translation *change* and `reloadReaderContent()` re-issued the entire surah.
+        assertThat(requestedTranslators).containsExactly("urdu_jalandhry")
+    }
+
+    @Test
+    fun `a real translation change still reloads`() = runTest {
+        val translator = MutableStateFlow("en.sahih")
+        every { settingsRepository.quranTranslatorId } returns translator
+
+        val vm = viewModel()
+        vm.onEvent(QuranEvent.LoadSurah(2))
+        advanceUntilIdle()
+        requestedTranslators.clear()
+
+        translator.value = "urdu_jalandhry"
+        advanceUntilIdle()
+
+        // The hydration guard suppresses the *first* emission only. A preference the user
+        // actually changes must still invalidate the reader.
+        assertThat(requestedTranslators).contains("urdu_jalandhry")
+    }
+}
+
+private fun surah(number: Int, english: String, transliteration: String, arabic: String) = Surah(
+    number = number,
+    nameArabic = arabic,
+    nameEnglish = english,
+    nameTransliteration = transliteration,
+    revelationType = RevelationType.MECCAN,
+    ayahCount = 7,
+    juzStart = 1,
+    orderInMushaf = number,
+    startPage = number,
+)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -639,6 +639,33 @@ Anything scoped to a day takes the date as a **parameter** rather than reading t
 inside itself — see `domain/usecase/calendar/`, where the grid builders take `today` — so the
 same call can be re-issued for the new day.
 
+#### A persisted preference is read from the repository, never off the UI state
+
+A `UiState` field that mirrors a preference is a **cache of it, not the value**. It holds a
+compiled-in default until the settings collector's first emission lands, and that emission is
+disk-bound — so on a cold open it generally arrives *after* the screen has already asked for
+content.
+
+`QuranViewModel` read `_readerState.value.selectedTranslatorId` as the argument to its surah,
+juz, page and search queries. Every user whose translation was not `sahih_international` — the
+default declared on the state class — got **English first**, then a second full-surah query when
+the real preference arrived. A flash and a wasted read on every reader open. Resolve it where it
+lives, inside the load:
+
+```kotlin
+private suspend fun translatorId(): String = settingsRepository.quranTranslatorId.first()
+```
+
+**And then guard the settings collector's first emission**, because it is hydration, not a
+change. Comparing it against the state's defaults reports a change that never happened, and the
+"invalidate and reload" branch that hangs off that comparison then re-issues a load which already
+used the right values. Worse for anything positional: a Mushaf edition change repaginates the
+Quran, so a phantom change repaginated a page number *from* an edition the reader was never on.
+
+The same reasoning rules out `stateIn(scope, Eagerly, <empty>)` on a flow that is only collected:
+the seed publishes an empty result — with `isLoading = false` — before the database has answered,
+which the screen renders as its empty state. Collect the flow.
+
 #### CPU-bound work goes on the injected `@DefaultDispatcher`
 
 `viewModelScope.launch` is `Dispatchers.Main`. `CalendarViewModel.navigateToYear` did ~365

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -327,6 +327,32 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.8 · A UiState default answering a question only the repository can
+
+- [x] ~~**`QuranViewModel`'s reader loads read the translator and Mushaf edition off
+  `_readerState`.**~~ **Resolved.** A persisted preference has exactly one source of truth — the
+  repository. A `UiState` field that *mirrors* one carries a compiled-in default until the
+  settings collector's first emission lands, and that emission is disk-bound, so on a cold open
+  it generally arrives **after** the screen has already asked for content. Every non-default user
+  therefore got the default's content first, then a second full query when the real preference
+  turned up: a visible flash and a wasted read on every reader open.
+
+  Two rules come out of it, and the second is the one that bites on the way to fixing the first:
+
+  - Resolve the preference where it lives (`settingsRepository.x.first()`), inside the load. The
+    file already did this in `loadVerseOfTheDay`; the reader paths did not.
+  - Once the loads read DataStore, **the settings collector's first emission is hydration, not a
+    change.** Comparing it against the state's defaults reports a change that never happened —
+    which re-issues the load, and for a non-default Mushaf edition repaginates a page number
+    *from* an edition the reader was never on. Guard the first emission.
+
+  Detect: a `_state.value.<field>` read as a *query argument*, where `<field>` is also written by
+  a settings collector.
+
+  ```bash
+  rg -n '_\w+State\.value\.\w+' app/src/main/java --glob '*ViewModel.kt' | grep -i 'get\|load\|search'
+  ```
+
 ### AP-7.7 · The same ViewModel written three times
 
 - [x] ~~**`AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel`, `ProphetViewModel`.**~~ **Resolved.**


### PR DESCRIPTION
**Layer 26** · epic #352 · on top of #395 (vm-25). Closes R1 and R2 of #364 — the first layer of the readers issue.

Both defects live entirely in the window between construction and the first real emission, which is why neither was caught: a test that hands the ViewModel its data instantly never enters that window. So the fakes in `QuranReaderHydrationTest` are deliberately slow and the assertions are taken *inside* it.

## R1 — Quran Home flashes "nothing here" on every cold open

```kotlin
quranUseCases.getSurahList()
    .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())   // ← seed
    .collect { … }
```

A flow wrapped in a `StateFlow` purely to collect it once. The seed emits `emptyList()` **immediately**, so the first update sets `surahs = []`, `filteredSurahs = []` *and* `isLoading = false` before Room has produced a single row — and the list renders its empty state instead of its skeleton. It also leaked an eager state holder never used as one.

## R2 — every non-default user sees the wrong translation, then pays for a second query

`loadSurah`, `loadJuz`, `loadPage`, the search and the info-screen play path all took their translator from `_readerState.value.selectedTranslatorId`. That field's default is `sahih_international`, and it is only replaced once the settings collector's first emission lands — which is disk-bound, so on a cold open it arrives *after* the screen has asked for content.

**Input → wrong output:** a user whose translation is `urdu_jalandhry` opens any surah. Sahih International English renders first; then `translationChanged` fires and `reloadReaderContent()` re-issues the whole surah. A visible flash **and** a wasted full-surah query on every reader open, for every non-default user.

The preference is now resolved from where it lives — which `loadVerseOfTheDay` in the same file already did, and the reader paths did not. The Mushaf edition had the identical shape at two more sites and is fixed with it.

### The consequence that had to be handled with it

Once the loads read DataStore, **the settings collector's first emission is hydration, not a change** — but it is still compared against the state's defaults, so it reports a change that never happened. Left alone that would now be *worse* than before: a non-default edition would take the `scriptChanged` branch and repaginate a page number **from an edition the reader was never on**. First emission guarded; a preference the user actually changes still invalidates the reader, and there's a test for that.

## Verified red first

| | before | after |
|---|---|---|
| `the reader loads the persisted translation, never the compiled-in default` | `[sahih_international, urdu_jalandhry]` | `[urdu_jalandhry]` |
| `the surah list is still loading before Room has emitted` | `isLoading = false` | `isLoading = true` |

The first assertion pins both halves of R2 at once: it is the complete list of queries issued, so a wrong translation and a duplicate query each fail it. Two control tests (`the surah list resolves once Room emits`, `a real translation change still reloads`) pass before and after — they exist to catch an over-correction.

The existing `QuranViewModelPageLoadTest` — which exercises the script-change/cache-drop path the hydration guard touches — stays green.

## Docs

- `ARCHITECTURE.md` §4.1 — a persisted preference is read from the repository, never off the UI state; hydration is not a change; and don't `stateIn` a flow you only collect.
- `CLEAN_ARCHITECTURE_CHECKLIST.md` — new **AP-7.8**, "a UiState default answering a question only the repository can", with a detector.

Gates: compile ✅ · 1,530 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, unchanged from the rest of the stack: it needs the content artifact from the private `nimaz-data` repo, which this session's token cannot reach, so every local run used `-x :app:fetchNimazData` and it fails identically on the base branch with that flag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_