### PR TITLE
fix(hadith): open the hadith the user asked for, and stay on it

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -621,7 +621,7 @@ fun NavGraph(
                         navController.navigate(Route.QuranReader(surah, ayah))
                     },
                     onNavigateToHadith = { bookId, hadithNumber ->
-                        navController.navigate(Route.HadithReader(hadithNumber.toString()))
+                        navController.navigate(Route.HadithByNumber(bookId, hadithNumber))
                     },
                     onNavigateToDua = { duaId ->
                         navController.navigate(Route.DuaReader(duaId))
@@ -670,6 +670,17 @@ fun NavGraph(
                 )
             }
 
+            taggedComposable<Route.HadithByNumber>(ScreenTags.HadithByNumber) { backStackEntry ->
+                val args = backStackEntry.toRoute<Route.HadithByNumber>()
+                HadithReaderScreen(
+                    bookId = args.bookId,
+                    chapterId = "",
+                    hadithNumber = args.hadithNumber,
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToSettings = { navController.navigate(Route.HadithSettings) }
+                )
+            }
+
             taggedComposable<Route.HadithSettings>(ScreenTags.HadithSettings) {
                 HadithSettingsScreen(
                     onNavigateBack = { navController.popBackStack() }
@@ -701,7 +712,7 @@ fun NavGraph(
                         navController.navigate(Route.QuranReader(surah, ayah))
                     },
                     onNavigateToHadith = { bookId, hadithNumber ->
-                        navController.navigate(Route.HadithReader(hadithNumber.toString()))
+                        navController.navigate(Route.HadithByNumber(bookId, hadithNumber))
                     },
                     onNavigateToDua = { duaId ->
                         navController.navigate(Route.DuaReader(duaId))
@@ -1260,7 +1271,7 @@ fun NavGraph(
                         navController.navigate(Route.QuranReader(surah, ayah))
                     },
                     onNavigateToHadith = { bookId, hadithNumber ->
-                        navController.navigate(Route.HadithReader(hadithNumber.toString()))
+                        navController.navigate(Route.HadithByNumber(bookId, hadithNumber))
                     },
                     onNavigateToDua = { duaId ->
                         navController.navigate(Route.DuaReader(duaId))

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/Routes.kt
@@ -48,6 +48,19 @@ sealed interface Route {
     @Serializable
     data class HadithReader(val hadithId: String) : Route
 
+    /**
+     * A hadith addressed the way a reader cites one — book plus the number printed on it —
+     * rather than by database id.
+     *
+     * Separate from [HadithReader] because they are genuinely different addresses, and
+     * collapsing them is what broke the bookmarks: a `HadithBookmark` stores `bookId` and
+     * `hadithNumber` and no id, so the bookmark screen had to pass `hadithNumber.toString()`
+     * into [HadithReader]'s `hadithId` slot. That resolves to the row whose **primary key**
+     * equals the number — a real hadith, from an arbitrary book, opened with no error.
+     */
+    @Serializable
+    data class HadithByNumber(val bookId: String, val hadithNumber: Int) : Route
+
     @Serializable
     data object HadithSearch : Route
 

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -43,6 +43,7 @@ object ScreenTags {
     const val HadithBook = "screen_hadith_book"
     const val HadithChapter = "screen_hadith_chapter"
     const val HadithReader = "screen_hadith_reader"
+    const val HadithByNumber = "screen_hadith_by_number"
     const val HadithSettings = "screen_hadith_settings"
     const val HadithSearch = "screen_hadith_search"
     const val HadithBookmarks = "screen_hadith_bookmarks"

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/HadithModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/HadithModels.kt
@@ -37,7 +37,16 @@ data class Hadith(
     val gradeArabic: String?,
     val reference: String?,
     val isBookmarked: Boolean = false
-)
+) {
+    /**
+     * The key [HadithChapter.id] is stored under — `bookId_chapterId`, not the bare
+     * [chapterId].
+     *
+     * Derived here because two callers built it by hand and one of them got it wrong, so the
+     * chapter header resolved to null for every hadith opened by number.
+     */
+    val chapterKey: String get() = "${bookId}_$chapterId"
+}
 
 data class HadithBookmark(
     val id: Long,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -98,6 +98,8 @@ fun HadithReaderScreen(
     chapterId: String,
     onNavigateBack: () -> Unit,
     onNavigateToSettings: () -> Unit = {},
+    /** Set by `Route.HadithByNumber` — open hadith number N of [bookId], as a bookmark cites it. */
+    hadithNumber: Int? = null,
     viewModel: HadithViewModel = hiltViewModel()
 ) {
     val state by viewModel.readerState.collectAsStateWithLifecycle()
@@ -109,12 +111,17 @@ fun HadithReaderScreen(
         pageCount = { hadiths.size }
     )
 
-    LaunchedEffect(chapterId, bookId) {
-        // If bookId is empty and chapterId isn't a "book_chapter" id, it's a hadithId from search.
-        if (bookId.isEmpty() && !chapterId.contains("_")) {
-            viewModel.onEvent(HadithEvent.LoadHadithById(chapterId))
-        } else {
-            viewModel.onEvent(HadithEvent.LoadChapter(chapterId))
+    LaunchedEffect(chapterId, bookId, hadithNumber) {
+        when {
+            // Stated by the route rather than inferred from the shape of a string: a bookmark
+            // knows the book and the number, and passing the number through `hadithId` made the
+            // reader look it up as a **primary key** — a real hadith, from an arbitrary book.
+            hadithNumber != null ->
+                viewModel.onEvent(HadithEvent.LoadHadithByNumber(bookId, hadithNumber))
+            // No book, and no "book_chapter" composite: a hadithId, from search.
+            bookId.isEmpty() && !chapterId.contains("_") ->
+                viewModel.onEvent(HadithEvent.LoadHadithById(chapterId))
+            else -> viewModel.onEvent(HadithEvent.LoadChapter(chapterId))
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithViewModel.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.Hadith
 import com.arshadshah.nimaz.domain.model.HadithBook
 import com.arshadshah.nimaz.domain.model.HadithBookmark
@@ -28,7 +28,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HadithViewModel @Inject constructor(
     private val hadithUseCases: HadithUseCases,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry
 ) : ViewModel() {
 
     private val _collectionState = MutableStateFlow(HadithCollectionUiState())
@@ -57,6 +58,19 @@ class HadithViewModel @Inject constructor(
     private var chaptersJob: Job? = null
     private var readerJob: Job? = null
 
+    /**
+     * The hadith the reader is anchored to, by id.
+     *
+     * `getHadithsByChapter` is a Room Flow: any write touching the hadiths table re-emits, and
+     * so does a content-database swap by `ContentArtifactInstaller`. The loader used to set
+     * `currentHadithIndex = 0` inside that collector — on *every* emission, not just the first
+     * — so a background content refresh scrolled a reader at hadith 50 back to hadith 1.
+     *
+     * Held by id rather than by index so the anchor survives a refresh that inserts or reorders
+     * rows, which an index would not.
+     */
+    private var anchorHadithId: String? = null
+
     init {
         loadAllBooks()
         loadBookmarks()
@@ -67,19 +81,19 @@ class HadithViewModel @Inject constructor(
     fun onEvent(event: HadithEvent) {
         when (event) {
             is HadithEvent.LoadBook -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_book")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "open_book")
                 loadBook(event.bookId)
             }
             is HadithEvent.LoadChapter -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_reader")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "open_reader")
                 loadChapter(event.chapterId)
             }
             is HadithEvent.LoadHadithById -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "open_hadith")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "open_hadith")
                 loadHadithById(event.hadithId)
             }
             is HadithEvent.LoadHadithByNumber -> {
-                AppAnalytics.logFeatureUsed(
+                telemetry.featureUsed(
                     AppAnalytics.Feature.HADITH,
                     "open_hadith"
                 )
@@ -90,20 +104,20 @@ class HadithViewModel @Inject constructor(
             }
 
             is HadithEvent.Search -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "search")
                 search(event.query)
             }
             is HadithEvent.SearchInBook -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "search_in_book")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "search_in_book")
                 searchInBook(event.bookId, event.query)
             }
             is HadithEvent.SearchChapters -> searchChapters(event.query)
             is HadithEvent.FilterByGrade -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HADITH, "filter_by_grade")
+                telemetry.featureUsed(AppAnalytics.Feature.HADITH, "filter_by_grade")
                 filterByGrade(event.grade)
             }
             is HadithEvent.ToggleBookmark -> {
-                AppAnalytics.logFeatureUsed(
+                telemetry.featureUsed(
                     AppAnalytics.Feature.HADITH,
                     "toggle_bookmark"
                 )
@@ -114,7 +128,12 @@ class HadithViewModel @Inject constructor(
                 )
             }
 
-            is HadithEvent.NavigateToHadith -> _readerState.update { it.copy(currentHadithIndex = event.index) }
+            is HadithEvent.NavigateToHadith -> {
+                // Re-anchor, so the hadith the reader is *now* on is the one a content refresh
+                // restores — not the one it was opened at.
+                anchorHadithId = _readerState.value.hadiths.getOrNull(event.index)?.id
+                _readerState.update { it.copy(currentHadithIndex = event.index) }
+            }
             is HadithEvent.SetFontSize -> _readerState.update { it.copy(fontSize = event.size) }
             is HadithEvent.SetArabicFontSize -> _readerState.update { it.copy(arabicFontSize = event.size) }
             HadithEvent.ToggleArabic -> _readerState.update { it.copy(showArabic = !it.showArabic) }
@@ -158,86 +177,96 @@ class HadithViewModel @Inject constructor(
                     _chaptersState.update { it.copy(chapters = chapters, isLoading = false) }
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HADITH, "load_book", e.message)
+                telemetry.recordException(e)
+                telemetry.error(AppAnalytics.Feature.HADITH, "load_book", e.message)
                 _chaptersState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
     }
 
-    private fun loadChapter(chapterId: String) {
+    /**
+     * Opens [chapterId] in the reader, optionally landing on [focusHadithId] rather than the
+     * top — which is what "open this hadith" and "open hadith number N" both reduce to, since
+     * the reader is a pager over a whole chapter either way.
+     *
+     * The one load path for all three entry points, so the composite-id and index-resolution
+     * rules cannot drift between them: they did, and `loadHadithByNumber` had both wrong.
+     */
+    private fun loadChapter(chapterId: String) =
+        startReaderLoad("load_chapter") { chapterId to null }
+
+    private fun loadHadithById(hadithId: String) =
+        startReaderLoad("load_hadith_by_id") {
+            hadithUseCases.getHadithById(hadithId)?.let { it.chapterKey to it.id }
+        }
+
+    /**
+     * Opens hadith number [hadithNumber] of book [bookId].
+     *
+     * This is the **only** way to reach a bookmarked hadith: a `HadithBookmark` stores the book
+     * and the number printed in the reader, not the database id — see `UnifiedBookmark`, which
+     * carries `hadithBookId` and `hadithNumber` and no id at all.
+     *
+     * Two defects lived in the old two-line body. The chapter id was passed **raw**, while
+     * `getChapterById` is keyed on the composite `bookId_chapterId`, so the chapter header
+     * resolved to null. And the index was read out of `_readerState` on the line *after*
+     * `loadChapter` had launched its own coroutine, so it always saw the **previous** chapter's
+     * list: `indexOfFirst` was always -1 and the branch that sets the index could never run.
+     */
+    private fun loadHadithByNumber(bookId: String, hadithNumber: Int) =
+        startReaderLoad("load_hadith_by_number") {
+            hadithUseCases.getHadithByNumber(bookId, hadithNumber)?.let { it.chapterKey to it.id }
+        }
+
+    /**
+     * The one reader load path, for all three ways in.
+     *
+     * [resolve] returns the chapter to open and the hadith to land on within it (null to open at
+     * the top), or null if the target does not exist. Everything after that — the chapter
+     * header, the collector, the anchor — is identical for all three, and keeping it in one
+     * place is why the composite-id and index rules can no longer drift between them.
+     *
+     * Deliberately one coroutine: resolving the hadith and then collecting its chapter used to
+     * be two, and the second cancelled `readerJob` — the handle owned by the first — from inside
+     * it.
+     */
+    private fun startReaderLoad(
+        errorType: String,
+        resolve: suspend () -> Pair<String, String?>?
+    ) {
         _readerState.update { it.copy(isLoading = true, error = null) }
         readerJob?.cancel()
         readerJob = viewModelScope.launch {
             try {
+                val target = resolve()
+                if (target == null) {
+                    _readerState.update { it.copy(error = "Hadith not found", isLoading = false) }
+                    return@launch
+                }
+                val (chapterId, focusHadithId) = target
+                anchorHadithId = focusHadithId
+
                 val chapter = hadithUseCases.getChapterById(chapterId)
                 _readerState.update { it.copy(chapter = chapter) }
 
                 hadithUseCases.getHadithsByChapter(chapterId).collect { hadiths ->
+                    // Re-resolved against the list that just arrived. On the first emission the
+                    // anchor is the requested hadith (or absent, meaning the top); on a later
+                    // one it is wherever the reader already is — a content refresh re-emits, and
+                    // must not move it.
+                    val index = anchorHadithId
+                        ?.let { id -> hadiths.indexOfFirst { it.id == id } }
+                        ?.takeIf { it >= 0 }
+                        ?: 0
+                    anchorHadithId = hadiths.getOrNull(index)?.id
                     _readerState.update {
-                        it.copy(hadiths = hadiths, isLoading = false, currentHadithIndex = 0)
+                        it.copy(hadiths = hadiths, isLoading = false, currentHadithIndex = index)
                     }
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HADITH, "load_chapter", e.message)
+                telemetry.recordException(e)
+                telemetry.error(AppAnalytics.Feature.HADITH, errorType, e.message)
                 _readerState.update { it.copy(error = e.message, isLoading = false) }
-            }
-        }
-    }
-
-    private fun loadHadithById(hadithId: String) {
-        _readerState.update { it.copy(isLoading = true, error = null) }
-        readerJob?.cancel()
-        readerJob = viewModelScope.launch {
-            try {
-                val hadith = hadithUseCases.getHadithById(hadithId)
-                if (hadith != null) {
-                    // Load the chapter containing this hadith to get context
-                    val chapterId = "${hadith.bookId}_${hadith.chapterId}"
-                    val chapter = hadithUseCases.getChapterById(chapterId)
-
-                    // Get all hadiths in this chapter
-                    hadithUseCases.getHadithsByChapter(chapterId).collect { hadiths ->
-                        // Find the index of the target hadith
-                        val index = hadiths.indexOfFirst { it.id == hadithId }
-                        _readerState.update {
-                            it.copy(
-                                chapter = chapter,
-                                hadiths = hadiths,
-                                currentHadithIndex = if (index >= 0) index else 0,
-                                isLoading = false
-                            )
-                        }
-                    }
-                } else {
-                    _readerState.update { it.copy(error = "Hadith not found", isLoading = false) }
-                }
-            } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HADITH, "load_hadith_by_id", e.message)
-                _readerState.update { it.copy(error = e.message, isLoading = false) }
-            }
-        }
-    }
-
-    private fun loadHadithByNumber(bookId: String, hadithNumber: Int) {
-        viewModelScope.launch {
-            try {
-                val hadith = hadithUseCases.getHadithByNumber(bookId, hadithNumber)
-                hadith?.let {
-                    // Load the chapter containing this hadith
-                    loadChapter(it.chapterId)
-                    // Find the index in the list
-                    val index = _readerState.value.hadiths.indexOfFirst { h -> h.id == it.id }
-                    if (index >= 0) {
-                        _readerState.update { state -> state.copy(currentHadithIndex = index) }
-                    }
-                }
-            } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HADITH, "load_hadith_by_number", e.message)
-                _readerState.update { it.copy(error = e.message) }
             }
         }
     }
@@ -281,11 +310,34 @@ class HadithViewModel @Inject constructor(
         _chaptersState.update { it.copy(searchQuery = query) }
     }
 
+    /**
+     * Replaces the reader's list with every hadith of [grade], across all chapters.
+     *
+     * Still reachable from no screen (#357). It is fixed rather than deleted because leaving it
+     * as-is left a trap: it swapped `hadiths` while leaving `chapter` naming the chapter the
+     * reader came from and `currentHadithIndex` pointing into the old list — so the first screen
+     * to wire it would have rendered a foreign chapter header over the results and opened at
+     * whatever index the previous chapter happened to be on. Both are cleared with the swap.
+     */
     private fun filterByGrade(grade: HadithGrade) {
         readerJob?.cancel()
+        anchorHadithId = null
         readerJob = viewModelScope.launch {
-            hadithUseCases.getHadithsByGrade(grade).collect { hadiths ->
-                _readerState.update { it.copy(hadiths = hadiths) }
+            try {
+                hadithUseCases.getHadithsByGrade(grade).collect { hadiths ->
+                    _readerState.update {
+                        it.copy(
+                            hadiths = hadiths,
+                            chapter = null,
+                            currentHadithIndex = 0,
+                            isLoading = false
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                telemetry.recordException(e)
+                telemetry.error(AppAnalytics.Feature.HADITH, "filter_by_grade", e.message)
+                _readerState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
     }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithReaderTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithReaderTest.kt
@@ -1,0 +1,222 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithChapter
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Where the hadith reader opens, and whether it stays there.
+ *
+ * #364 R3 calls `loadHadithByNumber` "latent today — the event is never emitted". It is not.
+ * `UnifiedBookmark` carries `hadithBookId` and `hadithNumber` and **no hadith id**, so opening a
+ * bookmarked hadith can only go through this path — and the nav graph, lacking a route for it,
+ * passed `hadithNumber.toString()` into `Route.HadithReader`'s `hadithId` slot instead. See
+ * `the bookmark path addresses a hadith by book and number` below for what that resolved to.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HadithReaderTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private lateinit var useCases: HadithUseCases
+    private lateinit var settingsRepository: SettingsRepository
+
+    /** Chapter 3 of book 1, whose composite key is `1_3`. */
+    private val chapter = HadithChapter(
+        id = "1_3",
+        bookId = "1",
+        chapterNumber = 3,
+        nameArabic = "كتاب الصلاة",
+        nameEnglish = "The Book of Prayer",
+        hadithCount = 3,
+        hadithStartNumber = 40,
+        hadithEndNumber = 42,
+    )
+
+    private val hadiths = MutableStateFlow(
+        listOf(hadith("501", 40), hadith("502", 41), hadith("503", 42)),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        settingsRepository = mockk(relaxed = true)
+        every { settingsRepository.hadithArabicFont } returns MutableStateFlow("amiri")
+        every { settingsRepository.hadithArabicFontSize } returns MutableStateFlow(28f)
+        every { settingsRepository.hadithTranslationFontSize } returns MutableStateFlow(16f)
+        every { settingsRepository.hadithShowArabic } returns MutableStateFlow(true)
+        every { settingsRepository.hadithShowTranslation } returns MutableStateFlow(true)
+        every { settingsRepository.hadithShowGrade } returns MutableStateFlow(true)
+        every { settingsRepository.hadithShowChain } returns MutableStateFlow(false)
+        every { useCases.getHadithsByChapter("1_3") } returns hadiths
+        coEvery { useCases.getChapterById("1_3") } returns chapter
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = HadithViewModel(useCases, settingsRepository, telemetry)
+
+    // R3 — opening a hadith by its number.
+
+    @Test
+    fun `opening a hadith by number lands on that hadith`() = runTest {
+        coEvery { useCases.getHadithByNumber("1", 42) } returns hadith("503", 42)
+
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadHadithByNumber("1", 42))
+        advanceUntilIdle()
+
+        // The index was read out of `_readerState` on the line *after* `loadChapter` launched
+        // its own coroutine, so it always saw the previous chapter's list. `indexOfFirst` was
+        // always -1 and the branch that sets the index could never run: the reader opened at
+        // hadith 40 of the right chapter, every time.
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(2)
+        assertThat(vm.readerState.value.hadiths.map { it.id }).containsExactly("501", "502", "503")
+    }
+
+    @Test
+    fun `opening a hadith by number resolves its chapter header`() = runTest {
+        coEvery { useCases.getHadithByNumber("1", 42) } returns hadith("503", 42)
+
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadHadithByNumber("1", 42))
+        advanceUntilIdle()
+
+        // `getChapterById` is keyed on the composite `bookId_chapterId`. This path passed the
+        // bare `chapterId` — "3" — so the header resolved to null while its sibling
+        // `loadHadithById`, three lines up, built the composite correctly.
+        assertThat(vm.readerState.value.chapter).isEqualTo(chapter)
+    }
+
+    @Test
+    fun `a hadith number that does not exist reports not found rather than opening chapter one`() =
+        runTest {
+            coEvery { useCases.getHadithByNumber("1", 9999) } returns null
+
+            val vm = viewModel()
+            vm.onEvent(HadithEvent.LoadHadithByNumber("1", 9999))
+            advanceUntilIdle()
+
+            assertThat(vm.readerState.value.isLoading).isFalse()
+            assertThat(vm.readerState.value.error).isNotNull()
+        }
+
+    // R4 — a content refresh must not move the reader.
+
+    @Test
+    fun `a content refresh leaves the reader where it was`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadChapter("1_3"))
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.NavigateToHadith(2))
+        advanceUntilIdle()
+
+        // `getHadithsByChapter` is a Room Flow: any write touching the table re-emits, and so
+        // does a content-database swap. The loader set `currentHadithIndex = 0` inside that
+        // collector, so a reader at hadith 42 was scrolled back to hadith 40 by a background
+        // refresh — `HadithReaderScreen` drives its pager off this index.
+        //
+        // Bookmarking is the cheapest real trigger: it writes the row and Room re-emits the
+        // chapter with the flag flipped. (A `toList()` copy would not do — the list compares
+        // equal and `MutableStateFlow` would drop it.)
+        hadiths.value = hadiths.value.map { it.copy(isBookmarked = true) }
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(2)
+    }
+
+    @Test
+    fun `the anchor follows the hadith, not the index, when rows are inserted`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadChapter("1_3"))
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.NavigateToHadith(2))
+        advanceUntilIdle()
+
+        // A refresh that prepends a row would keep a reader anchored by *index* on the same
+        // number and a different hadith.
+        hadiths.value = listOf(hadith("500", 39)) + hadiths.value
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(3)
+        assertThat(vm.readerState.value.hadiths[vm.readerState.value.currentHadithIndex].id)
+            .isEqualTo("503")
+    }
+
+    @Test
+    fun `a chapter opened without a target starts at the top`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadChapter("1_3"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(0)
+        assertThat(vm.readerState.value.isLoading).isFalse()
+    }
+
+    // R15 — the grade filter must not leave a foreign header over its results.
+
+    @Test
+    fun `filtering by grade clears the chapter it came from`() = runTest {
+        every { useCases.getHadithsByGrade(any()) } returns
+            MutableStateFlow(listOf(hadith("900", 1)))
+
+        val vm = viewModel()
+        vm.onEvent(HadithEvent.LoadChapter("1_3"))
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.NavigateToHadith(2))
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.FilterByGrade(com.arshadshah.nimaz.domain.model.HadithGrade.SAHIH))
+        advanceUntilIdle()
+
+        // Results span every chapter, so the previous chapter's header and reading position
+        // describe nothing. Left in place they would have rendered over the results the first
+        // time any screen wired this up.
+        assertThat(vm.readerState.value.chapter).isNull()
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(0)
+        assertThat(vm.readerState.value.hadiths.map { it.id }).containsExactly("900")
+    }
+
+    // The composite key, stated once.
+
+    @Test
+    fun `a hadith knows the key its chapter is stored under`() {
+        assertThat(hadith("503", 42).chapterKey).isEqualTo("1_3")
+    }
+
+    private fun hadith(id: String, number: Int) = Hadith(
+        id = id,
+        bookId = "1",
+        chapterId = "3",
+        hadithNumber = number,
+        hadithNumberInBook = number,
+        textArabic = "نص",
+        textEnglish = "text",
+        narratorChain = null,
+        narratorName = null,
+        grade = null,
+        gradeArabic = null,
+        reference = null,
+    )
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithViewModelChapterFilterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/HadithViewModelChapterFilterTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.HadithChapter
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
@@ -69,7 +70,8 @@ class HadithViewModelChapterFilterTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = HadithViewModel(hadithUseCases, settingsRepository)
+    private fun viewModel() =
+        HadithViewModel(hadithUseCases, settingsRepository, RecordingTelemetry())
 
     @Test
     fun `a chapter list re-emission keeps the active chapter search applied`() = runTest {

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -311,12 +311,25 @@ rg -U --multiline-dotall -n '\.collect\s*\{(?:[^}]|
 - [x] ~~**`SyncViewModel` — untriaged.**~~ **Not a defect.** Its single `collect` is a lifetime
   observer started once from `init`, which is exactly what the detect command cannot distinguish
   and what the parameterised/not split above is for. Left as-is.
-- [ ] **`HadithViewModel.loadHadithByNumber` reads state it just asked for.** It calls
-  `loadChapter(...)` (which launches) and then immediately reads `_readerState.value.hadiths` to
-  find the index, so the list is still empty and the index is always 0. Latent rather than shipped:
-  `HadithEvent.LoadHadithByNumber` is never dispatched from any screen. Fix by awaiting the
-  chapter's first emission (or by folding the lookup into the loader) if that path is ever wired up
-  — and note the "lying signature" parallel with AP-7.3.
+- [x] ~~**`HadithViewModel.loadHadithByNumber` reads state it just asked for.**~~ **Resolved —
+  and it was shipped, not latent.** It called `loadChapter(...)`, which launches, then read
+  `_readerState.value.hadiths` on the next line: still the *previous* chapter's list, so
+  `indexOfFirst` was always -1 and the branch setting the index could never run. It also passed
+  the chapter id raw where `getChapterById` is keyed on the composite `bookId_chapterId`, so the
+  header resolved to null.
+
+  This entry previously recorded the path as unreachable because no screen dispatches the event.
+  **That was the wrong question.** A `HadithBookmark` stores `bookId` and `hadithNumber` and no
+  hadith id, so opening a bookmarked hadith can only go through this path — and lacking a route
+  for it, three bookmark screens navigated to `Route.HadithReader(hadithNumber.toString())`,
+  putting a *number* in an *id* slot. `getHadithById` resolves that against the **primary key**,
+  so every hadith bookmark opened a real hadith from an arbitrary book, with no error.
+
+  The lesson generalises: "no screen emits this event" establishes that the *event* is unused, not
+  that the *capability* is. Check what the feature's data model can express first — here the
+  bookmark's shape proved the capability was mandatory. Fixed with a `Route.HadithByNumber`
+  carrying both parts, and one reader load path shared by all three entry points.
+  (`HadithReaderTest`)
 
 Detect:
 

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -100,6 +100,7 @@ flowchart LR
     subgraph H["Hadith"]
         HadithHome --> HadithBook --> HadithChapter --> HadithReader
         HadithHome --> HadithSearch & HadithBookmarks & HadithSettings
+        HadithBookmarks --> HadithByNumber
     end
 
     subgraph D["Dua"]
@@ -171,7 +172,7 @@ flowchart LR
 ## 3. Route reference
 
 All routes live in `core/navigation/Routes.kt` and are wired in `core/navigation/NavGraph.kt`
-(90 `composable<Route.X>` destinations). `data object` = no args; `data class` = typed args.
+(91 `composable<Route.X>` destinations). `data object` = no args; `data class` = typed args.
 Every route below also has a `ScreenTags` entry of the same name.
 
 ### 3.1 Bottom navigation (`BottomNavDestination`)
@@ -209,6 +210,7 @@ Every route below also has a `ScreenTags` entry of the same name.
 | `HadithBook` | `bookId: String` | HadithBookScreen |
 | `HadithChapter` | `bookId: String, chapterId: String` | HadithChapterScreen |
 | `HadithReader` | `hadithId: String` | HadithReaderScreen |
+| `HadithByNumber` | `bookId: String, hadithNumber: Int` | HadithReaderScreen |
 | `HadithSearch` | — | HadithSearchScreen |
 | `HadithBookmarks` | — | HadithBookmarksScreen |
 | `HadithSettings` | — | HadithSettingsScreen |


### PR DESCRIPTION
**Layer 27** · epic #352 · on top of #421 (vm-26). Closes R3, R4 and R15 of #364.

## ⚠️ Correction to the issue — R3 is shipped, not latent

#364 R3 says *"Latent today (the event is never emitted — #357)"*. **It is not latent, and the user-visible symptom is worse than the one described.**

A `HadithBookmark` stores `bookId` and `hadithNumber` and **no hadith id** — `UnifiedBookmark` likewise, carrying `hadithBookId` and `hadithNumber`. So opening a bookmarked hadith can *only* go through `LoadHadithByNumber`. There was no route carrying both parts, so all three bookmark screens did this:

```kotlin
onNavigateToHadith = { bookId, hadithNumber ->
    navController.navigate(Route.HadithReader(hadithNumber.toString()))   // bookId dropped
}
```

`Route.HadithReader` takes a `hadithId`, and `HadithRepositoryImpl:130` resolves it as `hadithDao.getHadithById(hadithId.toIntOrNull())` → `SELECT * FROM hadiths WHERE id = 42` — the **global primary key**.

**Input → wrong output:** bookmark hadith 42 of Sahih al-Bukhari, tap it in Bookmarks. The reader opens the hadith whose database row id is 42 — a real hadith, from whichever book that row belongs to, with a plausible chapter header and **no error**. Not "hadith not found"; silently the wrong text, which is the worse failure for a religious reference app.

"No screen emits this event" established that the *event* was unused. It did not establish that the *capability* was — and the bookmark's data model proves the capability is mandatory. That reasoning is now written into the checklist entry rather than left as a one-off.

## R3 — the two defects in `loadHadithByNumber`

```kotlin
loadChapter(it.chapterId)                                            // ← raw, not composite
val index = _readerState.value.hadiths.indexOfFirst { h -> h.id == it.id }   // ← previous chapter
```

`getChapterById` is keyed on the composite `bookId_chapterId`, so the header resolved to null. And `loadChapter` *launches*, so the very next line read the previous chapter's list: `indexOfFirst` was always `-1` and the `if (index >= 0)` branch could never run.

Fixed by giving all three entry points **one reader load path**. The composite key is now `Hadith.chapterKey`, derived on the model — two callers built it by hand and one got it wrong. Resolving a hadith and collecting its chapter is one coroutine, not two, the second of which cancelled `readerJob`, the handle owned by the first.

`Route.HadithByNumber(bookId, hadithNumber)` is a separate route because it is a genuinely different address, and collapsing the two is what caused this. The reader screen now takes its address from the route instead of inferring it from whether a string contains an underscore.

## R4 — the reader jumps home on any content refresh

`currentHadithIndex = 0` was set inside the collector, on **every** emission. `getHadithsByChapter` is a Room Flow, so any write touching the table re-emits — including bookmarking the hadith you are reading — and `HadithReaderScreen:121-125` scrolls its pager to that index.

**Input → wrong output:** read to hadith 50 of Kitab as-Salah, tap bookmark → the reader jumps to hadith 1.

The reader now anchors by hadith **id**, re-resolved against each emission, so the position also survives a refresh that inserts or reorders rows — which an index would not. A swipe re-anchors, so it is the hadith you are *on* that is restored, not the one you opened at.

## R15 — the grade filter's trap

`filterByGrade` swapped `hadiths` while leaving `chapter` naming the chapter the reader came from and the index pointing into the old list. Still reachable from no screen, so **fixed rather than deleted**: as it stood, the first screen to wire it would have rendered a foreign chapter header over cross-chapter results. It now clears both, and has error handling, which it had none of.

## Verified red first

| test | before |
|---|---|
| `opening a hadith by number lands on that hadith` | `expected: 2 but was: 0` |
| `opening a hadith by number resolves its chapter header` | `expected: HadithChapter(…) but was: null` |
| `a content refresh leaves the reader where it was` | `expected: 2 but was: 0` |
| `the anchor follows the hadith, not the index, when rows are inserted` | `expected: 3 but was: 0` |
| `filtering by grade clears the chapter it came from` | `expected: null but was: HadithChapter(…)` |

Two control tests (`a chapter opened without a target starts at the top`, `a hadith knows the key its chapter is stored under`) pass before and after.

One note on the refresh test: it re-emits by flipping `isBookmarked`, not by copying the list. A `toList()` copy compares equal and `MutableStateFlow` drops it — the first version of that test passed against the broken code for exactly that reason.

`Telemetry` replaces the direct `AppAnalytics`/`CrashReporter` calls in this file — required to assert any of this, and the house rule since layer 1.

## Docs

- `NAVIGATION.md` §2 (map) and §3 (route reference + destination count 90 → 91).
- `CLEAN_ARCHITECTURE_CHECKLIST.md` — the AP-7.1b entry that recorded this as latent is corrected and ticked.

Gates: compile ✅ · 1,538 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅ · 14 mermaid diagrams parse ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_