### PR TITLE
fix(quran,content): requests that land out of order stop winning

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
@@ -50,6 +50,18 @@ abstract class CatalogViewModel<T : Any>(
 
     private var detailJob: Job? = null
 
+    /**
+     * The item the detail surface is currently *for*, set synchronously when it is asked for.
+     *
+     * [detailJob] alone does not close the race: a coroutine cancelled after its last suspension
+     * point still runs to the end of its block, and `source.byId` *is* that suspension point
+     * with the state write immediately after it. Open Adam, back, open Muhammad quickly enough
+     * — the detail screen fires `LoadDetail` from a `LaunchedEffect(id)` and the instance is
+     * shared through the list screen's back-stack entry — and Adam's read resolving second put
+     * **Adam's story under Muhammad's route**, with `isLoading = false` to say it was ready.
+     */
+    private var requestedItemId: Int? = null
+
     init {
         observeItems()
         observeFavourites()
@@ -102,6 +114,7 @@ abstract class CatalogViewModel<T : Any>(
 
     private fun loadDetail(itemId: Int) {
         _detailState.update { it.copy(isLoading = true) }
+        requestedItemId = itemId
         detailJob?.cancel()
         detailJob = launchSafely(
             telemetry,
@@ -109,7 +122,9 @@ abstract class CatalogViewModel<T : Any>(
             "load_detail",
             onFailure = { _detailState.update { it.copy(isLoading = false) } },
         ) {
-            _detailState.update { it.copy(item = source.byId(itemId), isLoading = false) }
+            val item = source.byId(itemId)
+            if (requestedItemId != itemId) return@launchSafely
+            _detailState.update { it.copy(item = item, isLoading = false) }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModel.kt
@@ -12,6 +12,7 @@ import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -61,6 +62,28 @@ class QuranTopicsViewModel @Inject constructor(
     val surahSubjects: StateFlow<SurahSubjectsState> = _surahSubjects.asStateFlow()
 
     private val queries = MutableStateFlow("")
+
+    /**
+     * The in-flight browse navigation — a focus or a crumb rebase.
+     *
+     * One handle, because the browser is at one place at a time. Without it, tapping crumb 0
+     * and then crumb 2 left both `getTopicChildren` calls racing, and each ends in a whole-state
+     * update setting `focus` *and* `level` together: whichever query was slower wrote last, so
+     * a reader who tapped crumb 2 landed on crumb 0.
+     */
+    private var browseJob: Job? = null
+
+    /** The in-flight topic-detail load. See [requestedTopicId]. */
+    private var detailJob: Job? = null
+
+    /**
+     * The topic the detail pane is currently *for*, set synchronously when it is asked for.
+     *
+     * Cancelling [detailJob] is necessary but not sufficient: a coroutine cancelled after its
+     * last suspension point still runs to the end of its block. This is what the writes are
+     * checked against, the way [loadSurahSubjects] already checks its surah.
+     */
+    private var requestedTopicId: Int? = null
 
     /**
      * Only the query pipeline. The roots are *not* loaded here.
@@ -224,14 +247,27 @@ class QuranTopicsViewModel @Inject constructor(
             _browseState.update { it.copy(expanded = it.expanded + topic.id) }
             return
         }
+        val focusWhenAsked = state.focus
         viewModelScope.launch {
             val loaded = quranUseCases.getTopicChildren(topic.id, state.tree)
             _browseState.update {
                 // An empty result means the branch set and the corpus disagree. Cache it anyway
                 // so the row stops asking, and leave it closed rather than opening onto nothing.
+                //
+                // Caching is always safe — a node's children do not depend on where the browser
+                // is. *Expanding* does: a focus or rebase landing while this was in flight reset
+                // `expanded` and moved to a different level, where this row is not on screen, so
+                // opening it would re-open a node the reader had just navigated away from.
+                //
+                // Deliberately not sharing `browseJob`: two toggles on two rows are both
+                // legitimate and must not cancel each other.
                 it.copy(
                     children = it.children + (topic.id to loaded),
-                    expanded = if (loaded.isEmpty()) it.expanded else it.expanded + topic.id,
+                    expanded = when {
+                        loaded.isEmpty() -> it.expanded
+                        it.focus != focusWhenAsked -> it.expanded
+                        else -> it.expanded + topic.id
+                    },
                 )
             }
         }
@@ -241,7 +277,8 @@ class QuranTopicsViewModel @Inject constructor(
     private fun focus(topic: QuranTopic) {
         val state = _browseState.value
         val trail = state.focus + ancestorsWithin(state, topic) + topic
-        viewModelScope.launch {
+        browseJob?.cancel()
+        browseJob = viewModelScope.launch {
             val level = state.children[topic.id]
                 ?: quranUseCases.getTopicChildren(topic.id, state.tree)
             _browseState.update {
@@ -270,7 +307,8 @@ class QuranTopicsViewModel @Inject constructor(
         }
         val trail = state.focus.take(index + 1)
         val target = trail.last()
-        viewModelScope.launch {
+        browseJob?.cancel()
+        browseJob = viewModelScope.launch {
             val level = state.children[target.id]
                 ?: quranUseCases.getTopicChildren(target.id, state.tree)
             _browseState.update {
@@ -363,9 +401,12 @@ class QuranTopicsViewModel @Inject constructor(
      * holding is answering the question they opened the subject with.
      */
     private fun loadDetail(topicId: Int, tree: TopicTree, fromSurah: Int? = null) {
-        viewModelScope.launch {
+        requestedTopicId = topicId
+        detailJob?.cancel()
+        detailJob = viewModelScope.launch {
             _detailState.update { it.copy(isLoading = true) }
             val detail = quranUseCases.getTopicDetail(topicId, tree)
+            if (requestedTopicId != topicId) return@launch
             if (detail == null) {
                 _detailState.value = TopicDetailState(isLoading = false)
                 return@launch
@@ -386,6 +427,11 @@ class QuranTopicsViewModel @Inject constructor(
                 }
                 .sortedByDescending { it.isFromSurah }
 
+            // A hard assign here was the compounding half of the race: with two loads in
+            // flight, the one completing second replaced the whole object — wiping not just
+            // the other topic's detail but any previews that had already landed for it,
+            // walking straight past the staleness guard this same function applies below.
+            if (requestedTopicId != topicId) return@launch
             _detailState.value = TopicDetailState(
                 detail = detail,
                 citationGroups = groups,

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogDetailRaceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogDetailRaceTest.kt
@@ -1,0 +1,107 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Two detail requests in flight, resolving out of order.
+ *
+ * #364 R5 describes this against the three copies of the catalogue ViewModel; the dedupe layer
+ * collapsed them onto [CatalogViewModel], so it is one fix and one test rather than three of
+ * each — and the cancel-and-replace handle it asks for **landed with that dedupe**. This suite
+ * is what pins that: it passes on the current code and fails on the pre-dedupe shape, which is
+ * the only claim it is entitled to make.
+ *
+ * It does *not* exercise the narrower window a cancelled coroutine still leaves open — the read
+ * completing before the cancel lands, so the write runs anyway. Awaiting a gate is a
+ * cancellable suspension point, so cancelling kills the coroutine there every time and the
+ * window cannot be forced deterministically from a test. The `requestedItemId` guard added
+ * alongside this suite is defence for that case, and is honestly untested.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CatalogDetailRaceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private data class Row(val id: Int, val name: String)
+
+    private val all = MutableStateFlow(listOf(Row(1, "Adam"), Row(12, "Muhammad")))
+
+    /** Held open so a test can decide when a given id's read resolves. */
+    private val gates = mutableMapOf<Int, CompletableDeferred<Unit>>()
+
+    private inner class Source : CatalogSource<Row> {
+        override fun all(): Flow<List<Row>> = all
+        override fun favourites(): Flow<List<Row>> = MutableStateFlow(emptyList())
+        override suspend fun byId(id: Int): Row? {
+            gates[id]?.await()
+            return all.value.firstOrNull { it.id == id }
+        }
+
+        override suspend fun toggleFavourite(id: Int) = Unit
+        override fun idOf(item: Row): Int = item.id
+        override fun matches(item: Row, query: String) = item.name.contains(query, true)
+    }
+
+    private inner class TestCatalog : CatalogViewModel<Row>(Source(), telemetry, "test_catalog")
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `the slower of two detail reads cannot overwrite the newer one`() = runTest {
+        val adam = CompletableDeferred<Unit>()
+        gates[1] = adam
+
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        // Open Adam — its read is held open, as a slow first query would be.
+        vm.onEvent(CatalogEvent.LoadDetail(1))
+        advanceUntilIdle()
+
+        // Back, then open Muhammad before Adam's read has resolved. The detail screen fires
+        // `LoadDetail` from a `LaunchedEffect(id)`, and a shared instance is reachable through
+        // the list screen's back-stack entry, so both are genuinely in flight.
+        vm.onEvent(CatalogEvent.LoadDetail(12))
+        advanceUntilIdle()
+
+        // Adam's read now resolves — second.
+        adam.complete(Unit)
+        advanceUntilIdle()
+
+        // Before the guard: Adam's story rendered under Muhammad's route, with
+        // isLoading = false to say it was ready.
+        assertThat(vm.detailState.value.item?.id).isEqualTo(12)
+        assertThat(vm.detailState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `an uncontested detail load still resolves`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.LoadDetail(1))
+        advanceUntilIdle()
+
+        assertThat(vm.detailState.value.item?.id).isEqualTo(1)
+        assertThat(vm.detailState.value.isLoading).isFalse()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsRaceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsRaceTest.kt
@@ -1,0 +1,272 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import com.arshadshah.nimaz.domain.model.QuranTopic
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.TopicCitation
+import com.arshadshah.nimaz.domain.model.TopicDetail
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.GetSurahListUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicChildrenUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicDetailUseCase
+import com.arshadshah.nimaz.domain.usecase.GetTopicTreeRootsUseCase
+import com.arshadshah.nimaz.domain.usecase.HasThematicContentUseCase
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.SearchTopicsUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Two subject-browser requests in flight, resolving out of order.
+ *
+ * `QuranTopicsViewModel` is fully fakeable and already had 21 tests — and **none of them
+ * covered this**, which is exactly #364's point about it: the tests that exist are the ones the
+ * happy path suggests, and a race is not on the happy path. Every fake here can be held open,
+ * so "the slower one lands second" is stated rather than hoped for.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuranTopicsRaceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: QuranUseCases
+    private lateinit var settings: SettingsRepository
+
+    //  Doctrine ─ God ─ The names of God
+    //           └ Mercy
+    private val doctrine = topic(id = 1, name = "Doctrine")
+    private val god = topic(id = 11, name = "God", parent = 1)
+    private val mercy = topic(id = 13, name = "Mercy", parent = 1)
+    private val names = topic(id = 111, name = "The names of God", parent = 11)
+
+    private val children = mapOf(
+        1 to listOf(god, mercy),
+        11 to listOf(names),
+        13 to listOf(topic(id = 131, name = "Forgiveness", parent = 13)),
+        111 to listOf(topic(id = 1111, name = "The Merciful", parent = 111)),
+    )
+
+    /** Held open so a test decides when a given topic's children resolve. */
+    private val childGates = mutableMapOf<Int, CompletableDeferred<Unit>>()
+
+    /** Held open so a test decides when a given topic's detail resolves. */
+    private val detailGates = mutableMapOf<Int, CompletableDeferred<Unit>>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        val getChildren = mockk<GetTopicChildrenUseCase>()
+        coEvery { getChildren.invoke(any(), any()) } coAnswers {
+            val id = firstArg<Int>()
+            childGates[id]?.await()
+            children[id].orEmpty()
+        }
+        coEvery { getChildren.branchesIn(any()) } returns children.keys
+
+        val getDetail = mockk<GetTopicDetailUseCase>()
+        coEvery { getDetail.invoke(any(), any()) } coAnswers {
+            val id = firstArg<Int>()
+            detailGates[id]?.await()
+            TopicDetail(
+                topic = children.values.flatten().plus(doctrine).first { it.id == id },
+                tree = TopicTree.THEMATIC,
+                breadcrumb = emptyList(),
+                children = emptyList(),
+                related = emptyList(),
+                citations = listOf(citation(id)),
+            )
+        }
+
+        val getRoots = mockk<GetTopicTreeRootsUseCase>()
+        coEvery { getRoots.invoke(any()) } returns listOf(doctrine)
+
+        val hasContent = mockk<HasThematicContentUseCase>()
+        coEvery { hasContent.invoke() } returns true
+
+        val search = mockk<SearchTopicsUseCase>()
+        coEvery { search.invoke(any(), any()) } returns emptyList()
+        coEvery { search.pathsFor(any(), any()) } returns emptyMap()
+
+        settings = mockk(relaxed = true)
+        every { settings.quranTranslatorId } returns MutableStateFlow("sahih_international")
+
+        // `loadDetail` names each citation's surah from this list. A relaxed mock hands back a
+        // Flow that emits nothing, on which its `.first()` throws — and the throw lands before
+        // the state write, so the symptom is an empty detail rather than an error.
+        val getSurahList = mockk<GetSurahListUseCase>()
+        every { getSurahList.invoke() } returns flowOf(
+            listOf(
+                Surah(
+                    number = 1,
+                    nameArabic = "الفاتحة",
+                    nameEnglish = "The Opening",
+                    nameTransliteration = "Al-Fatihah",
+                    revelationType = RevelationType.MECCAN,
+                    ayahCount = 7,
+                    juzStart = 1,
+                    orderInMushaf = 1,
+                    startPage = 1,
+                ),
+            ),
+        )
+
+        useCases = mockk(relaxed = true)
+        every { useCases.getSurahList } returns getSurahList
+        every { useCases.getTopicChildren } returns getChildren
+        every { useCases.getTopicDetail } returns getDetail
+        every { useCases.getTopicTreeRoots } returns getRoots
+        every { useCases.hasThematicContent } returns hasContent
+        every { useCases.searchTopics } returns search
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `a slower crumb tap cannot land on top of a later one`() = runTest {
+        val vm = openedBrowser()
+
+        // Descend twice so there are crumbs to tap: Doctrine › God › The names of God.
+        vm.onEvent(QuranTopicsEvent.Focus(god))
+        advanceUntilIdle()
+        vm.onEvent(QuranTopicsEvent.Focus(names))
+        advanceUntilIdle()
+
+        // Crumb 0 (Doctrine) is on an uncached branch and slow; crumb 1 (God) answers at once.
+        val slow = CompletableDeferred<Unit>()
+        childGates[1] = slow
+
+        vm.onEvent(QuranTopicsEvent.RebaseTo(0))
+        advanceUntilIdle()
+        vm.onEvent(QuranTopicsEvent.RebaseTo(1))
+        advanceUntilIdle()
+
+        slow.complete(Unit)
+        advanceUntilIdle()
+
+        // Each of these ends in a whole-state update setting `focus` *and* `level` together, so
+        // the slower one landing second put the reader on the crumb they did not tap.
+        assertThat(vm.browseState.value.focus.map { it.id }).containsExactly(1, 11).inOrder()
+    }
+
+    @Test
+    fun `a toggle that resolves after a rebase does not reopen its node`() = runTest {
+        val vm = openedBrowser()
+
+        val slow = CompletableDeferred<Unit>()
+        childGates[13] = slow
+
+        vm.onEvent(QuranTopicsEvent.Toggle(mercy))
+        advanceUntilIdle()
+
+        // The reader gives up waiting and descends instead. `focus` resets `expanded`.
+        vm.onEvent(QuranTopicsEvent.Focus(god))
+        advanceUntilIdle()
+
+        slow.complete(Unit)
+        advanceUntilIdle()
+
+        // Mercy is not on screen at this level, so re-opening it would restore a node the
+        // reader had navigated away from. The children are still cached, because caching them
+        // is valid wherever the browser happens to be.
+        assertThat(vm.browseState.value.expanded).doesNotContain(13)
+        assertThat(vm.browseState.value.children).containsKey(13)
+    }
+
+    @Test
+    fun `two toggles do not cancel each other`() = runTest {
+        val vm = openedBrowser()
+
+        val slow = CompletableDeferred<Unit>()
+        childGates[11] = slow
+
+        vm.onEvent(QuranTopicsEvent.Toggle(god))
+        advanceUntilIdle()
+        vm.onEvent(QuranTopicsEvent.Toggle(mercy))
+        advanceUntilIdle()
+
+        slow.complete(Unit)
+        advanceUntilIdle()
+
+        // Opening two rows is two independent intentions — a shared cancel-and-replace handle
+        // here would have thrown away the first row's children.
+        assertThat(vm.browseState.value.expanded).containsAtLeast(11, 13)
+    }
+
+    @Test
+    fun `a slower detail load cannot replace a later one`() = runTest {
+        val vm = openedBrowser()
+
+        val slow = CompletableDeferred<Unit>()
+        detailGates[11] = slow
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(11, TopicTree.THEMATIC))
+        advanceUntilIdle()
+        vm.onEvent(QuranTopicsEvent.LoadDetail(13, TopicTree.THEMATIC))
+        advanceUntilIdle()
+
+        slow.complete(Unit)
+        advanceUntilIdle()
+
+        // `_detailState.value = TopicDetailState(...)` is a whole-object assign, so the loser
+        // of this race wiped the winner's detail *and* any previews already landed for it —
+        // walking past the staleness guard the same function applies to its previews.
+        assertThat(vm.detailState.value.detail?.topic?.id).isEqualTo(13)
+    }
+
+    @Test
+    fun `an uncontested detail load still resolves`() = runTest {
+        val vm = openedBrowser()
+
+        vm.onEvent(QuranTopicsEvent.LoadDetail(11, TopicTree.THEMATIC))
+        advanceUntilIdle()
+
+        assertThat(vm.detailState.value.detail?.topic?.id).isEqualTo(11)
+        assertThat(vm.detailState.value.isLoading).isFalse()
+    }
+
+    private fun openedBrowser(): QuranTopicsViewModel {
+        val vm = QuranTopicsViewModel(useCases, settings)
+        vm.onEvent(QuranTopicsEvent.OpenBrowser)
+        dispatcher.scheduler.advanceUntilIdle()
+        return vm
+    }
+
+    private fun citation(topicId: Int) = TopicCitation(
+        ayahId = topicId,
+        surahNumber = 1,
+        ayahNumber = 1,
+    )
+
+    private fun topic(id: Int, name: String, parent: Int? = null) = QuranTopic(
+        id = id,
+        name = name,
+        arabicName = "",
+        description = "",
+        wikiLink = "",
+        ayahCount = 12,
+        parentId = parent,
+        thematicParentId = parent,
+        ontologyParentId = null,
+        isThematic = true,
+        isOntology = false,
+        relatedTopicIds = emptyList(),
+    )
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -340,6 +340,33 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.9 · One handle for requests that are not alternatives
+
+- [x] ~~**`QuranTopicsViewModel.toggle` / `focus` / `rebaseTo`, and the catalogue detail load.**~~
+  **Resolved.** AP-7.1b says one `Job` per *identity of the request*. The follow-on question is
+  what counts as one identity, and it is not "one per function":
+
+  - `focus` and `rebaseTo` are **alternatives** — the browser is at one place at a time, and each
+    ends in a whole-state update setting `focus` *and* `level` together. They share `browseJob`,
+    cancel-and-replace. Without it, tapping crumb 0 then crumb 2 let the slower query write last
+    and the reader landed on the crumb they did not tap.
+  - `toggle` is **not** an alternative to another toggle: opening two rows is two intentions, and
+    a shared handle would throw away the first row's children. It keeps no handle, and instead
+    guards the part of its write that is position-dependent — caching a node's children is valid
+    wherever the browser is, *expanding* it is not, so a toggle resolving after a rebase caches
+    and does not open.
+
+  And the standing rule from the tracker's stats race: **cancelling is necessary, not
+  sufficient.** A coroutine cancelled after its last suspension point still runs to the end of
+  its block, so the write is checked against a `requested…Id` set synchronously at the call —
+  which `loadSurahSubjects` in the same file already did, while `loadDetail` next to it used a
+  whole-object assign that wiped the winner's already-landed previews.
+
+  Note on evidence: the browse races are pinned by failing-first tests
+  (`QuranTopicsRaceTest`). The post-suspension-point guard is **not** — awaiting a gate is a
+  cancellable suspension point, so a test cannot deterministically hold a coroutine between "read
+  returned" and "state written". It is defence, and labelled as such where it appears.
+
 ### AP-7.8 · A UiState default answering a question only the repository can
 
 - [x] ~~**`QuranViewModel`'s reader loads read the translator and Mushaf edition off


### PR DESCRIPTION
**Layer 28** · epic #352 · on top of #422 (vm-27). Closes R5 and R6 of #364, and the "out-of-order race tests" acceptance box.

R5 and R6 are the same defect in two features — a slower request landing second and winning — so they are one layer.

## R6 — the subject browser

`focus` and `rebaseTo` each launched with no handle, and each ends in a whole-state update setting `focus` **and** `level` together.

**Input → wrong output:** on the crumb bar, tap crumb 0 then crumb 2 within a few hundred ms. If crumb 0's `getTopicChildren` is slower (uncached branch, larger child set) it lands second and the final state is crumb 0's — the reader tapped crumb 2 and got crumb 0.

They are **alternatives** — the browser is at one place at a time — so they share one `browseJob`, cancel-and-replace.

**`toggle` deliberately does not join it.** Opening two rows is two intentions, and a shared handle would throw away the first row's children. It guards the position-dependent half of its write instead: caching a node's children is valid wherever the browser is, *expanding* it is not. A toggle resolving after a rebase now caches and stays closed, rather than re-opening a node the reader has navigated away from.

`loadDetail` had no handle and hard-assigned `TopicDetailState(...)` twice, so with two loads in flight the loser wiped the winner's detail **and** any previews already landed for it — walking straight past the staleness guard the same function applies to those previews, and which `loadSurahSubjects` twenty lines up applies to its surah. Now cancel-and-replace with that same guard.

## R5 — the catalogue detail race was already half-fixed

Worth stating plainly rather than claiming credit for it: **the cancel-and-replace handle #364 asks for on `loadDetail` landed with the dedupe layer** (#417), when the three byte-identical ViewModels became one `CatalogViewModel`. `CatalogDetailRaceTest` now pins it rather than leaving it incidental — and, as the issue notes, it is one test instead of three because there is one ViewModel instead of three.

The remaining `requestedItemId` guard covers the narrower window a cancelled coroutine still leaves: the read completing *before* the cancel lands, so the write runs anyway. **That guard is untested, and I'd rather say so than imply otherwise** — awaiting a gate is a cancellable suspension point, so a test cannot deterministically hold a coroutine between "read returned" and "state written". It is labelled as defence in both the suite and the checklist.

## Verified red first

| test | before |
|---|---|
| `a slower crumb tap cannot land on top of a later one` | `expected: [1, 11] but was: [1]` |
| `a toggle that resolves after a rebase does not reopen its node` | `expected not to contain: 13 but was: [13]` |
| `a slower detail load cannot replace a later one` | `expected: 13 but was: 11` |

Controls green throughout: `two toggles do not cancel each other` (which fails if `toggle` is given a shared handle — the over-correction this design invites) and two uncontested-load tests.

`QuranTopicsViewModel` was already fully fakeable and already had 21 tests. **None covered a race.** That is #364's own observation about this file, and it held.

## Docs

`CLEAN_ARCHITECTURE_CHECKLIST.md` gains **AP-7.9**: what counts as *one identity of a request*, which is the question AP-7.1b leaves open. It is not "one handle per function" — `focus`/`rebaseTo` share one because they are alternatives, `toggle` keeps none because two toggles are not.

Gates: compile ✅ · 1,545 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_