### PR TITLE
fix(qaida): credit a cell when its clip plays, not when a tap starts it

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QaidaAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QaidaAudioManager.kt
@@ -7,8 +7,11 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -69,6 +72,19 @@ class QaidaAudioManager @Inject constructor(
     // the right currentKey when playing a whole line via playSequence().
     private var sequenceKeys: List<String> = emptyList()
 
+    private val _completions = MutableSharedFlow<String>(extraBufferCapacity = 32)
+
+    /**
+     * Keys whose clip **played to its end**, as it happens.
+     *
+     * `state.currentKey` cannot answer this: it goes null both when a clip finishes and when
+     * [stop] cuts it off, and the difference is the whole question when playback is what
+     * credits a learner's progress. Only a natural media-item transition
+     * (`MEDIA_ITEM_TRANSITION_REASON_AUTO`) and a natural `STATE_ENDED` emit here — a tap
+     * elsewhere, a lesson change or [stop] emit nothing.
+     */
+    val completions: SharedFlow<String> = _completions.asSharedFlow()
+
     @OptIn(UnstableApi::class)
     private fun getOrCreatePlayer(): ExoPlayer {
         return player ?: ExoPlayer.Builder(context).build().also { newPlayer ->
@@ -80,6 +96,10 @@ class QaidaAudioManager @Inject constructor(
                         Player.STATE_ENDED -> {
                             // Whole clip / sequence finished playing.
                             if (!newPlayer.hasNextMediaItem()) {
+                                // The last item ran to its end, so it is heard. Emitted before
+                                // clearing `currentKey`, which is the only place it is still
+                                // known.
+                                _state.value.currentKey?.let(_completions::tryEmit)
                                 _state.update {
                                     it.copy(currentKey = null, isPlaying = false, isLoading = false)
                                 }
@@ -107,6 +127,11 @@ class QaidaAudioManager @Inject constructor(
                 }
 
                 override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    // AUTO means the previous item reached its end rather than being replaced,
+                    // so that key — not this one — is what the learner just heard.
+                    if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
+                        _state.value.currentKey?.let(_completions::tryEmit)
+                    }
                     val key = mediaItem?.mediaId?.takeIf { it.isNotEmpty() }
                         ?: sequenceKeys.getOrNull(newPlayer.currentMediaItemIndex)
                     if (key != null) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModel.kt
@@ -100,6 +100,28 @@ class QaidaReaderViewModel @Inject constructor(
                 ?.firstNotNullOfOrNull { line -> line.cells.firstOrNull { it.audioKey == key } }
         }.stateIn(viewModelScope, sharing, null)
 
+    /**
+     * The open lesson's cells, flattened, kept current by [observeLoadedCells].
+     *
+     * A snapshot rather than a read of [lessonContent] at the moment a clip ends: that flow is
+     * `WhileSubscribed`, so it is cold whenever no screen is collecting it — and audio outlives
+     * the screen. Crediting progress must not depend on something being on screen.
+     */
+    private var loadedCells: List<QaidaCell> = emptyList()
+
+    init {
+        observeLoadedCells()
+        observeHeardCells()
+    }
+
+    private fun observeLoadedCells() {
+        viewModelScope.launch {
+            lessonContent.collect { content ->
+                loadedCells = content?.lines?.flatMap { it.cells }.orEmpty()
+            }
+        }
+    }
+
     fun onEvent(event: QaidaReaderEvent) {
         when (event) {
             is QaidaReaderEvent.SelectLesson -> {
@@ -152,13 +174,39 @@ class QaidaReaderViewModel @Inject constructor(
         }
     }
 
-    /** Play a whole line back-to-back, marking each of its cells heard. */
+    /**
+     * Play a whole line back-to-back. Each cell is credited as **its own clip finishes**, by
+     * [observeHeardCells] — not here.
+     *
+     * This used to write all of the line's marks immediately and unconditionally, decoupled
+     * from playback: `playSequence` is fire-and-forget and nothing observed it. So tapping
+     * "play line" on an eight-cell line and immediately opening another lesson (which calls
+     * `audioManager.stop()`) recorded **all eight cells as heard** — enough, under
+     * `QaidaProgressRules`, to complete the line, award its stars and unlock the next lesson,
+     * for content the learner heard half a second of. The gating the whole Qaida progression
+     * rests on was bypassable with one tap.
+     */
     private fun playLine(lineId: Int) {
         val line = lessonContent.value?.lines?.firstOrNull { it.line.id == lineId } ?: return
         if (line.cells.isEmpty()) return
         audioManager.playSequence(line.cells.map { it.audioKey })
+    }
+
+    /**
+     * Credits a cell once its clip has actually played to the end.
+     *
+     * Driven by [QaidaAudioManager.completions], which emits only on a natural end — never on
+     * [QaidaAudioManager.stop], a lesson change, or a tap that replaces what is playing.
+     *
+     * Keyed against the loaded lesson so a clip cannot credit a cell from a lesson the learner
+     * has left; the same resolution [playingCell] does for highlighting.
+     */
+    private fun observeHeardCells() {
         viewModelScope.launch {
-            line.cells.forEach { qaidaUseCases.markCellHeard(it.lessonId, it.id) }
+            audioManager.completions.collect { key ->
+                val cell = loadedCells.firstOrNull { it.audioKey == key } ?: return@collect
+                qaidaUseCases.markCellHeard(cell.lessonId, cell.id)
+            }
         }
     }
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaProgressTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaProgressTest.kt
@@ -1,0 +1,170 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.data.audio.QaidaAudioManager
+import com.arshadshah.nimaz.data.audio.QaidaAudioState
+import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLine
+import com.arshadshah.nimaz.domain.model.QaidaLineContent
+import com.arshadshah.nimaz.domain.model.LineType
+import com.arshadshah.nimaz.domain.model.TokenType
+import com.arshadshah.nimaz.domain.usecase.QaidaUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Qaida progress is a gate, not a counter — completing a line awards stars and unlocks the next
+ * lesson. So "heard" has to mean heard.
+ *
+ * `playLine` wrote every one of the line's marks immediately, decoupled from playback:
+ * `playSequence` is fire-and-forget and nothing observed it. Tapping "play line" and
+ * immediately leaving credited the whole line.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QaidaProgressTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: QaidaUseCases
+    private lateinit var audioManager: QaidaAudioManager
+
+    /** Cells credited as heard, in order. */
+    private val marked = mutableListOf<Int>()
+
+    private val completions = MutableSharedFlow<String>(extraBufferCapacity = 32)
+
+    private val cells = listOf(cell(1, "a"), cell(2, "b"), cell(3, "c"))
+
+    private val content = QaidaLessonContent(
+        lesson = mockk(relaxed = true),
+        lines = listOf(
+            QaidaLineContent(
+                line = QaidaLine(
+                    id = 7,
+                    lessonId = 1,
+                    lineNumber = 1,
+                    lineType = LineType.entries.first(),
+                    instructionEnglish = null,
+                    instructionArabic = null,
+                    displayOrder = 0,
+                ),
+                cells = cells,
+            ),
+        ),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        audioManager = mockk(relaxed = true)
+
+        every { audioManager.state } returns MutableStateFlow(QaidaAudioState())
+        every { audioManager.completions } returns completions
+        every { useCases.getLessonContent(any()) } returns flowOf(content)
+        every { useCases.getCourseProgress() } returns flowOf(mockk(relaxed = true))
+        every { useCases.getLetters() } returns flowOf(emptyList())
+        every { useCases.getLessonProgress(any()) } returns flowOf(mockk(relaxed = true))
+        every { useCases.observeCompletedCells(any()) } returns flowOf(emptySet())
+        // Three matchers, not two: `MarkCellHeardUseCase.invoke` has a defaulted `now`, so the
+        // call site compiles to the synthetic three-arg bridge and a two-arg stub never matches.
+        coEvery { useCases.markCellHeard(any(), any(), any()) } answers {
+            marked += secondArg<Int>()
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun reader(): QaidaReaderViewModel {
+        val vm = QaidaReaderViewModel(useCases, audioManager)
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        dispatcher.scheduler.advanceUntilIdle()
+        return vm
+    }
+
+    @Test
+    fun `playing a line credits nothing until a clip actually finishes`() = runTest {
+        val vm = reader()
+
+        vm.onEvent(QaidaReaderEvent.PlayLine(7))
+        advanceUntilIdle()
+
+        // The shipped behaviour: all three marks written here, before a single clip had played.
+        assertThat(marked).isEmpty()
+    }
+
+    @Test
+    fun `each cell is credited as its own clip ends`() = runTest {
+        val vm = reader()
+        vm.onEvent(QaidaReaderEvent.PlayLine(7))
+        advanceUntilIdle()
+
+        completions.emit("a")
+        advanceUntilIdle()
+        assertThat(marked).containsExactly(1)
+
+        completions.emit("b")
+        advanceUntilIdle()
+        assertThat(marked).containsExactly(1, 2).inOrder()
+    }
+
+    @Test
+    fun `leaving part way through credits only what was heard`() = runTest {
+        val vm = reader()
+        vm.onEvent(QaidaReaderEvent.PlayLine(7))
+        advanceUntilIdle()
+
+        completions.emit("a")
+        advanceUntilIdle()
+
+        // The learner opens another lesson. `stop()` emits no completion, by design — that is
+        // the distinction `state.currentKey` could not make, since it goes null either way.
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        // Was: all three, which under QaidaProgressRules could complete the line, award its
+        // stars and unlock the next lesson for content heard for half a second.
+        assertThat(marked).containsExactly(1)
+    }
+
+    @Test
+    fun `a key from no loaded cell credits nothing`() = runTest {
+        val vm = reader()
+
+        completions.emit("not-in-this-lesson")
+        advanceUntilIdle()
+
+        assertThat(marked).isEmpty()
+    }
+
+    private fun cell(id: Int, key: String) = QaidaCell(
+        id = id,
+        lineId = 7,
+        lessonId = 1,
+        position = id,
+        textArabic = key,
+        transliteration = key,
+        tokenType = TokenType.entries.first(),
+        audioKey = key,
+        audioPath = "qaida/audio/$key.mp3",
+        highlightGroup = null,
+        letterId = null,
+        notes = null,
+    )
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModelTest.kt
@@ -33,6 +33,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -57,6 +58,7 @@ class QaidaReaderViewModelTest {
     private lateinit var useCases: QaidaUseCases
     private lateinit var audioManager: QaidaAudioManager
     private lateinit var audioStateFlow: MutableStateFlow<QaidaAudioState>
+    private lateinit var completionsFlow: MutableSharedFlow<String>
 
     @Before
     fun setUp() {
@@ -83,7 +85,9 @@ class QaidaReaderViewModelTest {
 
         audioManager = mockk(relaxed = true)
         audioStateFlow = MutableStateFlow(QaidaAudioState())
+        completionsFlow = MutableSharedFlow(extraBufferCapacity = 32)
         every { audioManager.state } returns audioStateFlow
+        every { audioManager.completions } returns completionsFlow
 
 
         // Default stubs — individual tests override the per-lesson ones.
@@ -154,7 +158,7 @@ class QaidaReaderViewModelTest {
     }
 
     @Test
-    fun `playLine plays the whole line and marks every cell heard`() = runTest {
+    fun `playLine plays the whole line and credits each cell as its clip ends`() = runTest {
         val vm = createViewModel()
 
         vm.lessonContent.test {
@@ -166,7 +170,18 @@ class QaidaReaderViewModelTest {
             advanceUntilIdle()
 
             verify { audioManager.playSequence(listOf("l1_alif", "l1_baa")) }
+            // This test previously asserted both marks **here**, which is the defect #364 R9
+            // describes: progress was written from the intent to play, not from playback. A
+            // learner who tapped and immediately left was credited with the whole line.
+            coVerify(exactly = 0) { markCellHeard.invoke(1, 11, any()) }
+
+            completionsFlow.emit("l1_alif")
+            advanceUntilIdle()
             coVerify { markCellHeard.invoke(1, 11, any()) }
+            coVerify(exactly = 0) { markCellHeard.invoke(1, 12, any()) }
+
+            completionsFlow.emit("l1_baa")
+            advanceUntilIdle()
             coVerify { markCellHeard.invoke(1, 12, any()) }
         }
     }

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -183,7 +183,7 @@ Adhan, Qaida tap-to-hear) plus an Adhan **download** pipeline. They share no pla
 | `data/audio/AdhanPlaybackService.kt` | foreground `mediaPlayback` service; plays the adhan when a prayer fires (works app-closed) using `ExoPlayer` with `USAGE_ALARM` + wake lock + audio focus |
 | `data/audio/AdhanDownloadService.kt` | foreground `dataSync` service that downloads both adhan variants with a progress notification (channel `adhan_download_channel`, id 7777) |
 | `data/audio/AdhanDownloadWorker.kt` | `@HiltWorker` background fallback for the download (see §3) |
-| `data/audio/QaidaAudioManager.kt` | `@Singleton`; stripped-down `ExoPlayer` for single Qaida tokens — **no service/notification/MediaSession/CDN**; exposes `val state: StateFlow<QaidaAudioState>` |
+| `data/audio/QaidaAudioManager.kt` | `@Singleton`; stripped-down `ExoPlayer` for single Qaida tokens — **no service/notification/MediaSession/CDN**; exposes `val state: StateFlow<QaidaAudioState>` and `val completions: SharedFlow<String>` |
 | `data/audio/AdhanSound.kt` | enum of adhans (MISHARY, ABDUL_BASIT, MAKKAH, SIMPLE_BEEP) with per-variant file names + download URLs |
 
 **Wiring.** None of these have a DI module — the managers are `@Singleton @Inject constructor(@ApplicationContext …)` (Hilt provides them automatically) and the services are `@AndroidEntryPoint` field-injecting their manager. Services are declared in `AndroidManifest.xml` with `foregroundServiceType` `mediaPlayback`/`dataSync`; permissions `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `FOREGROUND_SERVICE_DATA_SYNC`.
@@ -191,6 +191,15 @@ Adhan, Qaida tap-to-hear) plus an Adhan **download** pipeline. They share no pla
 **Media3/ExoPlayer specifics (Quran).** Ayahs are downloaded first then added as a `List<MediaItem>` for gapless sequential playback. ExoPlayer reports `0` duration for unloaded items, so durations are pre-extracted with `MediaMetadataRetriever`; a `ForwardingPlayer` (`getPlayer()`) translates per-item ExoPlayer position/duration into **whole-surah** ("total playlist") coordinates so the lock-screen scrubber reflects the surah, not one ayah. Recitations stream from `cdn.islamic.network`, cached under `filesDir/quran_audio/`. **Who** the reciters are is the `QuranReciter` catalogue in `domain/model/QuranReciter.kt` (frozen `id` + `aliases` for ids older builds persisted, display name, country, `RecitationStyle`); only the CDN wiring — which edition slug at which bitrate — stays in the data layer, as `RECITER_CDN_MAP`, now keyed by the enum. Before that the catalogue existed three times over (a `popularReciters` list in `SelectReciterScreen`, the map plus a `getReciterDisplayName` `when` in `QuranAudioManager`, and a third `when` in `QuranSettingsScreen`) and they disagreed: the settings row matched on ids the picker never writes, so eight of the ten reciters left it showing a raw id ("hussary") instead of a name. Three reciters that had working CDN editions and display names but were missing from the picker's hardcoded list — Muhammad Ayyoub, Muhammad Jibreel, Abdullah Basfar — are selectable now that one list drives everything. Adhan files cache under `filesDir/adhan/`, Qaida clips fall back to the bundled asset `file:///android_asset/qaida/audio/{key}.mp3`.
 
 **How ViewModels consume it.** ViewModels inject the manager **directly** and re-expose its flow (e.g. `QuranViewModel.audioState = audioManager.audioState`; `QaidaReaderViewModel.audioState = audioManager.state`; `SettingsViewModel` injects `adhanAudioManager` for preview/download). They drive playback via `onEvent`. *Deviation:* this bypasses the "ViewModels inject `XxxUseCases`" rule (§ARCHITECTURE), and `QuranViewModel` even exposes the manager as a public field — a known clean-architecture deviation, not a pattern to copy.
+
+**Qaida progress is credited by playback, not by intent.** `QaidaAudioManager.completions` emits an
+`audio_key` only when its clip reached its **natural** end — a media-item transition with
+`MEDIA_ITEM_TRANSITION_REASON_AUTO`, or `STATE_ENDED` with nothing queued after it. `stop()`, a
+lesson change and a tap that replaces what is playing emit nothing. `state.currentKey` cannot answer
+this question: it goes null in every one of those cases, and the difference is the whole point when
+completion awards stars and unlocks the next lesson. `QaidaReaderViewModel` collects `completions`
+and calls `markCellHeard` from there; `playLine` starts playback and writes no progress at all.
+(Tapping a single cell still marks eagerly — one tap, one clip, one intent.)
 
 **Gotchas.**
 - Two player APIs: ExoPlayer everywhere **except** `AdhanAudioManager.preview()` (legacy `MediaPlayer`).


### PR DESCRIPTION
**Layer 30** · epic #352 · on top of #424 (vm-29). Closes R9 of #364.

## The defect

```kotlin
audioManager.playSequence(line.cells.map { it.audioKey })
viewModelScope.launch { line.cells.forEach { qaidaUseCases.markCellHeard(it.lessonId, it.id) } }
```

Every mark written immediately and unconditionally, decoupled from playback. `playSequence` is fire-and-forget and nothing observed it.

**Input → wrong output:** a learner taps "play line" on an eight-cell line and immediately opens another lesson (which calls `audioManager.stop()`). **All eight cells are recorded as heard** — enough, under `QaidaProgressRules`, to complete the line, award its stars and **unlock the next lesson**, for content they heard half a second of.

This is not a counter drifting; Qaida progress is a **gate**. The sequencing the whole course rests on was bypassable with one tap.

## Why a new signal was needed

`state.currentKey` cannot answer "did this clip finish" — it goes null when a clip ends **and** when `stop()` cuts it off, and that difference is the entire question here. #364 suggests observing `currentKey` transitions; that would have credited interrupted clips.

So `QaidaAudioManager` exposes `completions: SharedFlow<String>`, emitting a key only on a natural end:
- a media-item transition with `MEDIA_ITEM_TRANSITION_REASON_AUTO` (the *previous* item ran out), or
- `STATE_ENDED` with nothing queued behind it.

`stop()`, a lesson change, and a tap that replaces what is playing emit nothing.

`playLine` now only starts playback. A collector credits each cell as its own clip ends.

**One subtlety worth flagging in review:** the collector resolves the key against a snapshot of the open lesson's cells, not against `lessonContent` directly. That flow is `stateIn(…, WhileSubscribed)`, so it is cold whenever no screen is collecting it — and audio outlives the screen. Crediting progress must not depend on something being on screen.

`onCellTapped` still marks eagerly, per the issue's own reasoning: one tap, one clip, one intent.

## A test that asserted the defect

`QaidaReaderViewModelTest.playLine plays the whole line and marks every cell heard` verified **both marks at tap time** — it encoded the bug as the specification. Rewritten to assert the opposite, with the completion emissions that now earn them.

## Verified red first

| test | before |
|---|---|
| `playing a line credits nothing until a clip actually finishes` | `expected to be empty but was: [1, 2, 3]` |
| `each cell is credited as its own clip ends` | `[1, 2, 3]` where `[1]` was expected |
| `leaving part way through credits only what was heard` | `[1, 2, 3]` — the whole line, for half a second of audio |

`a key from no loaded cell credits nothing` is the control.

## Docs

`SUBSYSTEMS.md` §1 — `completions` in the audio inventory row, plus what does and does not emit on it, and the rule that Qaida progress is credited by playback rather than intent.

Gates: compile ✅ · 1,553 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_