### PR TITLE
fix(khatam,quran): the last five reader bugs, and one thematic loader

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahInfoScreen.kt
@@ -48,6 +48,8 @@ import com.arshadshah.nimaz.presentation.components.organisms.BottomActions
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
 import com.arshadshah.nimaz.presentation.viewmodel.quran.QuranEvent
 import com.arshadshah.nimaz.presentation.viewmodel.quran.QuranViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.quran.SurahThematicEvent
+import com.arshadshah.nimaz.presentation.viewmodel.quran.SurahThematicViewModel
 
 /**
  * What a surah is, and where to go to learn more about it.
@@ -71,15 +73,19 @@ fun SurahInfoScreen(
     onOpenBackground: () -> Unit = {},
     onOpenPassages: () -> Unit = {},
     onOpenSubjects: () -> Unit = {},
-    viewModel: QuranViewModel = hiltViewModel()
+    viewModel: QuranViewModel = hiltViewModel(),
+    // The thematic layer comes from the ViewModel that owns it and that the two prose screens
+    // already use, rather than a second copy of the same three reads inside QuranViewModel.
+    thematicViewModel: SurahThematicViewModel = hiltViewModel(),
 ) {
     val homeState by viewModel.homeState.collectAsStateWithLifecycle()
-    val thematic by viewModel.surahThematic.collectAsStateWithLifecycle()
+    val thematic by thematicViewModel.thematic.collectAsStateWithLifecycle()
     val audioState by viewModel.audioState.collectAsStateWithLifecycle()
     val surah = homeState.surahs.find { it.number == surahNumber }
 
     LaunchedEffect(surahNumber) {
         viewModel.onEvent(QuranEvent.LoadSurahInfo(surahNumber))
+        thematicViewModel.onEvent(SurahThematicEvent.Load(surahNumber))
     }
 
     // The audio control bar should only reflect playback that belongs to THIS

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/KhatamViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/KhatamViewModel.kt
@@ -282,19 +282,49 @@ class KhatamViewModel @Inject constructor(
                 _formState.update { it.copy(isLoading = false) }
                 return@launch
             }
-            _formState.value = KhatamFormUiState(
-                mode = KhatamFormMode.Edit(khatamId),
-                name = khatam.name,
-                dailyTarget = khatam.dailyTarget,
-                preset = KhatamPacePreset.forTarget(khatam.dailyTarget),
-                notes = khatam.notes.orEmpty(),
-                deadline = khatam.deadline,
-                reminderEnabled = khatam.reminderEnabled,
-                reminderTime = khatam.reminderTime,
-                totalAyahsRead = khatam.totalAyahsRead,
-                isActiveKhatam = khatam.isActive,
-                isLoading = false
-            )
+            _formState.update { form ->
+                // A whole-object assign here threw away whatever the reader had typed while the
+                // first Room read was in flight: open Edit on a cold start, type "Ramadan 1447"
+                // into the name, and the load landing afterwards reverted it to the stored name.
+                //
+                // A field the reader has not touched is still at its blank default, so that is
+                // what decides. Untouched fields take the stored value; anything they have
+                // already changed is theirs and stays. The read-only facts below are not
+                // editable at all, so they always come from the record.
+                if ((form.mode as? KhatamFormMode.Edit)?.khatamId != khatamId) return@update form
+                val blank = KhatamFormUiState()
+                val dailyTarget =
+                    if (form.dailyTarget == blank.dailyTarget) khatam.dailyTarget
+                    else form.dailyTarget
+                form.copy(
+                    name = if (form.name == blank.name) khatam.name else form.name,
+                    dailyTarget = dailyTarget,
+                    preset = if (form.preset == blank.preset) {
+                        KhatamPacePreset.forTarget(khatam.dailyTarget)
+                    } else {
+                        form.preset
+                    },
+                    notes = if (form.notes == blank.notes) khatam.notes.orEmpty() else form.notes,
+                    deadline = if (form.deadline == blank.deadline) {
+                        khatam.deadline
+                    } else {
+                        form.deadline
+                    },
+                    reminderEnabled = if (form.reminderEnabled == blank.reminderEnabled) {
+                        khatam.reminderEnabled
+                    } else {
+                        form.reminderEnabled
+                    },
+                    reminderTime = if (form.reminderTime == blank.reminderTime) {
+                        khatam.reminderTime
+                    } else {
+                        form.reminderTime
+                    },
+                    totalAyahsRead = khatam.totalAyahsRead,
+                    isActiveKhatam = khatam.isActive,
+                    isLoading = false
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranUiState.kt
@@ -21,32 +21,6 @@ import com.arshadshah.nimaz.domain.model.TranslationLanguage
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import kotlinx.coroutines.flow.first
 
-/**
- * The Qur'an's thematic layer for one surah: its long-form background and its passage outline.
- *
- * [isAvailable] separates "this install has no thematic content" from "this surah has none".
- * Only the first is possible in practice — every surah has an overview and at least one passage
- * — but an install that upgraded before the schemaVersion 24 artifact arrived has neither, and
- * the screen says so instead of showing two empty sections.
- */
-data class SurahThematicUiState(
-    val overview: SurahOverview? = null,
-    val passages: List<AyahTheme> = emptyList(),
-
-    /**
-     * How many subjects this surah's verses are cited under.
-     *
-     * A count and not the list: the info screen labels one row with it, and loading a few
-     * hundred topics to render a single integer is what the counting query exists to avoid.
-     */
-    val subjectCount: Int = 0,
-
-    val isLoading: Boolean = true,
-) {
-    val isAvailable: Boolean
-        get() = overview != null || passages.isNotEmpty() || subjectCount > 0
-}
-
 data class QuranHomeUiState(
     val surahs: List<Surah> = emptyList(),
     val filteredSurahs: List<Surah> = emptyList(),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
@@ -14,6 +14,7 @@ import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.Khatam
 import com.arshadshah.nimaz.domain.model.KhatamDetailSnapshot
 import com.arshadshah.nimaz.domain.model.KhatamInsights
+import com.arshadshah.nimaz.domain.model.KhatamStatus
 import com.arshadshah.nimaz.domain.model.MushafPageLayout
 import com.arshadshah.nimaz.domain.model.MushafPagination
 import com.arshadshah.nimaz.domain.model.MushafScript
@@ -97,17 +98,6 @@ class QuranViewModel @Inject constructor(
     private val _surahInfo = MutableStateFlow<SurahInfo?>(null)
     val surahInfo: StateFlow<SurahInfo?> = _surahInfo.asStateFlow()
 
-    /**
-     * The surah's long-form background and its passage outline (schemaVersion 24).
-     *
-     * Kept beside [surahInfo] rather than folded into it: they are different content with
-     * different provenance and different sizes — one row of one sentence against ~8 KB of prose
-     * per surah — and the surah *list* reads the first for 114 rows and must never touch the
-     * second.
-     */
-    private val _surahThematic = MutableStateFlow(SurahThematicUiState())
-    val surahThematic: StateFlow<SurahThematicUiState> = _surahThematic.asStateFlow()
-
     val audioState: StateFlow<AudioState> = audioManager.audioState
 
     /**
@@ -134,14 +124,6 @@ class QuranViewModel @Inject constructor(
 
     private var passagesJob: Job? = null
 
-    /**
-     * One job for the info screen's thematic load, cancelled when a different surah asks.
-     *
-     * The screen is reachable from the surah list, from a deep link and from the reader, so two
-     * surahs can be requested in quick succession — without this, the slower of the two wins.
-     */
-    private var surahThematicJob: Job? = null
-
     // Debounced search support
     private val searchQueryFlow = MutableStateFlow("")
     private var searchJob: Job? = null
@@ -159,6 +141,15 @@ class QuranViewModel @Inject constructor(
     }
 
     private var readerTarget: ReaderTarget? = null
+
+    /**
+     * Khatams this instance has already asked to complete.
+     *
+     * `activeKhatamStream` re-emits on any change to the khatam or its read ayahs, and the
+     * completion branch is evaluated on every one — so without this, an emission arriving
+     * before the completed flag comes back round called `completeKhatam` again.
+     */
+    private val completedKhatamIds = mutableSetOf<Long>()
 
     /**
      * The in-flight collector for the *single-target* reading modes (surah, juz). Each load
@@ -279,8 +270,15 @@ class QuranViewModel @Inject constructor(
             )
 
             QuranEvent.ToggleTranslation -> {
-                val newValue = !_readerState.value.showTranslation
-                _readerState.update { it.copy(showTranslation = newValue) }
+                // Flipped inside the update so the read and the write are one operation. Read
+                // first and `observeQuranSettings` — which writes the same field from its own
+                // coroutine — can land between them, and the toggle then writes a value derived
+                // from a state that no longer exists.
+                var newValue = false
+                _readerState.update {
+                    newValue = !it.showTranslation
+                    it.copy(showTranslation = newValue)
+                }
                 viewModelScope.launch { settingsRepository.setShowTranslation(newValue) }
             }
 
@@ -489,30 +487,6 @@ class QuranViewModel @Inject constructor(
     private fun loadSurahInfo(surahNumber: Int) {
         viewModelScope.launch {
             _surahInfo.value = quranUseCases.getSurahInfo(surahNumber)
-        }
-        loadSurahThematic(surahNumber)
-    }
-
-    /**
-     * The background and passage outline, in one job.
-     *
-     * Both come from the same artifact and are shown on the same screen, so loading them
-     * separately would only buy two spinners that finish at the same time. A surah whose
-     * overview is absent is not an error — see [SurahThematicUiState.isAvailable].
-     */
-    private fun loadSurahThematic(surahNumber: Int) {
-        surahThematicJob?.cancel()
-        surahThematicJob = viewModelScope.launch {
-            _surahThematic.value = SurahThematicUiState(isLoading = true)
-            val overview = quranUseCases.getSurahOverview(surahNumber)
-            val themes = quranUseCases.getSurahThemes(surahNumber)
-            val subjects = quranUseCases.getTopicsForSurah.count(surahNumber)
-            _surahThematic.value = SurahThematicUiState(
-                overview = overview,
-                passages = themes,
-                subjectCount = subjects,
-                isLoading = false,
-            )
         }
     }
 
@@ -1043,7 +1017,18 @@ class QuranViewModel @Inject constructor(
                     )
                 }
                 val khatam = snapshot?.khatam
-                if (khatam != null && snapshot.readAyahIds.size >= Khatam.TOTAL_QURAN_AYAHS) {
+                // `activeKhatamStream` re-emits on any row change in the khatam or its read
+                // ayahs, and this branch is reached on every one of them. Without a guard,
+                // completing a khatam that does not immediately leave "active" — or any
+                // unrelated re-emission afterwards — called `completeKhatam` again, and again.
+                // The id set is per-ViewModel and only grows, which is all that is needed:
+                // finishing is a one-way transition and a fresh instance re-reads the flag.
+                if (khatam != null &&
+                    khatam.status != KhatamStatus.COMPLETED &&
+                    khatam.id !in completedKhatamIds &&
+                    snapshot.readAyahIds.size >= Khatam.TOTAL_QURAN_AYAHS
+                ) {
+                    completedKhatamIds += khatam.id
                     khatamUseCases.completeKhatam(khatam.id)
                 }
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicUiState.kt
@@ -62,3 +62,29 @@ data class SurahPassagesState(
 
 /** The reader's starting prose size; the state that defaults to it now owns it. */
 private const val DEFAULT_PROSE_FONT_SIZE = 16f
+
+/**
+ * The Qur'an's thematic layer for one surah: its long-form background and its passage outline.
+ *
+ * [isAvailable] separates "this install has no thematic content" from "this surah has none".
+ * Only the first is possible in practice — every surah has an overview and at least one passage
+ * — but an install that upgraded before the schemaVersion 24 artifact arrived has neither, and
+ * the screen says so instead of showing two empty sections.
+ */
+data class SurahThematicUiState(
+    val overview: SurahOverview? = null,
+    val passages: List<AyahTheme> = emptyList(),
+
+    /**
+     * How many subjects this surah's verses are cited under.
+     *
+     * A count and not the list: the info screen labels one row with it, and loading a few
+     * hundred topics to render a single integer is what the counting query exists to avoid.
+     */
+    val subjectCount: Int = 0,
+
+    val isLoading: Boolean = true,
+) {
+    val isAvailable: Boolean
+        get() = overview != null || passages.isNotEmpty() || subjectCount > 0
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicViewModel.kt
@@ -32,9 +32,36 @@ class SurahThematicViewModel @Inject constructor(
     private val _passagesState = MutableStateFlow(SurahPassagesState())
     val passagesState: StateFlow<SurahPassagesState> = _passagesState.asStateFlow()
 
+    /**
+     * The same surah's thematic layer as one object, for the surah **info** screen — which
+     * summarises what the other two screens then show in full.
+     *
+     * `QuranViewModel` used to load this itself, from `loadSurahInfo`, into its own
+     * `_surahThematic`. That was the same three reads against the same use cases producing the
+     * same state class, in the ViewModel this one exists precisely to keep the prose screens
+     * out of: its KDoc above says so, and the split was half-done because the info screen still
+     * read the copy. One load path now, so the two cannot drift.
+     */
+    private val _thematic = MutableStateFlow(SurahThematicUiState())
+    val thematic: StateFlow<SurahThematicUiState> = _thematic.asStateFlow()
+
     /** One job per surah, so a slower load for a surah since left cannot repaint this one. */
     private var loadJob: Job? = null
+
+    /** The surah whose load **completed**. Assigned on success, never on entry. */
     private var loadedSurah: Int? = null
+
+    /**
+     * The surah a load is currently running for.
+     *
+     * Split from [loadedSurah] because the old single marker was assigned at entry and so
+     * recorded a surah that might never arrive. Cancel the job — a pane swap, a fast back —
+     * and `loadedSurah == surahNumber` with `loadJob.isActive == false` made the guard
+     * short-circuit every retry, stranding the screen on `isLoading = true` **forever**. It
+     * also let a second `Load` for the surah already in flight restart the whole three-call
+     * load, despite the KDoc calling the event idempotent.
+     */
+    private var loadingSurah: Int? = null
 
     init {
         settingsRepository.quranTranslationFontSize
@@ -58,8 +85,11 @@ class SurahThematicViewModel @Inject constructor(
     }
 
     private fun load(surahNumber: Int) {
-        if (loadedSurah == surahNumber && loadJob?.isActive != true) return
-        loadedSurah = surahNumber
+        // Already showing it, or already fetching it: both are "nothing to do". A cancelled
+        // job satisfies neither, so a retry after one gets through.
+        if (loadedSurah == surahNumber) return
+        if (loadingSurah == surahNumber && loadJob?.isActive == true) return
+        loadingSurah = surahNumber
         loadJob?.cancel()
         loadJob = launchSafely(
             telemetry,
@@ -68,17 +98,21 @@ class SurahThematicViewModel @Inject constructor(
             onFailure = { throwable ->
                 // The surah was never actually loaded, so clear the marker: otherwise the
                 // guard above would short-circuit a later retry and strand the screen.
-                loadedSurah = null
+                loadingSurah = null
                 _backgroundState.update { it.copy(isLoading = false, error = throwable.message) }
                 _passagesState.update { it.copy(isLoading = false, error = throwable.message) }
+                _thematic.update { it.copy(isLoading = false) }
             },
         ) {
             _backgroundState.update { it.copy(isLoading = true, error = null) }
             _passagesState.update { it.copy(isLoading = true, error = null) }
+            _thematic.value = SurahThematicUiState(isLoading = true)
 
             val surah = quranUseCases.getSurahByNumber(surahNumber)
             val overview = quranUseCases.getSurahOverview(surahNumber)
             val passages = quranUseCases.getSurahThemes(surahNumber)
+            // A count, not the list: the info screen labels one row with it.
+            val subjectCount = quranUseCases.getTopicsForSurah.count(surahNumber)
 
             _backgroundState.update {
                 it.copy(surah = surah, overview = overview, isLoading = false)
@@ -86,6 +120,15 @@ class SurahThematicViewModel @Inject constructor(
             _passagesState.update {
                 it.copy(surah = surah, passages = passages, isLoading = false)
             }
+            _thematic.value = SurahThematicUiState(
+                overview = overview,
+                passages = passages,
+                subjectCount = subjectCount,
+                isLoading = false,
+            )
+            // Recorded only now that all three reads have landed.
+            loadedSurah = surahNumber
+            loadingSurah = null
             telemetry.featureUsed(DOMAIN, "open")
         }
     }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/KhatamEditFormTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/KhatamEditFormTest.kt
@@ -1,0 +1,115 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import com.arshadshah.nimaz.domain.model.Khatam
+import com.arshadshah.nimaz.domain.usecase.KhatamUseCases
+import com.arshadshah.nimaz.domain.usecase.ObserveKhatamByIdUseCase
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Opening a khatam for editing, while the first Room read is still in flight.
+ *
+ * `startEdit` assigned a whole fresh `KhatamFormUiState` once the record arrived, so anything
+ * typed in the meantime was replaced by the stored values — silently, and looking exactly like
+ * the app had discarded the edit.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class KhatamEditFormTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: KhatamUseCases
+    private lateinit var quranUseCases: QuranUseCases
+
+    /** Emits the stored khatam only when a test decides it has arrived. */
+    private val stored = MutableStateFlow<Khatam?>(null)
+
+    private val khatam = Khatam(
+        id = 7,
+        name = "Stored name",
+        notes = "Stored notes",
+        dailyTarget = 20,
+        totalAyahsRead = 100,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        quranUseCases = mockk(relaxed = true)
+
+        val observeById = mockk<ObserveKhatamByIdUseCase>()
+        every { observeById.invoke(any()) } returns stored
+        every { useCases.observeKhatamById } returns observeById
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = KhatamViewModel(useCases, quranUseCases)
+
+    @Test
+    fun `typing during the load survives it`() = runTest {
+        val vm = viewModel()
+
+        vm.onEvent(KhatamEvent.StartEdit(7))
+        advanceUntilIdle()
+        assertThat(vm.formState.value.isLoading).isTrue()
+
+        // The reader types while the spinner is still up.
+        vm.onEvent(KhatamEvent.UpdateName("Ramadan 1447"))
+        advanceUntilIdle()
+
+        stored.value = khatam
+        advanceUntilIdle()
+
+        // Was: reverted to "Stored name" the moment the read landed.
+        assertThat(vm.formState.value.name).isEqualTo("Ramadan 1447")
+        assertThat(vm.formState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `fields the reader did not touch take the stored values`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(KhatamEvent.StartEdit(7))
+        advanceUntilIdle()
+        vm.onEvent(KhatamEvent.UpdateName("Ramadan 1447"))
+        advanceUntilIdle()
+
+        stored.value = khatam
+        advanceUntilIdle()
+
+        // Preserving the reader's edit must not cost them the rest of the record — an edit
+        // screen missing the stored notes would be its own bug.
+        assertThat(vm.formState.value.notes).isEqualTo("Stored notes")
+        assertThat(vm.formState.value.dailyTarget).isEqualTo(20)
+        assertThat(vm.formState.value.totalAyahsRead).isEqualTo(100)
+    }
+
+    @Test
+    fun `an untouched form is filled entirely from the record`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(KhatamEvent.StartEdit(7))
+        advanceUntilIdle()
+
+        stored.value = khatam
+        advanceUntilIdle()
+
+        assertThat(vm.formState.value.name).isEqualTo("Stored name")
+        assertThat(vm.formState.value.notes).isEqualTo("Stored notes")
+        assertThat(vm.formState.value.isLoading).isFalse()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicLoadGuardTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicLoadGuardTest.kt
@@ -1,0 +1,153 @@
+package com.arshadshah.nimaz.presentation.viewmodel.quran
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.GetTopicsForSurahUseCase
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The load guard on the surah's thematic layer.
+ *
+ * `loadedSurah` was assigned **on entry**, so it recorded a surah that might never arrive. That
+ * is the difference between a guard that says "already showing it" and one that says "already
+ * asked for it", and only the first is safe to short-circuit on.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SurahThematicLoadGuardTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private lateinit var useCases: QuranUseCases
+    private lateinit var settings: SettingsRepository
+
+    /** How many times each surah's overview was fetched. */
+    private val overviewReads = mutableListOf<Int>()
+
+    /** Held open so a test can decide when a surah's read resolves. */
+    private val gates = mutableMapOf<Int, CompletableDeferred<Unit>>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+        every { settings.quranTranslationFontSize } returns MutableStateFlow(16f)
+
+        coEvery { useCases.getSurahOverview(any()) } coAnswers {
+            val surah = firstArg<Int>()
+            overviewReads += surah
+            gates[surah]?.await()
+            null
+        }
+        coEvery { useCases.getSurahByNumber(any()) } returns null
+        coEvery { useCases.getSurahThemes(any()) } returns emptyList()
+
+        val topicsForSurah = mockk<GetTopicsForSurahUseCase>()
+        coEvery { topicsForSurah.count(any()) } returns 3
+        every { useCases.getTopicsForSurah } returns topicsForSurah
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = SurahThematicViewModel(useCases, settings, telemetry)
+
+    /**
+     * **This passes on the pre-fix code too, and that is the finding.**
+     *
+     * #364 R12 predicts a permanent strand: cancel the job, and `loadedSurah == surahNumber`
+     * with an inactive job makes the guard short-circuit every retry. That state is not
+     * reachable. `loadJob?.cancel()` appears at exactly one site — inside `load()` — and the
+     * old code assigned `loadedSurah = surahNumber` on the line immediately before it, so a
+     * cancel was always followed by a relaunch for whichever surah was just recorded. The
+     * marker and the job could not diverge. The failure path did not strand either, because
+     * `onFailure` already reset the marker.
+     *
+     * What was real is the sibling defect the issue notes second — see the restart test below.
+     * Kept as the regression guard for the property the fix now provides *by construction*
+     * rather than by that coincidence: the marker means "loaded", so nothing that failed to
+     * load can ever block a retry.
+     */
+    @Test
+    fun `an interrupted load does not block coming back to that surah`() = runTest {
+        val stuck = CompletableDeferred<Unit>()
+        gates[2] = stuck
+
+        val vm = viewModel()
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        vm.onEvent(SurahThematicEvent.Load(3))
+        advanceUntilIdle()
+        gates.remove(2)
+        stuck.complete(Unit)
+
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        assertThat(vm.backgroundState.value.isLoading).isFalse()
+        assertThat(vm.thematic.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `re-sending Load for the surah already in flight does not restart it`() = runTest {
+        val slow = CompletableDeferred<Unit>()
+        gates[2] = slow
+
+        val vm = viewModel()
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        slow.complete(Unit)
+        advanceUntilIdle()
+
+        // The event's KDoc calls it "idempotent — safe to re-send". That was true of the result
+        // and false of the work: the second send fell through and re-ran all three reads.
+        assertThat(overviewReads).containsExactly(2)
+    }
+
+    @Test
+    fun `re-sending Load for a surah already shown does nothing`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        assertThat(overviewReads).containsExactly(2)
+    }
+
+    @Test
+    fun `the info screen's thematic state comes from the same single load`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SurahThematicEvent.Load(2))
+        advanceUntilIdle()
+
+        // R14: `QuranViewModel` used to run these same three reads into its own copy of this
+        // state, from `loadSurahInfo`. One load path now feeds the info screen and the two
+        // prose screens alike.
+        assertThat(vm.thematic.value.subjectCount).isEqualTo(3)
+        assertThat(vm.thematic.value.isLoading).isFalse()
+        assertThat(overviewReads).containsExactly(2)
+    }
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -340,6 +340,28 @@ rg -n -U --multiline-dotall \
   app/src/main/java --glob '*ViewModel.kt' | grep -v 'Job = viewModelScope'
 ```
 
+### AP-7.10 · A cache marker recording the request instead of the result
+
+- [x] ~~**`SurahThematicViewModel.load`.**~~ **Resolved.** `loadedSurah` was assigned on *entry*,
+  so it named a surah that might never arrive, and the guard that short-circuits on it could not
+  tell "already showing this" from "already asked for this". Split into `loadedSurah` (assigned
+  on success) and `loadingSurah` (assigned on entry, cleared on failure), which is what lets the
+  guard answer both questions correctly: re-sending `Load` for the surah in flight is a no-op,
+  and a load that never completed blocks nothing.
+
+  **Correction to #364 R12, which predicts a permanent strand from this.** That state is not
+  reachable in the shipped code: `loadJob?.cancel()` appears at exactly one site, inside
+  `load()`, on the line *after* the marker is reassigned — so a cancel is always followed by a
+  relaunch for the surah just recorded, and the two cannot diverge. The failure path did not
+  strand either, because `onFailure` already reset the marker. The real defect is the one the
+  issue lists second: a second `Load` for the surah already in flight fell through and re-ran
+  the whole three-call load, despite the event's KDoc calling it idempotent. Verified by test in
+  both directions. (`SurahThematicLoadGuardTest`)
+
+  The general rule is still worth having: **a marker used as a cache key must record what
+  completed, not what was attempted.** Getting that right removes a class of "why is this screen
+  stuck" bug rather than one instance of it.
+
 ### AP-7.9 · One handle for requests that are not alternatives
 
 - [x] ~~**`QuranTopicsViewModel.toggle` / `focus` / `rebaseTo`, and the catalogue detail load.**~~


### PR DESCRIPTION
**Layer 31** · epic #352 · on top of #425 (vm-30). **Closes #364** — R10 through R14, the last of the readers issue.

## R10 — editing a khatam discarded what you typed

`startEdit` assigned a whole fresh `KhatamFormUiState` once the record arrived.

**Input → wrong output:** open Edit on a cold start, type "Ramadan 1447" into the name while the spinner is still up, and the load landing afterwards reverts it to the stored name.

A field the reader has not touched is still at its blank default, so that is what decides: untouched fields take the stored value, anything already changed stays theirs, and the read-only facts (`totalAyahsRead`, `isActiveKhatam`) always come from the record. Per-field rather than a single dirty flag — preserving the edit must not cost them the rest of the record, and a test pins that too.

## R11 — a khatam could be completed repeatedly

`activeKhatamStream` re-emits on any change to the khatam or its read ayahs, and the completion branch ran on every one. Guarded on both the persisted `KhatamStatus.COMPLETED` and a per-instance id set — finishing is a one-way transition, so the set only grows and a fresh instance re-reads the flag.

## R12 — and a correction to it

`loadedSurah` was assigned on **entry**, so it named a surah that might never arrive. Split into `loadedSurah` (assigned on success) and `loadingSurah` (on entry, cleared on failure).

**#364 R12 predicts a permanent strand from this. That state is not reachable.** `loadJob?.cancel()` appears at exactly one site — inside `load()` — on the line *after* the marker is reassigned, so a cancel is always followed by a relaunch for the surah just recorded; the two cannot diverge. The failure path did not strand either, because `onFailure` already reset the marker.

The real defect is the one the issue lists second: **a second `Load` for the surah already in flight fell through and re-ran the whole three-call load**, despite the event's KDoc calling it "idempotent — safe to re-send" (true of the result, not of the work). That one goes red.

The test that would have caught the predicted strand is kept, with a KDoc saying plainly that it passes on the pre-fix code and why it is still worth having.

## R13 — `ToggleTranslation` read then wrote

Racing `observeQuranSettings`, which writes the same field from its own coroutine. Flipped inside the `update` so read and write are one operation.

## R14 — two ViewModels loading the same thing

`QuranViewModel.loadSurahThematic` ran the same three reads into its own copy of `SurahThematicUiState` that `SurahThematicViewModel` already produces — the ViewModel that exists *precisely* so the prose screens do not pay `QuranViewModel`'s construction cost, per its own KDoc. The split was half-done because `SurahInfoScreen` read the copy.

One load path now feeds the info screen and the two prose screens. `SurahThematicUiState` moves to the file that owns it (same package, no import churn), and the duplicate loader, field and job are gone from `QuranViewModel`.

## Verified red first

| test | before |
|---|---|
| `typing during the load survives it` | `expected: Ramadan 1447 but was: Stored name` |
| `re-sending Load for the surah already in flight does not restart it` | `expected: [2] but was: [2, 2]` |

Controls green throughout, including `fields the reader did not touch take the stored values` — which fails if R10 is "fixed" by simply not applying the record.

## Docs

`CLEAN_ARCHITECTURE_CHECKLIST.md` gains **AP-7.10**: a marker used as a cache key must record what *completed*, not what was *attempted*.

Gates: compile ✅ · 1,560 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_