### PR TITLE
fix(location): one row per place, the newest one current, one geocode

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -214,6 +214,8 @@ import com.arshadshah.nimaz.domain.usecase.SearchHelpUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchQuranUseCase
 import com.arshadshah.nimaz.domain.usecase.SeedMissingDefaultsUseCase
 import com.arshadshah.nimaz.domain.usecase.SetActiveKhatamUseCase
+import com.arshadshah.nimaz.domain.usecase.GetRecentLocationsUseCase
+import com.arshadshah.nimaz.domain.usecase.SaveCurrentLocationUseCase
 import com.arshadshah.nimaz.domain.usecase.SetCurrentLocationUseCase
 import com.arshadshah.nimaz.domain.usecase.TafseerUseCases
 import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
@@ -633,6 +635,8 @@ object UseCaseModule {
             insertLocation = InsertLocationUseCase(repository),
             deleteLocation = DeleteLocationUseCase(repository),
             setCurrentLocation = SetCurrentLocationUseCase(repository),
+            getRecentLocations = GetRecentLocationsUseCase(repository),
+            saveCurrentLocation = SaveCurrentLocationUseCase(repository),
             toggleFavorite = ToggleLocationFavoriteUseCase(repository)
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/LocationDao.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/database/dao/LocationDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import com.arshadshah.nimaz.data.local.database.entity.LocationEntity
 import kotlinx.coroutines.flow.Flow
@@ -13,6 +14,29 @@ import kotlinx.coroutines.flow.Flow
 interface LocationDao {
     @Query("SELECT * FROM locations ORDER BY isFavorite DESC, name ASC")
     fun getAllLocations(): Flow<List<LocationEntity>>
+
+    /**
+     * The most recently used locations, newest first.
+     *
+     * [getAllLocations] orders by `isFavorite DESC, name ASC`, so taking the first five of it
+     * gave an **alphabetical** "recent" row in which a newly saved location never appeared —
+     * save Zurich after Amsterdam…Edinburgh and it is still those five. `updatedAt` has been on
+     * this table since it was created, so recency needed no schema change, only a query that
+     * asks for it.
+     */
+    @Query("SELECT * FROM locations ORDER BY updatedAt DESC LIMIT :limit")
+    fun getRecentLocations(limit: Int): Flow<List<LocationEntity>>
+
+    /**
+     * A stored location at the same place, to three decimals — about 100 m, which is well
+     * inside the precision a prayer-time calculation needs and far enough apart that two
+     * genuinely different cities never collide.
+     */
+    @Query(
+        "SELECT * FROM locations WHERE ROUND(latitude, 3) = ROUND(:latitude, 3) " +
+            "AND ROUND(longitude, 3) = ROUND(:longitude, 3) LIMIT 1"
+    )
+    suspend fun findByCoordinates(latitude: Double, longitude: Double): LocationEntity?
 
     @Query("SELECT * FROM locations WHERE isCurrentLocation = 1 LIMIT 1")
     fun getCurrentLocation(): Flow<LocationEntity?>
@@ -49,6 +73,42 @@ interface LocationDao {
 
     @Query("UPDATE locations SET isCurrentLocation = 1 WHERE id = :id")
     suspend fun setCurrentLocation(id: Long)
+
+    /**
+     * Makes [location] the one and only current location, in a single transaction.
+     *
+     * `insertLocation` is `@Insert(onConflict = REPLACE)` on an **autogenerate** primary key, so
+     * it always inserts and never replaces. Every selection therefore added a row — the table
+     * grew without bound, and after the second selection several rows carried
+     * `isCurrentLocation = 1`. Both current-location reads are `… WHERE isCurrentLocation = 1
+     * LIMIT 1`, which with no ORDER BY returns the lowest rowid: **the oldest**. Select London
+     * then Cairo and `getCurrentLocationSync()` answered London, so widgets and workers
+     * disagreed with the screen.
+     *
+     * Clearing and setting must be one transaction, or a reader between the two statements sees
+     * no current location at all.
+     */
+    @Transaction
+    suspend fun saveCurrentLocation(location: LocationEntity, now: Long): Long {
+        clearCurrentLocation()
+        val existing = findByCoordinates(location.latitude, location.longitude)
+        if (existing == null) {
+            return insertLocation(location.copy(isCurrentLocation = true, updatedAt = now))
+        }
+        // Re-selecting somewhere already saved refreshes it rather than duplicating it — which
+        // is also what makes it the newest entry in the recent row.
+        updateLocation(
+            existing.copy(
+                name = location.name,
+                country = location.country,
+                city = location.city,
+                timezone = location.timezone,
+                isCurrentLocation = true,
+                updatedAt = now,
+            )
+        )
+        return existing.id
+    }
 
     @Query("UPDATE locations SET isFavorite = NOT isFavorite, updatedAt = :timestamp WHERE id = :id")
     suspend fun toggleFavorite(id: Long, timestamp: Long = System.currentTimeMillis())

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/PrayerRepositoryImpl.kt
@@ -258,6 +258,14 @@ class PrayerRepositoryImpl @Inject constructor(
         locationDao.setCurrentLocation(id)
     }
 
+    override fun getRecentLocations(limit: Int): Flow<List<Location>> {
+        return locationDao.getRecentLocations(limit).mapItems { it.toDomain() }
+    }
+
+    override suspend fun saveCurrentLocation(location: Location, now: Long): Long {
+        return locationDao.saveCurrentLocation(location.toEntity(), now)
+    }
+
     override suspend fun toggleFavorite(id: Long) {
         locationDao.toggleFavorite(id)
     }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/PrayerRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/PrayerRepository.kt
@@ -56,5 +56,14 @@ interface PrayerRepository {
     suspend fun updateLocation(location: Location)
     suspend fun deleteLocation(location: Location)
     suspend fun setCurrentLocation(id: Long)
+
+    /** The most recently used locations, newest first. */
+    fun getRecentLocations(limit: Int): Flow<List<Location>>
+
+    /**
+     * Makes [location] the one and only current location, inserting it or refreshing the stored
+     * row at the same coordinates, in one transaction. Returns that row's id.
+     */
+    suspend fun saveCurrentLocation(location: Location, now: Long): Long
     suspend fun toggleFavorite(id: Long)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/PrayerUseCases.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/PrayerUseCases.kt
@@ -1,5 +1,7 @@
 package com.arshadshah.nimaz.domain.usecase
 
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.PrayerName
 import com.arshadshah.nimaz.domain.model.PrayerRecord
@@ -27,6 +29,8 @@ data class PrayerUseCases(
     val insertLocation: InsertLocationUseCase,
     val deleteLocation: DeleteLocationUseCase,
     val setCurrentLocation: SetCurrentLocationUseCase,
+    val getRecentLocations: GetRecentLocationsUseCase,
+    val saveCurrentLocation: SaveCurrentLocationUseCase,
     val toggleFavorite: ToggleLocationFavoriteUseCase
 )
 
@@ -99,6 +103,52 @@ class DeleteLocationUseCase @Inject constructor(private val repository: PrayerRe
 
 class SetCurrentLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
     suspend operator fun invoke(id: Long) = repository.setCurrentLocation(id)
+}
+
+/** The most recently used locations, newest first — ordered by the database, not the caller. */
+class GetRecentLocationsUseCase @Inject constructor(private val repository: PrayerRepository) {
+    operator fun invoke(limit: Int = DEFAULT_LIMIT): Flow<List<Location>> =
+        repository.getRecentLocations(limit)
+
+    private companion object {
+        const val DEFAULT_LIMIT = 5
+    }
+}
+
+/**
+ * Records a chosen location as *the* current one.
+ *
+ * The caller passes where the user picked, not a fully-formed row: composing a `Location` in the
+ * ViewModel is what let it invent an id of 0 against an autogenerate primary key and insert a
+ * duplicate on every selection.
+ */
+class SaveCurrentLocationUseCase @Inject constructor(private val repository: PrayerRepository) {
+    suspend operator fun invoke(
+        name: String,
+        country: String,
+        latitude: Double,
+        longitude: Double,
+        timezone: String,
+        now: Long = System.currentTimeMillis(),
+    ): Long = repository.saveCurrentLocation(
+        Location(
+            id = 0,
+            name = name,
+            latitude = latitude,
+            longitude = longitude,
+            timezone = timezone,
+            country = country,
+            city = name,
+            isCurrentLocation = true,
+            isFavorite = false,
+            calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+            asrCalculation = AsrCalculation.STANDARD,
+            highLatitudeRule = null,
+            fajrAngle = null,
+            ishaAngle = null,
+        ),
+        now,
+    )
 }
 
 class ToggleLocationFavoriteUseCase @Inject constructor(private val repository: PrayerRepository) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModel.kt
@@ -29,6 +29,8 @@ import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -123,7 +125,10 @@ class LocationViewModel @Inject constructor(
     private fun loadRecentLocations() {
         viewModelScope.launch {
             try {
-                prayerUseCases.getAllLocations().collect { locations ->
+                // Ordered by the database, newest first. Taking the first five of
+                // `getAllLocations()` — which sorts `isFavorite DESC, name ASC` — produced an
+                // alphabetical "recent" row that a newly saved location never entered.
+                prayerUseCases.getRecentLocations().collect { locations ->
                     val recentLocations = locations
                         .map { location ->
                             SearchLocation(
@@ -150,10 +155,27 @@ class LocationViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The in-flight geocode.
+     *
+     * `UpdateSearchQuery` fires per keystroke, and each call launched an unhandled coroutine, so
+     * typing "london" put six network geocodes in the air with no ordering between them —
+     * whichever resolved last won. The `lon` results (Lonavla, Long Beach) landing after the
+     * `london` ones left the list describing a query the user had already finished typing, and
+     * `isSearching` flickered false as soon as *any* of them returned. AP-7.1b, already fixed
+     * this way in `HadithViewModel`.
+     */
+    private var searchJob: Job? = null
+
     private fun searchLocations(query: String) {
         if (query.length < 2) return
 
-        viewModelScope.launch {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            // Inside the cancellable block, so it debounces and cancel-and-replaces with one
+            // mechanism: a keystroke within the window kills the previous coroutine before it
+            // has issued anything at all.
+            delay(SEARCH_DEBOUNCE_MS)
             _state.update { it.copy(isSearching = true) }
             try {
                 val results = withContext(Dispatchers.IO) {
@@ -227,24 +249,17 @@ class LocationViewModel @Inject constructor(
                     name = "${location.name}, ${location.country}"
                 )
 
-                // Save to database for recent locations
-                val domainLocation = Location(
-                    id = 0,
+                // One transaction: clear the flag everywhere, then insert this place or
+                // refresh the row already at these coordinates. Composing a `Location` here —
+                // with `id = 0` against an autogenerate primary key — is what made every
+                // selection insert a duplicate and left several rows flagged current.
+                prayerUseCases.saveCurrentLocation(
                     name = location.name,
+                    country = location.country,
                     latitude = location.latitude,
                     longitude = location.longitude,
                     timezone = TimeZone.getDefault().id,
-                    country = location.country,
-                    city = location.name,
-                    isCurrentLocation = true,
-                    isFavorite = false,
-                    calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
-                    asrCalculation = AsrCalculation.STANDARD,
-                    highLatitudeRule = null,
-                    fajrAngle = null,
-                    ishaAngle = null
                 )
-                prayerUseCases.insertLocation(domainLocation)
 
                 // Update state
                 _state.update {
@@ -395,3 +410,6 @@ class LocationViewModel @Inject constructor(
         }
     }
 }
+
+/** Long enough that a fast typist issues one geocode, short enough to feel immediate. */
+private const val SEARCH_DEBOUNCE_MS = 300L

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/database/dao/LocationDaoTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/database/dao/LocationDaoTest.kt
@@ -1,0 +1,136 @@
+package com.arshadshah.nimaz.data.local.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.data.local.user.NimazUserDatabase
+import com.arshadshah.nimaz.data.local.database.entity.LocationEntity
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * How a chosen location is stored, and which one the app then reads back.
+ *
+ * Both defects here are invisible to a ViewModel test — they are about what the *table* ends up
+ * holding after two taps — so they are tested against a real Room database.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LocationDaoTest {
+
+    private lateinit var db: NimazUserDatabase
+    private lateinit var dao: LocationDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NimazUserDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.locationDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    // S7 — exactly one current location, and it is the one just chosen.
+
+    @Test
+    fun `selecting a second location replaces the first as current`() = runTest {
+        dao.saveCurrentLocation(location("London", 51.507, -0.128), now = 1_000)
+        dao.saveCurrentLocation(location("Cairo", 30.044, 31.236), now = 2_000)
+
+        // `insertLocation` is `@Insert(onConflict = REPLACE)` on an autogenerate primary key, so
+        // it always inserted. After two selections several rows carried isCurrentLocation = 1,
+        // and both current-location reads are `… WHERE isCurrentLocation = 1 LIMIT 1` with no
+        // ORDER BY — which returns the lowest rowid. **Selecting Cairo answered London.**
+        assertThat(dao.getCurrentLocationSync()?.name).isEqualTo("Cairo")
+    }
+
+    @Test
+    fun `only one row is ever flagged current`() = runTest {
+        dao.saveCurrentLocation(location("London", 51.507, -0.128), now = 1_000)
+        dao.saveCurrentLocation(location("Cairo", 30.044, 31.236), now = 2_000)
+        dao.saveCurrentLocation(location("Delhi", 28.614, 77.209), now = 3_000)
+
+        val flagged = dao.getAllLocationsSync().filter { it.isCurrentLocation }
+        assertThat(flagged.map { it.name }).containsExactly("Delhi")
+    }
+
+    @Test
+    fun `re-selecting the same place refreshes its row instead of duplicating it`() = runTest {
+        dao.saveCurrentLocation(location("London", 51.507, -0.128), now = 1_000)
+        dao.saveCurrentLocation(location("Cairo", 30.044, 31.236), now = 2_000)
+        dao.saveCurrentLocation(location("London", 51.507, -0.128), now = 3_000)
+
+        // The table grew by one row per selection, forever — the `distinctBy` in the ViewModel
+        // only hid it in the recent row.
+        assertThat(dao.getAllLocationsSync().map { it.name })
+            .containsExactly("London", "Cairo")
+    }
+
+    @Test
+    fun `coordinates within about a hundred metres are the same place`() = runTest {
+        dao.saveCurrentLocation(location("London", 51.5074, -0.1278), now = 1_000)
+        // The geocoder does not return byte-identical coordinates for the same query twice.
+        dao.saveCurrentLocation(location("London", 51.50742, -0.12781), now = 2_000)
+
+        assertThat(dao.getAllLocationsSync()).hasSize(1)
+    }
+
+    @Test
+    fun `two genuinely different places are not merged`() = runTest {
+        dao.saveCurrentLocation(location("London", 51.507, -0.128), now = 1_000)
+        dao.saveCurrentLocation(location("Croydon", 51.372, -0.101), now = 2_000)
+
+        assertThat(dao.getAllLocationsSync()).hasSize(2)
+    }
+
+    // S6 — the recent row is ordered by recency.
+
+    @Test
+    fun `recent locations are newest first, and include the one just saved`() = runTest {
+        dao.saveCurrentLocation(location("Amsterdam", 52.370, 4.895), now = 1_000)
+        dao.saveCurrentLocation(location("Berlin", 52.520, 13.405), now = 2_000)
+        dao.saveCurrentLocation(location("Cairo", 30.044, 31.236), now = 3_000)
+        dao.saveCurrentLocation(location("Delhi", 28.614, 77.209), now = 4_000)
+        dao.saveCurrentLocation(location("Edinburgh", 55.953, -3.188), now = 5_000)
+        dao.saveCurrentLocation(location("Zurich", 47.377, 8.542), now = 6_000)
+
+        // `getAllLocations()` orders `isFavorite DESC, name ASC`, so taking five of it gave
+        // Amsterdam…Edinburgh and **Zurich never appeared** in a row labelled "Recent".
+        assertThat(dao.getRecentLocations(5).first().map { it.name })
+            .containsExactly("Zurich", "Edinburgh", "Delhi", "Cairo", "Berlin").inOrder()
+    }
+
+    @Test
+    fun `re-selecting an old location brings it back to the front`() = runTest {
+        dao.saveCurrentLocation(location("Amsterdam", 52.370, 4.895), now = 1_000)
+        dao.saveCurrentLocation(location("Berlin", 52.520, 13.405), now = 2_000)
+        dao.saveCurrentLocation(location("Amsterdam", 52.370, 4.895), now = 3_000)
+
+        assertThat(dao.getRecentLocations(5).first().map { it.name })
+            .containsExactly("Amsterdam", "Berlin").inOrder()
+    }
+
+    private fun location(name: String, latitude: Double, longitude: Double) = LocationEntity(
+        id = 0,
+        name = name,
+        latitude = latitude,
+        longitude = longitude,
+        timezone = "UTC",
+        country = "",
+        city = name,
+        isCurrentLocation = true,
+        isFavorite = false,
+        calculationMethod = null,
+        asrCalculation = null,
+        highLatitudeRule = null,
+        fajrAngle = null,
+        ishaAngle = null,
+    )
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/UseCaseTestBuilders.kt
@@ -74,6 +74,8 @@ fun buildPrayerUseCases(repository: PrayerRepository) = PrayerUseCases(
     insertLocation = InsertLocationUseCase(repository),
     deleteLocation = DeleteLocationUseCase(repository),
     setCurrentLocation = SetCurrentLocationUseCase(repository),
+    getRecentLocations = GetRecentLocationsUseCase(repository),
+    saveCurrentLocation = SaveCurrentLocationUseCase(repository),
     toggleFavorite = ToggleLocationFavoriteUseCase(repository)
 )
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -589,6 +589,18 @@ Two Room `@Database`es, both provided in `core/di/DatabaseModule.kt`:
   `schemaVersion 23`; `MIGRATION_22_23` is deliberately empty, because the old tables are **left
   in place** rather than dropped so the original rows stay recoverable.
 
+**One current location, and it is the newest.** `locations` lives in the *user* database, and
+`LocationDao.saveCurrentLocation` is the only supported way to record a chosen place. It clears
+`isCurrentLocation` everywhere, then inserts — or refreshes the row already within ~100 m
+(`ROUND(lat, 3)`) — and flags it, **in one `@Transaction`**, so no reader can observe the table
+with zero or two current locations. Before it, the screen composed a `Location(id = 0, …)` and
+called `@Insert(onConflict = REPLACE)`, which on an autogenerate primary key always inserts: the
+table grew one row per selection and both `WHERE isCurrentLocation = 1 LIMIT 1` reads returned the
+**lowest rowid**, so widgets and workers saw the *first* place the user had ever picked. Recency
+comes from `getRecentLocations(limit)` ordering by the `updatedAt` that has been on the table since
+it was created — a "recent" row must never be built by taking the head of `getAllLocations()`,
+which sorts `isFavorite DESC, name ASC`. No schema change was needed for any of this.
+
 **Legacy user-data import.** `LegacyUserDataImport` copies an existing install's rows out of the
 content database into the user database the first time it is opened, driven by `UserDataMigrator`
 from `AppInitializer` (§9) and awaited before the splash screen lifts. It is one transaction of


### PR DESCRIPTION
**Layer 32** · epic #352 · on top of #426 (vm-31). Closes S5, S6 and S7 of #365.

## S7 — every selection inserted a row, and the app read the oldest

`selectLocation` composed a `Location(id = 0, …)` and called `insertLocation`, which is `@Insert(onConflict = REPLACE)` on an **autogenerate** primary key: it always inserts and never replaces.

**Input → wrong output:** select London, then Cairo. Both current-location reads are `… WHERE isCurrentLocation = 1 LIMIT 1` with no `ORDER BY`, so SQLite returns the lowest rowid — **`getCurrentLocationSync()` answers London.** Widgets and workers reading the current location disagree with what the screen shows. The table also grows one row per selection, forever; the `distinctBy` in the ViewModel only hid that in the UI.

`LocationDao.saveCurrentLocation` now clears the flag everywhere, then inserts — or refreshes the row already within ~100 m — and flags it, **in one `@Transaction`**, so no reader can observe zero or two current locations. The ViewModel passes what the user picked to a use case instead of composing a row, which is what let it invent an `id` in the first place.

## S6 — no schema change needed

**Correction to the issue.** #365 S6 says this "needs a schema change → `docs/SUBSYSTEMS.md` §5 and the schema-version line must be updated in the same commit". It does not: **`updatedAt` has been on `locations` since the table was created.** What was missing was a query that asked for it.

`getRecentLocations(limit)` orders by `updatedAt DESC`. Taking the head of `getAllLocations()` — which sorts `isFavorite DESC, name ASC` — is what produced an *alphabetical* "Recent" row: save Zurich after Amsterdam…Edinburgh and it was still those five, with the place you just chose nowhere in it.

No migration, no version bump, so `SUB-01` stays satisfied without one.

## S5 — six geocodes for one query

`UpdateSearchQuery` launched an unhandled coroutine per keystroke. Typing `london` put six network geocodes in the air with no ordering between them; if `lon` resolved after `london`, the list showed Lonavla and Long Beach under a field reading "london", and `isSearching` flickered false as soon as *any* of them returned.

One `searchJob`, cancel-and-replace, with the debounce **inside** the cancellable block — so a keystroke within the window kills the previous coroutine before it has issued anything. Same shape as `HadithViewModel`, which #365 itself points at.

**S5 ships without a test, and I'd rather flag that than paper over it.** `LocationViewModel` calls `LocationServices.getFusedLocationProviderClient(context)` in a *field initialiser*, so it cannot be constructed on the JVM at all — exactly what #365's TDD notes say, and what the `LocationDataSource` seam in #360 is for. The fix is structural and copies a pattern already proven elsewhere in the codebase.

## Verified red first

S6 and S7 are tested against a real Room database, because both are about what the *table* holds after two taps — invisible to a ViewModel test.

| test | before |
|---|---|
| `selecting a second location replaces the first as current` | `expected: Cairo but was: London` |
| `only one row is ever flagged current` | `[Delhi]` expected, got `London, Cairo, Delhi` |
| `re-selecting the same place refreshes its row instead of duplicating it` | London stored twice |
| `coordinates within about a hundred metres are the same place` | `expected: 1 but was: 2` |
| `recent locations are newest first, and include the one just saved` | Zurich missing, Amsterdam first |
| `re-selecting an old location brings it back to the front` | order unchanged |

`two genuinely different places are not merged` is the control — it fails if the coordinate rounding is made too coarse.

## Docs

`SUBSYSTEMS.md` §5 — the one-current-location invariant and why it must be one transaction, plus the note that recency comes from an existing column.

Gates: compile ✅ · 1,567 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_