### PR TITLE
fix(qibla,onboarding): a needle that means something the moment it appears

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModel.kt
@@ -165,10 +165,20 @@ class OnboardingViewModel @Inject constructor(
         _state.update { it.copy(notificationPermissionGranted = hasPermission) }
     }
 
+    /**
+     * Whether the app is exempt from battery optimisation.
+     *
+     * `as?` rather than `as`, matching `AppAnalytics` — which does the same lookup, defensively,
+     * two hundred lines away. This runs from `init`, so on any device or emulator without the
+     * service the hard cast threw during **ViewModel construction**: an onboarding crash on
+     * first launch, with nothing else on screen to fall back to. Absent service reads as "not
+     * exempt", which is the safe answer — it shows the user the prompt rather than silently
+     * skipping it.
+     */
     private fun checkBatteryOptimization() {
-        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
         val isIgnoringBatteryOptimizations =
-            powerManager.isIgnoringBatteryOptimizations(context.packageName)
+            powerManager?.isIgnoringBatteryOptimizations(context.packageName) ?: false
         _state.update { it.copy(batteryOptimizationDisabled = isIgnoringBatteryOptimizations) }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
@@ -69,19 +69,14 @@ class QiblaViewModel @Inject constructor(
 
     private val sensorListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
-            val alpha = 0.97f
             when (event.sensor.type) {
                 Sensor.TYPE_ACCELEROMETER -> {
-                    gravity[0] = alpha * gravity[0] + (1 - alpha) * event.values[0]
-                    gravity[1] = alpha * gravity[1] + (1 - alpha) * event.values[1]
-                    gravity[2] = alpha * gravity[2] + (1 - alpha) * event.values[2]
+                    smoothInto(gravity, event.values, seed = !hasGravity)
                     hasGravity = true
                 }
 
                 Sensor.TYPE_MAGNETIC_FIELD -> {
-                    geomagnetic[0] = alpha * geomagnetic[0] + (1 - alpha) * event.values[0]
-                    geomagnetic[1] = alpha * geomagnetic[1] + (1 - alpha) * event.values[1]
-                    geomagnetic[2] = alpha * geomagnetic[2] + (1 - alpha) * event.values[2]
+                    smoothInto(geomagnetic, event.values, seed = !hasMagnetic)
                     hasMagnetic = true
                 }
             }
@@ -196,6 +191,10 @@ class QiblaViewModel @Inject constructor(
         hasMagnetic = false
         prevRawAzimuth = 0f
         cumulativeAzimuth = 0f
+        // Reset with the rest of the sensor state. Left set, the rising-edge test below never
+        // fired for a user who left the screen facing the qibla and came back still facing it —
+        // no confirmation haptic until they turned away and back again.
+        wasFacingQibla = false
         _qiblaState.update { it.copy(isCompassReady = false, animatedAzimuth = 0f) }
     }
 
@@ -383,5 +382,30 @@ class QiblaViewModel @Inject constructor(
 
     private fun triggerHaptic() {
         vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
+    }
+}
+
+/** Low-pass coefficient for the accelerometer and magnetometer vectors. */
+private const val SMOOTHING = 0.97f
+
+/**
+ * Low-pass filter, seeded from the first sample.
+ *
+ * The vectors start as all-zero and `resetSensorState()` re-zeroes them on every
+ * `StartCompass`, while `SMOOTHING` is 0.97 — so the first sample contributed **3%** of its
+ * value and the filtered vector needed ~100 samples to reach 95% of the truth. At
+ * `SENSOR_DELAY_GAME` (~20 ms) that is **about two seconds**, and `isCompassReady` is
+ * published on the *first* successful `getRotationMatrix`. So the screen said ready and the
+ * needle swept in from a meaningless heading — every time, because the screen's
+ * `DisposableEffect` stops and starts the compass on each entry.
+ *
+ * Seeding costs nothing: one sample is a worse estimate than a hundred, but it is an
+ * estimate *of the right thing*, which zero is not.
+ */
+internal fun smoothInto(filtered: FloatArray, sample: FloatArray, seed: Boolean) {
+    for (i in filtered.indices) {
+        filtered[i] =
+            if (seed) sample[i]
+            else SMOOTHING * filtered[i] + (1 - SMOOTHING) * sample[i]
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/CompassSmoothingTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/CompassSmoothingTest.kt
@@ -1,0 +1,88 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * How long the qibla needle takes to mean anything.
+ *
+ * `QiblaViewModel` itself cannot be constructed in a JVM test — `SensorManager`, `Vibrator`,
+ * `Context` — and `updateCompassData` is reachable only through a `SensorEvent`, which is not
+ * constructible either. The filter is the whole of the defect though, and it is pure, so it is
+ * lifted out and tested directly rather than left untestable until the #360 seam lands.
+ */
+class CompassSmoothingTest {
+
+    /** A phone lying flat: gravity straight down. */
+    private val truth = floatArrayOf(0f, 0f, 9.81f)
+
+    @Test
+    fun `the first sample is taken at face value`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, truth, seed = true)
+
+        // Unseeded, `0.97 * 0 + 0.03 * 9.81` = 0.29 — three per cent of the truth, published
+        // as ready.
+        assertThat(filtered[2]).isEqualTo(9.81f)
+    }
+
+    @Test
+    fun `an unseeded filter is nowhere near the truth after one sample`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, truth, seed = false)
+
+        // The behaviour that shipped, stated so the seeding above has something to be measured
+        // against.
+        assertThat(filtered[2]).isLessThan(0.5f)
+    }
+
+    @Test
+    fun `an unseeded filter needs about a hundred samples to converge`() {
+        val filtered = FloatArray(3)
+        var samples = 0
+        while (abs(filtered[2] - truth[2]) > truth[2] * 0.05f) {
+            smoothInto(filtered, truth, seed = false)
+            samples++
+        }
+
+        // At SENSOR_DELAY_GAME (~20 ms) that is roughly two seconds of the needle sweeping in
+        // from a heading that means nothing — repeated on every entry, because the screen's
+        // DisposableEffect stops and starts the compass each time.
+        assertThat(samples).isGreaterThan(90)
+    }
+
+    @Test
+    fun `a seeded filter is within tolerance immediately`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, truth, seed = true)
+
+        assertThat(abs(filtered[2] - truth[2])).isLessThan(truth[2] * 0.05f)
+    }
+
+    @Test
+    fun `later samples are still smoothed, not replaced`() {
+        val filtered = FloatArray(3)
+        smoothInto(filtered, truth, seed = true)
+
+        // A single noisy reading must not throw the needle: that is what the filter is for, and
+        // seeding must not turn it into a pass-through.
+        smoothInto(filtered, floatArrayOf(0f, 0f, 50f), seed = false)
+
+        // 0.97 × 9.81 + 0.03 × 50 ≈ 11.02: the spike moves the estimate by about 1.2, not to 50.
+        assertThat(filtered[2]).isLessThan(12f)
+        assertThat(filtered[2]).isGreaterThan(9.81f)
+    }
+
+    @Test
+    fun `every axis is filtered`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, floatArrayOf(1f, 2f, 3f), seed = true)
+
+        assertThat(filtered.toList()).containsExactly(1f, 2f, 3f).inOrder()
+    }
+}


### PR DESCRIPTION
**Layer 33** · epic #352 · on top of #427 (vm-32). Closes S8, S9 and S10 of #365 — **and #365 with them**.

## S8 — the needle is wrong for ~2 seconds, every time

The accelerometer and magnetometer vectors start all-zero, and `resetSensorState()` re-zeroes them on every `StartCompass`, while the low-pass coefficient is `0.97`. So the first sample contributes **3%** of its value, and the filtered vector needs ~100 samples to reach 95% of the truth — about **two seconds** at `SENSOR_DELAY_GAME`.

But `isCompassReady` is published on the *first* successful `getRotationMatrix`.

**Input → wrong output:** open the Qibla screen facing 90°. The compass reports ready immediately and the needle sweeps in from a meaningless heading over two seconds. `QiblaScreen`'s `DisposableEffect` stops and starts the compass on each entry, so it repeats every single time.

Seeded from the first sample now. One sample is a worse estimate than a hundred, but it is an estimate **of the right thing**, which zero is not.

## S9 — one line

`resetSensorState()` cleared `gravity`, `geomagnetic`, `hasGravity`, `hasMagnetic`, `prevRawAzimuth` and `cumulativeAzimuth` — but not `wasFacingQibla`. Leave the screen facing the qibla, come back still facing it, and the rising-edge test `isFacingQibla && !wasFacingQibla` is false: no confirmation haptic until you turn away and back.

## S10 — an onboarding crash on first launch

```kotlin
val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
```

`checkBatteryOptimization` is called from `init`, so on any device or emulator without the service this threw during **ViewModel construction** — an onboarding crash with nothing else on screen to fall back to. `AppAnalytics` does the same lookup with `as?` and a null fallback two hundred lines away.

Now `as?` with `?: false`, which is also the safe default: it shows the user the prompt rather than silently skipping it.

## Making S8 testable without waiting for #360

`QiblaViewModel` cannot be constructed on the JVM (`SensorManager`, `Vibrator`, `Context`), and `updateCompassData` is reachable only through a `SensorEvent`, which is not constructible either — which is why this file has no tests at all today.

The filter is the whole of the defect and it is **pure**, so it moves to a file-level `internal fun smoothInto(filtered, sample, seed)`. That is a much smaller step than #360's `CompassDataSource` seam and doesn't wait on it. Six tests, notably:

- `an unseeded filter needs about a hundred samples to converge` — measures the defect rather than asserting around it.
- `later samples are still smoothed, not replaced` — seeding must not turn the filter into a pass-through; a single noisy reading must still not throw the needle.

S9 and S10 are one-line changes in code that cannot be instantiated in a JVM test; both are stated in the commit rather than covered.

Gates: compile ✅ · 1,573 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_