### PR TITLE
fix(analytics): measure the thing that happens, not the branch nobody reaches

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
@@ -523,6 +523,8 @@ object AppAnalytics {
         const val SETTINGS = "settings"
         const val SYNC = "sync"
         const val TAFSEER = "tafseer"
+        const val TAFSEER_CHAPTERS = "tafseer_chapters"
+        const val NIGHT_WORSHIP = "night_worship"
         const val TASBIH = "tasbih"
         const val ZAKAT = "zakat"
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -173,6 +175,17 @@ fun OnboardingScreen(
 
     val totalPages = infoPages.size + 1 // +1 for permissions page
     val pagerState = rememberNimazPagerState(pageCount = { totalPages })
+
+    // The onboarding funnel's only producer. `OnboardingEvent.SetCurrentPage` was emitted by
+    // nothing — the pager drove itself from `pagerState.currentPage` locally — so
+    // `AppAnalytics.Event.ONBOARDING_STEP`, documented as the event that "reveals where people
+    // drop off", had fired **zero times in production**. `snapshotFlow` reports settled pages
+    // only, so a swipe that is released half way does not count as reaching the next step.
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collect { viewModel.onEvent(OnboardingEvent.SetCurrentPage(it)) }
+    }
 
     NimazScreenScaffold(
         // Opts out of the app ornament: onboarding owns its own gradient backdrop.

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModel.kt
@@ -132,18 +132,28 @@ class CalendarViewModel @Inject constructor(
             }
             is CalendarEvent.NavigateToMonth -> navigateToMonth(event.month, event.year)
             is CalendarEvent.NavigateToHijriMonth -> navigateToHijriMonth(event.month, event.year)
+            // No producer — see `NavigateToPreviousMonth`/`NavigateToNextMonth` below, which are
+            // what the screen dispatches and were the only calendar actions with no analytics.
             is CalendarEvent.SetViewMode -> {
-                telemetry.featureUsed(DOMAIN, "set_view_mode")
                 setViewMode(event.mode)
             }
             is CalendarEvent.NavigateToYear -> {
-                telemetry.featureUsed(DOMAIN, "navigate_year")
                 navigateToYear(event.year, event.isHijri)
             }
             CalendarEvent.LoadToday -> loadToday()
             CalendarEvent.LoadUpcomingEvents -> loadUpcomingEvents()
-            CalendarEvent.NavigateToPreviousMonth -> navigateToPreviousMonth()
-            CalendarEvent.NavigateToNextMonth -> navigateToNextMonth()
+            // The only thing the calendar screen actually does, and the only thing it had no
+            // analytics for — while `SetViewMode` and `NavigateToYear` above, which no screen
+            // dispatches, were the two events that did.
+            CalendarEvent.NavigateToPreviousMonth -> {
+                telemetry.featureUsed(DOMAIN, "navigate_month")
+                navigateToPreviousMonth()
+            }
+
+            CalendarEvent.NavigateToNextMonth -> {
+                telemetry.featureUsed(DOMAIN, "navigate_month")
+                navigateToNextMonth()
+            }
             CalendarEvent.NavigateToPreviousYear -> navigateToPreviousYear()
             CalendarEvent.NavigateToNextYear -> navigateToNextYear()
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.data.audio.AudioState
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.domain.model.Ayah
@@ -80,6 +81,7 @@ class QuranViewModel @Inject constructor(
     val audioManager: QuranAudioManager,
     private val settingsRepository: SettingsRepository,
     private val khatamUseCases: KhatamUseCases,
+    private val telemetry: Telemetry,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -229,7 +231,7 @@ class QuranViewModel @Inject constructor(
     fun onEvent(event: QuranEvent) {
         when (event) {
             is QuranEvent.LoadSurah -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "open_surah")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "open_surah")
                 loadSurah(event.surahNumber)
             }
             is QuranEvent.LoadJuz -> loadJuz(event.juzNumber)
@@ -237,13 +239,13 @@ class QuranViewModel @Inject constructor(
             is QuranEvent.PrefetchPage -> loadPage(event.pageNumber, makeActive = false)
             is QuranEvent.LoadMushafPageLayout -> loadMushafPageLayout(event.pageNumber)
             is QuranEvent.Search -> {
-                AppAnalytics.logSearch("quran", event.query.trim().length)
+                telemetry.search("quran", event.query.trim().length)
                 search(event.query)
             }
             is QuranEvent.SetTopTab -> _homeState.update { it.copy(topTab = event.index) }
             is QuranEvent.SetTab -> _homeState.update { it.copy(selectedTab = event.index) }
             is QuranEvent.ToggleBookmark -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "toggle_bookmark")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "toggle_bookmark")
                 toggleBookmark(
                     event.ayahId,
                     event.surahNumber,
@@ -287,12 +289,14 @@ class QuranViewModel @Inject constructor(
                 _homeState.update { it.copy(searchQuery = "", filteredSurahs = it.surahs) }
             }
 
-            is QuranEvent.PlaySurahAudio -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_surah_audio")
-                playSurahAudio(event.surahNumber, event.surahName)
-            }
+            // Deliberately unlogged: no screen emits this. The analytics that used to sit here
+            // reported zero for "surah audio played" while `PlaySurahFromInfo` below — the branch
+            // the play button actually reaches — recorded nothing. A dashboard reading zero for a
+            // thing users do daily is worse than no dashboard. The unreachable *handler* is #357's
+            // wire-or-delete call, not this layer's.
+            is QuranEvent.PlaySurahAudio -> playSurahAudio(event.surahNumber, event.surahName)
             is QuranEvent.PlayAyahAudio -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN, "play_ayah_audio")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "play_ayah_audio")
                 playAyahAudio(
                     event.ayahGlobalId,
                     event.surahNumber,
@@ -303,7 +307,10 @@ class QuranViewModel @Inject constructor(
             QuranEvent.PauseAudio -> audioManager.togglePlayPause()
             QuranEvent.ResumeAudio -> audioManager.togglePlayPause()
             QuranEvent.StopAudio -> audioManager.stop()
-            is QuranEvent.PlaySurahFromInfo -> playSurahFromInfo(event.surahNumber)
+            is QuranEvent.PlaySurahFromInfo -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "play_surah_audio")
+                playSurahFromInfo(event.surahNumber)
+            }
             is QuranEvent.LoadSurahInfo -> loadSurahInfo(event.surahNumber)
             is QuranEvent.MarkAyahsReadForKhatam -> markAyahsReadForKhatam(event.ayahIds)
             is QuranEvent.UnmarkAyahReadForKhatam -> unmarkAyahReadForKhatam(event.ayahId)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/SurahThematicViewModel.kt
@@ -79,8 +79,10 @@ class SurahThematicViewModel @Inject constructor(
                 if (event.query.isNotBlank()) telemetry.search(DOMAIN, event.query.trim().length)
             }
 
-            SurahThematicEvent.ClearFilter ->
+            SurahThematicEvent.ClearFilter -> {
+                telemetry.featureUsed(DOMAIN, "clear_filter")
                 _passagesState.update { it.copy(query = "") }
+            }
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerChaptersViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerChaptersViewModel.kt
@@ -2,6 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.quran
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.domain.model.Surah
@@ -29,6 +30,10 @@ class TafseerChaptersViewModel @Inject constructor(
     val state: StateFlow<TafseerChaptersUiState> = _state.asStateFlow()
 
     init {
+        // A read-only ViewModel has no `onEvent` to hang this on, so construction *is* the
+        // action: this screen is reached by an explicit tap and nothing else builds it. Every
+        // sibling reader logs an open; this one logged nothing at all.
+        telemetry.featureUsed(AppAnalytics.Feature.TAFSEER_CHAPTERS, "open")
         combine(
             quranUseCases.getSurahList(),
             tafseerUseCases.getTafseerNotes()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
@@ -107,12 +107,16 @@ class ZakatViewModel @Inject constructor(
                 settingsRepository.setZakatCurrency(event.currency)
             }
 
-            ZakatEvent.Calculate -> {
-                telemetry.featureUsed(DOMAIN, "calculate")
-                calculate()
-            }
+            // No producer: the screen recalculates through `recalculate()` on every amount
+            // entry, so this branch never runs. Its analytics used to live here, which is why
+            // the dashboard read "nobody calculates zakat" — false, and worse than silence.
+            // The signal now fires from `calculate()`, once per filled-in form.
+            ZakatEvent.Calculate -> calculate()
 
-            ZakatEvent.ClearAll -> clearAll()
+            ZakatEvent.ClearAll -> {
+                hasLoggedCalculation = false
+                clearAll()
+            }
             ZakatEvent.ToggleBreakdown -> _calculatorState.update { it.copy(showBreakdown = !it.showBreakdown) }
             ZakatEvent.SaveCalculation -> {
                 telemetry.featureUsed(DOMAIN, "save")
@@ -164,7 +168,20 @@ class ZakatViewModel @Inject constructor(
         launchSafely(telemetry, DOMAIN, type) { write() }
     }
 
+    /**
+     * Whether this form has already reported a calculation.
+     *
+     * `recalculate()` runs on every keystroke, so logging inside [calculate] unguarded would
+     * emit one event per digit typed. One event per filled-in form is what a funnel wants; the
+     * flag clears when the form does.
+     */
+    private var hasLoggedCalculation = false
+
     private fun calculate() {
+        if (!hasLoggedCalculation) {
+            hasLoggedCalculation = true
+            telemetry.featureUsed(DOMAIN, "calculate")
+        }
         _calculatorState.update { it.copy(isCalculating = true, error = null) }
 
         run {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
@@ -8,6 +8,8 @@ import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +27,7 @@ import kotlin.time.Instant
 class NightWorshipViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(NightWorshipUiState())
@@ -36,8 +39,20 @@ class NightWorshipViewModel @Inject constructor(
 
     fun onEvent(event: NightWorshipEvent) {
         when (event) {
-            NightWorshipEvent.AddRakahPair -> _state.update { it.copy(rakahCount = it.rakahCount + 2) }
-            NightWorshipEvent.ResetRakahs -> _state.update { it.copy(rakahCount = 0) }
+            // The screen's primary interaction, and it was unrecorded. That matters more here
+            // than usual: the rakah count is deliberately **not persisted**, and this file's own
+            // KDoc asks whether the counter is worth keeping. Usage is the only way to answer
+            // that, and it was not being collected.
+            NightWorshipEvent.AddRakahPair -> {
+                telemetry.featureUsed(AppAnalytics.Feature.NIGHT_WORSHIP, "add_rakah_pair")
+                _state.update { it.copy(rakahCount = it.rakahCount + 2) }
+            }
+
+            NightWorshipEvent.ResetRakahs -> {
+                telemetry.featureUsed(AppAnalytics.Feature.NIGHT_WORSHIP, "reset_rakahs")
+                _state.update { it.copy(rakahCount = 0) }
+            }
+
             NightWorshipEvent.Refresh -> loadNightTimes()
         }
     }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AnalyticsReachabilityTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AnalyticsReachabilityTest.kt
@@ -1,0 +1,112 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+/**
+ * An analytics call on a branch nothing can reach is worse than no analytics at all: the
+ * dashboard reads zero, and zero is indistinguishable from "nobody does this".
+ *
+ * Three shipped that way — `zakat/calculate`, `quran/play_surah_audio`, and two of the calendar's
+ * three instrumented events — and every one was invisible to the whole test suite, because a test
+ * can only assert about code it runs. This asserts about code it *doesn't*: for each `onEvent`
+ * branch that logs, is there a screen that dispatches that event?
+ *
+ * Source-scanning rather than reflection, deliberately. The question is "does a producer exist in
+ * `presentation/screens/`", which is a fact about the source tree, and reflection cannot see it.
+ */
+class AnalyticsReachabilityTest {
+
+    private val viewModelDir = File("src/main/java/com/arshadshah/nimaz/presentation/viewmodel")
+    private val uiDirs = listOf(
+        File("src/main/java/com/arshadshah/nimaz/presentation/screens"),
+        File("src/main/java/com/arshadshah/nimaz/presentation/components"),
+        File("src/main/java/com/arshadshah/nimaz/core/navigation"),
+        File("src/main/java/com/arshadshah/nimaz/presentation/widget"),
+    )
+
+    /**
+     * The **existing** unreachable-analytics backlog, captured so this test can be a ratchet.
+     *
+     * Every entry is a branch that logs and that no screen, component, widget or nav callback
+     * dispatches — so its metric reads zero in production and always will. They are listed
+     * rather than fixed here because each is a wire-or-delete **product** decision, which is
+     * exactly what #357 tracks: whether "start a tasbih session" or "filter hadith by grade" is
+     * a feature someone meant to ship or a leftover.
+     *
+     * #359 names three of these. Scanning found **29**.
+     *
+     * The list only ever shrinks. A new unreachable analytics branch fails this test on the PR
+     * that introduces it, which is the whole point — all three of #359's findings survived
+     * because nothing could see them.
+     */
+    private val accepted = setOf(
+        "DuaEvent.LoadDuasByOccasion",
+        "DuaEvent.Search",
+        "DuaEvent.SearchCategories",
+        "FastingEvent.AddMakeupFast",
+        "FastingEvent.BreakFast",
+        "FastingEvent.CompleteFast",
+        "FastingEvent.LogRecommendedFast",
+        "FastingEvent.MissFast",
+        "FastingEvent.StartFast",
+        "HadithEvent.FilterByGrade",
+        "HadithEvent.Search",
+        "HadithEvent.SearchChapters",
+        "HadithEvent.SearchInBook",
+        "HomeEvent.UpdateLocation",
+        "PrayerTrackerEvent.UpdatePrayerStatus",
+        "QaidaReaderEvent.PreviousLesson",
+        "QaidaReaderEvent.Resume",
+        "QuranEvent.PlaySurahAudio",
+        "SettingsEvent.LoadSettings",
+        "SettingsEvent.SetReminderMinutes",
+        "SettingsEvent.SetShowReminderBefore",
+        "TasbihEvent.CompleteSession",
+        "TasbihEvent.FilterByCategory",
+        "TasbihEvent.PauseSession",
+        "TasbihEvent.ResumeSession",
+        "TasbihEvent.StartSession",
+        "TasbihEvent.ToggleAutoLap",
+        "TasbihEvent.UpdateCustomPreset",
+        "ZakatEvent.ToggleBreakdown",
+    )
+
+    @Test
+    fun `every analytics-bearing event branch has a producer`() {
+        val ui = uiDirs.filter { it.isDirectory }
+            .flatMap { it.walkTopDown().filter { f -> f.extension == "kt" } }
+            .joinToString("\n") { it.readText() }
+
+        val unreachable = mutableListOf<String>()
+
+        viewModelDir.walkTopDown().filter { it.name.endsWith("ViewModel.kt") }.forEach { file ->
+            val body = file.readText()
+            val onEvent = body.substringAfter("fun onEvent(", "").takeIf { it.isNotEmpty() }
+                ?: return@forEach
+
+            // `is XxxEvent.Name ->` or `XxxEvent.Name ->`, and whether its branch logs.
+            BRANCH.findAll(onEvent).forEach { match ->
+                val event = match.groupValues[1]
+                val branch = onEvent.substring(
+                    match.range.last,
+                    minOf(onEvent.length, match.range.last + BRANCH_WINDOW),
+                )
+                val logs = LOGGING.containsMatchIn(branch.substringBefore("\n            is ")
+                    .substringBefore("\n            Xxx"))
+                if (!logs) return@forEach
+                if (event in accepted) return@forEach
+                if (!ui.contains(event)) unreachable += "$event  (${file.name})"
+            }
+        }
+
+        assertThat(unreachable).isEmpty()
+    }
+
+    private companion object {
+        val BRANCH = Regex("""(?:is\s+)?(\w+Event\.\w+)\s*->""")
+        val LOGGING = Regex("""telemetry\.(featureUsed|search|settingChanged|prayerTracked|fastTracked)|AppAnalytics\.log""")
+        const val BRANCH_WINDOW = 220
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
 import android.content.Context
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
@@ -94,7 +95,7 @@ class QuranReaderHydrationTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
 
     // R1 — the home list must stay on its skeleton until Room answers.
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
 import android.content.Context
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
@@ -81,7 +82,7 @@ class QuranSurahFilterTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
 
     @Test
     fun `the list narrows to the transliterated name`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModelPageLoadTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModelPageLoadTest.kt
@@ -3,6 +3,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
 import android.content.Context
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
 import com.arshadshah.nimaz.domain.model.Ayah
 import com.arshadshah.nimaz.domain.model.MushafScript
@@ -117,7 +118,7 @@ class QuranViewModelPageLoadTest {
     }
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
 
     private fun ayahOnPage(page: Int) = Ayah(
         id = page,

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerChaptersViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerChaptersViewModelTest.kt
@@ -68,7 +68,7 @@ class TafseerChaptersViewModelTest {
     }
 
     @Test
-    fun `a successful load clears loading and reports nothing`() = runTest {
+    fun `a successful load clears loading and reports no failure`() = runTest {
         val surahs = listOf(
             Surah(
                 number = 1,
@@ -90,6 +90,10 @@ class TafseerChaptersViewModelTest {
         assertThat(state.value.surahs).hasSize(1)
         assertThat(state.value.isLoading).isFalse()
         assertThat(state.value.error).isNull()
-        assertThat(telemetry.calls).isEmpty()
+        // No *failure* reported. There is now a usage signal, though: this screen logged
+        // nothing at all while every sibling reader logged an open, so its metric read zero.
+        assertThat(telemetry.errors).isEmpty()
+        assertThat(telemetry.exceptions).isEmpty()
+        assertThat(telemetry.featureUsages.map { it.action }).containsExactly("open")
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.worship
 
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import io.mockk.every
 import io.mockk.mockk
@@ -63,7 +64,7 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `publishes tonight's window with fajr after the last third`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(calculator, settings)
+        val viewModel = NightWorshipViewModel(calculator, settings, RecordingTelemetry())
         dispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.state.value
@@ -80,7 +81,7 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `stops loading once the night times resolve`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(calculator, settings)
+        val viewModel = NightWorshipViewModel(calculator, settings, RecordingTelemetry())
         dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(false, viewModel.state.value.isLoading)
@@ -89,7 +90,7 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `rakah counter moves two at a time and resets`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(calculator, settings)
+        val viewModel = NightWorshipViewModel(calculator, settings, RecordingTelemetry())
         dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, viewModel.state.value.rakahCount)


### PR DESCRIPTION
**Layer 34** · epic #352 · on top of #428 (vm-33). Covers §1–§3 of #359 and its two hardest acceptance boxes.

## The onboarding funnel has never fired

`OnboardingEvent.SetCurrentPage` was emitted by **nothing** — `OnboardingScreen` drove its pager from `pagerState.currentPage` locally and never told the ViewModel. So `AppAnalytics.Event.ONBOARDING_STEP`, whose own KDoc calls it the event that *"reveals where people drop off"*, has recorded **zero** in production, and `OnboardingUiState.currentPage` was written by nothing and read by nothing.

A `snapshotFlow { pagerState.currentPage }.distinctUntilChanged()` is its producer now. Settled pages only, so a swipe released half way doesn't count as reaching the next step.

## Three logs on branches nothing can reach

Each reported **zero for something users do daily** — worse than no dashboard, because zero looks like an answer.

| Was | Now |
|---|---|
| `zakat/calculate` on `ZakatEvent.Calculate` — no producer; the screen recalculates via `recalculate()` on every amount entry | fires from `calculate()`, guarded to once per filled-in form rather than once per digit typed |
| `quran/play_surah_audio` on `PlaySurahAudio` — no producer | moved to `PlaySurahFromInfo`, which is what the play button reaches |
| calendar: `SetViewMode` + `NavigateToYear` instrumented (no producers), month navigation not instrumented (the only thing the screen does) | `navigate_month` on the prev/next branches the screen dispatches |

## Two ViewModels with no usage analytics

`TafseerChaptersViewModel` (a read-only VM — construction *is* the action, and every sibling reader logs an open) and `NightWorshipViewModel`.

The night-worship one matters beyond coverage: the rakah count is deliberately **not persisted**, and that file's own KDoc asks whether the counter is worth keeping. Usage is the only way to answer that, and it wasn't being collected.

`QuranViewModel` also moves onto the injected `Telemetry` — it was still on the static `AppAnalytics` object.

## The reachability test — and what it found

#359 asks for a test that "fails if an analytics branch has no producer in `presentation/screens/`". It can't be an ordinary test: the question is about code that *never runs*. So it scans the source tree — for every `onEvent` branch that logs, does any screen, component, widget or nav callback dispatch that event?

**It found 29, not the 3 the issue names.**

<details><summary>The 29</summary>

`DuaEvent.{LoadDuasByOccasion, Search, SearchCategories}` · `FastingEvent.{AddMakeupFast, BreakFast, CompleteFast, LogRecommendedFast, MissFast, StartFast}` · `HadithEvent.{FilterByGrade, Search, SearchChapters, SearchInBook}` · `HomeEvent.UpdateLocation` · `PrayerTrackerEvent.UpdatePrayerStatus` · `QaidaReaderEvent.{PreviousLesson, Resume}` · `QuranEvent.PlaySurahAudio` · `SettingsEvent.{LoadSettings, SetReminderMinutes, SetShowReminderBefore}` · `TasbihEvent.{CompleteSession, FilterByCategory, PauseSession, ResumeSession, StartSession, ToggleAutoLap, UpdateCustomPreset}` · `ZakatEvent.ToggleBreakdown`

</details>

They are captured in an `accepted` list rather than fixed here, because **each is a wire-or-delete product decision** — is "start a tasbih session" or "filter hadith by grade" a feature someone meant to ship, or a leftover? That is exactly what #357 tracks, and I'm not making 29 of those calls unilaterally.

The list only ever shrinks. A **new** unreachable analytics branch fails the PR that introduces it — which is the point, since all three of #359's findings survived precisely because nothing could see them.

## One test changed meaning

`TafseerChaptersViewModelTest` asserted the ViewModel "reports nothing". That's now wrong by design; it asserts no *failure* instead, plus the open it should always have had.

Gates: compile ✅ · 1,574 tests, 1 failure ✅ · `check_docs.py` 23/23 ✅

The one failure is `DeviceStateCorpusTest`, the private-artifact one, identical on the base branch with `-x :app:fetchNimazData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMnX6kUjr1i9AK4FnQXKPH)_