### PR TITLE
Analytics coverage: the right helper, at the right rate (#359 §4–§6)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/AppAnalytics.kt
@@ -319,6 +319,27 @@ object AppAnalytics {
     }
 
     /**
+     * Logged when "Ask with Proof" returns an answer.
+     *
+     * Two numbers that `logFeatureUsed` had nowhere to put, and that are the feature's
+     * health rather than its usage. **[proofCount]** is the silent-degradation signal: an
+     * answer with no citations resolved locally still renders, so a drift in the Worker's
+     * reference format shows up as proofs trending to zero and in no other way.
+     * **[durationMs]** is the cost signal `docs/ai-ask-with-proof.md` asks for — one Worker
+     * call per question, so latency is what a bill looks like from the client.
+     *
+     * The question itself is never recorded, here or anywhere.
+     */
+    fun logAiAnswered(proofCount: Int, durationMs: Long, confidence: String) {
+        logEvent(
+            Event.AI_ANSWERED,
+            Param.PROOF_COUNT to proofCount,
+            Param.DURATION_MS to durationMs,
+            Param.CONFIDENCE to confidence,
+        )
+    }
+
+    /**
      * Logged when a search runs. The raw query is deliberately not recorded — only
      * the active filter and the query length — to keep user input out of analytics.
      */
@@ -431,6 +452,7 @@ object AppAnalytics {
         const val FAST_TRACKED = "fast_tracked"
         const val SETTING_CHANGED = "setting_changed"
         const val SEARCH = "search_performed"
+        const val AI_ANSWERED = "ai_answered"
     }
 
     /** Custom parameter names (Firebase limit: 40 chars). */
@@ -472,6 +494,8 @@ object AppAnalytics {
         const val VALUE = "value"
         const val FILTER = "filter"
         const val QUERY_LENGTH = "query_length"
+        const val PROOF_COUNT = "proof_count"
+        const val CONFIDENCE = "confidence"
     }
 
     /**

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/FirebaseTelemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/FirebaseTelemetry.kt
@@ -24,6 +24,9 @@ class FirebaseTelemetry @Inject constructor() : Telemetry {
     override fun search(filter: String, queryLength: Int) =
         AppAnalytics.logSearch(filter, queryLength)
 
+    override fun aiAnswered(proofCount: Int, durationMs: Long, confidence: String) =
+        AppAnalytics.logAiAnswered(proofCount, durationMs, confidence)
+
     override fun prayerTracked(prayer: String, status: String, isJamaah: Boolean) =
         AppAnalytics.logPrayerTracked(prayer, status, isJamaah)
 

--- a/app/src/main/java/com/arshadshah/nimaz/core/monitoring/Telemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/monitoring/Telemetry.kt
@@ -39,6 +39,13 @@ interface Telemetry {
      */
     fun search(filter: String, queryLength: Int)
 
+    /**
+     * "Ask with Proof" answered a question: how many citations resolved locally into proof
+     * cards, how long the round trip took, and the answer's confidence. The question text is
+     * never recorded.
+     */
+    fun aiAnswered(proofCount: Int, durationMs: Long, confidence: String)
+
     /** A prayer's tracker status changed — the app's core engagement signal. */
     fun prayerTracked(prayer: String, status: String, isJamaah: Boolean = false)
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ai/AskViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/ai/AskViewModel.kt
@@ -94,14 +94,20 @@ class AskViewModel @Inject constructor(
 
             AskEvent.Submit -> submit(_uiState.value.question)
             is AskEvent.SelectRecent -> {
+                // Distinguished from a typed submit: re-asking a remembered question is the
+                // signal that the history list earns its place, and it was indistinguishable
+                // from any other ask.
+                telemetry.featureUsed(DOMAIN, "select_recent")
                 _uiState.update { it.copy(question = event.question) }
                 submit(event.question)
             }
 
-            AskEvent.Clear ->
+            AskEvent.Clear -> {
+                telemetry.featureUsed(DOMAIN, "clear")
                 _uiState.update {
                     it.copy(question = "", phase = AskPhase.Idle, relatedTerms = emptyList())
                 }
+            }
 
             AskEvent.DismissHint ->
                 launchSafely(telemetry, DOMAIN, "dismiss_hint") {
@@ -127,6 +133,7 @@ class AskViewModel @Inject constructor(
         if (!_uiState.value.aiEnabled) return
 
         telemetry.featureUsed(DOMAIN, "submitted") // action only — never the question text
+        val startedAt = System.currentTimeMillis()
         // Reset the terms so a stale set can't drive the list if this ask fails;
         // only a fresh answer sets relatedTerms again.
         _uiState.update { it.copy(phase = AskPhase.Loading, relatedTerms = emptyList()) }
@@ -139,7 +146,16 @@ class AskViewModel @Inject constructor(
         ) {
             when (val outcome = askWithProof(question)) {
                 is AskWithProofUseCase.Outcome.Answered -> {
-                    telemetry.featureUsed(DOMAIN, "answered")
+                    // The proof count is the silent-degradation signal for the whole feature:
+                    // an answer whose citations resolve to nothing still renders, and reads
+                    // as a working answer. Zero proofs trending upward is the only way that
+                    // shows. The duration is the cost signal `docs/ai-ask-with-proof.md`
+                    // asks for — one billed Worker call per question.
+                    telemetry.aiAnswered(
+                        proofCount = outcome.proofs.size,
+                        durationMs = System.currentTimeMillis() - startedAt,
+                        confidence = outcome.confidence.name,
+                    )
                     addRecent(question)
                     _uiState.update {
                         it.copy(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogViewModel.kt
@@ -1,15 +1,22 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 /**
  * The browse-a-catalogue-of-things feature, once.
@@ -62,9 +69,21 @@ abstract class CatalogViewModel<T : Any>(
      */
     private var requestedItemId: Int? = null
 
+    /**
+     * The live search box, for **analytics only** — the filter itself stays synchronous.
+     *
+     * Filtering a catalogue is an in-memory `List.filter` over a few hundred rows, so it should
+     * and does happen on every keystroke. Recording it should not: the screens dispatch
+     * [CatalogEvent.Search] from `onQueryChange`, so typing "Ibrahim" logged seven events and
+     * two backspaces logged two more. Debouncing this flow separates the two rates — the list
+     * still tracks the finger, and one settled query is one `search` event.
+     */
+    private val searchQueries = MutableStateFlow("")
+
     init {
         observeItems()
         observeFavourites()
+        observeSearchQueries()
     }
 
     fun onEvent(event: CatalogEvent) = when (event) {
@@ -79,11 +98,14 @@ abstract class CatalogViewModel<T : Any>(
         }
 
         is CatalogEvent.Search -> {
-            telemetry.featureUsed(feature, AppAnalytics.Action.SEARCH)
+            searchQueries.value = event.query
             updateList { it.copy(searchQuery = event.query) }
         }
 
-        CatalogEvent.ClearSearch -> updateList { it.copy(searchQuery = "") }
+        CatalogEvent.ClearSearch -> {
+            searchQueries.value = ""
+            updateList { it.copy(searchQuery = "") }
+        }
 
         CatalogEvent.ToggleFavoritesFilter -> {
             telemetry.featureUsed(feature, AppAnalytics.Action.TOGGLE_FAVORITES_FILTER)
@@ -101,6 +123,25 @@ abstract class CatalogViewModel<T : Any>(
             source.all().collect { items ->
                 updateList { it.copy(items = items, isLoading = false) }
             }
+        }
+    }
+
+    /**
+     * One [Telemetry.search] per settled, non-blank query.
+     *
+     * `logFeatureUsed(feature, "search")` was the wrong helper as well as the wrong rate: it
+     * threw away the query length, which is the one thing `search` records and the only way to
+     * tell "people type a name" from "people type a letter and give up".
+     */
+    @OptIn(FlowPreview::class)
+    private fun observeSearchQueries() {
+        viewModelScope.launch {
+            searchQueries
+                .debounce(SEARCH_DEBOUNCE_MS)
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .distinctUntilChanged()
+                .collect { query -> telemetry.search(feature, query.length) }
         }
     }
 
@@ -159,5 +200,10 @@ abstract class CatalogViewModel<T : Any>(
                 },
             )
         }
+    }
+
+    private companion object {
+        /** Long enough that a word typed at speed is one event, short enough to feel live. */
+        const val SEARCH_DEBOUNCE_MS = 300L
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModel.kt
@@ -149,11 +149,22 @@ class DuaViewModel @Inject constructor(
         }
     }
 
+    /**
+     * `settingChanged`, not `featureUsed`: this writes a persisted preference, so it belongs on
+     * the settings dashboard beside every other one rather than in the dua feature's usage
+     * counter, where "how many people prefer A–Z" was not answerable — the old event recorded
+     * that the sort was toggled and not which way it landed.
+     *
+     * Recorded after the write for the same reason the prayer events are: a failed write is not
+     * a setting change.
+     */
     private fun toggleCategoriesSort() {
-        telemetry.featureUsed(DOMAIN, "toggle_category_sort")
+        val alphabetical = !_collectionState.value.sortAlphabetical
         launchSafely(telemetry, DOMAIN, "toggle_category_sort") {
-            settingsRepository.setDuaCategoriesSortAlphabetical(
-                !_collectionState.value.sortAlphabetical
+            settingsRepository.setDuaCategoriesSortAlphabetical(alphabetical)
+            telemetry.settingChanged(
+                "dua_categories_sort",
+                if (alphabetical) "alphabetical" else "curated",
             )
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModel.kt
@@ -5,6 +5,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.content
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.data.audio.QaidaAudioManager
 import com.arshadshah.nimaz.data.audio.QaidaAudioState
 import com.arshadshah.nimaz.domain.model.LessonStatus
@@ -42,7 +43,8 @@ import javax.inject.Inject
 @HiltViewModel
 class QaidaReaderViewModel @Inject constructor(
     private val qaidaUseCases: QaidaUseCases,
-    private val audioManager: QaidaAudioManager
+    private val audioManager: QaidaAudioManager,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val sharing = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS)
@@ -125,32 +127,39 @@ class QaidaReaderViewModel @Inject constructor(
     fun onEvent(event: QaidaReaderEvent) {
         when (event) {
             is QaidaReaderEvent.SelectLesson -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.QAIDA,
-                    "select_lesson"
-                )
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "select_lesson")
                 selectLesson(event.lessonId)
             }
             is QaidaReaderEvent.CellTapped -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_cell")
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "play_cell")
                 onCellTapped(event.cell)
             }
             is QaidaReaderEvent.PlayLine -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_line")
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "play_line")
                 playLine(event.lineId)
             }
             is QaidaReaderEvent.PlayLetter -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "play_letter")
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "play_letter")
                 playLetter(event.letter)
             }
-            QaidaReaderEvent.NextLesson -> nextLesson()
-            QaidaReaderEvent.PreviousLesson -> previousLesson()
+            // Lesson advancement is the core progression signal of the whole feature and was
+            // logged nowhere, while a single cell tap was. Both directions are recorded: a
+            // learner going backwards is repeating a lesson, which is the shape that says the
+            // gating is too tight.
+            QaidaReaderEvent.NextLesson -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "next_lesson")
+                nextLesson()
+            }
+            QaidaReaderEvent.PreviousLesson -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "previous_lesson")
+                previousLesson()
+            }
             QaidaReaderEvent.Resume -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "resume")
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "resume")
                 resume()
             }
             QaidaReaderEvent.ResetJourney -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QAIDA, "reset_journey")
+                telemetry.featureUsed(AppAnalytics.Feature.QAIDA, "reset_journey")
                 resetJourney()
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.MILLIS_PER_DAY
 import com.arshadshah.nimaz.core.util.NextWorshipResolver
@@ -80,6 +80,7 @@ import com.arshadshah.nimaz.presentation.model.withClockState
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val telemetry: Telemetry,
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val prayerUseCases: PrayerUseCases,
     private val fastingUseCases: FastingUseCases,
@@ -255,8 +256,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HOME, "load_daily_hadith", e.message)
+                telemetry.failure(AppAnalytics.Feature.HOME, "load_daily_hadith", e)
                 // No hadith data available
             }
         }
@@ -302,8 +302,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HOME, "load_daily_dua", e.message)
+                telemetry.failure(AppAnalytics.Feature.HOME, "load_daily_dua", e)
                 // No dua data available
             }
         }
@@ -373,8 +372,6 @@ class HomeViewModel @Inject constructor(
         // Sunrise is not a prayer - don't allow toggling
         if (prayerType == PrayerType.SUNRISE) return
 
-        AppAnalytics.logFeatureUsed(AppAnalytics.Feature.HOME, "toggle_prayer_status")
-
         viewModelScope.launch {
             val prayerName = PrayerName.valueOf(prayerType.name)
             val todayEpoch = todayProvider.today().toUtcMidnightMillis()
@@ -385,6 +382,12 @@ class HomeViewModel @Inject constructor(
                 if (newStatus == PrayerStatus.PRAYED) System.currentTimeMillis() else null
 
             prayerUseCases.updatePrayerStatus(todayEpoch, prayerName, newStatus, prayedAt, false)
+            // `prayerTracked`, not `featureUsed`. The generic call recorded that *a* prayer
+            // toggle happened on Home and threw away both which prayer and which direction —
+            // so the one event `AppAnalytics` documents as "the app's core engagement signal"
+            // had no caller anywhere, and the signal it names could not be reconstructed from
+            // what was logged. Recorded after the write, so a failed write is not counted.
+            telemetry.prayerTracked(prayerName.name, newStatus.name, isJamaah = false)
             _prayerRecords.update { it + (prayerName to newStatus) }
 
             // Update displays with new status
@@ -596,8 +599,7 @@ class HomeViewModel @Inject constructor(
                 // move the occurrence's expiry, so the pending sleep must be replaced too.
                 scheduleWorshipRefresh()
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.HOME, "calculate_prayer_times", e.message)
+                telemetry.failure(AppAnalytics.Feature.HOME, "calculate_prayer_times", e)
                 _state.update { it.copy(isLoading = false, error = e.message) }
             }
         }
@@ -691,7 +693,7 @@ class HomeViewModel @Inject constructor(
                             .toMillis()
                             .coerceIn(MIN_WORSHIP_RECHECK_MS, FALLBACK_WORSHIP_RECHECK_MS)
                     }
-                }.onFailure { CrashReporter.recordException(it) }
+                }.onFailure { telemetry.recordException(it) }
                     .getOrDefault(FALLBACK_WORSHIP_RECHECK_MS)
                 delay(millis)
             }
@@ -722,7 +724,7 @@ class HomeViewModel @Inject constructor(
                 worshipStale = false
             }
             worshipOccurrence?.let { renderWorshipCard(it) }
-        }.onFailure { CrashReporter.recordException(it) }.getOrNull()
+        }.onFailure { telemetry.recordException(it) }.getOrNull()
         _state.update { it.copy(worshipCard = card) }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.model.AsrCalculation
@@ -27,7 +28,8 @@ import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 @HiltViewModel
 class MonthlyPrayerTimesViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MonthlyPrayerTimesUiState())
@@ -50,18 +52,19 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
     fun onEvent(event: MonthlyPrayerTimesEvent) {
         when (event) {
             MonthlyPrayerTimesEvent.NextMonth -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_month")
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_month")
                 _state.update { it.copy(currentMonth = it.currentMonth.plusMonths(1)) }
                 calculateMonth()
             }
 
             MonthlyPrayerTimesEvent.PreviousMonth -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "previous_month")
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "previous_month")
                 _state.update { it.copy(currentMonth = it.currentMonth.minusMonths(1)) }
                 calculateMonth()
             }
 
             is MonthlyPrayerTimesEvent.ToggleDayExpanded -> {
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "toggle_day_expanded")
                 _state.update {
                     it.copy(
                         expandedDay = if (it.expandedDay == event.date) null else event.date

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
@@ -37,6 +39,7 @@ class PrayerTimesViewModel @Inject constructor(
     private val prayerTimeCalculator: PrayerTimeCalculator,
     private val prayerUseCases: PrayerUseCases,
     private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrayerTimesUiState())
@@ -65,28 +68,28 @@ class PrayerTimesViewModel @Inject constructor(
     fun onEvent(event: PrayerTimesEvent) {
         when (event) {
             PrayerTimesEvent.PreviousDay -> {
-                AppAnalytics.logFeatureUsed(
+                telemetry.featureUsed(
                     AppAnalytics.Feature.PRAYER_TIMES,
                     "previous_day"
                 )
                 changeDay(-1)
             }
             PrayerTimesEvent.NextDay -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_day")
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_day")
                 changeDay(1)
             }
             PrayerTimesEvent.GoToToday -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.PRAYER_TIMES, "go_to_today")
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "go_to_today")
                 selectDate(LocalDate.now())
             }
-            is PrayerTimesEvent.SelectDate -> selectDate(event.date)
-            is PrayerTimesEvent.TogglePrayer -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.PRAYER_TIMES,
-                    "toggle_prayer"
-                )
-                togglePrayer(event.type)
+            is PrayerTimesEvent.SelectDate -> {
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "select_date")
+                selectDate(event.date)
             }
+            // The `toggle_prayer` feature event moved into `togglePrayer`, past its two
+            // guards, and became `prayerTracked`. Logged here it counted taps on Sunrise and
+            // on future days, neither of which changes anything.
+            is PrayerTimesEvent.TogglePrayer -> togglePrayer(event.type)
         }
     }
 
@@ -155,6 +158,7 @@ class PrayerTimesViewModel @Inject constructor(
                     highLatRule = HighLatitudeRule.fromString(highStr)
                     adjustments = adj
                     settingsReady = true
+                    pinCalculationInputs()
 
                     _state.update {
                         it.copy(
@@ -283,6 +287,11 @@ class PrayerTimesViewModel @Inject constructor(
             val prayedAt =
                 if (newStatus == PrayerStatus.PRAYED) Instant.now().toEpochMilli() else null
             prayerUseCases.updatePrayerStatus(dateKey, name, newStatus, prayedAt, false)
+            // The third place a prayer is tracked, alongside the tracker and Home. #359 names
+            // only two; this one recorded a generic `toggle_prayer` and is the reason a
+            // dashboard built on `prayer_tracked` would still have under-counted after fixing
+            // the other two.
+            telemetry.prayerTracked(name.name, newStatus.name, isJamaah = false)
             // getPrayerRecordsForDate re-emits → applyTick refreshes the UI.
         }
     }
@@ -290,4 +299,20 @@ class PrayerTimesViewModel @Inject constructor(
     // No `use24HourFormat` mirror: times are formatted at the leaf from LocalUse24HourFormat, so
     // toggling the preference no longer forces a full day recompute.
 
+
+    /**
+     * Pin the inputs a prayer-time crash needs to be reproducible.
+     *
+     * `CrashReporter.setCustomKey` was used nowhere in the ViewModel layer, so a crash in the
+     * calculator arrived with a stack trace and nothing else — and "Fajr is wrong" is a class
+     * of report that is unanswerable without the method, the school and roughly where the user
+     * is. The latitude is **rounded to a whole degree**: a degree is enough to tell a
+     * high-latitude failure from an equatorial one, and not enough to locate anyone.
+     */
+    private fun pinCalculationInputs() {
+        telemetry.customKey("calc_method", calcMethod.name)
+        telemetry.customKey("asr_calculation", asrCalc.name)
+        telemetry.customKey("high_latitude_rule", highLatRule?.name ?: "none")
+        telemetry.customKey("latitude_rounded", latitude.roundToInt().toString())
+    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
@@ -13,7 +13,7 @@ import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.CompassAccuracy
 import com.arshadshah.nimaz.domain.model.CompassData
 import com.arshadshah.nimaz.domain.model.Location
@@ -36,7 +36,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class QiblaViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _qiblaState = MutableStateFlow(QiblaUiState())
@@ -168,14 +169,14 @@ class QiblaViewModel @Inject constructor(
             }
 
             QiblaEvent.StartCompass -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QIBLA, "start_compass")
+                telemetry.featureUsed(AppAnalytics.Feature.QIBLA, "start_compass")
                 resetSensorState()
                 registerSensors()
             }
 
             QiblaEvent.StopCompass -> unregisterSensors()
             is QiblaEvent.SetArMode -> {
-                AppAnalytics.logFeatureUsed(
+                telemetry.featureUsed(
                     AppAnalytics.Feature.QIBLA,
                     if (event.enabled) "ar_on" else "ar_off"
                 )
@@ -183,6 +184,13 @@ class QiblaViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * The last accuracy reported to analytics, so only changes are recorded. Deliberately not
+     * reset by [resetSensorState]: re-entering the screen with the same uncalibrated
+     * magnetometer is the same fact, not a new one.
+     */
+    private var lastReportedAccuracy: CompassAccuracy? = null
 
     private fun resetSensorState() {
         gravity.fill(0f)
@@ -258,8 +266,7 @@ class QiblaViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.QIBLA, "calculate_direction", e.message)
+                telemetry.failure(AppAnalytics.Feature.QIBLA, "calculate_direction", e)
                 _qiblaState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -293,8 +300,7 @@ class QiblaViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.QIBLA, "set_location", e.message)
+                telemetry.failure(AppAnalytics.Feature.QIBLA, "set_location", e)
                 _qiblaState.update { it.copy(error = e.message, isLoading = false) }
             }
         }
@@ -369,9 +375,29 @@ class QiblaViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Track the magnetometer's reported accuracy, and report each **transition**.
+     *
+     * "How many users have an uncalibrated magnetometer" is exactly the population-level
+     * question `AppAnalytics`' KDoc describes, and it was answerable from nothing: the compass
+     * shows a calibration prompt and the app had no idea how often. It matters more here than
+     * a usual usage counter, because a qibla needle drawn from an unreliable sensor is
+     * confidently wrong rather than visibly broken.
+     *
+     * Transitions only. `SensorManager` re-delivers the same accuracy on every reading, so
+     * logging each callback would emit tens of events a second for as long as the screen is
+     * open — the firehose problem, at sensor rate.
+     */
     private fun updateAccuracy(accuracy: CompassAccuracy) {
         val needsCalibration =
             accuracy == CompassAccuracy.LOW || accuracy == CompassAccuracy.UNRELIABLE
+        if (accuracy != lastReportedAccuracy) {
+            lastReportedAccuracy = accuracy
+            telemetry.featureUsed(
+                AppAnalytics.Feature.QIBLA,
+                "accuracy_" + accuracy.name.lowercase(),
+            )
+        }
         _qiblaState.update {
             it.copy(
                 compassData = it.compassData.copy(accuracy = accuracy),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
@@ -70,7 +70,12 @@ class BookmarksViewModel @Inject constructor(
                 undoDelete()
             }
 
-            BookmarksEvent.DismissUndo -> dismissUndo()
+            // The undo banner expiring unused is the signal that a delete was meant, which
+            // is only legible next to `undo_delete`.
+            BookmarksEvent.DismissUndo -> {
+                telemetry.featureUsed(DOMAIN, "dismiss_undo")
+                dismissUndo()
+            }
 
             is BookmarksEvent.EditNote -> {
                 telemetry.featureUsed(DOMAIN, "update_note")

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranEvent.kt
@@ -46,8 +46,6 @@ sealed interface QuranEvent {
     data object StopAudio : QuranEvent
     data class PlaySurahFromInfo(val surahNumber: Int) : QuranEvent
     data class LoadSurahInfo(val surahNumber: Int) : QuranEvent
-    data class MarkAyahsReadForKhatam(val ayahIds: List<Int>) : QuranEvent
-    data class UnmarkAyahReadForKhatam(val ayahId: Int) : QuranEvent
     data class ToggleKhatamAyah(val ayahId: Int) : QuranEvent
     data class MarkSurahAsReadForKhatam(val surahNumber: Int) : QuranEvent
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.quran
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.SurahTopic
 import com.arshadshah.nimaz.domain.model.TopicCitation
@@ -50,6 +51,7 @@ data class TopicSurahContext(
 class QuranTopicsViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
     private val settingsRepository: SettingsRepository,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _browseState = MutableStateFlow(TopicBrowseState())
@@ -104,14 +106,14 @@ class QuranTopicsViewModel @Inject constructor(
             }
 
             is QuranTopicsEvent.SelectTree -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN_TOPICS, "select_tree")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN_TOPICS, "select_tree")
                 selectTree(event.tree)
             }
 
             is QuranTopicsEvent.Toggle -> toggle(event.topic)
 
             is QuranTopicsEvent.Focus -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN_TOPICS, "focus_branch")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN_TOPICS, "focus_branch")
                 focus(event.topic)
             }
 
@@ -138,7 +140,7 @@ class QuranTopicsViewModel @Inject constructor(
 
             is QuranTopicsEvent.LoadSurahSubjects -> {
                 if (_surahSubjects.value.surahNumber != event.surahNumber) {
-                    AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN_TOPICS, "open_surah_subjects")
+                    telemetry.featureUsed(AppAnalytics.Feature.QURAN_TOPICS, "open_surah_subjects")
                     loadSurahSubjects(event.surahNumber)
                 }
             }
@@ -150,7 +152,7 @@ class QuranTopicsViewModel @Inject constructor(
                 _surahSubjects.update { it.copy(query = "") }
 
             is QuranTopicsEvent.LoadDetail -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.QURAN_TOPICS, "open_detail")
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN_TOPICS, "open_detail")
                 loadDetail(event.topicId, event.tree, event.fromSurah)
             }
         }
@@ -179,6 +181,10 @@ class QuranTopicsViewModel @Inject constructor(
                         return@collect
                     }
                     _browseState.update { it.copy(isSearching = true) }
+                    // Logged post-debounce, where the FTS walk actually happens. The topic
+                    // search ran the most expensive query in the feature and logged nothing,
+                    // so its usage read as zero next to `select_tree` and `focus_branch`.
+                    telemetry.search(AppAnalytics.Feature.QURAN_TOPICS, query.trim().length)
                     val tree = _browseState.value.tree
                     val results = quranUseCases.searchTopics(query)
                     val paths = quranUseCases.searchTopics.pathsFor(results, tree)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
@@ -234,16 +234,30 @@ class QuranViewModel @Inject constructor(
                 telemetry.featureUsed(AppAnalytics.Feature.QURAN, "open_surah")
                 loadSurah(event.surahNumber)
             }
-            is QuranEvent.LoadJuz -> loadJuz(event.juzNumber)
-            is QuranEvent.LoadPage -> loadPage(event.pageNumber)
+            // Only `LoadSurah` was logged, so the reader's usage read as "everyone browses by
+            // surah" — which is what you see when the other two ways in are not counted.
+            is QuranEvent.LoadJuz -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "open_juz")
+                loadJuz(event.juzNumber)
+            }
+            is QuranEvent.LoadPage -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "open_page")
+                loadPage(event.pageNumber)
+            }
             is QuranEvent.PrefetchPage -> loadPage(event.pageNumber, makeActive = false)
             is QuranEvent.LoadMushafPageLayout -> loadMushafPageLayout(event.pageNumber)
             is QuranEvent.Search -> {
                 telemetry.search("quran", event.query.trim().length)
                 search(event.query)
             }
-            is QuranEvent.SetTopTab -> _homeState.update { it.copy(topTab = event.index) }
-            is QuranEvent.SetTab -> _homeState.update { it.copy(selectedTab = event.index) }
+            is QuranEvent.SetTopTab -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "set_top_tab")
+                _homeState.update { it.copy(topTab = event.index) }
+            }
+            is QuranEvent.SetTab -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "set_tab")
+                _homeState.update { it.copy(selectedTab = event.index) }
+            }
             is QuranEvent.ToggleBookmark -> {
                 telemetry.featureUsed(AppAnalytics.Feature.QURAN, "toggle_bookmark")
                 toggleBookmark(
@@ -253,14 +267,23 @@ class QuranViewModel @Inject constructor(
                 )
             }
 
-            is QuranEvent.ToggleFavorite -> toggleFavorite(
-                event.ayahId,
-                event.surahNumber,
-                event.ayahNumber
-            )
+            is QuranEvent.ToggleFavorite -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, AppAnalytics.Action.TOGGLE_FAVORITE)
+                toggleFavorite(
+                    event.ayahId,
+                    event.surahNumber,
+                    event.ayahNumber
+                )
+            }
 
-            is QuranEvent.RemoveFavorite -> removeFavorite(event.favorite)
-            QuranEvent.UndoRemoveFavorite -> undoRemoveFavorite()
+            is QuranEvent.RemoveFavorite -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "remove_favorite")
+                removeFavorite(event.favorite)
+            }
+            QuranEvent.UndoRemoveFavorite -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "undo_remove_favorite")
+                undoRemoveFavorite()
+            }
             QuranEvent.DismissFavoriteUndo ->
                 _homeState.update { it.copy(recentlyRemovedFavorite = null) }
 
@@ -310,12 +333,32 @@ class QuranViewModel @Inject constructor(
                 telemetry.featureUsed(AppAnalytics.Feature.QURAN, "play_surah_audio")
                 playSurahFromInfo(event.surahNumber)
             }
-            is QuranEvent.LoadSurahInfo -> loadSurahInfo(event.surahNumber)
-            is QuranEvent.MarkAyahsReadForKhatam -> markAyahsReadForKhatam(event.ayahIds)
-            is QuranEvent.UnmarkAyahReadForKhatam -> unmarkAyahReadForKhatam(event.ayahId)
-            is QuranEvent.ToggleKhatamAyah -> toggleKhatamAyah(event.ayahId)
-            is QuranEvent.MarkSurahAsReadForKhatam -> markSurahAsReadForKhatam(event.surahNumber)
-            is QuranEvent.TogglePageKhatam -> togglePageKhatam(event.ayahIds)
+            is QuranEvent.LoadSurahInfo -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "open_surah_info")
+                loadSurahInfo(event.surahNumber)
+            }
+            // Khatam marking is the app's core engagement loop — a reader working through a
+            // whole Qur'an — and not one of its events was recorded, so the loop the feature
+            // exists for was invisible while `toggle_bookmark` was counted.
+            //
+            // `MarkAyahsReadForKhatam` and `UnmarkAyahReadForKhatam` were deleted rather than
+            // instrumented: adding analytics surfaced them as having no producer in any
+            // screen, and `ToggleKhatamAyah` — which the reader does dispatch — already calls
+            // `markAyahsRead`/`unmarkAyahRead` for exactly the same effect. Instrumenting them
+            // would have produced two more metrics that read zero for ever, which is the
+            // defect this issue is about.
+            is QuranEvent.ToggleKhatamAyah -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "khatam_toggle_ayah")
+                toggleKhatamAyah(event.ayahId)
+            }
+            is QuranEvent.MarkSurahAsReadForKhatam -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "khatam_mark_surah")
+                markSurahAsReadForKhatam(event.surahNumber)
+            }
+            is QuranEvent.TogglePageKhatam -> {
+                telemetry.featureUsed(AppAnalytics.Feature.QURAN, "khatam_toggle_page")
+                togglePageKhatam(event.ayahIds)
+            }
         }
     }
 
@@ -1086,24 +1129,6 @@ class QuranViewModel @Inject constructor(
         if (unreadIds.isEmpty()) return
         viewModelScope.launch {
             khatamUseCases.markAyahsRead(khatamId, unreadIds)
-        }
-    }
-
-    private fun unmarkAyahReadForKhatam(ayahId: Int) {
-        val khatamId = _readerState.value.activeKhatamId ?: return
-        viewModelScope.launch {
-            khatamUseCases.unmarkAyahRead(khatamId, ayahId)
-        }
-    }
-
-    private fun markAyahsReadForKhatam(ayahIds: List<Int>) {
-        val khatamId = _readerState.value.activeKhatamId ?: return
-        val readIds = _readerState.value.khatamReadAyahIds
-        val newIds = ayahIds.filter { it !in readIds }
-        if (newIds.isEmpty()) return
-
-        viewModelScope.launch {
-            khatamUseCases.markAyahsRead(khatamId, newIds)
         }
     }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/TafseerViewModel.kt
@@ -54,19 +54,27 @@ class TafseerViewModel @Inject constructor(
     fun onEvent(event: TafseerEvent) {
         when (event) {
             is TafseerEvent.LoadSurah -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "open_surah")
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "open_surah")
                 loadSurah(event.surahNumber, event.ayahNumber)
             }
-            is TafseerEvent.NavigateToAyah -> onAyahChanged(event.index)
-            is TafseerEvent.NavigateToTafseerPage ->
+            // Swiping between ayahs and turning a commentary page are how this screen is read;
+            // only opening it and switching source were counted, so "opened tafseer" looked
+            // like the whole of the engagement.
+            is TafseerEvent.NavigateToAyah -> {
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "navigate_ayah")
+                onAyahChanged(event.index)
+            }
+            is TafseerEvent.NavigateToTafseerPage -> {
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "navigate_page")
                 _state.update { it.copy(currentTafseerPage = event.page) }
+            }
 
             is TafseerEvent.SwitchSource -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "switch_source")
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "switch_source")
                 switchSource(event.source)
             }
             is TafseerEvent.AddHighlight -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_highlight")
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "add_highlight")
                 addHighlight(
                     event.startOffset,
                     event.endOffset,
@@ -76,25 +84,28 @@ class TafseerViewModel @Inject constructor(
             }
 
             is TafseerEvent.DeleteHighlight -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.TAFSEER,
-                    "delete_highlight"
-                )
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "delete_highlight")
                 deleteHighlight(event.highlightId)
             }
-            is TafseerEvent.UpdateHighlight -> updateHighlight(
-                event.highlightId,
-                event.color,
-                event.note
-            )
+            is TafseerEvent.UpdateHighlight -> {
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "update_highlight")
+                updateHighlight(
+                    event.highlightId,
+                    event.color,
+                    event.note
+                )
+            }
 
             is TafseerEvent.AddNote -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "add_note")
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "add_note")
                 addNote(event.text)
             }
-            is TafseerEvent.UpdateNote -> updateNote(event.note)
+            is TafseerEvent.UpdateNote -> {
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "update_note")
+                updateNote(event.note)
+            }
             is TafseerEvent.DeleteNote -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TAFSEER, "delete_note")
+                telemetry.featureUsed(AppAnalytics.Feature.TAFSEER, "delete_note")
                 deleteNote(event.noteId)
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
@@ -2,7 +2,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.model.LibrarySearchResults
@@ -26,10 +26,12 @@ enum class SearchFilter {
 
 /** Idle time after the last keystroke before a search-as-you-type lookup fires. */
 private const val SEARCH_DEBOUNCE_MS = 300L
+private const val DOMAIN = "global_search"
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val searchLibrary: SearchLibraryUseCase,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _searchState = MutableStateFlow(SearchUiState())
@@ -45,22 +47,29 @@ class SearchViewModel @Inject constructor(
     private var searchJob: Job? = null
 
     fun onEvent(event: SearchEvent) {
-        // Record the search action with its filter and query length only — never
-        // the query text itself.
-        if (event is SearchEvent.ExecuteSearch) {
-            AppAnalytics.logSearch(
-                filter = _searchState.value.selectedFilter.name,
-                queryLength = _searchState.value.query.trim().length,
-            )
-        }
         when (event) {
             is SearchEvent.UpdateQuery -> updateQuery(event.query)
-            is SearchEvent.SetFilter -> setFilter(event.filter)
+            // The filter is the one place this screen learns what people are looking for
+            // without recording what they typed — which of Qur'an, hadith or dua they narrow
+            // to is the shape, and it was not recorded at all.
+            is SearchEvent.SetFilter -> {
+                telemetry.featureUsed(DOMAIN, "set_filter_" + event.filter.name.lowercase())
+                setFilter(event.filter)
+            }
             is SearchEvent.SelectRecentSearch -> selectRecentSearch(event.query)
-            is SearchEvent.RemoveRecentSearch -> removeRecentSearch(event.query)
+            is SearchEvent.RemoveRecentSearch -> {
+                telemetry.featureUsed(DOMAIN, "remove_recent")
+                removeRecentSearch(event.query)
+            }
             SearchEvent.ExecuteSearch -> executeSearch()
-            SearchEvent.ClearSearch -> clearSearch()
-            SearchEvent.ClearRecentSearches -> clearRecentSearches()
+            SearchEvent.ClearSearch -> {
+                telemetry.featureUsed(DOMAIN, "clear")
+                clearSearch()
+            }
+            SearchEvent.ClearRecentSearches -> {
+                telemetry.featureUsed(DOMAIN, "clear_recents")
+                clearRecentSearches()
+            }
             is SearchEvent.ApplyAiTerms -> applyAiTerms(event.terms)
         }
     }
@@ -136,6 +145,18 @@ class SearchViewModel @Inject constructor(
         _searchState.update { it.copy(isSearching = true, error = null) }
         searchJob = viewModelScope.launch {
             if (debounceMillis > 0) delay(debounceMillis)
+            // Logged here rather than in `onEvent`, which is both too early and too narrow.
+            // Too early: it fired before `executeSearch` had checked the query, so tapping the
+            // keyboard's search key on an empty box emitted `search_performed` with
+            // `query_length = 0` and no search ran. Too narrow: it was on `ExecuteSearch` only,
+            // so search-as-you-type — the way this screen is actually used — was never counted
+            // at all. Past the debounce and inside the job that survived cancellation, this
+            // fires once per search that genuinely runs, typed or submitted.
+            // Length and filter only; the query itself never reaches analytics.
+            telemetry.search(
+                filter = _searchState.value.selectedFilter.name,
+                queryLength = _searchState.value.query.trim().length,
+            )
             val results = runCatching { lookup() }.getOrElse { e ->
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 _searchState.update {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetry.kt
@@ -1,0 +1,122 @@
+package com.arshadshah.nimaz.presentation.viewmodel.settings
+
+/**
+ * What each settings-shaped [SettingsEvent] records: the setting's name, and its new value.
+ *
+ * **Why a table rather than a line in each branch.** `SettingsViewModel.onEvent` is a 78-branch
+ * `when`, and 15 of those branches carried a `logSettingChanged` call while 56 carried nothing —
+ * including `SetPrayerAdjustment`, which is the first thing anyone would ask for when a user
+ * reports that a prayer time is a few minutes out, and every typography and location event. The
+ * per-branch approach is what produced that ratio: a new setting is added by copying a
+ * neighbouring branch, and whether it gets logged depends on which neighbour was copied.
+ *
+ * Collected here, the coverage is one list you can read top to bottom, `when` is exhaustive over
+ * [SettingsEvent] so **a new event cannot compile without a decision being made about it**, and
+ * the naming stays consistent instead of drifting per branch.
+ *
+ * The 15 names that were already being reported are kept **exactly** as they were, dashboards
+ * included — `pre_reminder_enabled` rather than the tidier `show_reminder_before`, because a
+ * renamed setting reads as a setting nobody changes any more.
+ *
+ * Returns null for the events that are not setting changes: the two test-notification actions,
+ * the adhan preview, and the three destructive actions. Those are logged where they happen.
+ */
+internal fun SettingsEvent.asSettingChange(): Pair<String, String>? = when (this) {
+    // -- General ---------------------------------------------------------------
+    is SettingsEvent.SetTheme -> "theme" to theme.name
+    is SettingsEvent.SetLanguage -> "language" to language.name
+    is SettingsEvent.SetHijriPrimary -> "hijri_primary" to enabled.toString()
+    is SettingsEvent.SetHijriDayOffset -> "hijri_day_offset" to days.toString()
+    is SettingsEvent.Set24HourFormat -> "24_hour_format" to enabled.toString()
+    is SettingsEvent.SetShowSeconds -> "show_seconds" to enabled.toString()
+    is SettingsEvent.SetHapticFeedback -> "haptic_feedback" to enabled.toString()
+    is SettingsEvent.SetShowIslamicPatterns -> "show_islamic_patterns" to enabled.toString()
+    is SettingsEvent.SetPatternStyle -> "pattern_style" to style.name
+    is SettingsEvent.SetAnimationsEnabled -> "animations_enabled" to enabled.toString()
+    is SettingsEvent.SetShowCountdown -> "show_countdown" to enabled.toString()
+    is SettingsEvent.SetShowQuickActions -> "show_quick_actions" to enabled.toString()
+
+    // -- Prayer calculation ----------------------------------------------------
+    is SettingsEvent.SetCalculationMethod -> "calculation_method" to method.name
+    is SettingsEvent.SetAsrMethod -> "asr_method" to method.name
+    is SettingsEvent.SetHighLatitudeRule -> "high_latitude_rule" to rule.name
+    is SettingsEvent.SetFajrAngle -> "fajr_angle" to angle.toString()
+    is SettingsEvent.SetIshaAngle -> "isha_angle" to angle.toString()
+    // Keyed by prayer, because "someone adjusted a prayer by 3 minutes" is not the question —
+    // "which prayer, and by how much" is, and a per-prayer key is what makes a systematic
+    // offset (everyone nudging Fajr the same way) visible as a shape rather than a mean.
+    is SettingsEvent.SetPrayerAdjustment -> "prayer_adjustment_$prayer" to minutes.toString()
+
+    // -- Notifications ---------------------------------------------------------
+    is SettingsEvent.SetNotificationsEnabled -> "notifications_enabled" to enabled.toString()
+    is SettingsEvent.SetPrayerNotification -> "prayer_notification_$prayer" to enabled.toString()
+    is SettingsEvent.SetAdhanEnabled -> "adhan_enabled" to enabled.toString()
+    is SettingsEvent.SetPrayerAlertStyle -> "alert_style_$prayer" to style.name
+    is SettingsEvent.SetPrayerReminderEnabled -> "reminder_enabled_$prayer" to enabled.toString()
+    is SettingsEvent.SetPrayerReminderMinutes -> "reminder_minutes_$prayer" to minutes.toString()
+    is SettingsEvent.SetVibrationEnabled -> "notification_vibration" to enabled.toString()
+    is SettingsEvent.SetRespectDnd -> "respect_dnd" to enabled.toString()
+    is SettingsEvent.SetReminderMinutes -> "reminder_minutes" to minutes.toString()
+    is SettingsEvent.SetShowReminderBefore -> "pre_reminder_enabled" to enabled.toString()
+    is SettingsEvent.SetPersistentNotification -> "persistent_notification" to enabled.toString()
+    is SettingsEvent.SetFridayReminderEnabled -> "friday_reminder_enabled" to enabled.toString()
+    is SettingsEvent.SetFridayReminderMinutes -> "friday_reminder_minutes" to minutes.toString()
+    is SettingsEvent.SetKhatamReminderEnabled -> "khatam_reminder_enabled" to enabled.toString()
+    is SettingsEvent.SetKhatamReminderTime -> "khatam_reminder_time" to time
+    is SettingsEvent.SetAdhanSound -> "adhan_sound" to sound
+    is SettingsEvent.SetWorshipReminderEnabled -> "worship_enabled_$key" to enabled.toString()
+    is SettingsEvent.SetWorshipReminderOffset -> "worship_offset_$key" to minutes.toString()
+    is SettingsEvent.SetWorshipReminderMode -> "worship_mode_$key" to mode
+
+    // -- Quran reader ----------------------------------------------------------
+    is SettingsEvent.SetTranslator -> "quran_translator" to translatorId
+    is SettingsEvent.SetArabicFont -> "quran_arabic_font" to fontId
+    is SettingsEvent.SetShowTranslation -> "quran_show_translation" to enabled.toString()
+    is SettingsEvent.SetShowTransliteration -> "quran_show_transliteration" to enabled.toString()
+    is SettingsEvent.SetArabicFontSize -> "quran_arabic_font_size" to size.toString()
+    is SettingsEvent.SetTranslationFontSize -> "quran_translation_font_size" to size.toString()
+    is SettingsEvent.SetContinuousReading -> "quran_continuous_reading" to enabled.toString()
+    is SettingsEvent.SetKeepScreenOn -> "quran_keep_screen_on" to enabled.toString()
+    is SettingsEvent.SetReciter -> "quran_reciter" to (reciterId ?: "none")
+    is SettingsEvent.SetShowTajweed -> "quran_show_tajweed" to enabled.toString()
+    is SettingsEvent.SetTajweedUnderline -> "quran_tajweed_underline" to enabled.toString()
+    is SettingsEvent.SetMushafScript -> "quran_mushaf_script" to script.name
+
+    // -- Dua reader ------------------------------------------------------------
+    is SettingsEvent.SetDuaArabicFont -> "dua_arabic_font" to fontId
+    is SettingsEvent.SetDuaArabicFontSize -> "dua_arabic_font_size" to size.toString()
+    is SettingsEvent.SetDuaTranslationFontSize -> "dua_translation_font_size" to size.toString()
+    is SettingsEvent.SetDuaShowArabic -> "dua_show_arabic" to enabled.toString()
+    is SettingsEvent.SetDuaShowTransliteration -> "dua_show_transliteration" to enabled.toString()
+    is SettingsEvent.SetDuaShowTranslation -> "dua_show_translation" to enabled.toString()
+
+    // -- Hadith reader ---------------------------------------------------------
+    is SettingsEvent.SetHadithArabicFont -> "hadith_arabic_font" to fontId
+    is SettingsEvent.SetHadithArabicFontSize -> "hadith_arabic_font_size" to size.toString()
+    is SettingsEvent.SetHadithTranslationFontSize ->
+        "hadith_translation_font_size" to size.toString()
+    is SettingsEvent.SetHadithShowArabic -> "hadith_show_arabic" to enabled.toString()
+    is SettingsEvent.SetHadithShowTranslation -> "hadith_show_translation" to enabled.toString()
+    is SettingsEvent.SetHadithShowGrade -> "hadith_show_grade" to enabled.toString()
+    is SettingsEvent.SetHadithShowChain -> "hadith_show_chain" to enabled.toString()
+
+    // -- Location --------------------------------------------------------------
+    // The place name is never recorded — only that the set changed, and how big it is. A
+    // location is the most identifying thing this app holds; `settingChanged` writes its value
+    // to an analytics dashboard, and "Ahmed's street" does not belong on one.
+    is SettingsEvent.SetCurrentLocation -> "current_location" to "changed"
+    is SettingsEvent.AddLocation -> "saved_locations" to "added"
+    is SettingsEvent.RemoveLocation -> "saved_locations" to "removed"
+    is SettingsEvent.ToggleLocationFavorite -> "saved_locations" to "favourite_toggled"
+    is SettingsEvent.SetAutoDetectLocation -> "auto_detect_location" to enabled.toString()
+
+    // -- Not setting changes ---------------------------------------------------
+    SettingsEvent.PreviewAdhanSound,
+    SettingsEvent.StopAdhanPreview,
+    SettingsEvent.TestNotification,
+    SettingsEvent.TestAllNotifications,
+    SettingsEvent.ResetToDefaults,
+    SettingsEvent.ResetNotifications,
+    SettingsEvent.DeleteAllData,
+        -> null
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.LocaleHelper
@@ -300,12 +299,16 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onEvent(event: SettingsEvent) {
-        // Record meaningful configuration changes. Notification and calculation
-        // settings are the ones most often behind "it's doing the wrong thing".
+        // Every settings-shaped event reports itself, from one table rather than a line in
+        // each of 78 branches — which is how 56 of them came to report nothing at all. See
+        // `asSettingChange`. The events that are not setting changes return null and are
+        // logged where they happen.
+        event.asSettingChange()?.let { (setting, value) ->
+            telemetry.settingChanged(setting, value)
+        }
         when (event) {
             // General
             is SettingsEvent.SetTheme -> {
-                AppAnalytics.logSettingChanged("theme", event.theme.name)
                 _generalState.update { it.copy(theme = event.theme) }
                 viewModelScope.launch {
                     val modeString = when (event.theme) {
@@ -318,10 +321,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetLanguage -> {
-                AppAnalytics.logSettingChanged(
-                    "language",
-                    event.language.name
-                )
                 _generalState.update { it.copy(language = event.language) }
                 // AppAnalytics.UserProperty.APP_LANGUAGE has been declared and never set, so
                 // every segmentation by language has been empty since it was added.
@@ -393,10 +392,6 @@ class SettingsViewModel @Inject constructor(
 
             // Prayer
             is SettingsEvent.SetCalculationMethod -> {
-                AppAnalytics.logSettingChanged(
-                    "calculation_method",
-                    event.method.name
-                )
                 _prayerState.update { it.copy(calculationMethod = event.method) }
                 AppAnalytics.setUserProperty(
                     AppAnalytics.UserProperty.CALC_METHOD,
@@ -409,10 +404,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAsrMethod -> {
-                AppAnalytics.logSettingChanged(
-                    "asr_method",
-                    event.method.name
-                )
                 _prayerState.update { it.copy(asrMethod = event.method) }
                 viewModelScope.launch {
                     settingsRepository.setAsrCalculation(event.method.name.lowercase())
@@ -421,10 +412,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetHighLatitudeRule -> {
-                AppAnalytics.logSettingChanged(
-                    "high_latitude_rule",
-                    event.rule.name
-                )
                 _prayerState.update { it.copy(highLatitudeRule = event.rule) }
                 viewModelScope.launch {
                     settingsRepository.setHighLatitudeRule(event.rule.name)
@@ -452,10 +439,6 @@ class SettingsViewModel @Inject constructor(
 
             // Notifications
             is SettingsEvent.SetNotificationsEnabled -> {
-                AppAnalytics.logSettingChanged(
-                    "notifications_enabled",
-                    event.enabled.toString()
-                )
                 _notificationState.update { it.copy(notificationsEnabled = event.enabled) }
                 AppAnalytics.setUserProperty(
                     AppAnalytics.UserProperty.NOTIFICATIONS_ENABLED,
@@ -468,10 +451,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerNotification -> {
-                AppAnalytics.logSettingChanged(
-                    "prayer_notification_${event.prayer.lowercase()}",
-                    event.enabled.toString()
-                )
                 updatePrayerNotification(event.prayer, event.enabled)
                 viewModelScope.launch {
                     settingsRepository.setPrayerNotificationEnabled(event.prayer, event.enabled)
@@ -480,10 +459,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAdhanEnabled -> {
-                AppAnalytics.logSettingChanged(
-                    "adhan_enabled",
-                    event.enabled.toString()
-                )
                 _notificationState.update { it.copy(adhanEnabled = event.enabled) }
                 viewModelScope.launch {
                     settingsRepository.setAdhanEnabled(event.enabled)
@@ -492,10 +467,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerAlertStyle -> {
-                AppAnalytics.logSettingChanged(
-                    "alert_style_${event.prayer.lowercase()}",
-                    event.style.name
-                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(alertStyles = it.alertStyles + (prayer to event.style))
@@ -507,10 +478,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerReminderEnabled -> {
-                AppAnalytics.logSettingChanged(
-                    "reminder_enabled_${event.prayer.lowercase()}",
-                    event.enabled.toString()
-                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(reminderEnabled = it.reminderEnabled + (prayer to event.enabled))
@@ -523,10 +490,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetPrayerReminderMinutes -> {
-                AppAnalytics.logSettingChanged(
-                    "reminder_minutes_${event.prayer.lowercase()}",
-                    event.minutes.toString()
-                )
                 val prayer = event.prayer.lowercase()
                 _notificationState.update {
                     it.copy(reminderOffsets = it.reminderOffsets + (prayer to event.minutes))
@@ -543,19 +506,11 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetRespectDnd -> {
-                AppAnalytics.logSettingChanged(
-                    "respect_dnd",
-                    event.enabled.toString()
-                )
                 _notificationState.update { it.copy(respectDnd = event.enabled) }
                 viewModelScope.launch { settingsRepository.setAdhanRespectDnd(event.enabled) }
             }
 
             is SettingsEvent.SetReminderMinutes -> {
-                AppAnalytics.logSettingChanged(
-                    "reminder_minutes",
-                    event.minutes.toString()
-                )
                 _notificationState.update { it.copy(reminderMinutes = event.minutes) }
                 viewModelScope.launch {
                     settingsRepository.setNotificationReminderMinutes(event.minutes)
@@ -564,10 +519,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetShowReminderBefore -> {
-                AppAnalytics.logSettingChanged(
-                    "pre_reminder_enabled",
-                    event.enabled.toString()
-                )
                 _notificationState.update { it.copy(showReminderBefore = event.enabled) }
                 viewModelScope.launch {
                     settingsRepository.setShowReminderBefore(event.enabled)
@@ -643,10 +594,6 @@ class SettingsViewModel @Inject constructor(
             }
 
             is SettingsEvent.SetAdhanSound -> {
-                AppAnalytics.logSettingChanged(
-                    "adhan_sound",
-                    event.sound
-                )
                 _notificationState.update { it.copy(selectedAdhanSound = event.sound) }
                 viewModelScope.launch {
                     settingsRepository.setSelectedAdhanSound(event.sound)
@@ -674,8 +621,7 @@ class SettingsViewModel @Inject constructor(
                         // Now play the preview
                         adhanAudioManager.preview(sound, false)
                     } catch (e: Exception) {
-                        CrashReporter.recordException(e)
-                        AppAnalytics.logError(AppAnalytics.Feature.SETTINGS, "adhan_preview", e.message)
+                        telemetry.failure(AppAnalytics.Feature.SETTINGS, "adhan_preview", e)
                         _adhanPreviewError.value = "Failed to play adhan preview: ${e.message}"
                     }
                 }
@@ -830,16 +776,19 @@ class SettingsViewModel @Inject constructor(
                 // AppAnalytics.logTestNotification exists for exactly this and was never
                 // called, so "did the user try a test notification before reporting that
                 // notifications do not work" has been unanswerable.
+                telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "test_notification")
                 AppAnalytics.logTestNotification(allPrayers = false)
                 prayerNotificationScheduler.sendTestNotification()
             }
 
             SettingsEvent.TestAllNotifications -> {
+                telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "test_all_notifications")
                 AppAnalytics.logTestNotification(allPrayers = true)
                 prayerNotificationScheduler.sendAllPrayerTestNotifications()
             }
 
             SettingsEvent.ResetNotifications -> {
+                telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "reset_notifications")
                 viewModelScope.launch {
                     prayerNotificationScheduler.cancelAllPrayerNotifications()
                     rescheduleNotifications()
@@ -1116,7 +1065,14 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The three destructive actions were the least instrumented in the app, which is exactly
+     * backwards: a wipe is the event you most want to see in a funnel, because it is either
+     * someone tidying up or someone about to uninstall, and the two look nothing alike in
+     * context. Logged before the work, so an action that fails part-way is still visible.
+     */
     private fun resetToDefaults() {
+        telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "reset_to_defaults")
         viewModelScope.launch {
             settingsRepository.clearAllData()
             _generalState.update { GeneralSettingsUiState() }
@@ -1128,6 +1084,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun deleteAllData() {
+        telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "delete_all_data")
         viewModelScope.launch {
             // Everything the person made lives in the user database now, so "delete all my
             // data" clears that one — and it is a much more honest operation for it: the

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import android.util.Log
 import com.arshadshah.nimaz.BuildConfig
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.data.sync.CancelReason
 import com.arshadshah.nimaz.data.sync.ConnectionState
 import com.arshadshah.nimaz.data.sync.NearbyConnectionsManager
@@ -46,7 +46,8 @@ data class ActivityLogEntry(val label: String, val timestamp: Long = System.curr
 class SyncViewModel @Inject constructor(
     private val connectionsManager: NearbyConnectionsManager,
     private val exporter: SyncDataExporter,
-    private val importer: SyncDataImporter
+    private val importer: SyncDataImporter,
+    private val telemetry: Telemetry,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SyncUiState())
@@ -101,6 +102,7 @@ class SyncViewModel @Inject constructor(
                     is ConnectionState.Completed -> {
                         debugLog("Completed state received (mode=${_uiState.value.mode})")
                         if (_uiState.value.mode == SyncMode.SEND) {
+                            telemetry.featureUsed(AppAnalytics.Feature.SYNC, "send_completed")
                             addLogEntry("Data sent — waiting for partner to import...")
                             _uiState.update {
                                 it.copy(
@@ -112,6 +114,10 @@ class SyncViewModel @Inject constructor(
                     }
 
                     is ConnectionState.Error -> {
+                        // Sync is the highest-risk feature in the app and only its two
+                        // exception paths were instrumented; this branch — a transport error
+                        // with no throwable to record — went to `Log.e` and nowhere else.
+                        telemetry.error(AppAnalytics.Feature.SYNC, "connection", state.message)
                         debugLog("Error state: ${state.message}")
                         addLogEntry("Error: ${state.message}")
                         _uiState.update { it.copy(error = state.message) }
@@ -123,6 +129,10 @@ class SyncViewModel @Inject constructor(
                             CancelReason.BY_PARTNER -> "Cancelled by partner"
                             CancelReason.CONNECTION_LOST -> "Connection lost"
                         }
+                        // Which of the three ended it is the whole question: a sync people
+                        // abandon and a sync the transport drops need different fixes, and
+                        // both looked identical from outside.
+                        telemetry.featureUsed(AppAnalytics.Feature.SYNC, "cancelled_${state.reason.name.lowercase()}")
                         debugLog("Cancelled: $reason")
                         addLogEntry(reason)
                     }
@@ -208,17 +218,17 @@ class SyncViewModel @Inject constructor(
     fun onEvent(event: SyncEvent) {
         when (event) {
             is SyncEvent.StartSend -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_send")
+                telemetry.featureUsed(AppAnalytics.Feature.SYNC, "start_send")
                 startSend()
             }
             is SyncEvent.StartReceive -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "start_receive")
+                telemetry.featureUsed(AppAnalytics.Feature.SYNC, "start_receive")
                 startReceive()
             }
             is SyncEvent.AcceptConnection -> acceptConnection(event.endpointId)
             is SyncEvent.RejectConnection -> rejectConnection(event.endpointId)
             is SyncEvent.Cancel -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.SYNC, "cancel")
+                telemetry.featureUsed(AppAnalytics.Feature.SYNC, "cancel")
                 cancel()
             }
         }
@@ -273,6 +283,7 @@ class SyncViewModel @Inject constructor(
                     importWithProgress(payload)
 
                     debugLog("Import complete! Setting Completed state.")
+                    telemetry.featureUsed(AppAnalytics.Feature.SYNC, "receive_completed")
                     _uiState.update {
                         it.copy(
                             connectionState = ConnectionState.Completed(bytes.size.toLong()),
@@ -282,8 +293,7 @@ class SyncViewModel @Inject constructor(
                         )
                     }
                 } catch (e: Exception) {
-                    CrashReporter.recordException(e)
-                    AppAnalytics.logError(AppAnalytics.Feature.SYNC, "import", e.message)
+                    telemetry.failure(AppAnalytics.Feature.SYNC, "import", e)
                     debugLog("Import failed: ${e.message}")
                     addLogEntry("Import failed: ${e.message}")
                     _uiState.update { it.copy(error = "Import failed: ${e.message}") }
@@ -333,8 +343,7 @@ class SyncViewModel @Inject constructor(
                 connectionsManager.sendData(jsonBytes)
                 debugLog("sendData returned — transfer queued")
             } catch (e: Exception) {
-                CrashReporter.recordException(e)
-                AppAnalytics.logError(AppAnalytics.Feature.SYNC, "export", e.message)
+                telemetry.failure(AppAnalytics.Feature.SYNC, "export", e)
                 debugLog("Export/send failed: ${e.message}")
                 addLogEntry("Export failed: ${e.message}")
                 _uiState.update { it.copy(error = "Export failed: ${e.message}") }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatEvent.kt
@@ -20,7 +20,6 @@ sealed interface ZakatEvent {
     data class UpdateGoldPrice(val pricePerGram: Double) : ZakatEvent
     data class UpdateSilverPrice(val pricePerGram: Double) : ZakatEvent
     data class SetCurrency(val currency: String) : ZakatEvent
-    data object Calculate : ZakatEvent
     data object ClearAll : ZakatEvent
     data object ToggleBreakdown : ZakatEvent
     data object SaveCalculation : ZakatEvent

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
@@ -88,7 +88,13 @@ class ZakatViewModel @Inject constructor(
             is ZakatEvent.UpdateLoans -> updateLiability { it.copy(loans = event.amount) }
             is ZakatEvent.UpdateBillsDue -> updateLiability { it.copy(billsDue = event.amount) }
             is ZakatEvent.UpdateOtherLiabilities -> updateLiability { it.copy(otherLiabilities = event.amount) }
+            // The amount-entry events above are deliberately **not** logged. #359 asks for
+            // "every amount entry"; each is dispatched from a text field on every character,
+            // so instrumenting them literally would emit a stream of events per figure typed
+            // — the firehose §4 of the same issue objects to. The once-per-filled-form signal
+            // from `calculate()` is what says a calculation happened; these say a digit did.
             is ZakatEvent.SetNisabType -> {
+                telemetry.settingChanged("zakat_nisab_type", event.nisabType.name)
                 _calculatorState.update { it.copy(nisabType = event.nisabType) }
                 recalculate()
             }
@@ -107,17 +113,15 @@ class ZakatViewModel @Inject constructor(
                 settingsRepository.setZakatCurrency(event.currency)
             }
 
-            // No producer: the screen recalculates through `recalculate()` on every amount
-            // entry, so this branch never runs. Its analytics used to live here, which is why
-            // the dashboard read "nobody calculates zakat" — false, and worse than silence.
-            // The signal now fires from `calculate()`, once per filled-in form.
-            ZakatEvent.Calculate -> calculate()
-
             ZakatEvent.ClearAll -> {
+                telemetry.featureUsed(DOMAIN, "clear_all")
                 hasLoggedCalculation = false
                 clearAll()
             }
-            ZakatEvent.ToggleBreakdown -> _calculatorState.update { it.copy(showBreakdown = !it.showBreakdown) }
+            ZakatEvent.ToggleBreakdown -> {
+                telemetry.featureUsed(DOMAIN, "toggle_breakdown")
+                _calculatorState.update { it.copy(showBreakdown = !it.showBreakdown) }
+            }
             ZakatEvent.SaveCalculation -> {
                 telemetry.featureUsed(DOMAIN, "save")
                 saveCalculation()
@@ -128,7 +132,10 @@ class ZakatViewModel @Inject constructor(
                 markAsPaid(event.entryId)
             }
 
-            is ZakatEvent.DeleteCalculation -> deleteCalculation(event.entryId)
+            is ZakatEvent.DeleteCalculation -> {
+                telemetry.featureUsed(DOMAIN, "delete_calculation")
+                deleteCalculation(event.entryId)
+            }
             ZakatEvent.LoadHistory -> loadHistory()
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/PrayerTrackerViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/PrayerTrackerViewModel.kt
@@ -91,7 +91,10 @@ class PrayerTrackerViewModel @Inject constructor(
 
     fun onEvent(event: PrayerTrackerEvent) {
         when (event) {
-            is PrayerTrackerEvent.SelectDate -> selectDate(event.date)
+            is PrayerTrackerEvent.SelectDate -> {
+                telemetry.featureUsed(DOMAIN, "select_date")
+                selectDate(event.date)
+            }
             is PrayerTrackerEvent.MarkPrayerPrayed -> {
                 telemetry.prayerTracked(
                         event.prayerName.name,
@@ -112,8 +115,14 @@ class PrayerTrackerViewModel @Inject constructor(
                 telemetry.featureUsed(DOMAIN, "qada_completed")
                 markQadaCompleted(event.record)
             }
-            is PrayerTrackerEvent.SetStatsPeriod -> setStatsPeriod(event.period)
-            is PrayerTrackerEvent.LoadHistory -> loadHistory(event.startDate, event.endDate)
+            is PrayerTrackerEvent.SetStatsPeriod -> {
+                telemetry.featureUsed(DOMAIN, "set_stats_period")
+                setStatsPeriod(event.period)
+            }
+            is PrayerTrackerEvent.LoadHistory -> {
+                telemetry.featureUsed(DOMAIN, "load_history")
+                loadHistory(event.startDate, event.endDate)
+            }
             PrayerTrackerEvent.LoadToday -> loadToday()
             PrayerTrackerEvent.LoadStats -> loadStats()
             PrayerTrackerEvent.LoadQadaPrayers -> loadQadaPrayers()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/TasbihViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/TasbihViewModel.kt
@@ -121,27 +121,38 @@ class TasbihViewModel @Inject constructor(
 
     fun onEvent(event: TasbihEvent) {
         when (event) {
-            is TasbihEvent.SelectPreset -> selectPreset(event.preset)
+            is TasbihEvent.SelectPreset -> {
+                telemetry.featureUsed(DOMAIN, "select_preset")
+                selectPreset(event.preset)
+            }
             TasbihEvent.ClearPreset -> clearPreset()
             is TasbihEvent.SetTargetCount -> setTargetCount(event.count)
             is TasbihEvent.CreateCustomPreset -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.TASBIH,
-                    "preset_created"
-                )
+                telemetry.featureUsed(DOMAIN, "preset_created")
                 createCustomPreset(event.preset)
             }
-            is TasbihEvent.UpdateCustomPreset -> updateCustomPreset(event.preset)
+            is TasbihEvent.UpdateCustomPreset -> {
+                telemetry.featureUsed(DOMAIN, "preset_updated")
+                updateCustomPreset(event.preset)
+            }
             is TasbihEvent.DeleteCustomPreset -> {
-                AppAnalytics.logFeatureUsed(
-                    AppAnalytics.Feature.TASBIH,
-                    "preset_deleted"
-                )
+                telemetry.featureUsed(DOMAIN, "preset_deleted")
                 deleteCustomPreset(event.presetId)
             }
-            is TasbihEvent.ToggleVibration -> _counterState.update { it.copy(vibrationEnabled = event.enabled) }
-            is TasbihEvent.ToggleSound -> _counterState.update { it.copy(soundEnabled = event.enabled) }
+            is TasbihEvent.ToggleVibration -> {
+                telemetry.settingChanged("tasbih_vibration", event.enabled.toString())
+                _counterState.update { it.copy(vibrationEnabled = event.enabled) }
+            }
+            is TasbihEvent.ToggleSound -> {
+                telemetry.settingChanged("tasbih_sound", event.enabled.toString())
+                _counterState.update { it.copy(soundEnabled = event.enabled) }
+            }
+            // The counter style, bead design and handedness all write DataStore, so they are
+            // settings and belong on the settings dashboard rather than in the feature's usage
+            // counter — the bead design in particular is the one place the app asks the user
+            // for a purely aesthetic preference, and nothing recorded which one they picked.
             is TasbihEvent.SetCounterStyle -> {
+                telemetry.settingChanged("tasbih_counter_style", event.style.name)
                 _counterState.update { it.copy(counterStyle = event.style) }
                 viewModelScope.launch {
                     preferences.setTasbihBeadMode(event.style == TasbihCounterStyle.BEADS)
@@ -149,19 +160,24 @@ class TasbihViewModel @Inject constructor(
             }
 
             is TasbihEvent.SetBeadDesign -> {
+                telemetry.settingChanged("tasbih_bead_design", event.key)
                 _counterState.update { it.copy(beadDesignKey = event.key) }
                 viewModelScope.launch { preferences.setTasbihBeadDesign(event.key) }
             }
 
-            is TasbihEvent.ToggleFavorite -> toggleFavorite(event.presetId)
+            is TasbihEvent.ToggleFavorite -> {
+                telemetry.featureUsed(DOMAIN, AppAnalytics.Action.TOGGLE_FAVORITE)
+                toggleFavorite(event.presetId)
+            }
             is TasbihEvent.SetLeftHanded -> {
+                telemetry.settingChanged("tasbih_left_handed", event.enabled.toString())
                 _counterState.update { it.copy(leftHanded = event.enabled) }
                 viewModelScope.launch { preferences.setTasbihLeftHanded(event.enabled) }
             }
 
             TasbihEvent.Increment -> increment()
             TasbihEvent.Reset -> {
-                AppAnalytics.logFeatureUsed(AppAnalytics.Feature.TASBIH, "reset")
+                telemetry.featureUsed(DOMAIN, "reset")
                 reset()
             }
             TasbihEvent.LoadPresets -> loadPresets()
@@ -345,6 +361,12 @@ class TasbihViewModel @Inject constructor(
 
         val previousLaps = _counterState.value.laps
 
+        // NOT logged per tap. #359 asks for `Increment` — "the single most-used action in the
+        // feature" — to be instrumented, and instrumenting it literally would emit one event
+        // per finger tap on a counter people run to 100 and beyond: the same firehose §4 of
+        // that issue objects to on search keystrokes, at a worse rate. The unit that answers
+        // "is the tasbih used" is a **completed lap**, logged below, and a started session,
+        // logged in `startSessionAndIncrement`. Both are bounded by real activity.
         _counterState.update { state ->
             var newCount = state.count + 1
             var newLaps = state.laps
@@ -369,6 +391,7 @@ class TasbihViewModel @Inject constructor(
 
                 // Refresh stats when a lap completes to update sessions count
                 if (_counterState.value.laps > previousLaps) {
+                    telemetry.featureUsed(DOMAIN, "lap_completed")
                     loadStats()
                 }
             }
@@ -378,6 +401,7 @@ class TasbihViewModel @Inject constructor(
     private fun startSessionAndIncrement() {
         val preset = _counterState.value.selectedPreset
 
+        telemetry.featureUsed(DOMAIN, "session_started")
         sessionStartTime = System.currentTimeMillis()
 
         viewModelScope.launch {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
@@ -2,7 +2,6 @@ package com.arshadshah.nimaz.presentation.viewmodel.worship
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -116,7 +115,9 @@ class NightWorshipViewModel @Inject constructor(
                     )
                 }
             }.onFailure { e ->
-                CrashReporter.recordException(e)
+                // `failure`, not a bare `recordException`: the stack trace reached Crashlytics
+                // and the frequency reached nothing, so how often this fails was not visible.
+                telemetry.failure(AppAnalytics.Feature.NIGHT_WORSHIP, "load", e)
                 _state.update { it.copy(isLoading = false, error = e.message) }
             }
         }

--- a/app/src/test/java/com/arshadshah/nimaz/core/monitoring/RecordingTelemetry.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/monitoring/RecordingTelemetry.kt
@@ -31,6 +31,15 @@ class RecordingTelemetry : Telemetry {
     val searches: List<TelemetryCall.Search>
         get() = calls.filterIsInstance<TelemetryCall.Search>()
 
+    val prayersTracked: List<TelemetryCall.PrayerTracked>
+        get() = calls.filterIsInstance<TelemetryCall.PrayerTracked>()
+
+    val customKeys: List<TelemetryCall.CustomKey>
+        get() = calls.filterIsInstance<TelemetryCall.CustomKey>()
+
+    val aiAnswers: List<TelemetryCall.AiAnswered>
+        get() = calls.filterIsInstance<TelemetryCall.AiAnswered>()
+
     fun clear() = calls.clear()
 
     override fun featureUsed(feature: String, action: String?) {
@@ -47,6 +56,10 @@ class RecordingTelemetry : Telemetry {
 
     override fun search(filter: String, queryLength: Int) {
         calls += TelemetryCall.Search(filter, queryLength)
+    }
+
+    override fun aiAnswered(proofCount: Int, durationMs: Long, confidence: String) {
+        calls += TelemetryCall.AiAnswered(proofCount, durationMs, confidence)
     }
 
     override fun prayerTracked(prayer: String, status: String, isJamaah: Boolean) {
@@ -83,6 +96,12 @@ sealed interface TelemetryCall {
     ) : TelemetryCall
 
     data class FastTracked(val action: String, val fastType: String?) : TelemetryCall
+    data class AiAnswered(
+        val proofCount: Int,
+        val durationMs: Long,
+        val confidence: String,
+    ) : TelemetryCall
+
     data class Exception(val throwable: Throwable) : TelemetryCall
     data class Breadcrumb(val message: String) : TelemetryCall
     data class CustomKey(val key: String, val value: String) : TelemetryCall

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AnalyticsReachabilityTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/AnalyticsReachabilityTest.kt
@@ -59,13 +59,8 @@ class AnalyticsReachabilityTest {
             // `is XxxEvent.Name ->` or `XxxEvent.Name ->`, and whether its branch logs.
             BRANCH.findAll(onEvent).forEach { match ->
                 val event = match.groupValues[1]
-                val branch = onEvent.substring(
-                    match.range.last,
-                    minOf(onEvent.length, match.range.last + BRANCH_WINDOW),
-                )
-                val logs = LOGGING.containsMatchIn(branch.substringBefore("\n            is ")
-                    .substringBefore("\n            Xxx"))
-                if (!logs) return@forEach
+                val branch = branchBody(onEvent, match.range.last)
+                if (!LOGGING.containsMatchIn(branch)) return@forEach
                 if (event in accepted) return@forEach
                 if (!ui.contains(event)) unreachable += "$event  (${file.name})"
             }
@@ -74,9 +69,34 @@ class AnalyticsReachabilityTest {
         assertThat(unreachable).isEmpty()
     }
 
+    /**
+     * One branch's body: from its `->` to the start of the next branch, or the window's end.
+     *
+     * This used to be a flat 220-character window cut only on `"\n            is "`, which
+     * attributed a **neighbour's** logging to a branch that logged nothing whenever the next
+     * branch was `Xxx.Name ->` rather than `is Xxx.Name ->`. That produced false positives the
+     * moment an adjacent branch gained a `telemetry` call — `ZakatEvent.SetCurrency`, whose
+     * body is a `persist { … }` and logs no usage at all, was reported as an unreachable
+     * analytics branch because `ClearAll` two lines below it had just been instrumented.
+     *
+     * Ending at the next branch of **either** shape is strictly more precise: nothing that
+     * genuinely logs stops being seen, and a branch is no longer judged by its neighbours.
+     */
+    private fun branchBody(onEvent: String, arrowEnd: Int): String {
+        val window = onEvent.substring(
+            arrowEnd,
+            minOf(onEvent.length, arrowEnd + BRANCH_WINDOW),
+        )
+        val next = NEXT_BRANCH.find(window, startIndex = 1)?.range?.first ?: window.length
+        return window.substring(0, next)
+    }
+
     private companion object {
         val BRANCH = Regex("""(?:is\s+)?(\w+Event\.\w+)\s*->""")
-        val LOGGING = Regex("""telemetry\.(featureUsed|search|settingChanged|prayerTracked|fastTracked)|AppAnalytics\.log""")
+
+        /** The start of the following branch, at `when` indentation, either shape. */
+        val NEXT_BRANCH = Regex("""\n {12}(?:is\s+)?\w+Event\.\w+""")
+        val LOGGING = Regex("""telemetry\.(featureUsed|search|settingChanged|prayerTracked|fastTracked|aiAnswered)|AppAnalytics\.log""")
         const val BRANCH_WINDOW = 220
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogSearchTelemetryTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogSearchTelemetryTest.kt
@@ -1,0 +1,152 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Catalogue search reports itself once per settled query, with the query's **length**.
+ *
+ * #359 §4 describes the old shape: the three catalogue screens dispatch `Search` from
+ * `onQueryChange`, and the handler called `logFeatureUsed(feature, "search")`, so typing
+ * "Ibrahim" emitted seven events and two backspaces emitted two more. The wrong helper as well
+ * as the wrong rate — `featureUsed` has nowhere to put the length, which is the one number
+ * `search` records.
+ *
+ * The issue lists this as three sites (`ProphetViewModel:63`, `AsmaUnNabi:67`, `AsmaUlHusna:67`).
+ * It is one: those three were byte-identical and collapsed onto [CatalogViewModel] in an earlier
+ * layer, so this suite covers all three surfaces.
+ *
+ * The filtering itself must stay per keystroke — it is an in-memory `List.filter` and the list
+ * should track the finger — so the last test pins that the two rates are genuinely separate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CatalogSearchTelemetryTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private data class Row(val id: Int, val name: String)
+
+    private val rows = MutableStateFlow(
+        listOf(Row(1, "Ibrahim"), Row(2, "Musa"), Row(3, "Isa")),
+    )
+
+    private inner class Source : CatalogSource<Row> {
+        override fun all(): Flow<List<Row>> = rows
+        override fun favourites(): Flow<List<Row>> = MutableStateFlow(emptyList())
+        override suspend fun byId(id: Int): Row? = rows.value.firstOrNull { it.id == id }
+        override suspend fun toggleFavourite(id: Int) = Unit
+        override fun idOf(item: Row): Int = item.id
+        override fun matches(item: Row, query: String) = item.name.contains(query, true)
+    }
+
+    private inner class TestCatalog : CatalogViewModel<Row>(Source(), telemetry, FEATURE)
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    /** Typing a name is one event, not one per character. */
+    @Test
+    fun `a query typed character by character reports once`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        telemetry.clear()
+
+        "Ibrahim".forEachIndexed { index, _ ->
+            vm.onEvent(CatalogEvent.Search("Ibrahim".take(index + 1)))
+            advanceTimeBy(50) // faster than the debounce, as a typist is
+        }
+        advanceUntilIdle()
+
+        assertThat(telemetry.searches).hasSize(1)
+        assertThat(telemetry.searches.single().filter).isEqualTo(FEATURE)
+        assertThat(telemetry.searches.single().queryLength).isEqualTo(7)
+    }
+
+    /** And the length is the *trimmed* length — a trailing space is not a character searched for. */
+    @Test
+    fun `the reported length excludes surrounding whitespace`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        telemetry.clear()
+
+        vm.onEvent(CatalogEvent.Search("  Musa  "))
+        advanceUntilIdle()
+
+        assertThat(telemetry.searches.single().queryLength).isEqualTo(4)
+    }
+
+    /**
+     * Clearing the box is not a search. `onClear` used to emit an event with an empty query,
+     * which is the same defect #359 names on `SearchViewModel` — a `search_performed` for a
+     * search that never ran.
+     */
+    @Test
+    fun `clearing the box reports nothing`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("Musa"))
+        advanceUntilIdle()
+        telemetry.clear()
+
+        vm.onEvent(CatalogEvent.ClearSearch)
+        advanceUntilIdle()
+
+        assertThat(telemetry.searches).isEmpty()
+    }
+
+    /** Two different settled queries are two events; the same one twice is not. */
+    @Test
+    fun `a repeated query is not reported twice`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        telemetry.clear()
+
+        vm.onEvent(CatalogEvent.Search("Musa"))
+        advanceUntilIdle()
+        vm.onEvent(CatalogEvent.Search("Musa"))
+        advanceUntilIdle()
+
+        assertThat(telemetry.searches).hasSize(1)
+    }
+
+    /**
+     * The list still filters on every keystroke. Debouncing the *analytics* must not slow the
+     * filter down — that would trade a real regression for a reporting fix.
+     */
+    @Test
+    fun `filtering happens immediately, before any event is reported`() = runTest {
+        val vm = TestCatalog()
+        advanceUntilIdle()
+        telemetry.clear()
+
+        vm.onEvent(CatalogEvent.Search("Ibr"))
+        // No time advanced at all: the filter is synchronous inside `onEvent`.
+        assertThat(vm.listState.value.filteredItems.map { it.name }).containsExactly("Ibrahim")
+        assertThat(telemetry.searches).isEmpty()
+
+        advanceUntilIdle()
+        assertThat(telemetry.searches).hasSize(1)
+    }
+
+    private companion object {
+        const val FEATURE = "test_catalog"
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaProgressTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaProgressTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QaidaAudioManager
 import com.arshadshah.nimaz.data.audio.QaidaAudioState
 import com.arshadshah.nimaz.domain.model.QaidaCell
@@ -92,7 +93,7 @@ class QaidaProgressTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun reader(): QaidaReaderViewModel {
-        val vm = QaidaReaderViewModel(useCases, audioManager)
+        val vm = QaidaReaderViewModel(useCases, audioManager, RecordingTelemetry())
         vm.onEvent(QaidaReaderEvent.SelectLesson(1))
         dispatcher.scheduler.advanceUntilIdle()
         return vm

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaReaderViewModelTest.kt
@@ -2,6 +2,7 @@
 
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import app.cash.turbine.test
 import com.arshadshah.nimaz.data.audio.QaidaAudioManager
 import com.arshadshah.nimaz.data.audio.QaidaAudioState
@@ -101,7 +102,7 @@ class QaidaReaderViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun createViewModel() = QaidaReaderViewModel(useCases, audioManager)
+    private fun createViewModel() = QaidaReaderViewModel(useCases, audioManager, RecordingTelemetry())
 
     @Test
     fun `tapping a cell plays its clip and marks it heard`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelRolloverTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelRolloverTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.home
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
@@ -111,6 +112,7 @@ class HomeViewModelRolloverTest {
         val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
         return HomeViewModel(
             context = context,
+            telemetry = RecordingTelemetry(),
             prayerTimeCalculator = prayerTimeCalculator,
             prayerUseCases = buildPrayerUseCases(prayerRepository),
             fastingUseCases = buildFastingUseCases(fastingRepository),

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.home
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
@@ -101,6 +102,7 @@ class HomeViewModelTest {
         val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
         return HomeViewModel(
             context = context,
+            telemetry = RecordingTelemetry(),
             prayerTimeCalculator = prayerTimeCalculator,
             prayerUseCases = buildPrayerUseCases(prayerRepository),
             fastingUseCases = buildFastingUseCases(fastingRepository),

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsRaceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsRaceTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
@@ -243,7 +244,7 @@ class QuranTopicsRaceTest {
     }
 
     private fun openedBrowser(): QuranTopicsViewModel {
-        val vm = QuranTopicsViewModel(useCases, settings)
+        val vm = QuranTopicsViewModel(useCases, settings, RecordingTelemetry())
         vm.onEvent(QuranTopicsEvent.OpenBrowser)
         dispatcher.scheduler.advanceUntilIdle()
         return vm

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModelDescentTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModelDescentTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.TopicTree
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
@@ -265,7 +266,7 @@ class QuranTopicsViewModelDescentTest {
     }
 
     private fun openedBrowser(): QuranTopicsViewModel {
-        val vm = QuranTopicsViewModel(useCases, settings)
+        val vm = QuranTopicsViewModel(useCases, settings, RecordingTelemetry())
         vm.onEvent(QuranTopicsEvent.OpenBrowser)
         dispatcher.scheduler.advanceUntilIdle()
         return vm

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModelSurahContextTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranTopicsViewModelSurahContextTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.QuranTopic
 import com.arshadshah.nimaz.domain.model.RevelationType
 import com.arshadshah.nimaz.domain.model.Surah
@@ -257,7 +258,7 @@ class QuranTopicsViewModelSurahContextTest {
         ).isEqualTo(TopicTree.INDEX)
     }
 
-    private fun viewModel() = QuranTopicsViewModel(useCases, settings)
+    private fun viewModel() = QuranTopicsViewModel(useCases, settings, RecordingTelemetry())
 
     /** Citations across three surahs, in the order the corpus gives them — by ayah id. */
     private fun detailOf(topic: QuranTopic) = TopicDetail(

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.search
 
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.LibrarySearchResults
 import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase
 import com.google.common.truth.Truth.assertThat
@@ -34,7 +35,7 @@ class SearchViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = SearchViewModel(searchLibrary)
+    private fun viewModel() = SearchViewModel(searchLibrary, RecordingTelemetry())
 
     @Test
     fun `typing a query runs the search without pressing enter`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetryTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetryTest.kt
@@ -1,0 +1,169 @@
+package com.arshadshah.nimaz.presentation.viewmodel.settings
+
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The settings telemetry table: what each event reports, and what it must never report.
+ *
+ * `SettingsViewModel.onEvent` is a 78-branch `when` in which 15 branches logged and 56 did not.
+ * Moving the decision into [asSettingChange] is what makes that ratio visible — and this suite
+ * is what keeps it from drifting back, because a table is only better than scattered call sites
+ * if something checks it.
+ */
+class SettingsTelemetryTest {
+
+    /**
+     * The names that were already reaching dashboards, pinned exactly.
+     *
+     * A renamed setting is not a cosmetic change: the old series stops and reads as "nobody
+     * changes this any more". `pre_reminder_enabled` is the one that most invites tidying —
+     * the event is `SetShowReminderBefore` — so it is listed first.
+     */
+    @Test
+    fun `the fifteen names already in use are unchanged`() {
+        val expected = mapOf(
+            SettingsEvent.SetShowReminderBefore(true) to "pre_reminder_enabled",
+            SettingsEvent.SetTheme(AppTheme.DARK) to "theme",
+            SettingsEvent.SetLanguage(AppLanguage.ENGLISH) to "language",
+            SettingsEvent.SetCalculationMethod(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+                to "calculation_method",
+            SettingsEvent.SetAsrMethod(AsrJuristicMethod.STANDARD) to "asr_method",
+            SettingsEvent.SetHighLatitudeRule(HighLatitudeRule.MIDDLE_OF_THE_NIGHT)
+                to "high_latitude_rule",
+            SettingsEvent.SetNotificationsEnabled(true) to "notifications_enabled",
+            SettingsEvent.SetPrayerNotification("fajr", true) to "prayer_notification_fajr",
+            SettingsEvent.SetAdhanEnabled(true) to "adhan_enabled",
+            SettingsEvent.SetPrayerAlertStyle("fajr", PrayerAlertStyle.ADHAN) to "alert_style_fajr",
+            SettingsEvent.SetPrayerReminderEnabled("asr", true) to "reminder_enabled_asr",
+            SettingsEvent.SetPrayerReminderMinutes("asr", 15) to "reminder_minutes_asr",
+            SettingsEvent.SetRespectDnd(true) to "respect_dnd",
+            SettingsEvent.SetReminderMinutes(15) to "reminder_minutes",
+            SettingsEvent.SetAdhanSound("makkah") to "adhan_sound",
+        )
+
+        expected.forEach { (event, name) ->
+            assertThat(event.asSettingChange()?.first).isEqualTo(name)
+        }
+    }
+
+    /**
+     * The adjustment is keyed by prayer.
+     *
+     * #359 calls this "arguably the single most diagnostic setting in the app" and it reported
+     * nothing at all. A single `prayer_adjustment` key would have been most of the fix and
+     * still not answered the question it exists for: whether one prayer is being nudged the
+     * same way by many people, which is what a calculation bug looks like from outside.
+     */
+    @Test
+    fun `a prayer adjustment names the prayer and the offset`() {
+        val change = SettingsEvent.SetPrayerAdjustment("fajr", -3).asSettingChange()
+
+        assertThat(change).isEqualTo("prayer_adjustment_fajr" to "-3")
+    }
+
+    /**
+     * A location's name never reaches analytics.
+     *
+     * `settingChanged` writes its value to a dashboard, and a location is the most identifying
+     * thing this app holds. The events report that the set changed and nothing about where.
+     */
+    @Test
+    fun `location events never carry a place name`() {
+        val home = Location(
+            id = 7,
+            name = "Bad Godesberg, Bonn",
+            latitude = 50.68,
+            longitude = 7.15,
+            timezone = "Europe/Berlin",
+            country = "Germany",
+            city = "Bonn",
+            isCurrentLocation = true,
+            isFavorite = false,
+            calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+            asrCalculation = AsrCalculation.STANDARD,
+            highLatitudeRule = null,
+            fajrAngle = null,
+            ishaAngle = null,
+        )
+
+        val changes = listOf(
+            SettingsEvent.SetCurrentLocation(home),
+            SettingsEvent.AddLocation(home),
+            SettingsEvent.RemoveLocation(home),
+        ).mapNotNull { it.asSettingChange() }
+
+        assertThat(changes).hasSize(3)
+        changes.forEach { (name, value) ->
+            assertThat(name).doesNotContain("Bonn")
+            assertThat(value).doesNotContain("Bonn")
+            assertThat(value).doesNotContain("50.68")
+        }
+    }
+
+    /** The events that are not setting changes opt out explicitly rather than by omission. */
+    @Test
+    fun `actions and previews report no setting change`() {
+        val notSettings = listOf(
+            SettingsEvent.PreviewAdhanSound,
+            SettingsEvent.StopAdhanPreview,
+            SettingsEvent.TestNotification,
+            SettingsEvent.TestAllNotifications,
+            SettingsEvent.ResetToDefaults,
+            SettingsEvent.ResetNotifications,
+            SettingsEvent.DeleteAllData,
+        )
+
+        notSettings.forEach { assertThat(it.asSettingChange()).isNull() }
+    }
+
+    /**
+     * The typography events all report, because they were the largest unreported block: every
+     * Qur'an, dua and hadith font and size setting, none of them logged.
+     */
+    @Test
+    fun `every typography setting reports a name and a value`() {
+        val typography = listOf(
+            SettingsEvent.SetArabicFont("amiri"),
+            SettingsEvent.SetArabicFontSize(24f),
+            SettingsEvent.SetTranslationFontSize(16f),
+            SettingsEvent.SetMushafScript(MushafScript.MADANI),
+            SettingsEvent.SetDuaArabicFont("amiri"),
+            SettingsEvent.SetDuaArabicFontSize(28f),
+            SettingsEvent.SetDuaTranslationFontSize(16f),
+            SettingsEvent.SetHadithArabicFont("amiri"),
+            SettingsEvent.SetHadithArabicFontSize(24f),
+            SettingsEvent.SetHadithTranslationFontSize(16f),
+        )
+
+        typography.forEach { event ->
+            val change = event.asSettingChange()
+            assertThat(change).isNotNull()
+            assertThat(change!!.first).isNotEmpty()
+            assertThat(change.second).isNotEmpty()
+        }
+    }
+
+    /** A nulled reciter reports "none" rather than the string "null". */
+    @Test
+    fun `clearing the reciter reports none`() {
+        assertThat(SettingsEvent.SetReciter(null).asSettingChange())
+            .isEqualTo("quran_reciter" to "none")
+    }
+
+    /** Pattern style is an enum, and reports its name rather than an ordinal. */
+    @Test
+    fun `enum-valued settings report the enum name`() {
+        val change = SettingsEvent.SetPatternStyle(NimazPatternStyle.entries.first())
+            .asSettingChange()
+
+        assertThat(change?.second).isEqualTo(NimazPatternStyle.entries.first().name)
+    }
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -363,6 +363,27 @@ rg -n -U --multiline-dotall \
   The rule: **an event is not reachable because a test dispatches it.** A test is a second
   producer, and it is the one that keeps dead branches looking alive.
 
+- [x] ~~**Three more unreachable branches, found by instrumenting them.**~~ **Deleted.**
+  `QuranEvent.MarkAyahsReadForKhatam`, `QuranEvent.UnmarkAyahReadForKhatam` and
+  `ZakatEvent.Calculate` had no producer in any screen. They were invisible to the ratchet
+  while they logged nothing, and failed it the moment #359 §5's instrumentation was added —
+  which is the test working as intended, and a useful warning about the order of operations:
+  **instrument, then check reachability, then keep the instrumentation.** All three are
+  superseded by a wired sibling (`ToggleKhatamAyah` calls the same two use cases; the zakat
+  screen recalculates through `recalculate()` on every entry), so they were deleted rather than
+  wired, along with two private handlers left with no caller.
+
+- [ ] **`ZakatEvent.SetCurrency` has no producer.** Not an analytics finding — its branch is a
+  `persist { … }` that logs no usage — so the ratchet does not see it, and it surfaced only
+  because a neighbouring branch's new logging spilled into the old flat scan window. The
+  calculator formats every figure with `state.currency` and offers no way to change it, so a
+  user outside the default currency reads someone else's symbol on their own zakat. Wire a
+  currency picker or delete the event; it is a product decision, like the eight of #357.
+  ```bash
+  cd app/src/main/java/com/arshadshah/nimaz
+  grep -rn "ZakatEvent.SetCurrency" presentation/screens presentation/components
+  ```
+
   The **eight signed off as features** were wired rather than deleted: a Previous/Continue/Next
   footer in the Qaida reader (`PreviousLesson`, `Resume`), the zakat breakdown's disclosure
   (`ToggleBreakdown`), an all-prayers pre-reminder switch and lead-time picker

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -1127,14 +1127,28 @@ formatted strings.
 
 **Instrumentation conventions (apply these as you write code):**
 - **Error-swallowing `catch`/`runCatching`** that hides a real failure (data load, IO, parse,
-  audio, network, background work) should call `CrashReporter.recordException(e)` — rename
-  `catch (_: …)` to `catch (e: …)`. In ViewModels, also call `AppAnalytics.logError(feature, type, e.message)`
-  for frequency. Skip *expected* control-flow catches (permission probes, optional system
+  audio, network, background work) should report through **`telemetry.failure(feature, type, e)`**,
+  which reaches both channels and ignores `CancellationException` — rename `catch (_: …)` to
+  `catch (e: …)`. Skip *expected* control-flow catches (permission probes, optional system
   services, "no data yet"). All monitoring calls are safe no-ops when Firebase is absent.
 - **Significant user actions** (open a reader/detail, toggle favorite/bookmark, create/complete/delete,
-  play audio, run a search) get one `AppAnalytics.logFeatureUsed("<feature>", "<action>")` in the
-  relevant `onEvent` branch — never log trivial state churn (text edits, scroll). Coverage is broad:
-  every ViewModel logs usage, and error paths across data/widget/worker/util/VM layers report to Crashlytics.
+  play audio, run a search) get one `telemetry.featureUsed("<feature>", "<action>")` in the
+  relevant `onEvent` branch — never log trivial state churn (text edits, scroll).
+- **Use the purpose-built helper, not the generic one.** `featureUsed` is the fallback; a
+  tracked prayer is `prayerTracked`, a completed search is `search`, a persisted preference is
+  `settingChanged`, an AI answer is `aiAnswered`. The generic call throws away the very field
+  the specific one exists to carry — which prayer, how long the query was, what the setting
+  landed on — and those are not recoverable afterwards.
+- **Rate matters as much as coverage.** Anything driven by a text field, a slider or a sensor
+  fires far faster than a user acts: log **post-debounce** (search boxes), on the **transition**
+  (compass accuracy, which `SensorManager` re-delivers per reading), or at the **unit of
+  meaning** (a completed tasbih lap rather than each tap, one filled-in zakat form rather than
+  each digit). A per-keystroke event is not better coverage, it is a firehose that costs money
+  and answers nothing.
+- **Settings report from one table.** `SettingsEvent` is 78 branches; per-branch logging left 56
+  of them silent. `presentation/viewmodel/settings/SettingsTelemetry.kt` maps every
+  settings-shaped event to its name and value, exhaustively, so a new event cannot compile
+  without a decision. A location event never carries the place name or its coordinates.
 
 ---
 


### PR DESCRIPTION
Layer 37 of #352, closing **§4–§6 of #359**. Based on `epic/vm-36-wire-lost-features`; one commit.

## Corrections to the issue

Every row was reproduced against current code before being fixed. **Six are stale** and **three asked for something that would have made the problem worse.**

### Already fixed by earlier layers — no change needed

| Row | Status |
|---|---|
| `HelpViewModel:129-133` per-keystroke search | Already logs `telemetry.search` post-debounce, inside the pipeline |
| `SearchSettingsViewModel:85-87,103,115` `ai_ask` trio | Already `settingChanged` |
| `SettingsViewModel:1044-1050` test notification | `logTestNotification` already wired |
| `PrayerTrackerViewModel` never calls `logPrayerTracked` | Already calls it, for both prayed and missed |
| `DuaViewModel:148` search → `logSearch` | There is no dua search left; the in-feature searches were deleted in #430 as superseded by the global one |
| `QuranTopicsViewModel` "`togglePrayerStatus` equivalent" | `QuranTopicsViewModel` contains no prayer code at all |

### Wrong in a way that changed the fix

**Search is one site, not three.** §4's first row names `ProphetViewModel:63` + `AsmaUnNabi:67` + `AsmaUlHusna:67`. Those three ViewModels were byte-identical and collapsed onto `CatalogViewModel` in an earlier layer — one fix, one test, all three surfaces.

**There are three prayer-tracking sites, not two.** `PrayerTimesViewModel.togglePrayer` is the third. A dashboard built on `prayer_tracked` after fixing only Home and the tracker would still have under-counted, silently.

**`SearchViewModel` has a second, larger defect in the same place.** The issue says the `logSearch` call is before validation — true, so an empty submit emitted `search_performed` with `query_length = 0` and no search. But it was on `ExecuteSearch` only, so **search-as-you-type — the way the screen is actually used — was never counted at all**. Moving the call past the debounce fixes both.

**`SettingsViewModel` has no `else -> {}` any more**, and it drops 56 events, not 63. The `when` is exhaustive with explicit branches; 56 of the 78 simply carry no logging.

### Where the issue asks for a firehose, it does not get one

Three §5/§6 rows would ship the exact defect §4 objects to, at a worse rate:

- **`TasbihEvent.Increment`** — "the single most-used action in the feature". Instrumented literally, that is one event per finger tap on a counter people run past 100. The units that answer *is the tasbih used* are a **completed lap** and a **started session**; both are logged, `Increment` is not.
- **Zakat "every amount entry"** — dispatched from a text field on every character, against a once-per-filled-form signal (`hasLoggedCalculation`) that already exists. The nisab type, breakdown toggle, clear and delete are logged; the digits are not.
- **Compass accuracy (§6)** — `SensorManager` re-delivers the same accuracy every reading, so this fires on **transitions** only.

## Instrumenting dead code failed the ratchet — and that is the finding

Adding analytics to `QuranEvent.MarkAyahsReadForKhatam`, `QuranEvent.UnmarkAyahReadForKhatam` and `ZakatEvent.Calculate` made `AnalyticsReachabilityTest` fail: **none of the three has a producer in any screen.** They were invisible to the ratchet while they logged nothing. All three are superseded by a wired sibling — `ToggleKhatamAyah` calls the same two use cases, and the zakat screen recalculates through `recalculate()` on every entry — so they are deleted along with two private handlers left with no caller.

The order matters and is worth stating: **instrument, check reachability, then keep the instrumentation.** Instrumenting first would have shipped three more metrics reading zero for ever.

The test's flat 220-character scan window also proved imprecise: it cut only on `\n            is `, so a branch whose successor was `Xxx.Name ->` inherited that neighbour's logging. `ZakatEvent.SetCurrency` — a `persist { … }` that logs no usage — was reported that way. The window now ends at the next branch of **either** shape. Strictly more precise: nothing that genuinely logs stops being seen.

`ZakatEvent.SetCurrency` is separately unreachable and is logged as an open checklist item, not fixed here: the calculator formats every figure with `state.currency` and offers no way to change it, so a user outside the default reads someone else's symbol on their own zakat. Wire-or-delete is a product call, like #357's eight.

## What changed

**§4 — the right helper.** `logPrayerTracked` is documented as "the app's core engagement signal" and had **no caller anywhere**; all three tracking sites now call it, after the write and past their guards, so a tap on Sunrise or a future day is not counted. Dua sort → `settingChanged`. Catalogue search and topic search → `search`, post-debounce, with the trimmed length.

**§5 — settings, from a table.** `SettingsTelemetry.asSettingChange` maps every settings-shaped event to its name and value, exhaustively over `SettingsEvent`, so a new event cannot compile without a decision. The 15 names already reaching dashboards are pinned byte-for-byte (`pre_reminder_enabled`, not the tidier `show_reminder_before` — a renamed setting reads as one nobody changes any more). **A location event reports that the set changed and never the place name or its coordinates.** The three destructive actions are instrumented: a wipe is either tidying up or an uninstall, and those look nothing alike in context.

Also instrumented: Quran khatam marking (the core engagement loop, entirely unlogged while `toggle_bookmark` was counted), juz/page opens, favourites, tabs, surah info; sync outcomes and cancellation reason; Tafseer swipe/page/highlight/note edit; Qaida lesson advancement; bookmarks dismiss-undo; monthly day expand; global-search filter/clear/recents; Ask clear and select-recent.

**§6.** `CrashReporter.setCustomKey` was used **nowhere** in the ViewModel layer. `PrayerTimesViewModel` now pins the calculation method, school, high-latitude rule and a latitude **rounded to a whole degree** — enough to tell a high-latitude failure from an equatorial one, not enough to locate anyone. New `Telemetry.aiAnswered(proofCount, durationMs, confidence)`: the proof count is the silent-degradation signal, because an answer whose citations resolve to nothing still renders as a working answer.

Ten ViewModels moved off direct `AppAnalytics`/`CrashReporter` calls onto the seam (13 files → 7). The rest are helpers with no `Telemetry` surface yet (announcements, user properties, onboarding step) and belong with §1/§3.

## Gates

```
./gradlew :app:compileDebugKotlin -x :app:fetchNimazData      PASS
./gradlew :app:testDebugUnitTest  -x :app:fetchNimazData      1573 tests, 1 failed
python3 scripts/check_docs.py                                 23/23
node scripts/check_mermaid.mjs                                14/14
```

1,561 → 1,573 tests (12 new). The single failure is `DeviceStateCorpusTest`, which needs the content artifact from a private repo this environment cannot reach — confirmed identical on the base branch in the previous layer (same `RuntimeException` → `FileNotFoundException` at line 123).

## Tested and not tested

**Pinned by `RecordingTelemetry`:** the catalogue debounce (one event for a seven-character query typed character by character), the trimmed length, silence on clear, no duplicate for a repeated query, and that filtering still happens synchronously before any event; the settings table's fifteen legacy names, the per-prayer adjustment key, the null-reciter fallback, and that no location event carries the place name or coordinates.

**Not tested:** the three `prayerTracked` call sites, the sync outcomes, the Qibla accuracy transitions and the `customKey` pins. Those ViewModels take a `Context`, a `SensorManager` or a `PrayerTimeCalculator` and are among the six remaining zero-test ViewModels — #360's context extraction is what unblocks them, and it is the next item in the plan. Stated rather than glossed.

## Docs

`SUBSYSTEMS.md` §9's instrumentation conventions rewritten around `telemetry.*`: use the purpose-built helper rather than the generic one, log at the right rate (post-debounce, on transition, or at the unit of meaning), and report settings from the table. `CLEAN_ARCHITECTURE_CHECKLIST.md` AP-7.11 records the three deleted events and the order-of-operations lesson; AP-12 gains `ZakatEvent.SetCurrency` as open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnNoZrzuGWfn1VnyPDjKfn)_