### PR TITLE
Prayer times, notifications and settings — the eight of #362 that were still real

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -88,6 +89,7 @@ import com.arshadshah.nimaz.presentation.theme.NimazCornerRadius
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
 import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesUiState
 import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesViewModel
 import java.time.LocalDate
 import java.time.YearMonth
@@ -104,6 +106,9 @@ fun MonthlyPrayerTimesScreen(
     // Captured from the composition so the (non-composable) PDF export can honour the preference.
     val use24HourForExport = LocalUse24HourFormat.current
     var exportMenuExpanded by remember { mutableStateOf(false) }
+    // Resolved in composition because the PDF export is not a composable and cannot read
+    // resources; the ViewModel deliberately does not hardcode a city name.
+    val pdfLocationName = locationLabel(state)
     val canExport = !state.isLoading && state.dayPrayerTimes.isNotEmpty()
 
     fun shareRows(rows: List<DayPrayerTimes>) {
@@ -120,7 +125,7 @@ fun MonthlyPrayerTimesScreen(
             }
             val file = PrayerTimesPdfExporter.export(
                 context = context,
-                locationName = state.locationName,
+                locationName = pdfLocationName,
                 methodLabel = state.methodLabel,
                 rows = pdfRows,
                 latitude = state.latitude,
@@ -132,6 +137,15 @@ fun MonthlyPrayerTimesScreen(
                 mimeType = "application/pdf",
             )
         }.onFailure { CrashReporter.recordException(it) }
+    }
+
+    // The Ramadan timetable is computed off the main thread and lands in state; take it, share
+    // it, and tell the ViewModel it is consumed so a recomposition cannot fire the sheet twice.
+    LaunchedEffect(state.ramadanExport) {
+        state.ramadanExport?.let { rows ->
+            shareRows(rows)
+            viewModel.onEvent(MonthlyPrayerTimesEvent.RamadanExportConsumed)
+        }
     }
 
     NimazScreenScaffold(
@@ -153,7 +167,7 @@ fun MonthlyPrayerTimesScreen(
                     ) {
                         NimazDropdownRow(
                             text = stringResource(R.string.monthly_this_month),
-                            description = "${state.currentMonth.formatMonthYear()} · ${
+                            description = "${state.currentMonth?.formatMonthYear().orEmpty()} · ${
                                 pluralStringResource(
                                     R.plurals.days_count_format,
                                     state.dayPrayerTimes.size,
@@ -173,7 +187,9 @@ fun MonthlyPrayerTimesScreen(
                                 leadingIcon = Icons.Default.DarkMode,
                                 onClick = {
                                     exportMenuExpanded = false
-                                    shareRows(viewModel.ramadanDays())
+                                    viewModel.onEvent(
+                                        MonthlyPrayerTimesEvent.PrepareRamadanExport
+                                    )
                                 },
                             )
                         }
@@ -189,9 +205,9 @@ fun MonthlyPrayerTimesScreen(
         ) {
             // Pinned month-navigation header — stays put while the list scrolls.
             MonthNavigationHeader(
-                monthYear = state.currentMonth.formatMonthYear(),
-                hijriLabel = hijriRangeLabel(state.currentMonth),
-                locationName = state.locationName,
+                monthYear = state.currentMonth?.formatMonthYear().orEmpty(),
+                hijriLabel = state.currentMonth?.let { hijriRangeLabel(it) }.orEmpty(),
+                locationName = locationLabel(state),
                 isRamadan = state.ramadanHijriYear != null,
                 onPrevious = { viewModel.onEvent(MonthlyPrayerTimesEvent.PreviousMonth) },
                 onNext = { viewModel.onEvent(MonthlyPrayerTimesEvent.NextMonth) }
@@ -804,3 +820,19 @@ private fun previewInstant(hour: Int, minute: Int): kotlin.time.Instant =
         java.time.LocalDate.now().atTime(hour, minute)
             .atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli()
     )
+
+/**
+ * What to call the place the timetable was computed for.
+ *
+ * The ViewModel used to write `if (name.isNotBlank()) name else "Dublin, Ireland"` — a hardcoded
+ * English string, chosen independently of the coordinates `resolveLocation` had already picked. A
+ * user with coordinates set and a blank display name got a correct timetable under a foreign
+ * city's name. The state now carries the resolved name and whether it is the app's fallback, and
+ * the copy is decided here, in the layer that can read resources.
+ */
+@Composable
+private fun locationLabel(state: MonthlyPrayerTimesUiState): String = when {
+    state.isUsingFallbackLocation -> stringResource(R.string.location_using_default)
+    !state.locationName.isNullOrBlank() -> state.locationName
+    else -> stringResource(R.string.location_not_set)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
@@ -109,7 +109,11 @@ private data class PrayerSky(
 )
 
 @Composable
-private fun rememberPrayerSky(state: PrayerTimesUiState, today: java.time.LocalDate): PrayerSky {
+private fun rememberPrayerSky(
+    state: PrayerTimesUiState,
+    today: java.time.LocalDate,
+    selectedDate: java.time.LocalDate,
+): PrayerSky {
     val now by rememberNow(TickResolution.MINUTES)
     val prayers = remember(state.prayers, now) { state.prayers.withClockState(now) }
     val next = prayers.firstOrNull { it.isNext }
@@ -124,7 +128,8 @@ private fun rememberPrayerSky(state: PrayerTimesUiState, today: java.time.LocalD
     }
     val timeOfDay = (nowLocal.hour * 60 + nowLocal.minute) / 1440f
 
-    val timeLabel = if (state.isToday) clockTimeText(now) else state.selectedDate.formatWeekdayDayMonth()
+    val timeLabel =
+        if (state.isToday) clockTimeText(now) else selectedDate.formatWeekdayDayMonth()
     val statusLabel = if (state.isToday && nextAt != null) {
         val parts by rememberCountdownTo(nextAt)
         stringResource(
@@ -135,7 +140,7 @@ private fun rememberPrayerSky(state: PrayerTimesUiState, today: java.time.LocalD
     } else if (state.isToday) {
         nextName
     } else {
-        "${daysFromToday(state.selectedDate, today)} · " +
+        "${daysFromToday(selectedDate, today)} · " +
             "${state.sunriseAt?.let { clockTimeText(it) } ?: "--:--"} — " +
             "${state.sunsetAt?.let { clockTimeText(it) } ?: "--:--"}"
     }
@@ -156,8 +161,12 @@ fun PrayerTimesScreen(
     viewModel: PrayerTimesViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val today = remember { LocalDate.now() }
-    val sky = rememberPrayerSky(state, today)
+    // Both follow the ViewModel rather than a `remember { LocalDate.now() }`, which froze at
+    // whatever day the screen was opened — so across midnight "today" stayed yesterday and the
+    // "Today" chip, which renders only `if (!state.isToday)`, never appeared to offer a way back.
+    val today = state.selectedDate.takeIf { state.isToday } ?: LocalDate.now()
+    val selectedDate = state.selectedDate ?: today
+    val sky = rememberPrayerSky(state, today, selectedDate)
     var showMonthSheet by remember { mutableStateOf(false) }
 
     // Edge-to-edge: the living sky reaches the very top, behind the status bar,
@@ -233,7 +242,7 @@ fun PrayerTimesScreen(
             elevation = 4.dp,
         ) {
             DayNavBar(
-                selectedDate = state.selectedDate,
+                selectedDate = selectedDate,
                 isToday = state.isToday,
                 onPrev = { viewModel.onEvent(PrayerTimesEvent.PreviousDay) },
                 onNext = { viewModel.onEvent(PrayerTimesEvent.NextDay) },
@@ -262,7 +271,7 @@ fun PrayerTimesScreen(
                 },
         ) {
             AnimatedContent(
-                targetState = state.selectedDate,
+                targetState = selectedDate,
                 transitionSpec = {
                     val dir = if (targetState.isAfter(initialState)) 1 else -1
                     (slideInHorizontally(tween(260)) { w -> dir * w } + fadeIn(tween(260))) togetherWith

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
@@ -36,6 +36,7 @@ import com.arshadshah.nimaz.core.navigation.DUA_CATEGORY_WITR_AND_NIGHT_PRAYER
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazClockText
@@ -128,7 +129,13 @@ fun NightWorshipContent(
         ) {
             Spacer(Modifier.height(4.dp))
 
-            NightWindowCard(lastThirdAt = state.lastThirdAt, fajrAt = state.fajrAt)
+            NightWindowCard(
+                lastThirdAt = state.lastThirdAt,
+                fajrAt = state.fajrAt,
+                isLoading = state.isLoading,
+                hasError = state.error != null,
+                onRetry = { onEvent(NightWorshipEvent.Refresh) },
+            )
 
             RakahCounterCard(
                 count = state.rakahCount,
@@ -176,8 +183,23 @@ fun NightWorshipContent(
 /** Where "now" sits relative to tonight's window. */
 private enum class NightWindow { BEFORE, OPEN, CLOSED }
 
+/**
+ * [isLoading] and [hasError] were both on the state and **neither was read**.
+ *
+ * The card renders "Set your location to see tonight's times" whenever the instants are null, so
+ * for the length of a settings read plus three astronomical passes every cold open showed that
+ * copy and then snapped to real times — a user-visible defect caused purely by an unread field.
+ * And because a genuine failure produced the same null instants, it was indistinguishable from
+ * loading, with no way to retry: `NightWorshipEvent.Refresh` existed and no screen emitted it.
+ */
 @Composable
-private fun NightWindowCard(lastThirdAt: Instant?, fajrAt: Instant?) {
+private fun NightWindowCard(
+    lastThirdAt: Instant?,
+    fajrAt: Instant?,
+    isLoading: Boolean,
+    hasError: Boolean,
+    onRetry: () -> Unit,
+) {
     NimazCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -193,12 +215,29 @@ private fun NightWindowCard(lastThirdAt: Instant?, fajrAt: Instant?) {
             )
             Spacer(Modifier.height(8.dp))
 
+            if (isLoading && lastThirdAt == null) {
+                NimazLoadingState(modifier = Modifier.fillMaxWidth())
+                return@Column
+            }
+
             if (lastThirdAt == null || fajrAt == null) {
                 Text(
-                    text = stringResource(R.string.night_worship_times_unavailable),
+                    text = stringResource(
+                        if (hasError) R.string.night_worship_times_failed
+                        else R.string.night_worship_times_unavailable
+                    ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (hasError) {
+                    Spacer(Modifier.height(12.dp))
+                    NimazButton(
+                        text = stringResource(R.string.try_again),
+                        onClick = onRetry,
+                        variant = NimazButtonVariant.OUTLINED,
+                        size = NimazButtonSize.SMALL,
+                    )
+                }
                 return@Column
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesEvent.kt
@@ -6,4 +6,10 @@ sealed interface MonthlyPrayerTimesEvent {
     data object NextMonth : MonthlyPrayerTimesEvent
     data object PreviousMonth : MonthlyPrayerTimesEvent
     data class ToggleDayExpanded(val date: LocalDate) : MonthlyPrayerTimesEvent
+
+    /** Compute the Ramadan timetable for sharing. The result lands in `ramadanExport`. */
+    data object PrepareRamadanExport : MonthlyPrayerTimesEvent
+
+    /** The share sheet has consumed `ramadanExport`; clear it so it cannot fire twice. */
+    data object RamadanExportConsumed : MonthlyPrayerTimesEvent
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesUiState.kt
@@ -4,14 +4,36 @@ import java.time.LocalDate
 import java.time.YearMonth
 import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 
+/**
+ * [currentMonth] and [expandedDay] are **not** defaulted to `now()`.
+ *
+ * They were, and a data-class default is evaluated when the instance is constructed — which for a
+ * ViewModel's initial state is once, at `init`. After a month boundary `currentMonth` was still
+ * the previous month until the user tapped, and `expandedDay` highlighted a row in the wrong
+ * month. It also made the state class untestable without freezing the system clock, because
+ * merely constructing it read the wall clock.
+ *
+ * The ViewModel sets both from `TodayProvider`, which also tells it when the day changes.
+ *
+ * [locationName] is null until a location resolves, and [isUsingFallbackLocation] says whether
+ * the coordinates behind the timetable are the user's or the app's default. The screen turns
+ * those two into copy; the ViewModel does not hardcode a city.
+ */
 data class MonthlyPrayerTimesUiState(
-    val currentMonth: YearMonth = YearMonth.now(),
+    val currentMonth: YearMonth? = null,
     val dayPrayerTimes: List<DayPrayerTimes> = emptyList(),
-    val locationName: String = "Location not set",
+    val locationName: String? = null,
+    val isUsingFallbackLocation: Boolean = false,
     val methodLabel: String = "",
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
     val ramadanHijriYear: Int? = null,
     val isLoading: Boolean = true,
-    val expandedDay: LocalDate? = LocalDate.now()
+    val expandedDay: LocalDate? = null,
+    /**
+     * The Ramadan timetable, once computed, waiting for the share sheet to take it. Null both
+     * before it is asked for and after it has been consumed — a one-shot in state rather than a
+     * ViewModel method the screen calls for a value.
+     */
+    val ramadanExport: List<DayPrayerTimes>? = null,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModel.kt
@@ -2,6 +2,8 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.di.DefaultDispatcher
+import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
@@ -17,13 +19,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
-import kotlinx.datetime.toLocalDateTime
 import com.arshadshah.nimaz.domain.model.DayPrayerTimes
 
 @HiltViewModel
 class MonthlyPrayerTimesViewModel @Inject constructor(
     private val prayerUseCases: PrayerUseCases,
+    private val todayProvider: TodayProvider,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     private val telemetry: Telemetry,
 ) : ViewModel() {
 
@@ -33,25 +39,69 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
     /** The user's calculation settings, mirrored so a month can be built without suspending. */
     private var settings: PrayerCalculationSettings? = null
 
+    /** The in-flight month build, cancelled and replaced so a fast pager cannot stack them. */
+    private var monthJob: Job? = null
+
     // No `use24HourFormat` mirror: the month table formats its times at the leaf.
 
     init {
+        observeToday()
         observeSettings()
+    }
+
+    /**
+     * Anchor the grid to the current month, and re-anchor when the day rolls over.
+     *
+     * `currentMonth` and `expandedDay` were data-class defaults reading `YearMonth.now()` /
+     * `LocalDate.now()`, evaluated once when the state was constructed — so a screen left open
+     * across a month boundary went on showing the previous month with no way to know, and
+     * `expandedDay` highlighted a row that no longer meant today.
+     *
+     * The re-anchor only follows the clock while the user is *on* the current month: someone
+     * who has paged forward to Ramadan should not be yanked back at midnight.
+     */
+    private fun observeToday() {
+        viewModelScope.launch {
+            todayProvider.todayChanges.collect { today ->
+                val month = YearMonth.from(today)
+                val wasOnCurrentMonth = _state.value.currentMonth?.let { it == month.minusMonths(1) }
+                    ?: true
+                _state.update {
+                    it.copy(
+                        currentMonth = if (it.currentMonth == null || wasOnCurrentMonth) {
+                            month
+                        } else {
+                            it.currentMonth
+                        },
+                        expandedDay = today,
+                    )
+                }
+                calculateMonth()
+            }
+        }
     }
 
     fun onEvent(event: MonthlyPrayerTimesEvent) {
         when (event) {
             MonthlyPrayerTimesEvent.NextMonth -> {
                 telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "next_month")
-                _state.update { it.copy(currentMonth = it.currentMonth.plusMonths(1)) }
+                _state.update { it.copy(currentMonth = it.currentMonth?.plusMonths(1)) }
                 calculateMonth()
             }
 
             MonthlyPrayerTimesEvent.PreviousMonth -> {
                 telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "previous_month")
-                _state.update { it.copy(currentMonth = it.currentMonth.minusMonths(1)) }
+                _state.update { it.copy(currentMonth = it.currentMonth?.minusMonths(1)) }
                 calculateMonth()
             }
+
+            MonthlyPrayerTimesEvent.PrepareRamadanExport -> {
+                telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "export_ramadan")
+                prepareRamadanExport()
+            }
+
+            MonthlyPrayerTimesEvent.RamadanExportConsumed ->
+                _state.update { it.copy(ramadanExport = null) }
 
             is MonthlyPrayerTimesEvent.ToggleDayExpanded -> {
                 telemetry.featureUsed(AppAnalytics.Feature.PRAYER_TIMES, "toggle_day_expanded")
@@ -78,7 +128,15 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
                 settings = resolved
                 _state.update {
                     it.copy(
-                        locationName = resolved.location.name.ifBlank { DEFAULT_LOCATION_NAME },
+                        // The header names the place the maths used, or says it is a default —
+                        // never a third thing. It used to read `if (name.isNotBlank()) name else
+                        // "Dublin, Ireland"`, a hardcoded English string beside a `resolveLocation`
+                        // that had already decided the coordinates. A user who set coordinates
+                        // manually (lat/lng set, display name blank) got a correct timetable under
+                        // a foreign city's name — and a foreign city above your prayer times is a
+                        // good reason to conclude the times are wrong.
+                        locationName = resolved.location.name.takeIf { name -> name.isNotBlank() },
+                        isUsingFallbackLocation = resolved.location.isFallback,
                         methodLabel = "${resolved.calculationMethod.shortName()} · " +
                                 resolved.asrCalculation.shortName(),
                         latitude = resolved.location.latitude,
@@ -90,33 +148,61 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Build the visible month **off the main thread**.
+     *
+     * This ran with no dispatcher — so on `Main` — and does 28–31 passes of solar geometry for
+     * six prayers each plus 28–31 Hijri conversions, on every settings emission and every month
+     * tap. The injected default dispatcher is where that belongs; the two `_state` writes stay on the
+     * collector's context, which is what `withContext` gives back.
+     */
     private fun calculateMonth() {
-        viewModelScope.launch {
+        val month = _state.value.currentMonth ?: return
+        monthJob?.cancel()
+        monthJob = viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
-            val month = _state.value.currentMonth
-            val days = (1..month.lengthOfMonth()).map { dayTimesFor(month.atDay(it)) }
-            val ramadanYear = days
-                .map { HijriDateCalculator.toHijri(it.date) }
-                .firstOrNull { it.month == 9 }
-                ?.year
+            val (days, ramadanYear) = withContext(defaultDispatcher) {
+                val computed = (1..month.lengthOfMonth()).map { dayTimesFor(month.atDay(it)) }
+                computed to computed
+                    .map { HijriDateCalculator.toHijri(it.date) }
+                    .firstOrNull { it.month == 9 }
+                    ?.year
+            }
             _state.update {
                 it.copy(dayPrayerTimes = days, ramadanHijriYear = ramadanYear, isLoading = false)
             }
         }
     }
 
-    /** Full Hijri Ramadan (day 1 → last) for the Ramadan year currently in view. */
-    fun ramadanDays(): List<DayPrayerTimes> {
-        val year = _state.value.ramadanHijriYear ?: return emptyList()
-        val start = HijriDateCalculator.getFirstDayOfRamadan(year)
-        val end = HijriDateCalculator.getLastDayOfRamadan(year)
-        val out = mutableListOf<DayPrayerTimes>()
-        var date = start
-        while (!date.isAfter(end)) {
-            out.add(dayTimesFor(date))
-            date = date.plusDays(1)
+    /**
+     * Compute the full Hijri Ramadan (day 1 → last) for the year currently in view, and publish
+     * it for the share sheet to pick up.
+     *
+     * This was a **public, synchronous, non-suspending** function computing ~30 more days of
+     * prayer times, called straight from a click handler — so the share button ran a month of
+     * astronomy inside composition's event callback, on the UI thread. On a low-end device that
+     * is a visible freeze and a candidate ANR.
+     *
+     * It is now an event whose result lands in state, which fixes the UDF violation at the same
+     * time: the screen dispatches and renders, rather than calling into the ViewModel for a
+     * value.
+     */
+    private fun prepareRamadanExport() {
+        val year = _state.value.ramadanHijriYear ?: return
+        viewModelScope.launch {
+            val rows = withContext(defaultDispatcher) {
+                val start = HijriDateCalculator.getFirstDayOfRamadan(year)
+                val end = HijriDateCalculator.getLastDayOfRamadan(year)
+                buildList {
+                    var date = start
+                    while (!date.isAfter(end)) {
+                        add(dayTimesFor(date))
+                        date = date.plusDays(1)
+                    }
+                }
+            }
+            _state.update { it.copy(ramadanExport = rows) }
         }
-        return out
     }
 
     private fun dayTimesFor(date: LocalDate): DayPrayerTimes {
@@ -124,17 +210,19 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
             ?.let { prayerUseCases.getDaySchedule(date, it) }
             .orEmpty()
         val timesMap = prayerTimes.associate { it.type to it.time }
-        val tz = kotlinx.datetime.TimeZone.currentSystemDefault()
         fun fmt(type: PrayerType): kotlin.time.Instant? = timesMap[type]
-        // Fasting length (Fajr → Maghrib), computed from the raw times so it is
-        // independent of the display clock format / locale.
-        val fajrLocal = timesMap[PrayerType.FAJR]?.toLocalDateTime(tz)
-        val maghribLocal = timesMap[PrayerType.MAGHRIB]?.toLocalDateTime(tz)
-        val fastMinutes = if (fajrLocal != null && maghribLocal != null) {
-            var mins = (maghribLocal.hour * 60 + maghribLocal.minute) -
-                    (fajrLocal.hour * 60 + fajrLocal.minute)
-            if (mins < 0) mins += 24 * 60
-            mins
+        // Fasting length (Fajr → Maghrib) as **elapsed time**, from the instants themselves.
+        //
+        // It used to convert both to local wall-clock and subtract hour/minute fields, which is
+        // wrong twice. Seconds were discarded — a floor of the difference of two floors, so
+        // 05:00:59 → 20:00:01 reported 900 minutes against a true 899. And wall-clock fields do
+        // not know about DST: a zone whose transition falls between Fajr and Maghrib (Lord Howe
+        // shifts 30 minutes) reported a fast half an hour out. Instants have neither problem,
+        // and the timezone conversion this needed disappears with it.
+        val fajr = timesMap[PrayerType.FAJR]
+        val maghrib = timesMap[PrayerType.MAGHRIB]
+        val fastMinutes = if (fajr != null && maghrib != null) {
+            (maghrib - fajr).inWholeMinutes.toInt()
         } else {
             null
         }
@@ -151,8 +239,4 @@ class MonthlyPrayerTimesViewModel @Inject constructor(
     }
 
 
-    private companion object {
-        /** Shown until the user's location resolves; the same fallback the calculation uses. */
-        const val DEFAULT_LOCATION_NAME = "Dublin, Ireland"
-    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesUiState.kt
@@ -21,7 +21,15 @@ data class PrayerTimesUiState(
      * header must not assert a city they have never been to.
      */
     val isUsingFallbackLocation: Boolean = false,
-    val selectedDate: LocalDate = LocalDate.now(),
+    /**
+     * Null until the ViewModel anchors it, rather than a `LocalDate.now()` data-class default.
+     *
+     * A default is evaluated when the instance is constructed, so it froze at whatever day the
+     * screen was opened and nothing re-evaluated it. The ViewModel sets it from `TodayProvider`
+     * and re-anchors at midnight; making it nullable is what stops the old shape being written
+     * back by habit.
+     */
+    val selectedDate: LocalDate? = null,
     val isToday: Boolean = true,
     val prayers: List<PrayerTimeDisplay> = emptyList(),
     /** Tomorrow's Fajr, so the UI can wrap the countdown once today's Isha has passed. */

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesViewModel.kt
@@ -2,7 +2,9 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.core.di.DefaultDispatcher
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -28,6 +30,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlinx.datetime.TimeZone
@@ -38,6 +43,8 @@ import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
 class PrayerTimesViewModel @Inject constructor(
     private val prayerUseCases: PrayerUseCases,
     private val settingsRepository: SettingsRepository,
+    private val todayProvider: TodayProvider,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     private val telemetry: Telemetry,
 ) : ViewModel() {
 
@@ -52,10 +59,42 @@ class PrayerTimesViewModel @Inject constructor(
     private var statuses: Map<PrayerName, PrayerStatus> = emptyMap()
     private var statusJob: Job? = null
 
+    /** The in-flight day recompute, cancelled and replaced so a fast pager cannot stack them. */
+    private var dayJob: Job? = null
+
+    /** Tomorrow's Fajr for the after-Isha wrap, computed with the day rather than per publish. */
+    private var tomorrowFajr: kotlin.time.Instant? = null
+
     private val tz get() = TimeZone.currentSystemDefault()
 
     init {
+        observeToday()
         observeSettings()
+    }
+
+    /**
+     * Follow the day across midnight — but only while the user is still on today.
+     *
+     * `selectedDate` was captured once, as a data-class default reading `LocalDate.now()`, and
+     * nothing re-evaluated it. Leaving the Prayer Times screen open across 00:00 — a plausible
+     * state for an app whose whole point is Fajr — left it showing yesterday, with
+     * `tomorrowFajrAt` pointing at yesterday's tomorrow. Worse, there was **no way back**: the
+     * "Today" chip only renders `if (!state.isToday)`, and `isToday` kept its last published
+     * value of `true`, so the affordance to return never appeared. `NimazClock`'s shared ticker
+     * drives the leaf UI and never pokes the ViewModel.
+     *
+     * Someone who has paged to another day is left where they are; re-anchoring under them
+     * would be its own bug.
+     */
+    private fun observeToday() {
+        viewModelScope.launch {
+            todayProvider.todayChanges.collect { today ->
+                val selected = _state.value.selectedDate
+                if (selected == null || selected == today.minusDays(1)) {
+                    selectDate(today)
+                }
+            }
+        }
     }
 
     fun onEvent(event: PrayerTimesEvent) {
@@ -87,7 +126,7 @@ class PrayerTimesViewModel @Inject constructor(
     }
 
     private fun changeDay(delta: Long) {
-        val target = _state.value.selectedDate.plusDays(delta)
+        val target = (_state.value.selectedDate ?: todayProvider.today()).plusDays(delta)
         selectDate(target)
     }
 
@@ -124,11 +163,39 @@ class PrayerTimesViewModel @Inject constructor(
     }
 
     /** Recompute the cached prayer instants + day-info for the selected date. */
+    /**
+     * Recompute the cached prayer instants + day-info for the selected date, **off the main
+     * thread**.
+     *
+     * This was called synchronously from the settings `collect` (which runs on
+     * `Dispatchers.Main.immediate`) and from `selectDate`, so a day's solar geometry for six
+     * prayers ran on the UI thread on every settings emission and every date change.
+     */
     private fun recomputeDay() {
         val resolved = settings ?: return
-        val date = _state.value.selectedDate
+        val date = _state.value.selectedDate ?: return
+        dayJob?.cancel()
+        dayJob = viewModelScope.launch {
+            recompute(date, resolved)
+        }
+    }
 
-        dayTimes = prayerUseCases.getDaySchedule(date, resolved)
+    private suspend fun recompute(date: LocalDate, resolved: PrayerCalculationSettings) {
+        val computed = withContext(defaultDispatcher) {
+            val day = prayerUseCases.getDaySchedule(date, resolved)
+            // Tomorrow's Fajr is only needed for today's after-Isha wrap, and it is computed
+            // **here** rather than in `publishDisplays`. It used to run there, which meant a
+            // second full day of astronomy on every publish — including every Room re-emission
+            // of the tracker statuses, so toggling one prayer recomputed a whole day's solar
+            // geometry on the UI thread.
+            val tomorrow = if (date == todayProvider.today()) {
+                prayerUseCases.getDaySchedule(date.plusDays(1), resolved)
+                    .firstOrNull { it.type == PrayerType.FAJR }?.time
+            } else null
+            day to tomorrow
+        }
+        dayTimes = computed.first
+        tomorrowFajr = computed.second
 
         // Day-info: sunrise/sunset/daylight + method label + moon phase.
         val byType = dayTimes.associate { it.type to it.time }
@@ -185,8 +252,8 @@ class PrayerTimesViewModel @Inject constructor(
      */
     private fun publishDisplays() {
         if (dayTimes.isEmpty()) return
-        val date = _state.value.selectedDate
-        val today = LocalDate.now()
+        val date = _state.value.selectedDate ?: return
+        val today = todayProvider.today()
         val isToday = date == today
 
         val displays = dayTimes
@@ -201,12 +268,6 @@ class PrayerTimesViewModel @Inject constructor(
                 )
             }
 
-        // Only today can wrap past Isha, and only today needs tomorrow's Fajr.
-        val tomorrowFajr = settings
-            ?.takeIf { isToday }
-            ?.let { prayerUseCases.getDaySchedule(today.plusDays(1), it) }
-            ?.firstOrNull { it.type == PrayerType.FAJR }?.time
-
         _state.update {
             it.copy(
                 isToday = isToday,
@@ -218,8 +279,8 @@ class PrayerTimesViewModel @Inject constructor(
 
     private fun togglePrayer(type: PrayerType) {
         if (type == PrayerType.SUNRISE) return
-        val date = _state.value.selectedDate
-        if (date.isAfter(LocalDate.now())) return // can't track future prayers
+        val date = _state.value.selectedDate ?: return
+        if (date.isAfter(todayProvider.today())) return // can't track future prayers
         viewModelScope.launch {
             val dateKey = date.toEpochDay() * 86_400_000L
             val name = PrayerName.valueOf(type.name)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsEvent.kt
@@ -14,7 +14,6 @@ sealed interface SettingsEvent {
     data class SetHijriPrimary(val enabled: Boolean) : SettingsEvent
     data class SetHijriDayOffset(val days: Int) : SettingsEvent
     data class Set24HourFormat(val enabled: Boolean) : SettingsEvent
-    data class SetShowSeconds(val enabled: Boolean) : SettingsEvent
     data class SetHapticFeedback(val enabled: Boolean) : SettingsEvent
     data class SetShowIslamicPatterns(val enabled: Boolean) : SettingsEvent
     data class SetPatternStyle(val style: NimazPatternStyle) : SettingsEvent
@@ -26,8 +25,6 @@ sealed interface SettingsEvent {
     data class SetCalculationMethod(val method: CalculationMethod) : SettingsEvent
     data class SetAsrMethod(val method: AsrJuristicMethod) : SettingsEvent
     data class SetHighLatitudeRule(val rule: HighLatitudeRule) : SettingsEvent
-    data class SetFajrAngle(val angle: Double) : SettingsEvent
-    data class SetIshaAngle(val angle: Double) : SettingsEvent
     data class SetPrayerAdjustment(val prayer: String, val minutes: Int) : SettingsEvent
 
     // Notifications
@@ -97,7 +94,6 @@ sealed interface SettingsEvent {
     data class AddLocation(val location: Location) : SettingsEvent
     data class RemoveLocation(val location: Location) : SettingsEvent
     data class ToggleLocationFavorite(val locationId: Long) : SettingsEvent
-    data class SetAutoDetectLocation(val enabled: Boolean) : SettingsEvent
 
     // Actions
     data object ResetToDefaults : SettingsEvent

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetry.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsTelemetry.kt
@@ -28,7 +28,6 @@ internal fun SettingsEvent.asSettingChange(): Pair<String, String>? = when (this
     is SettingsEvent.SetHijriPrimary -> "hijri_primary" to enabled.toString()
     is SettingsEvent.SetHijriDayOffset -> "hijri_day_offset" to days.toString()
     is SettingsEvent.Set24HourFormat -> "24_hour_format" to enabled.toString()
-    is SettingsEvent.SetShowSeconds -> "show_seconds" to enabled.toString()
     is SettingsEvent.SetHapticFeedback -> "haptic_feedback" to enabled.toString()
     is SettingsEvent.SetShowIslamicPatterns -> "show_islamic_patterns" to enabled.toString()
     is SettingsEvent.SetPatternStyle -> "pattern_style" to style.name
@@ -40,8 +39,6 @@ internal fun SettingsEvent.asSettingChange(): Pair<String, String>? = when (this
     is SettingsEvent.SetCalculationMethod -> "calculation_method" to method.name
     is SettingsEvent.SetAsrMethod -> "asr_method" to method.name
     is SettingsEvent.SetHighLatitudeRule -> "high_latitude_rule" to rule.name
-    is SettingsEvent.SetFajrAngle -> "fajr_angle" to angle.toString()
-    is SettingsEvent.SetIshaAngle -> "isha_angle" to angle.toString()
     // Keyed by prayer, because "someone adjusted a prayer by 3 minutes" is not the question —
     // "which prayer, and by how much" is, and a per-prayer key is what makes a systematic
     // offset (everyone nudging Fajr the same way) visible as a shape rather than a mean.
@@ -108,7 +105,6 @@ internal fun SettingsEvent.asSettingChange(): Pair<String, String>? = when (this
     is SettingsEvent.AddLocation -> "saved_locations" to "added"
     is SettingsEvent.RemoveLocation -> "saved_locations" to "removed"
     is SettingsEvent.ToggleLocationFavorite -> "saved_locations" to "favourite_toggled"
-    is SettingsEvent.SetAutoDetectLocation -> "auto_detect_location" to enabled.toString()
 
     // -- Not setting changes ---------------------------------------------------
     SettingsEvent.PreviewAdhanSound,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsUiState.kt
@@ -14,7 +14,6 @@ data class GeneralSettingsUiState(
     val useHijriPrimary: Boolean = false,
     val hijriDayOffset: Int = 0,
     val use24HourFormat: Boolean = false,
-    val showSeconds: Boolean = false,
     val hapticFeedback: Boolean = true,
     val showIslamicPatterns: Boolean = true,
     val patternStyle: NimazPatternStyle = NimazPatternStyle.CORNER_MEDALLION,
@@ -27,8 +26,6 @@ data class PrayerSettingsUiState(
     val calculationMethod: CalculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
     val asrMethod: AsrJuristicMethod = AsrJuristicMethod.STANDARD,
     val highLatitudeRule: HighLatitudeRule = HighLatitudeRule.MIDDLE_OF_THE_NIGHT,
-    val fajrAngle: Double = 18.0,
-    val ishaAngle: Double = 17.0,
     val fajrAdjustment: Int = 0,
     val sunriseAdjustment: Int = 0,
     val dhuhrAdjustment: Int = 0,
@@ -114,6 +111,5 @@ data class LocationSettingsUiState(
     val currentLocation: Location? = null,
     val savedLocations: List<Location> = emptyList(),
     val favoriteLocations: List<Location> = emptyList(),
-    val autoDetectLocation: Boolean = true,
     val isLoading: Boolean = true
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.LocaleHelper
@@ -103,6 +104,7 @@ class SettingsViewModel @Inject constructor(
     private val telemetry: Telemetry,
     val adhanAudioManager: AdhanAudioManager,
     private val userDatabase: NimazUserDatabase,
+    private val todayProvider: TodayProvider,
 ) : ViewModel() {
 
     private val _generalState = MutableStateFlow(GeneralSettingsUiState())
@@ -174,11 +176,22 @@ class SettingsViewModel @Inject constructor(
      * The prayer notification rows show each prayer's time in their header, so the setting
      * reads against the thing it governs rather than as an abstraction.
      */
-    val todayPrayerTimes: StateFlow<PrayerTimes?> = prayerUseCases.getCurrentLocation()
-        .map { location ->
+    /**
+     * Today's times for the notification rows — re-derived when the **day** changes, not only
+     * when the location does.
+     *
+     * `LocalDate.now()` was read inside the `map`, so the date was fixed at whatever it was when
+     * `getCurrentLocation()` last emitted. A settings screen left open across midnight went on
+     * showing yesterday's prayer times next to each notification row. Combining with
+     * `todayChanges` makes the day an input rather than an ambient read.
+     */
+    val todayPrayerTimes: StateFlow<PrayerTimes?> = combine(
+        prayerUseCases.getCurrentLocation(),
+        todayProvider.todayChanges,
+    ) { location, today ->
             location?.let {
                 runCatching {
-                    prayerUseCases.getPrayerTimesForDate(LocalDate.now(), it)
+                    prayerUseCases.getPrayerTimesForDate(today, it)
                 }.getOrNull()
             }
         }
@@ -350,7 +363,6 @@ class SettingsViewModel @Inject constructor(
                 viewModelScope.launch { settingsRepository.setUse24HourFormat(event.enabled) }
             }
 
-            is SettingsEvent.SetShowSeconds -> _generalState.update { it.copy(showSeconds = event.enabled) }
             is SettingsEvent.SetHapticFeedback -> {
                 _generalState.update { it.copy(hapticFeedback = event.enabled) }
                 viewModelScope.launch { settingsRepository.setHapticFeedback(event.enabled) }
@@ -417,16 +429,6 @@ class SettingsViewModel @Inject constructor(
                     settingsRepository.setHighLatitudeRule(event.rule.name)
                     rescheduleNotifications()
                 }
-            }
-
-            is SettingsEvent.SetFajrAngle -> {
-                _prayerState.update { it.copy(fajrAngle = event.angle) }
-                viewModelScope.launch { rescheduleNotifications() }
-            }
-
-            is SettingsEvent.SetIshaAngle -> {
-                _prayerState.update { it.copy(ishaAngle = event.angle) }
-                viewModelScope.launch { rescheduleNotifications() }
             }
 
             is SettingsEvent.SetPrayerAdjustment -> {
@@ -764,12 +766,6 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.AddLocation -> addLocation(event.location)
             is SettingsEvent.RemoveLocation -> removeLocation(event.location)
             is SettingsEvent.ToggleLocationFavorite -> toggleLocationFavorite(event.locationId)
-            is SettingsEvent.SetAutoDetectLocation -> _locationState.update {
-                it.copy(
-                    autoDetectLocation = event.enabled
-                )
-            }
-
             // Actions
             SettingsEvent.ResetToDefaults -> resetToDefaults()
             SettingsEvent.TestNotification -> {
@@ -1075,12 +1071,29 @@ class SettingsViewModel @Inject constructor(
         telemetry.featureUsed(AppAnalytics.Feature.SETTINGS, "reset_to_defaults")
         viewModelScope.launch {
             settingsRepository.clearAllData()
-            _generalState.update { GeneralSettingsUiState() }
-            _prayerState.update { PrayerSettingsUiState() }
-            _notificationState.update { NotificationSettingsUiState() }
-            _quranState.update { QuranSettingsUiState() }
+            resetAllUiState()
             _shouldRestart.value = true
         }
+    }
+
+    /**
+     * Every settings surface back to its defaults, in one place.
+     *
+     * The two reset paths disagreed about what "reset everything" means: `resetToDefaults`
+     * cleared general, prayer, notification and Quran; `deleteAllData` cleared those plus
+     * location; **neither** cleared Dua or Hadith. So after "reset to defaults" the Dua and
+     * Hadith settings screens went on showing pre-reset font sizes. `_shouldRestart` papered
+     * over it — the app restarts and reloads — but two functions that disagree about the same
+     * word are a trap for the next person to add a state holder to only one of them.
+     */
+    private fun resetAllUiState() {
+        _generalState.update { GeneralSettingsUiState() }
+        _prayerState.update { PrayerSettingsUiState() }
+        _notificationState.update { NotificationSettingsUiState() }
+        _quranState.update { QuranSettingsUiState() }
+        _duaState.update { DuaSettingsUiState() }
+        _hadithState.update { HadithSettingsUiState() }
+        _locationState.update { LocationSettingsUiState() }
     }
 
     private fun deleteAllData() {
@@ -1109,11 +1122,7 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.clearAllData()
 
             // Reset UI state to defaults
-            _generalState.update { GeneralSettingsUiState() }
-            _prayerState.update { PrayerSettingsUiState() }
-            _notificationState.update { NotificationSettingsUiState() }
-            _quranState.update { QuranSettingsUiState() }
-            _locationState.update { LocationSettingsUiState() }
+            resetAllUiState()
             _shouldRestart.value = true
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipUiState.kt
@@ -15,7 +15,11 @@ import kotlin.time.Instant
  * @param lastThirdAt when the last third of the *live* night begins (adhan2 `SunnahTimes`).
  * @param fajrAt the Fajr that closes the live night — the morning after it began, which is *today's*
  *   Fajr in the pre-dawn hours and *tomorrow's* once today's Fajr has passed.
- * @param ishaAt the live night's Isha, the earliest sensible start for Witr.
+ *
+ * `ishaAt` was here too, populated by a **third full astronomical pass** whose result nothing
+ * read. Its KDoc described it as "the earliest sensible start for Witr" — a feature that was
+ * never built. The field and the pass are gone; if Witr guidance is wanted later, the pass costs
+ * nothing to add back next to the two that are used.
  * @param rakahCount in-memory tally for the current visit. Not persisted: we have no data on how
  *   people actually use this yet, and inventing a "completed night" model before that would be
  *   guessing. If the count turns out to be worth keeping, that is an easy follow-up.
@@ -24,7 +28,6 @@ data class NightWorshipUiState(
     val isLoading: Boolean = true,
     val lastThirdAt: Instant? = null,
     val fajrAt: Instant? = null,
-    val ishaAt: Instant? = null,
     val rakahCount: Int = 0,
     val error: String? = null,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
@@ -4,6 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.arshadshah.nimaz.core.di.DefaultDispatcher
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.domain.model.PrayerCalculationSettings
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.withContext
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -21,14 +28,26 @@ import kotlin.time.Instant
 @HiltViewModel
 class NightWorshipViewModel @Inject constructor(
     private val prayerUseCases: PrayerUseCases,
+    private val todayProvider: TodayProvider,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     private val telemetry: Telemetry,
 ) : ViewModel() {
+
+    private fun refresh() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+            computeNightTimes(
+                prayerUseCases.observeCalculationSettings().first(),
+                todayProvider.today(),
+            )
+        }
+    }
 
     private val _state = MutableStateFlow(NightWorshipUiState())
     val state: StateFlow<NightWorshipUiState> = _state.asStateFlow()
 
     init {
-        loadNightTimes()
+        observeNightTimes()
     }
 
     fun onEvent(event: NightWorshipEvent) {
@@ -47,7 +66,10 @@ class NightWorshipViewModel @Inject constructor(
                 _state.update { it.copy(rakahCount = 0) }
             }
 
-            NightWorshipEvent.Refresh -> loadNightTimes()
+            // Still handled, and now genuinely a refresh rather than the only way to get
+            // current data: the settings and the day are observed, so this is the manual retry
+            // the error state offers.
+            NightWorshipEvent.Refresh -> refresh()
         }
     }
 
@@ -70,48 +92,90 @@ class NightWorshipViewModel @Inject constructor(
      * the last third from that date and the closing Fajr from the morning after it.
      * The calculation behind these is Android-free and pure, so each date is one cheap pass.
      */
-    private fun loadNightTimes() {
+    /**
+     * Recompute the live night whenever its inputs change: the user's calculation settings, and
+     * the day itself.
+     *
+     * This ran once from `init` and read every setting with `.first()` — a one-shot snapshot.
+     * `NightWorshipEvent.Refresh` existed and **no screen emitted it**, so:
+     *
+     *  - changing the calculation method or moving location left the card on the old city's
+     *    times, because the ViewModel instance survives on the same back-stack entry and `init`
+     *    does not run again;
+     *  - keeping the app open past Fajr left the window on `CLOSED` for ever, with nothing able
+     *    to advance it to the next night.
+     *
+     * `ARCHITECTURE.md` records this exact class of defect as resolved for `SettingsViewModel`,
+     * and the documented fix there is the one applied here: **collect**, do not `.first()`.
+     */
+    private fun observeNightTimes() {
         viewModelScope.launch {
-            runCatching {
-                // One settings read for the whole derivation. Read piecemeal before, and without
-                // the per-prayer adjustments at all — so a user who had nudged Fajr saw the night
-                // window close at an unadjusted Fajr while every other screen used the adjusted
-                // one. The snapshot carries all six adjustments, so that divergence is gone.
-                val settings = prayerUseCases.observeCalculationSettings().first()
+            combine(
+                prayerUseCases.observeCalculationSettings(),
+                todayProvider.todayChanges,
+            ) { settings, today -> settings to today }
+                .collectLatest { (settings, today) -> computeNightTimes(settings, today) }
+        }
+    }
 
-                val today = LocalDate.now()
+    /**
+     * Resolve the night window that is *live right now*.
+     *
+     * The last third of the night straddles midnight: the Sunnah times for a given date measure
+     * from that date's Maghrib to the *next* morning's Fajr, so its last-third instant lands in
+     * the small hours of the following calendar day. That makes "which date owns the current
+     * night" depend on the time of day:
+     *
+     *  - **Before today's Fajr** you are still inside the night that began *yesterday*. Its last
+     *    third is happening *this* morning, and it closes at *today's* Fajr. Anchoring on `today`
+     *    here — as the original code did — pointed the whole card at *tomorrow* night, so at
+     *    12:47am the open window read "opens in 23h". That was the reported time bug.
+     *  - **After today's Fajr** tonight's window is the next one: it begins this evening and its
+     *    last third lands tomorrow morning, closing at tomorrow's Fajr.
+     *
+     * The calculation behind these is Android-free and pure, so each date is one cheap pass — but
+     * three of them plus a settings read is still not main-thread work, hence the injected default dispatcher.
+     */
+    private suspend fun computeNightTimes(
+        settings: PrayerCalculationSettings,
+        today: LocalDate,
+    ) {
+        runCatching {
+            withContext(defaultDispatcher) {
                 val now = Clock.System.now()
 
                 fun prayerOn(date: LocalDate, type: PrayerType): Instant? =
                     prayerUseCases.getDaySchedule(date, settings).find { it.type == type }?.time
 
                 val fajrToday = prayerOn(today, PrayerType.FAJR)
-                // Pre-dawn (before today's Fajr) → the live night began yesterday; otherwise it is
-                // tonight's, still to come. This is the fix for the after-midnight "opens in 23h" bug.
-                val nightStart = if (fajrToday != null && now < fajrToday) today.minusDays(1) else today
+                // Pre-dawn (before today's Fajr) → the live night began yesterday; otherwise it
+                // is tonight's, still to come. This is the fix for the after-midnight
+                // "opens in 23h" bug.
+                val nightStart =
+                    if (fajrToday != null && now < fajrToday) today.minusDays(1) else today
 
                 val sunnah = prayerUseCases.getSunnahNightTimes(nightStart, settings)
                 // Close the window at the Fajr that *ends* this night — the morning after it starts.
-                val fajr = if (nightStart == today) prayerOn(today.plusDays(1), PrayerType.FAJR) else fajrToday
-                val isha = prayerOn(nightStart, PrayerType.ISHA)
+                val fajr =
+                    if (nightStart == today) prayerOn(today.plusDays(1), PrayerType.FAJR)
+                    else fajrToday
 
-                Triple(sunnah.lastThirdOfTheNight, fajr, isha)
-            }.onSuccess { (lastThird, fajr, isha) ->
-                _state.update {
-                    it.copy(
-                        isLoading = false,
-                        lastThirdAt = lastThird,
-                        fajrAt = fajr,
-                        ishaAt = isha,
-                        error = null,
-                    )
-                }
-            }.onFailure { e ->
-                // `failure`, not a bare `recordException`: the stack trace reached Crashlytics
-                // and the frequency reached nothing, so how often this fails was not visible.
-                telemetry.failure(AppAnalytics.Feature.NIGHT_WORSHIP, "load", e)
-                _state.update { it.copy(isLoading = false, error = e.message) }
+                sunnah.lastThirdOfTheNight to fajr
             }
+        }.onSuccess { (lastThird, fajr) ->
+            _state.update {
+                it.copy(
+                    isLoading = false,
+                    lastThirdAt = lastThird,
+                    fajrAt = fajr,
+                    error = null,
+                )
+            }
+        }.onFailure { e ->
+            // `failure`, not a bare `recordException`: the stack trace reached Crashlytics
+            // and the frequency reached nothing, so how often this fails was not visible.
+            telemetry.failure(AppAnalytics.Feature.NIGHT_WORSHIP, "load", e)
+            _state.update { it.copy(isLoading = false, error = e.message) }
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1705,6 +1705,7 @@
     <string name="night_worship_opens_in">Beginnt in</string>
     <string name="night_worship_closed">Das Zeitfenster heute Nacht ist vorbei</string>
     <string name="night_worship_times_unavailable">Lege deinen Standort fest, um die Zeiten zu sehen</string>
+    <string name="night_worship_times_failed">Die Zeiten für heute Nacht konnten nicht ermittelt werden.</string>
     <string name="night_worship_rakah_title">Gebetene Rakat</string>
     <string name="night_worship_rakah_body">Das Nachtgebet wird paarweise verrichtet</string>
     <string name="night_worship_add_pair">+2 Rakat</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1740,6 +1740,7 @@
     <string name="night_worship_opens_in">Commence dans</string>
     <string name="night_worship_closed">La fenêtre de cette nuit est passée</string>
     <string name="night_worship_times_unavailable">Définissez votre position pour voir les horaires</string>
+    <string name="night_worship_times_failed">Les horaires de cette nuit n\'ont pas pu être calculés.</string>
     <string name="night_worship_rakah_title">Rakats accomplies</string>
     <string name="night_worship_rakah_body">La prière de nuit se fait deux par deux</string>
     <string name="night_worship_add_pair">+2 rakats</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1675,6 +1675,7 @@
     <string name="night_worship_opens_in">Dimulai dalam</string>
     <string name="night_worship_closed">Waktu malam ini telah berlalu</string>
     <string name="night_worship_times_unavailable">Atur lokasi Anda untuk melihat waktunya</string>
+    <string name="night_worship_times_failed">Waktu malam ini tidak dapat dihitung.</string>
     <string name="night_worship_rakah_title">Rakaat dikerjakan</string>
     <string name="night_worship_rakah_body">Salat malam dikerjakan dua rakaat sekali salam</string>
     <string name="night_worship_add_pair">+2 rakaat</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1676,6 +1676,7 @@
     <string name="night_worship_opens_in">Bermula dalam</string>
     <string name="night_worship_closed">Tempoh malam ini telah berlalu</string>
     <string name="night_worship_times_unavailable">Tetapkan lokasi anda untuk melihat waktunya</string>
+    <string name="night_worship_times_failed">Waktu malam ini tidak dapat ditentukan.</string>
     <string name="night_worship_rakah_title">Rakaat didirikan</string>
     <string name="night_worship_rakah_body">Solat malam didirikan dua rakaat satu salam</string>
     <string name="night_worship_add_pair">+2 rakaat</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1711,6 +1711,7 @@
     <string name="night_worship_opens_in">Başlamasına</string>
     <string name="night_worship_closed">Bu gecenin vakti geçti</string>
     <string name="night_worship_times_unavailable">Vakitleri görmek için konumunuzu ayarlayın</string>
+    <string name="night_worship_times_failed">Bu gecenin vakitleri hesaplanamadı.</string>
     <string name="night_worship_rakah_title">Kılınan rekât</string>
     <string name="night_worship_rakah_body">Gece namazı ikişer rekât kılınır</string>
     <string name="night_worship_add_pair">+2 rekât</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1930,6 +1930,7 @@
     <string name="night_worship_opens_in">Opens in</string>
     <string name="night_worship_closed">Tonight\'s window has passed</string>
     <string name="night_worship_times_unavailable">Set your location to see tonight\'s times</string>
+    <string name="night_worship_times_failed">Tonight\'s times could not be worked out.</string>
     <string name="night_worship_rakah_title">Rakahs prayed</string>
     <string name="night_worship_rakah_body">Night prayer is offered two by two</string>
     <string name="night_worship_add_pair">+2 rakah</string>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerCalculationFakes.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/PrayerCalculationFakes.kt
@@ -5,6 +5,7 @@ import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.PrayerCalculationSettings
+import com.arshadshah.nimaz.domain.model.PrayerRecord
 import com.arshadshah.nimaz.domain.model.PrayerTime
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.model.ResolvedLocation
@@ -92,6 +93,14 @@ class FakePrayerTimetableRepository(
 
     override suspend fun getSunnahNightTimes(date: LocalDate): SunnahNightTimes =
         getSunnahNightTimes(date, settingsFlow.value)
+
+    /**
+     * A day with nothing tracked. `PrayerTimesViewModel` collects this to decorate each row with
+     * its status, so it has to answer — but "which prayers were marked" is not what this double
+     * is about, and a test that cares should use a real repository mock.
+     */
+    override fun getPrayerRecordsForDate(date: Long): Flow<List<PrayerRecord>> =
+        MutableStateFlow(emptyList())
 }
 
 /** Delegation target: every member fails, so only the overridden ones are usable. */

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/FastLengthTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/FastLengthTest.kt
@@ -1,0 +1,79 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.junit.Test
+import kotlin.time.Instant
+
+/**
+ * The fast length is **elapsed time between two instants**, not the difference of two wall clocks.
+ *
+ * The month table computed it as
+ * `(maghrib.hour*60 + maghrib.minute) - (fajr.hour*60 + fajr.minute)`, which is wrong twice: it
+ * floors both operands before subtracting, so seconds vanish; and wall-clock fields do not know
+ * about a DST transition falling between the two.
+ *
+ * This suite is arithmetic over `Instant`, so it needs none of the app — which is the point. The
+ * old form could not be tested at this level at all, because it needed a `LocalDateTime` and
+ * therefore a timezone, and the timezone was the bug.
+ */
+class FastLengthTest {
+
+    /** What the ViewModel now does. */
+    private fun fastMinutes(fajr: Instant, maghrib: Instant): Int =
+        (maghrib - fajr).inWholeMinutes.toInt()
+
+    /** What it used to do, kept here so the difference is demonstrable rather than asserted. */
+    private fun legacyFastMinutes(fajr: Instant, maghrib: Instant, zone: TimeZone): Int {
+        val f = fajr.toLocalDateTime(zone)
+        val m = maghrib.toLocalDateTime(zone)
+        var mins = (m.hour * 60 + m.minute) - (f.hour * 60 + f.minute)
+        if (mins < 0) mins += 24 * 60
+        return mins
+    }
+
+    /**
+     * The issue's own example: Fajr 05:00:59, Maghrib 20:00:01. True elapsed is 899 minutes and
+     * 2 seconds, so a whole-minute answer is 899. The old form reported 900 — it floored 05:00:59
+     * to 05:00 and 20:00:01 to 20:00 and subtracted those.
+     */
+    @Test
+    fun `seconds are not discarded on both sides before subtracting`() {
+        val fajr = Instant.parse("2026-03-14T05:00:59Z")
+        val maghrib = Instant.parse("2026-03-14T20:00:01Z")
+
+        assertThat(fastMinutes(fajr, maghrib)).isEqualTo(899)
+        assertThat(legacyFastMinutes(fajr, maghrib, TimeZone.UTC)).isEqualTo(900)
+    }
+
+    /**
+     * A DST transition between Fajr and Maghrib.
+     *
+     * London springs forward at 01:00 UTC on 29 March 2026, so a fast that starts before it and
+     * ends after it spans one hour less wall-clock than elapsed time. Reading hour/minute fields
+     * reports the wall-clock difference; the instants report the truth.
+     */
+    @Test
+    fun `a DST transition between fajr and maghrib does not change the fast length`() {
+        val london = TimeZone.of("Europe/London")
+        val fajr = Instant.parse("2026-03-29T00:30:00Z")
+        val maghrib = Instant.parse("2026-03-29T18:30:00Z")
+
+        // 18 hours of real elapsed time, whatever the clocks did in between.
+        assertThat(fastMinutes(fajr, maghrib)).isEqualTo(18 * 60)
+        // The old form sees 01:30 → 19:30 local and reports an hour more.
+        assertThat(legacyFastMinutes(fajr, maghrib, london)).isEqualTo(18 * 60 + 60)
+    }
+
+    /** An ordinary day is unchanged — the fix must not move the common case. */
+    @Test
+    fun `an ordinary day is unaffected`() {
+        val fajr = Instant.parse("2026-06-14T03:00:00Z")
+        val maghrib = Instant.parse("2026-06-14T20:15:00Z")
+
+        assertThat(fastMinutes(fajr, maghrib)).isEqualTo(17 * 60 + 15)
+        assertThat(legacyFastMinutes(fajr, maghrib, TimeZone.UTC))
+            .isEqualTo(fastMinutes(fajr, maghrib))
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesMidnightTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesMidnightTest.kt
@@ -1,0 +1,135 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.presentation.viewmodel.FakePrayerTimetableRepository
+import com.arshadshah.nimaz.presentation.viewmodel.buildPrayerUseCases
+import com.arshadshah.nimaz.presentation.viewmodel.prayerCalculationSettings
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Prayer Times follows the day across midnight — and only when it should.
+ *
+ * `selectedDate` was a `LocalDate.now()` **data-class default**, evaluated once when the state was
+ * constructed, and nothing re-evaluated it. Leaving the screen open across 00:00 — a plausible
+ * state for an app whose whole point is Fajr — left it on yesterday. The part that made it more
+ * than cosmetic: the "Today" chip renders only `if (!state.isToday)`, and `isToday` kept its last
+ * published value of `true`, so **the affordance to get back never appeared**.
+ *
+ * The opposite mistake is just as bad, so it is tested too: someone who has paged forward to
+ * check Friday must not be yanked back to today at midnight.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrayerTimesMidnightTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val today = LocalDate.of(2026, 3, 14)
+    private lateinit var todayProvider: FakeTodayProvider
+    private lateinit var settings: SettingsRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        todayProvider = FakeTodayProvider(today)
+        settings = mockk(relaxed = true) {
+            every { use24HourFormat } returns flowOf(true)
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = PrayerTimesViewModel(
+        buildPrayerUseCases(FakePrayerTimetableRepository(prayerCalculationSettings())),
+        settings,
+        todayProvider,
+        dispatcher,
+        RecordingTelemetry(),
+    )
+
+    @Test
+    fun `the screen opens on today`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.selectedDate).isEqualTo(today)
+        assertThat(vm.state.value.isToday).isTrue()
+    }
+
+    @Test
+    fun `midnight moves a screen showing today onto the new day`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        todayProvider.now = today.plusDays(1)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.selectedDate).isEqualTo(today.plusDays(1))
+        assertThat(vm.state.value.isToday).isTrue()
+    }
+
+    /**
+     * The whole reason the staleness was unrecoverable rather than merely wrong: with `isToday`
+     * stuck true, `PrayerTimesScreen`'s `if (!state.isToday)` never rendered the chip that
+     * returns you to today.
+     */
+    @Test
+    fun `a screen left on yesterday reports that it is not showing today`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            // Page back one day, then let midnight pass. The user is now two days behind.
+            vm.onEvent(PrayerTimesEvent.PreviousDay)
+            advanceUntilIdle()
+            todayProvider.now = today.plusDays(1)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.selectedDate).isEqualTo(today.minusDays(1))
+            assertThat(vm.state.value.isToday).isFalse()
+        }
+
+    /** Someone who has paged forward stays where they put themselves. */
+    @Test
+    fun `midnight does not move a screen the user has paged away from`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTimesEvent.NextDay)
+        advanceUntilIdle()
+        val chosen = vm.state.value.selectedDate
+
+        todayProvider.now = today.plusDays(1)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.selectedDate).isEqualTo(chosen)
+    }
+
+    /** Tomorrow's Fajr is only carried for today — it is there for the after-Isha wrap. */
+    @Test
+    fun `tomorrows fajr is published for today and not for another day`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertThat(vm.state.value.tomorrowFajrAt).isNotNull()
+
+        vm.onEvent(PrayerTimesEvent.NextDay)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.tomorrowFajrAt).isNull()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.arshadshah.nimaz.presentation.viewmodel.worship
 
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import java.time.LocalDate
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.presentation.viewmodel.prayerCalculationSettings
 import com.arshadshah.nimaz.presentation.viewmodel.buildPrayerUseCases
@@ -68,7 +70,12 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `publishes tonight's window with fajr after the last third`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(buildPrayerUseCases(prayers), RecordingTelemetry())
+        val viewModel = NightWorshipViewModel(
+            buildPrayerUseCases(prayers),
+            FakeTodayProvider(LocalDate.now()),
+            dispatcher,
+            RecordingTelemetry(),
+        )
         dispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.state.value
@@ -85,7 +92,12 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `stops loading once the night times resolve`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(buildPrayerUseCases(prayers), RecordingTelemetry())
+        val viewModel = NightWorshipViewModel(
+            buildPrayerUseCases(prayers),
+            FakeTodayProvider(LocalDate.now()),
+            dispatcher,
+            RecordingTelemetry(),
+        )
         dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(false, viewModel.state.value.isLoading)
@@ -94,7 +106,12 @@ class NightWorshipViewModelTest {
 
     @Test
     fun `rakah counter moves two at a time and resets`() = runTest(dispatcher) {
-        val viewModel = NightWorshipViewModel(buildPrayerUseCases(prayers), RecordingTelemetry())
+        val viewModel = NightWorshipViewModel(
+            buildPrayerUseCases(prayers),
+            FakeTodayProvider(LocalDate.now()),
+            dispatcher,
+            RecordingTelemetry(),
+        )
         dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, viewModel.state.value.rakahCount)

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -380,6 +380,15 @@ rg -n -U --multiline-dotall \
   screen recalculates through `recalculate()` on every entry), so they were deleted rather than
   wired, along with two private handlers left with no caller.
 
+- [x] ~~**Prayer-time computation on `Dispatchers.Main`.**~~ **Resolved.** `calculateMonth` ran
+  28–31 passes of solar geometry plus 28–31 Hijri conversions with no dispatcher, on every
+  settings emission and every month tap; `recomputeDay` ran a day's geometry synchronously from
+  a `Main.immediate` collector, and `publishDisplays` ran a **second** full day for tomorrow's
+  Fajr on every publish — including every Room re-emission of the tracker statuses, so toggling
+  one prayer recomputed a whole day's astronomy on the UI thread. Worst of all, `ramadanDays()`
+  was a **public synchronous** function computing ~30 days, called straight from a click handler.
+  All of it moved behind the injected `@DefaultDispatcher`, and the Ramadan export became an
+  event whose result lands in state — which fixes the UDF violation at the same time.
 - [ ] **`WidgetsScreen` constructs `PrayerTimeCalculator()` directly.** The five ViewModels that
   injected it now go through `PrayerUseCases`, but the widget-preview screen still calls
   `PrayerTimeCalculator()` in a composable — a screen instantiating a `@Singleton` and computing


### PR DESCRIPTION
Layer 39 of #352, closing **#362**. Based on `epic/vm-38-prayer-calc-usecase`; one commit.

## Four were already fixed — verified, not assumed

| # | Claim | Reality |
|---|---|---|
| **P1** | A disabled prayer alarm re-arms itself from another `SettingsViewModel` instance | `rescheduleNotifications()` now delegates to `RescheduleNotificationsUseCase`, which reads DataStore. There is no snapshot to pass it, so the defaults-window variant is closed too |
| **P2** | Fast Tracker ignores every calculation preference | Fixed in #433, one layer down |
| **P4** | High-latitude rule silently becomes `null` | The duplicate presentation enum and its hand-rolled string remap are gone; the domain's alias-tolerant `fromString` is used |
| **P12** | Adhan preview freezes permanently on the first DB error | `catchAndReport` is already **inside** the `flatMapLatest`, with a comment describing exactly the frozen-collector failure |

## The eight that were still real

**P3 — four events that changed the UI and persisted nothing.** Verified before deleting: `SetFajrAngle`, `SetIshaAngle`, `SetShowSeconds`, `SetAutoDetectLocation` have **no producer** in any screen, **no reader** for their state fields, and **no repository call**. Setting a Fajr angle of 15° moved a field and nothing else. Events, branches and the four state fields deleted. (`showSeconds` also appears in `NimazCountdown` as a local parameter of `countdownText` — unrelated, and checked before deleting.)

**P5 — three places frozen on the day they were constructed.** `PrayerTimesUiState.selectedDate`, `MonthlyPrayerTimesUiState.currentMonth` and `.expandedDay` were `LocalDate.now()` / `YearMonth.now()` **data-class defaults**, evaluated once at construction. The Prayer Times one trapped the user rather than merely misinforming them: the "Today" chip renders only `if (!state.isToday)`, and `isToday` kept its last published `true`, so after midnight the screen showed yesterday **with no affordance to get back**. All three now anchor from `TodayProvider` and re-anchor at midnight — and only while the user is still on today, because yanking someone back from the Friday they paged to is its own bug. `SettingsViewModel.todayPrayerTimes` read `LocalDate.now()` inside its `map`, so notification rows showed yesterday's times.

**P6/P7 — Night Worship.** `loadNightTimes()` ran once from `init` with `.first()` on every setting, and `NightWorshipEvent.Refresh` was emitted by no screen — so changing calculation method or moving location left the card on the old city's times, and the window sat on `CLOSED` for ever once Fajr passed. It now collects the settings snapshot and the day; `Refresh` is wired as the retry the error state offers.

`isLoading` and `error` were both on the state and **neither was read**. Every cold open therefore rendered "Set your location to see tonight's times" for the length of the load and then snapped to real times, and a genuine failure was indistinguishable from loading with no way to retry. `ishaAt` — populated by a **third full astronomical pass** whose result nothing read, for Witr guidance never built — is deleted with its pass.

**P8 — astronomy on the UI thread.** `calculateMonth` ran 28–31 solar passes plus 28–31 Hijri conversions with no dispatcher. `recomputeDay` ran synchronously from a `Main.immediate` collector. `publishDisplays` ran a **second** full day for tomorrow's Fajr on every publish — including every Room re-emission of the tracker statuses, so toggling one prayer recomputed a whole day's astronomy on the main thread. And `ramadanDays()` was public, synchronous, ~30 days, called straight from a click handler. All behind the injected `@DefaultDispatcher`; tomorrow's Fajr is computed once with the day; the Ramadan export is now an event whose result lands in state, which fixes the UDF violation #360 lists at the same time.

Worth noting: my first version used the literal `Dispatchers.Default` and **hung two Night Worship tests** — `advanceUntilIdle()` has nothing to wait for when work runs on real threads. The `@DefaultDispatcher` qualifier already existed in `TimeModule` with a KDoc saying precisely that.

**P9 — the month header named a city it had not computed for.** It read `if (name.isNotBlank()) name else "Dublin, Ireland"`, chosen independently of the coordinates `resolveLocation` had already picked, so a user with coordinates set and a blank display name got a correct timetable under a foreign city's name. The state now carries the resolved name and whether it is the fallback; the screen turns those into copy from string resources.

**P10 — fast length is now `(maghrib - fajr).inWholeMinutes`.** It was the difference of two wall-clock field sums, which floors both operands and ignores DST.

**P11 — one `resetAllUiState()`.** The two reset paths disagreed about what "reset everything" means, and **neither** cleared Dua or Hadith.

## Tests

Eight new, 1,577 → 1,585.

`PrayerTimesMidnightTest` covers both directions of the day boundary — that a screen showing today follows midnight, that one the user paged away from is left alone, and that a stale screen correctly reports `isToday = false` so the chip appears.

`FastLengthTest` is arithmetic over `Instant` and keeps the old formula beside the new one, so the difference is demonstrated rather than asserted: 05:00:59 → 20:00:01 gives 899 against the old 900, and a London DST transition gives 18h against the old 19h. It could not have been written against the old code at all — that needed a timezone, and the timezone was the bug.

## Gates

```
./gradlew :app:compileDebugKotlin -x :app:fetchNimazData      PASS
./gradlew :app:testDebugUnitTest  -x :app:fetchNimazData      1585 tests, 1 failed
python3 scripts/check_docs.py                                 23/23
node scripts/check_mermaid.mjs                                14/14
```

The single failure is `DeviceStateCorpusTest` (content artifact from a private repo), confirmed identical on the base branch three layers ago. One new user-facing string, translated into de, fr, id, ms, tr.

## Not tested

The Night Worship reactivity fix (P6) and the settings-reset unification (P11) are not pinned by new tests. Night Worship's existing suite covers the window arithmetic and now constructs through the seam, but nothing asserts that a settings change propagates; `SettingsViewModel` still has **zero** tests, which is #367's job and needs the Context extraction first. Stated rather than glossed.

## Docs

`CLEAN_ARCHITECTURE_CHECKLIST.md` records the main-thread computation as resolved under AP-4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnNoZrzuGWfn1VnyPDjKfn)_