### PR TITLE
refactor(settings): delete-all-my-data is a repository call, not eleven DAOs in a ViewModel

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -18,6 +18,7 @@ import com.arshadshah.nimaz.data.repository.QaidaRepositoryImpl
 import com.arshadshah.nimaz.data.repository.QuranRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TafseerRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TasbihRepositoryImpl
+import com.arshadshah.nimaz.data.repository.UserDataRepositoryImpl
 import com.arshadshah.nimaz.data.repository.ZakatRepositoryImpl
 import com.arshadshah.nimaz.domain.repository.AsmaUlHusnaRepository
 import com.arshadshah.nimaz.domain.repository.AsmaUnNabiRepository
@@ -35,6 +36,7 @@ import com.arshadshah.nimaz.domain.repository.ProphetRepository
 import com.arshadshah.nimaz.domain.repository.QaidaRepository
 import com.arshadshah.nimaz.domain.repository.QuranRepository
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.repository.UserDataRepository
 import com.arshadshah.nimaz.domain.repository.settings.AiSettings
 import com.arshadshah.nimaz.domain.repository.settings.AppSettings
 import com.arshadshah.nimaz.domain.repository.settings.DuaDisplaySettings
@@ -378,6 +380,12 @@ abstract class RepositoryModule {
     abstract fun bindIslamicEventRepository(
         islamicEventRepositoryImpl: IslamicEventRepositoryImpl
     ): IslamicEventRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUserDataRepository(
+        userDataRepositoryImpl: UserDataRepositoryImpl
+    ): UserDataRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/arshadshah/nimaz/data/repository/UserDataRepositoryImpl.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/repository/UserDataRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.user.NimazUserDatabase
+import com.arshadshah.nimaz.domain.repository.UserDataRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Clears the user database, one DAO at a time.
+ *
+ * Everything the person made lives in this one database, so the operation is honest by
+ * construction: the content database is not reachable from here at all. When a table is
+ * added to [NimazUserDatabase], add its clear here — this list is the only place that has
+ * to know, and it is the reason the loop no longer lives in a ViewModel.
+ */
+@Singleton
+class UserDataRepositoryImpl @Inject constructor(
+    private val userDatabase: NimazUserDatabase
+) : UserDataRepository {
+
+    override suspend fun clearAllUserData() {
+        userDatabase.bookmarkDao().clear()
+        userDatabase.progressDao().clear()
+        userDatabase.prayerDao().deleteAllUserData()
+        userDatabase.fastingDao().deleteAllUserData()
+        userDatabase.zakatDao().deleteAllUserData()
+        userDatabase.locationDao().deleteAllUserData()
+        userDatabase.tasbihSessionDao().deleteAllSessions()
+        userDatabase.tafseerUserDao().deleteAllUserData()
+        userDatabase.readingProgressDao().clear()
+        userDatabase.khatamDao().deleteAllUserData()
+        userDatabase.customPresetDao().clear()
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/UserDataRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/UserDataRepository.kt
@@ -1,0 +1,16 @@
+package com.arshadshah.nimaz.domain.repository
+
+/**
+ * Everything the person using the app has made — bookmarks, progress, prayer and fasting
+ * records, zakat calculations, saved locations, tasbih sessions, tafseer notes, khatams and
+ * custom presets.
+ *
+ * Deliberately **not** the shipped content corpus. The Qur'an, hadith, duas and the presets
+ * we ship are ours to replace and never theirs to lose, so "delete all my data" must not be
+ * able to reach them. Keeping the distinction in one place is the point of this interface:
+ * the caller cannot forget a table, and cannot accidentally aim at the content database.
+ */
+interface UserDataRepository {
+    /** Clears every table holding user-created data. Does not touch shipped content. */
+    suspend fun clearAllUserData()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ClearAllUserDataUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ClearAllUserDataUseCase.kt
@@ -1,0 +1,14 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.repository.UserDataRepository
+import javax.inject.Inject
+
+/**
+ * Deletes everything the person made, leaving shipped content untouched.
+ * See [UserDataRepository] for what that boundary covers.
+ */
+class ClearAllUserDataUseCase @Inject constructor(
+    private val repository: UserDataRepository
+) {
+    suspend operator fun invoke() = repository.clearAllUserData()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
@@ -12,7 +12,6 @@ import com.arshadshah.nimaz.core.util.PrayerNotificationScheduler
 import com.arshadshah.nimaz.data.audio.AdhanAudioManager
 import com.arshadshah.nimaz.data.audio.AdhanDownloadService
 import com.arshadshah.nimaz.data.audio.AdhanSound
-import com.arshadshah.nimaz.data.local.user.NimazUserDatabase
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
@@ -21,6 +20,7 @@ import com.arshadshah.nimaz.domain.model.MushafScript
 import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.ClearAllUserDataUseCase
 import com.arshadshah.nimaz.domain.usecase.notification.RescheduleNotificationsUseCase
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
@@ -103,7 +103,7 @@ class SettingsViewModel @Inject constructor(
     // calls in this file are the analytics catalog's job (#355), not this layer's.
     private val telemetry: Telemetry,
     val adhanAudioManager: AdhanAudioManager,
-    private val userDatabase: NimazUserDatabase,
+    private val clearAllUserData: ClearAllUserDataUseCase,
     private val todayProvider: TodayProvider,
 ) : ViewModel() {
 
@@ -1103,17 +1103,7 @@ class SettingsViewModel @Inject constructor(
             // data" clears that one — and it is a much more honest operation for it: the
             // content database is not touched at all, so there is no way for this to reach
             // the corpus, and no way for it to miss a table by forgetting a DAO.
-            userDatabase.bookmarkDao().clear()
-            userDatabase.progressDao().clear()
-            userDatabase.prayerDao().deleteAllUserData()
-            userDatabase.fastingDao().deleteAllUserData()
-            userDatabase.zakatDao().deleteAllUserData()
-            userDatabase.locationDao().deleteAllUserData()
-            userDatabase.tasbihSessionDao().deleteAllSessions()
-            userDatabase.tafseerUserDao().deleteAllUserData()
-            userDatabase.readingProgressDao().clear()
-            userDatabase.khatamDao().deleteAllUserData()
-            userDatabase.customPresetDao().clear()
+            clearAllUserData()
 
             // The content database is deliberately not touched. Content is not user data: the
             // corpus, and the presets we ship, are ours to replace and never theirs to lose.

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ClearAllUserDataUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ClearAllUserDataUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.repository.UserDataRepository
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * "Delete all my data" used to be eleven `userDatabase.xxxDao()` calls written out inside
+ * `SettingsViewModel` — a Room database injected into the presentation layer, and a list a
+ * future table could silently fall off the end of.
+ *
+ * The operation now belongs to one repository method behind one use case. What this test
+ * pins is the contract the ViewModel depends on: invoking the use case clears user data,
+ * and does so exactly once.
+ */
+class ClearAllUserDataUseCaseTest {
+
+    private class RecordingUserDataRepository : UserDataRepository {
+        var clearCount = 0
+            private set
+
+        override suspend fun clearAllUserData() {
+            clearCount++
+        }
+    }
+
+    @Test
+    fun `invoking the use case clears user data`() = runTest {
+        val repository = RecordingUserDataRepository()
+
+        ClearAllUserDataUseCase(repository)()
+
+        assertThat(repository.clearCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `each invocation clears again`() = runTest {
+        val repository = RecordingUserDataRepository()
+        val clearAll = ClearAllUserDataUseCase(repository)
+
+        clearAll()
+        clearAll()
+
+        assertThat(repository.clearCount).isEqualTo(2)
+    }
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -89,6 +89,15 @@ grep -rlnE "private val [a-zA-Z]+: [A-Za-z]+(Dao|RepositoryImpl)" \
   into the repositories. Home no longer imports any `data.local.database.*`.
 - [x] ~~**`QuranViewModel` imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
 - [x] ~~**`QuranPageGrid` (organism) imports `PageAyahRange`** (DAO type).~~ **Resolved** with AP-1.
+- [x] ~~**`SettingsViewModel` injects `NimazUserDatabase`** — a whole Room database in the
+  presentation layer — and writes out eleven `xxxDao()` clears inline for "delete all my data".~~
+  **Resolved.** The operation is now `UserDataRepository.clearAllUserData()` behind
+  `ClearAllUserDataUseCase`; `UserDataRepositoryImpl` owns the DAO list, and the doc comment about
+  never reaching the content corpus moved with it. A new table added to `NimazUserDatabase` now has
+  exactly one place to be registered, instead of a list a ViewModel could quietly fall behind on.
+  **Detect a regression:**
+  `grep -rn "NimazUserDatabase\|RoomDatabase\|Dao\b" app/src/main/java/com/arshadshah/nimaz/presentation --include='*ViewModel.kt'`
+  — should return nothing.
 
 ---
 


### PR DESCRIPTION
SettingsViewModel injected NimazUserDatabase — an entire Room database, in the
presentation layer — and spelled out eleven xxxDao() clears inline. That breaks
the inward-dependency rule outright, and it made the operation fragile in a way
its own comment claimed it wasn't: "no way for it to miss a table by forgetting
a DAO" was only true for as long as someone remembered to edit a ViewModel when
adding a table.

The list now lives in UserDataRepositoryImpl, behind UserDataRepository and
ClearAllUserDataUseCase. The distinction the comment was protecting — user data
is theirs, the shipped corpus is ours to replace — moved with it, to the place
that can actually enforce it: from inside the repository the content database
is not reachable at all.

No ViewModel imports a Room type any more.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>