### PR TITLE
fix(bookmarks): offer the undo after the delete succeeds, not before

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
@@ -303,38 +303,53 @@ class BookmarksViewModel @Inject constructor(
      */
     private val pendingRestores = ArrayDeque<Pair<UnifiedBookmark, suspend () -> Unit>>()
 
+    /**
+     * Deletes a bookmark, and only then offers the undo.
+     *
+     * The undo snackbar and the pending-restore entry used to be written the moment the
+     * event arrived, outside the coroutine that did the deleting. A delete that threw
+     * therefore left the row on screen *and* an "Undo" for it — the UI asserting
+     * something untrue, and an undo that would have re-inserted a bookmark which was
+     * never removed. Both now happen inside the block, after the delete has returned, so
+     * a failure leaves the screen exactly as it was and reports through `launchSafely`.
+     */
     private fun deleteBookmark(id: String) {
         val state = _bookmarksState.value
         val unified = state.allBookmarks.find { it.id == id } ?: return
-        when (unified.type) {
+        val operation: Pair<suspend () -> Unit, suspend () -> Unit> = when (unified.type) {
             BookmarkType.QURAN -> {
                 val original = state.quranBookmarks
                     .find { BookmarkType.QURAN.idFor(it.ayahId) == id } ?: return
-                pendingRestores.addLast(unified to { quranUseCases.insertBookmark(original) })
-                launchSafely(telemetry, DOMAIN, "delete") {
-                    quranUseCases.deleteBookmark(original.ayahId)
-                }
+                Pair<suspend () -> Unit, suspend () -> Unit>(
+                    { quranUseCases.deleteBookmark(original.ayahId) },
+                    { quranUseCases.insertBookmark(original) },
+                )
             }
 
             BookmarkType.HADITH -> {
                 val original = state.hadithBookmarks
                     .find { BookmarkType.HADITH.idFor(it.hadithId) == id } ?: return
-                pendingRestores.addLast(unified to { hadithUseCases.insertBookmark(original) })
-                launchSafely(telemetry, DOMAIN, "delete") {
-                    hadithUseCases.deleteBookmark(original.hadithId)
-                }
+                Pair<suspend () -> Unit, suspend () -> Unit>(
+                    { hadithUseCases.deleteBookmark(original.hadithId) },
+                    { hadithUseCases.insertBookmark(original) },
+                )
             }
 
             BookmarkType.DUA -> {
                 val original = state.duaBookmarks
                     .find { BookmarkType.DUA.idFor(it.duaId) == id } ?: return
-                pendingRestores.addLast(unified to { duaUseCases.insertBookmark(original) })
-                launchSafely(telemetry, DOMAIN, "delete") {
-                    duaUseCases.deleteBookmark(original.duaId)
-                }
+                Pair<suspend () -> Unit, suspend () -> Unit>(
+                    { duaUseCases.deleteBookmark(original.duaId) },
+                    { duaUseCases.insertBookmark(original) },
+                )
             }
         }
-        _bookmarksState.update { it.copy(recentlyDeleted = unified) }
+        val (delete, restore) = operation
+        launchSafely(telemetry, DOMAIN, "delete") {
+            delete()
+            pendingRestores.addLast(unified to restore)
+            _bookmarksState.update { it.copy(recentlyDeleted = unified) }
+        }
     }
 
     private fun undoDelete() {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModel.kt
@@ -257,8 +257,23 @@ class ZakatViewModel @Inject constructor(
         }
     }
 
+    /**
+     * `ZakatHistoryUiState.isLoading` defaults to `true` and was only ever cleared *inside*
+     * the collect, so a stream that failed before its first emission — a missing table after
+     * a content-database replacement, say — left the history screen spinning for the life of
+     * the ViewModel, with nothing on screen to say why.
+     *
+     * The failure clears the spinner so the empty state shows instead. It does not set
+     * `error`: `ZakatScreen` never reads that field, so writing it would be error production
+     * with nothing rendering it. Reporting still happens through `launchSafely`.
+     */
     private fun loadHistory() {
-        launchSafely(telemetry, DOMAIN, "load_history") {
+        launchSafely(
+            telemetry,
+            DOMAIN,
+            "load_history",
+            onFailure = { _historyState.update { it.copy(isLoading = false) } },
+        ) {
             zakatUseCases.getAllHistory().collect { entries ->
                 val totalPaid = zakatUseCases.getTotalPaid()
                 _historyState.update {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModelTest.kt
@@ -89,6 +89,23 @@ class BookmarksViewModelTest {
     }
 
     @Test
+    fun `a delete that fails does not offer an undo for something still there`() = runTest {
+        quranBookmarks.value = listOf(quranBookmark(1, 100))
+        coEvery { quran.deleteBookmark(any()) } throws IllegalStateException("database is locked")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(BookmarksEvent.DeleteBookmark("quran_1"))
+        advanceUntilIdle()
+
+        // The delete threw, so the bookmark is still there. Offering "Deleted — Undo"
+        // would be the UI stating something untrue, and an undo tapped against it would
+        // re-insert a row that was never removed.
+        assertThat(vm.bookmarksState.value.recentlyDeleted).isNull()
+        assertThat(telemetry.errors.map { it.domain }).contains("bookmarks")
+    }
+
+    @Test
     fun `two deletes in a row can both be undone`() = runTest {
         quranBookmarks.value = listOf(quranBookmark(1, 100), quranBookmark(2, 200))
         val vm = viewModel()

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatViewModelTest.kt
@@ -63,6 +63,22 @@ class ZakatViewModelTest {
     private fun viewModel() = ZakatViewModel(useCases, settings, telemetry)
 
     @Test
+    fun `a failing history stream clears the spinner instead of hanging on it`() = runTest {
+        // ZakatHistoryUiState.isLoading defaults to true and loadHistory only cleared it
+        // *inside* the collect, so a stream that threw before its first emission left the
+        // history screen spinning for the lifetime of the ViewModel.
+        every { useCases.getAllHistory() } returns kotlinx.coroutines.flow.flow {
+            throw IllegalStateException("no such table: zakat_history")
+        }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.historyState.value.isLoading).isFalse()
+        assertThat(telemetry.errors.map { it.domain }).contains("zakat")
+    }
+
+    @Test
     fun `clearing the last asset clears the result instead of leaving it stale`() = runTest {
         val vm = viewModel()
         advanceUntilIdle()

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -237,6 +237,39 @@ This one is **pervasive and lower priority** — listed so it's tracked, not bec
   (the wrapper is the seam the UI depends on), but if a use case adds no value and the feature is
   trivial, that's fine — don't over-engineer net-new tiny features.
 
+### AP-7.12 · A `launchSafely` without `onFailure` is not automatically a defect
+
+`launchSafely` **always reports to telemetry** — that is what it does. A call site without
+`onFailure` is therefore silent *to the user*, not silent to monitoring, and whether that is
+wrong depends entirely on what the ViewModel does with its state. Triaged all 25 such sites:
+
+- [x] ~~**`BookmarksViewModel.deleteBookmark` wrote the undo state outside the coroutine.**~~
+  **Resolved.** The pending-restore entry and the "Deleted — Undo" snackbar were set the moment
+  the event arrived, so a delete that threw left the row on screen *with* an Undo beside it —
+  and that undo would have re-inserted a bookmark which was never removed. Both now happen
+  inside the block, after the delete returns.
+- [x] ~~**`ZakatViewModel.loadHistory` could strand its spinner.**~~ **Resolved.**
+  `ZakatHistoryUiState.isLoading` defaults to `true` and was cleared only *inside* the collect,
+  so a stream failing before first emission span for ever. `onFailure` now clears it.
+- [ ] **The remaining 23 are correct as telemetry-only — do not "fix" them.** Their state is
+  driven by observed settings/data flows, so a failed write simply does not move the UI: the
+  switch stays where it was, the row stays in the list, the entry never joins history. That is
+  truthful and self-correcting, and it already reports. Adding `onFailure` to set an `error`
+  would in most cases be **error production with no rendering** — `BookmarksScreen`,
+  `ZakatScreen`, `SearchSettingsScreen` (outside its consent sheet), `TafseerScreen` and
+  `CatalogScreen` never read `state.error`. Only `DuaCategoryScreen`/`DuaReaderScreen` and
+  `IslamicCalendarScreen` render one.
+
+**The test to apply per site**, in order: (1) does the ViewModel write state optimistically,
+*outside* the coroutine? Then move it inside — the bug is the UI claiming success. (2) Can a
+failure strand a loading flag, including one that is a `UiState` **default** rather than an
+assignment? Then clear it in `onFailure`. (3) Otherwise, does a screen actually render the
+error field? If not, wiring one changes nothing a user can see. Leave it, and record why.
+
+**Detect new call sites:** `grep -rn "launchSafely(" app/src/main --include='*ViewModel.kt'`,
+then check each against the three questions above. Note a site whose *inner* flow uses
+`catchAndReport` needs no outer `onFailure` — that is the documented pattern, not an omission.
+
 ### AP-7.1 · Nested `collect` (silently kills reactivity)
 
 - [x] ~~**Khatam observers in `QuranViewModel` and `KhatamViewModel`.**~~ **Resolved.** Both


### PR DESCRIPTION
deleteBookmark pushed the pending-restore entry and set recentlyDeleted — the
"Deleted — Undo" snackbar — outside the coroutine that did the deleting, so both
happened whether or not the delete worked. A delete that threw left the bookmark
on screen and an Undo beside it: the UI asserting something untrue, and an undo
that would have re-inserted a row which was never removed.

Both now happen inside the block, after the delete returns. A failure leaves the
screen exactly as it was and reports through launchSafely.

Worth recording why this is the fix rather than wiring onFailure to set an error:
BookmarksScreen never renders BookmarksUiState.error. Setting it would have been
error production with no rendering — invisible either way, and a tick against
#358 that changed nothing the user can see. The honest fix inside the ViewModel
layer is to stop claiming the action happened.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>