### PR TITLE
test(onboarding,prayer): the last two ViewModels with no tests, and what was stopping them

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
@@ -2,9 +2,12 @@ package com.arshadshah.nimaz.presentation.screens.onboarding
 
 import android.Manifest
 import android.app.Activity
+import android.content.Intent
 import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -36,6 +39,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
@@ -122,6 +126,8 @@ fun OnboardingScreen(
     ) { granted ->
         viewModel.onEvent(OnboardingEvent.UpdatePermissionStatus(notification = granted))
     }
+
+    val context = LocalContext.current
 
     val batteryOptimizationLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -262,7 +268,13 @@ fun OnboardingScreen(
                                 }
                             },
                             onRequestBattery = {
-                                batteryOptimizationLauncher.launch(viewModel.getBatteryOptimizationIntent())
+                                // The Intent is built here rather than handed out by the
+                                // ViewModel: a ViewModel returning an android.content.Intent
+                                // points the dependency arrow the wrong way (see PowerSettings).
+                                batteryOptimizationLauncher.launch(
+                                    Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                                        .apply { data = "package:${context.packageName}".toUri() }
+                                )
                             }
                         )
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModel.kt
@@ -1,30 +1,18 @@
 package com.arshadshah.nimaz.presentation.viewmodel.onboarding
 
-import android.Manifest
-import android.annotation.SuppressLint
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.location.Geocoder
 import android.os.Build
-import android.os.PowerManager
-import android.provider.Settings
-import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.domain.repository.DeviceLocationRepository
+import com.arshadshah.nimaz.domain.repository.PermissionChecker
+import com.arshadshah.nimaz.domain.repository.PowerSettings
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.repository.settings.AppSettings
 import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
-import com.google.android.gms.location.FusedLocationProviderClient
-import com.google.android.gms.location.LocationServices
-import com.google.android.gms.location.Priority
-import com.google.android.gms.tasks.CancellationTokenSource
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,14 +22,15 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import java.util.Locale
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val deviceLocation: DeviceLocationRepository,
+    private val permissions: PermissionChecker,
+    private val powerSettings: PowerSettings,
     private val appSettings: AppSettings,
     private val locationSettings: LocationSettings,
     private val telemetry: Telemetry,
@@ -50,8 +39,6 @@ class OnboardingViewModel @Inject constructor(
     private val _state = MutableStateFlow(OnboardingUiState())
     val state: StateFlow<OnboardingUiState> = _state.asStateFlow()
 
-    private val fusedLocationClient: FusedLocationProviderClient =
-        LocationServices.getFusedLocationProviderClient(context)
 
     init {
         checkOnboardingStatus()
@@ -145,29 +132,13 @@ class OnboardingViewModel @Inject constructor(
     }
 
     private fun checkLocationPermission() {
-        val hasPermission = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
-
-        _state.update { it.copy(locationPermissionGranted = hasPermission) }
+        _state.update { it.copy(locationPermissionGranted = permissions.hasLocationPermission()) }
     }
 
     private fun checkNotificationPermission() {
-        val hasPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true // Permission not required before Android 13
+        _state.update {
+            it.copy(notificationPermissionGranted = permissions.hasNotificationPermission())
         }
-
-        _state.update { it.copy(notificationPermissionGranted = hasPermission) }
     }
 
     /**
@@ -181,41 +152,16 @@ class OnboardingViewModel @Inject constructor(
      * skipping it.
      */
     private fun checkBatteryOptimization() {
-        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
-        val isIgnoringBatteryOptimizations =
-            powerManager?.isIgnoringBatteryOptimizations(context.packageName) ?: false
-        _state.update { it.copy(batteryOptimizationDisabled = isIgnoringBatteryOptimizations) }
-    }
-
-    fun hasLocationPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    fun hasNotificationPermission(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
+        _state.update {
+            it.copy(batteryOptimizationDisabled = powerSettings.isIgnoringBatteryOptimizations())
         }
     }
 
-    fun getBatteryOptimizationIntent(): Intent {
-        return Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-            data = "package:${context.packageName}".toUri()
-        }
-    }
+    fun hasLocationPermission(): Boolean = permissions.hasLocationPermission()
 
-    @SuppressLint("MissingPermission")
+    fun hasNotificationPermission(): Boolean = permissions.hasNotificationPermission()
+
+
     private fun detectLocation() {
         if (!hasLocationPermission()) {
             _state.update { it.copy(error = "Location permission not granted") }
@@ -226,9 +172,12 @@ class OnboardingViewModel @Inject constructor(
             try {
                 val location = getCurrentLocation()
                 if (location != null) {
-                    val locationName = withContext(Dispatchers.IO) {
-                        reverseGeocode(location.first, location.second)
-                    }
+                    // No `withContext(Dispatchers.IO)` here any more: geocoding moved behind
+                    // DeviceLocationRepository, whose implementation already does its own
+                    // `withContext(ioDispatcher)`. Wrapping it again pinned the work to a real
+                    // dispatcher that no test scheduler can advance — which is half of why this
+                    // ViewModel had no tests.
+                    val locationName = reverseGeocode(location.first, location.second)
 
                     // Save location to DataStore
                     locationSettings.updateLocation(
@@ -254,66 +203,9 @@ class OnboardingViewModel @Inject constructor(
         }
     }
 
-    @SuppressLint("MissingPermission")
-    private suspend fun getCurrentLocation(): Pair<Double, Double>? {
-        return suspendCancellableCoroutine { continuation ->
-            val cancellationTokenSource = CancellationTokenSource()
+    private suspend fun getCurrentLocation(): Pair<Double, Double>? =
+        deviceLocation.currentCoordinates()?.let { it.latitude to it.longitude }
 
-            fusedLocationClient.getCurrentLocation(
-                Priority.PRIORITY_HIGH_ACCURACY,
-                cancellationTokenSource.token
-            ).addOnSuccessListener { location ->
-                if (location != null) {
-                    continuation.resume(Pair(location.latitude, location.longitude))
-                } else {
-                    continuation.resume(null)
-                }
-            }.addOnFailureListener { e ->
-                continuation.resumeWithException(e)
-            }
-
-            continuation.invokeOnCancellation {
-                cancellationTokenSource.cancel()
-            }
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private suspend fun reverseGeocode(latitude: Double, longitude: Double): String {
-        return try {
-            val geocoder = Geocoder(context, Locale.getDefault())
-            val addresses = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                suspendCancellableCoroutine { continuation ->
-                    geocoder.getFromLocation(latitude, longitude, 1) { addresses ->
-                        continuation.resume(addresses)
-                    }
-                }
-            } else {
-                geocoder.getFromLocation(latitude, longitude, 1) ?: emptyList()
-            }
-
-            val address = addresses.firstOrNull()
-            if (address != null) {
-                buildString {
-                    address.locality?.let { append(it) }
-                    if (isEmpty() && address.subAdminArea != null) {
-                        append(address.subAdminArea)
-                    }
-                    if (isEmpty() && address.adminArea != null) {
-                        append(address.adminArea)
-                    }
-                    address.countryName?.let { country ->
-                        if (isNotEmpty()) append(", ")
-                        append(country)
-                    }
-                }.ifEmpty { "Unknown Location" }
-            } else {
-                "Unknown Location"
-            }
-        } catch (e: Exception) {
-            CrashReporter.recordException(e)
-            AppAnalytics.logError(AppAnalytics.Feature.ONBOARDING, "reverse_geocode", e.message)
-            "Unknown Location"
-        }
-    }
+    private suspend fun reverseGeocode(latitude: Double, longitude: Double): String =
+        deviceLocation.reverseGeocode(latitude, longitude) ?: "Unknown Location"
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,211 @@
+package com.arshadshah.nimaz.presentation.viewmodel.onboarding
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.SearchLocation
+import com.arshadshah.nimaz.domain.repository.Coordinates
+import com.arshadshah.nimaz.domain.repository.DeviceLocationRepository
+import com.arshadshah.nimaz.domain.repository.PermissionChecker
+import com.arshadshah.nimaz.domain.repository.PowerSettings
+import com.arshadshah.nimaz.domain.repository.settings.AppSettings
+import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `OnboardingViewModel` had zero tests, and could not have had any: it built a
+ * `FusedLocationProviderClient` in a **property initializer**, so merely constructing it on the
+ * JVM reached into Play Services. `DeviceLocationRepository`'s own KDoc named this ViewModel as
+ * the second of the two stuck that way.
+ *
+ * It now takes the seams, which is what makes everything below expressible.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private class FakeDeviceLocation(
+        private val coordinates: Coordinates? = Coordinates(51.5074, -0.1278),
+        private val name: String? = "London",
+        private val failWith: Throwable? = null,
+    ) : DeviceLocationRepository {
+        override suspend fun currentCoordinates(): Coordinates? {
+            failWith?.let { throw it }
+            return coordinates
+        }
+
+        override suspend fun search(query: String, limit: Int): List<SearchLocation> = emptyList()
+        override suspend fun reverseGeocode(latitude: Double, longitude: Double): String? = name
+    }
+
+    private class FakePermissions(
+        private val location: Boolean = true,
+        private val notification: Boolean = true,
+    ) : PermissionChecker {
+        override fun hasLocationPermission() = location
+        override fun hasNotificationPermission() = notification
+    }
+
+    private class FakePower(private val exempt: Boolean = false) : PowerSettings {
+        override fun isIgnoringBatteryOptimizations() = exempt
+    }
+
+    private class FakeAppSettings(completed: Boolean = false) : AppSettings {
+        val completedFlow = MutableStateFlow(completed)
+        override val onboardingCompleted: Flow<Boolean> = completedFlow
+        override suspend fun setOnboardingCompleted(completed: Boolean) {
+            completedFlow.value = completed
+        }
+
+        override val appLanguage: Flow<String> = MutableStateFlow("en")
+        override suspend fun setAppLanguage(language: String) = Unit
+    }
+
+    private class RecordingLocationSettings : LocationSettings {
+        var saved: Triple<Double, Double, String>? = null
+            private set
+
+        override val latitude: Flow<Double> = MutableStateFlow(0.0)
+        override val longitude: Flow<Double> = MutableStateFlow(0.0)
+        override val locationName: Flow<String> = MutableStateFlow("")
+        override val userPreferences: Flow<UserPreferences> = MutableStateFlow(mockk(relaxed = true))
+        override suspend fun updateLocation(latitude: Double, longitude: Double, name: String) {
+            saved = Triple(latitude, longitude, name)
+        }
+    }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(
+        deviceLocation: DeviceLocationRepository = FakeDeviceLocation(),
+        permissions: PermissionChecker = FakePermissions(),
+        power: PowerSettings = FakePower(),
+        appSettings: AppSettings = FakeAppSettings(),
+        locationSettings: LocationSettings = RecordingLocationSettings(),
+        telemetry: RecordingTelemetry = RecordingTelemetry(),
+    ) = OnboardingViewModel(
+        deviceLocation, permissions, power, appSettings, locationSettings, telemetry,
+    )
+
+    @Test
+    fun `permission and battery state is read from the seams at construction`() =
+        runTest(dispatcher) {
+            val vm = viewModel(
+                permissions = FakePermissions(location = true, notification = false),
+                power = FakePower(exempt = true),
+            )
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.locationPermissionGranted).isTrue()
+            assertThat(vm.state.value.notificationPermissionGranted).isFalse()
+            assertThat(vm.state.value.batteryOptimizationDisabled).isTrue()
+        }
+
+    @Test
+    fun `a detected location is reverse-geocoded and persisted`() = runTest(dispatcher) {
+        val settings = RecordingLocationSettings()
+        val vm = viewModel(locationSettings = settings)
+        advanceUntilIdle()
+
+        vm.onEvent(OnboardingEvent.DetectLocation)
+        advanceUntilIdle()
+
+        assertThat(settings.saved).isEqualTo(Triple(51.5074, -0.1278, "London"))
+        assertThat(vm.state.value.locationDetected).isTrue()
+        assertThat(vm.state.value.locationName).isEqualTo("London")
+    }
+
+    @Test
+    fun `detection without permission does not reach the device`() = runTest(dispatcher) {
+        val settings = RecordingLocationSettings()
+        val vm = viewModel(
+            permissions = FakePermissions(location = false),
+            locationSettings = settings,
+        )
+        advanceUntilIdle()
+
+        vm.onEvent(OnboardingEvent.DetectLocation)
+        advanceUntilIdle()
+
+        assertThat(settings.saved).isNull()
+        assertThat(vm.state.value.locationDetected).isFalse()
+    }
+
+    @Test
+    fun `a location fix that throws is reported and surfaced, not swallowed`() =
+        runTest(dispatcher) {
+            val telemetry = RecordingTelemetry()
+            val vm = viewModel(
+                deviceLocation = FakeDeviceLocation(failWith = IllegalStateException("no provider")),
+                telemetry = telemetry,
+            )
+            advanceUntilIdle()
+
+            vm.onEvent(OnboardingEvent.DetectLocation)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.error).isNotNull()
+            assertThat(vm.state.value.locationDetected).isFalse()
+        }
+
+    @Test
+    fun `an empty fix says so rather than claiming a location`() = runTest(dispatcher) {
+        val settings = RecordingLocationSettings()
+        val vm = viewModel(
+            deviceLocation = FakeDeviceLocation(coordinates = null),
+            locationSettings = settings,
+        )
+        advanceUntilIdle()
+
+        vm.onEvent(OnboardingEvent.DetectLocation)
+        advanceUntilIdle()
+
+        assertThat(settings.saved).isNull()
+        assertThat(vm.state.value.error).isNotNull()
+    }
+
+    @Test
+    fun `completing onboarding persists the flag`() = runTest(dispatcher) {
+        val appSettings = FakeAppSettings(completed = false)
+        val vm = viewModel(appSettings = appSettings)
+        advanceUntilIdle()
+
+        vm.onEvent(OnboardingEvent.CompleteOnboarding)
+        advanceUntilIdle()
+
+        assertThat(appSettings.completedFlow.value).isTrue()
+    }
+
+    @Test
+    fun `dismissing the error clears it`() = runTest(dispatcher) {
+        val vm = viewModel(
+            deviceLocation = FakeDeviceLocation(failWith = IllegalStateException("no provider")),
+        )
+        advanceUntilIdle()
+        vm.onEvent(OnboardingEvent.DetectLocation)
+        advanceUntilIdle()
+        assertThat(vm.state.value.error).isNotNull()
+
+        vm.onEvent(OnboardingEvent.DismissError)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.error).isNull()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/MonthlyPrayerTimesViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.presentation.viewmodel.FakePrayerTimetableRepository
+import com.arshadshah.nimaz.presentation.viewmodel.buildPrayerUseCases
+import com.arshadshah.nimaz.presentation.viewmodel.prayerCalculationSettings
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+/**
+ * `MonthlyPrayerTimesViewModel` had no tests at all, while owning two things that are easy to
+ * get wrong and invisible when they are: the month grid is anchored to "today" and re-anchors
+ * on rollover, and the month build is a cancel-and-replace job so a fast pager cannot stack
+ * a month's worth of astronomy per swipe.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MonthlyPrayerTimesViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val today = LocalDate.of(2026, 3, 15)
+    private lateinit var prayers: FakePrayerTimetableRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        prayers = FakePrayerTimetableRepository(prayerCalculationSettings())
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(now: LocalDate = today) = MonthlyPrayerTimesViewModel(
+        buildPrayerUseCases(prayers),
+        FakeTodayProvider(now),
+        dispatcher,
+        RecordingTelemetry(),
+    )
+
+    @Test
+    fun `the grid opens on the current month`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.currentMonth).isEqualTo(YearMonth.of(2026, 3))
+    }
+
+    @Test
+    fun `a full month of days is built`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // March has 31 days; the grid is one row per day, not per visible cell.
+        assertThat(vm.state.value.dayPrayerTimes).hasSize(31)
+        assertThat(vm.state.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `paging forward moves the month and rebuilds it`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(MonthlyPrayerTimesEvent.NextMonth)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.currentMonth).isEqualTo(YearMonth.of(2026, 4))
+        assertThat(vm.state.value.dayPrayerTimes).hasSize(30)
+    }
+
+    @Test
+    fun `paging back from January lands in the previous December`() = runTest(dispatcher) {
+        val vm = viewModel(now = LocalDate.of(2026, 1, 10))
+        advanceUntilIdle()
+
+        vm.onEvent(MonthlyPrayerTimesEvent.PreviousMonth)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.currentMonth).isEqualTo(YearMonth.of(2025, 12))
+        assertThat(vm.state.value.dayPrayerTimes).hasSize(31)
+    }
+
+    @Test
+    fun `expanding a day is a toggle, not a latch`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val day = LocalDate.of(2026, 3, 20)
+
+        vm.onEvent(MonthlyPrayerTimesEvent.ToggleDayExpanded(day))
+        advanceUntilIdle()
+        assertThat(vm.state.value.expandedDay).isEqualTo(day)
+
+        vm.onEvent(MonthlyPrayerTimesEvent.ToggleDayExpanded(day))
+        advanceUntilIdle()
+        assertThat(vm.state.value.expandedDay).isNull()
+    }
+
+    @Test
+    fun `the ramadan export is a one-shot and clears once consumed`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(MonthlyPrayerTimesEvent.PrepareRamadanExport)
+        advanceUntilIdle()
+        assertThat(vm.state.value.ramadanExport).isNotNull()
+
+        // Held in state rather than exposed as a method the screen calls for a value, so it
+        // has to be cleared explicitly or a recomposition would re-open the share sheet.
+        vm.onEvent(MonthlyPrayerTimesEvent.RamadanExportConsumed)
+        advanceUntilIdle()
+        assertThat(vm.state.value.ramadanExport).isNull()
+    }
+}

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -237,6 +237,22 @@ This one is **pervasive and lower priority** — listed so it's tracked, not bec
   (the wrapper is the seam the UI depends on), but if a use case adds no value and the feature is
   trivial, that's fine — don't over-engineer net-new tiny features.
 
+### AP-7.14 · A ViewModel that cannot be constructed on the JVM has no tests, and that is why
+
+- [x] ~~**`OnboardingViewModel` built a `FusedLocationProviderClient` in a property initializer.**~~
+  **Resolved.** Constructing the ViewModel therefore reached into Play Services before a single
+  line of its own logic ran, so no JVM unit test could exist — `DeviceLocationRepository`'s KDoc
+  had already named it as the second of the two stuck that way, `LocationViewModel` having been
+  freed in #435. It now injects `DeviceLocationRepository`, `PermissionChecker` and
+  `PowerSettings`; `Context` is gone entirely, and `getBatteryOptimizationIntent(): Intent` — a
+  ViewModel handing the UI an `android.content.Intent` — moved to `OnboardingScreen`, which is
+  what `PowerSettings`' KDoc asks for. Seven tests now cover permission reads, detection,
+  persistence, the empty fix, the throwing fix, completion and error dismissal.
+  A second, quieter blocker went with it: `detectLocation` wrapped its geocode in
+  `withContext(Dispatchers.IO)`, a **real** dispatcher no test scheduler can advance. The
+  repository implementation already does its own `withContext(ioDispatcher)`, so the wrapper was
+  both redundant and untestable.
+
 ### AP-7.13 · Raw `viewModelScope.launch` (an uncaught throw is a crash)
 
 `viewModelScope` is a `SupervisorJob` + `Dispatchers.Main.immediate`. A `SupervisorJob`


### PR DESCRIPTION
MonthlyPrayerTimesViewModel simply had none: six tests now cover the month
anchor, the month build, paging in both directions across a year boundary, the
expand toggle, and the one-shot Ramadan export.

OnboardingViewModel could not have had any. It built a
FusedLocationProviderClient in a property initializer, so constructing it on the
JVM reached into Play Services before any of its own logic ran.
DeviceLocationRepository's KDoc already named it as the second ViewModel stuck
that way — LocationViewModel was freed in #435 and this one was left behind.

It now injects DeviceLocationRepository, PermissionChecker and PowerSettings.
Context is gone, and getBatteryOptimizationIntent(): Intent moved to
OnboardingScreen: a ViewModel handing the UI an android.content.Intent points
the dependency arrow the wrong way, which is exactly what PowerSettings' KDoc
says about it.

A second blocker went with it. detectLocation wrapped its geocode in
withContext(Dispatchers.IO) — a real dispatcher no test scheduler can advance,
which is what made the persistence test hang rather than fail. The repository
implementation already does its own withContext(ioDispatcher), so the wrapper
was redundant as well as untestable.

Every ViewModel in the package now has at least one test. #367 closed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>