### PR TITLE
refactor(viewmodel): five of the six ViewModels no longer hold a Context

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -18,6 +18,14 @@ import com.arshadshah.nimaz.data.repository.QaidaRepositoryImpl
 import com.arshadshah.nimaz.data.repository.QuranRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TafseerRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TasbihRepositoryImpl
+import com.arshadshah.nimaz.core.text.StringProvider
+import com.arshadshah.nimaz.domain.repository.AdhanDownloader
+import com.arshadshah.nimaz.domain.repository.AppLocale
+import com.arshadshah.nimaz.data.platform.AndroidAppLocale
+import com.arshadshah.nimaz.data.platform.ServiceAdhanDownloader
+import com.arshadshah.nimaz.domain.repository.WidgetRefresher
+import com.arshadshah.nimaz.data.widget.WorkManagerWidgetRefresher
+import com.arshadshah.nimaz.data.text.AndroidStringProvider
 import com.arshadshah.nimaz.data.repository.UserDataRepositoryImpl
 import com.arshadshah.nimaz.data.repository.ZakatRepositoryImpl
 import com.arshadshah.nimaz.domain.repository.AsmaUlHusnaRepository
@@ -380,6 +388,22 @@ abstract class RepositoryModule {
     abstract fun bindIslamicEventRepository(
         islamicEventRepositoryImpl: IslamicEventRepositoryImpl
     ): IslamicEventRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindStringProvider(impl: AndroidStringProvider): StringProvider
+
+    @Binds
+    @Singleton
+    abstract fun bindAppLocale(impl: AndroidAppLocale): AppLocale
+
+    @Binds
+    @Singleton
+    abstract fun bindAdhanDownloader(impl: ServiceAdhanDownloader): AdhanDownloader
+
+    @Binds
+    @Singleton
+    abstract fun bindWidgetRefresher(impl: WorkManagerWidgetRefresher): WidgetRefresher
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -19,6 +19,10 @@ import com.arshadshah.nimaz.data.repository.QuranRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TafseerRepositoryImpl
 import com.arshadshah.nimaz.data.repository.TasbihRepositoryImpl
 import com.arshadshah.nimaz.core.text.StringProvider
+import com.arshadshah.nimaz.domain.repository.CompassSensors
+import com.arshadshah.nimaz.domain.repository.Haptics
+import com.arshadshah.nimaz.data.device.AndroidCompassSensors
+import com.arshadshah.nimaz.data.device.AndroidHaptics
 import com.arshadshah.nimaz.domain.repository.AdhanDownloader
 import com.arshadshah.nimaz.domain.repository.AppLocale
 import com.arshadshah.nimaz.data.platform.AndroidAppLocale
@@ -392,6 +396,14 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindStringProvider(impl: AndroidStringProvider): StringProvider
+
+    @Binds
+    @Singleton
+    abstract fun bindCompassSensors(impl: AndroidCompassSensors): CompassSensors
+
+    @Binds
+    @Singleton
+    abstract fun bindHaptics(impl: AndroidHaptics): Haptics
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/arshadshah/nimaz/core/text/StringProvider.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/text/StringProvider.kt
@@ -1,0 +1,32 @@
+package com.arshadshah.nimaz.core.text
+
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+
+/**
+ * Localized strings, without a `Context`.
+ *
+ * Most user-facing text belongs in the composable that shows it, resolved with
+ * `stringResource`. This seam is for the cases where it genuinely cannot be: a ViewModel that
+ * **searches or sorts** on a label has to have the resolved string in hand, because the
+ * comparison happens where the list is filtered, not where it is drawn.
+ *
+ * `BookmarksViewModel` is the worked example — its search matches a bookmark's title and its
+ * ALPHABETICAL order sorts by it, so moving the labels to the screen would have quietly
+ * changed what "Quran" matches.
+ *
+ * The point is the narrowing. A ViewModel holding `@ApplicationContext` can reach the whole
+ * platform — system services, the package manager, the file system. One holding a
+ * [StringProvider] can resolve a string and nothing else, and a test can hand it a fake.
+ *
+ * **Do not reach for this to avoid `stringResource`.** If a label is only ever displayed,
+ * resolve it in the composable.
+ */
+interface StringProvider {
+
+    /** The string for [id], with [args] substituted into its format specifiers. */
+    fun get(@StringRes id: Int, vararg args: Any): String
+
+    /** The plural form of [id] appropriate to [count], with [args] substituted. */
+    fun quantity(@PluralsRes id: Int, count: Int, vararg args: Any): String
+}

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderContent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderContent.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.core.util
 
 import android.content.Context
+import com.arshadshah.nimaz.core.text.StringProvider
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.WorshipReminderType
 
@@ -13,6 +14,18 @@ import com.arshadshah.nimaz.domain.model.WorshipReminderType
  * for that reminder.
  */
 object WorshipReminderContent {
+
+    // StringProvider overloads, for callers that must not hold a Context (see
+    // core/text/StringProvider.kt). Same resource ids, resolved through the seam.
+    fun name(strings: StringProvider, type: WorshipReminderType): String =
+        strings.get(nameRes(type))
+
+    fun arabic(strings: StringProvider, type: WorshipReminderType): String =
+        strings.get(arabicRes(type))
+
+    fun body(strings: StringProvider, type: WorshipReminderType, subKey: String? = null): String =
+        strings.get(bodyRes(type))
+
 
     /** Short display name shown as the card eyebrow and used in generic copy. */
     fun name(context: Context, type: WorshipReminderType): String =

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderContent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/WorshipReminderContent.kt
@@ -24,7 +24,32 @@ object WorshipReminderContent {
         strings.get(arabicRes(type))
 
     fun body(strings: StringProvider, type: WorshipReminderType, subKey: String? = null): String =
-        strings.get(bodyRes(type))
+        when (type) {
+            // Mirrors the Context overload below exactly. The first cut of this dropped the
+            // subKey branch and always returned bodyRes(type), which silently gave every
+            // Arafah/Ashura reminder the Arafah body.
+            WorshipReminderType.ARAFAH_ASHURA_FAST -> strings.get(
+                if (subKey == "ashura") R.string.worship_ashura_body
+                else R.string.worship_arafah_body
+            )
+
+            else -> strings.get(bodyRes(type))
+        }
+
+    fun title(strings: StringProvider, type: WorshipReminderType, subKey: String? = null): String =
+        when (type) {
+            WorshipReminderType.MONDAY_THURSDAY_FAST -> strings.get(
+                if (subKey == "thursday") R.string.worship_mon_thu_title_thursday
+                else R.string.worship_mon_thu_title_monday
+            )
+
+            WorshipReminderType.ARAFAH_ASHURA_FAST -> strings.get(
+                if (subKey == "ashura") R.string.worship_ashura_title
+                else R.string.worship_arafah_title
+            )
+
+            else -> strings.get(titleRes(type))
+        }
 
 
     /** Short display name shown as the card eyebrow and used in generic copy. */

--- a/app/src/main/java/com/arshadshah/nimaz/data/device/AndroidCompassSensors.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/device/AndroidCompassSensors.kt
@@ -1,0 +1,117 @@
+package com.arshadshah.nimaz.data.device
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.repository.CompassOrientation
+import com.arshadshah.nimaz.domain.repository.CompassSensors
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/** Low-pass coefficient for the accelerometer and magnetometer vectors. */
+private const val SMOOTHING = 0.97f
+
+/**
+ * Smooths [sample] into [filtered] in place.
+ *
+ * With [seed] the sample is taken at face value. An unseeded filter starts at zero and needs
+ * roughly a hundred samples to converge, which is what used to publish `isCompassReady` on the
+ * first successful `getRotationMatrix` — the screen said ready and the needle then swept in
+ * from a meaningless heading. One sample is a worse estimate than a hundred, but it is an
+ * estimate *of the right thing*, which zero is not.
+ */
+internal fun smoothInto(filtered: FloatArray, sample: FloatArray, seed: Boolean) {
+    for (i in filtered.indices) {
+        filtered[i] =
+            if (seed) sample[i]
+            else SMOOTHING * filtered[i] + (1 - SMOOTHING) * sample[i]
+    }
+}
+
+@Singleton
+class AndroidCompassSensors @Inject constructor(
+    @ApplicationContext private val context: Context
+) : CompassSensors {
+
+    private val sensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+    private val accelerometer: Sensor?
+        get() = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+
+    private val magnetometer: Sensor?
+        get() = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
+
+    override val isAvailable: Boolean
+        get() = accelerometer != null && magnetometer != null
+
+    override fun orientation(): Flow<CompassOrientation> = callbackFlow {
+        val gravity = FloatArray(3)
+        val geomagnetic = FloatArray(3)
+        var hasGravity = false
+        var hasMagnetic = false
+        var accuracy = CompassAccuracy.UNRELIABLE
+
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                when (event.sensor.type) {
+                    Sensor.TYPE_ACCELEROMETER -> {
+                        smoothInto(gravity, event.values, seed = !hasGravity)
+                        hasGravity = true
+                    }
+
+                    Sensor.TYPE_MAGNETIC_FIELD -> {
+                        smoothInto(geomagnetic, event.values, seed = !hasMagnetic)
+                        hasMagnetic = true
+                    }
+                }
+                if (!hasGravity || !hasMagnetic) return
+
+                val rotation = FloatArray(9)
+                val inclination = FloatArray(9)
+                if (!SensorManager.getRotationMatrix(rotation, inclination, gravity, geomagnetic)) {
+                    return
+                }
+                val orientation = FloatArray(3)
+                SensorManager.getOrientation(rotation, orientation)
+                trySend(
+                    CompassOrientation(
+                        azimuthDegrees =
+                            ((Math.toDegrees(orientation[0].toDouble()).toFloat() + 360) % 360),
+                        pitchDegrees = Math.toDegrees(orientation[1].toDouble()).toFloat(),
+                        rollDegrees = Math.toDegrees(orientation[2].toDouble()).toFloat(),
+                        accuracy = accuracy,
+                    )
+                )
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor, value: Int) {
+                if (sensor.type != Sensor.TYPE_MAGNETIC_FIELD) return
+                accuracy = when (value) {
+                    SensorManager.SENSOR_STATUS_ACCURACY_HIGH -> CompassAccuracy.HIGH
+                    SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM -> CompassAccuracy.MEDIUM
+                    SensorManager.SENSOR_STATUS_ACCURACY_LOW -> CompassAccuracy.LOW
+                    else -> CompassAccuracy.UNRELIABLE
+                }
+            }
+        }
+
+        accelerometer?.let {
+            sensorManager.registerListener(listener, it, SensorManager.SENSOR_DELAY_GAME)
+        }
+        magnetometer?.let {
+            sensorManager.registerListener(listener, it, SensorManager.SENSOR_DELAY_GAME)
+        }
+
+        // The listener's lifetime is the collection's. Cancelling the collect unregisters,
+        // which is what the ViewModel's onCleared() used to have to remember to do.
+        awaitClose { sensorManager.unregisterListener(listener) }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/device/AndroidHaptics.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/device/AndroidHaptics.kt
@@ -1,0 +1,28 @@
+package com.arshadshah.nimaz.data.device
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import com.arshadshah.nimaz.domain.repository.Haptics
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidHaptics @Inject constructor(
+    @ApplicationContext private val context: Context
+) : Haptics {
+
+    private val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager)
+            .defaultVibrator
+    } else {
+        @Suppress("DEPRECATION")
+        context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+    }
+
+    override fun tap() =
+        vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/platform/AndroidAppLocale.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/platform/AndroidAppLocale.kt
@@ -1,0 +1,26 @@
+package com.arshadshah.nimaz.data.platform
+
+import android.content.Context
+import com.arshadshah.nimaz.core.util.LocaleHelper
+import com.arshadshah.nimaz.data.audio.AdhanDownloadService
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.domain.repository.AdhanDownloader
+import com.arshadshah.nimaz.domain.repository.AppLocale
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidAppLocale @Inject constructor(
+    @ApplicationContext private val context: Context
+) : AppLocale {
+    override fun apply(languageCode: String) = LocaleHelper.setLocale(context, languageCode)
+}
+
+@Singleton
+class ServiceAdhanDownloader @Inject constructor(
+    @ApplicationContext private val context: Context
+) : AdhanDownloader {
+    override fun download(adhanSoundName: String) =
+        AdhanDownloadService.downloadSelected(context, AdhanSound.fromName(adhanSoundName))
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/text/AndroidStringProvider.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/text/AndroidStringProvider.kt
@@ -1,0 +1,22 @@
+package com.arshadshah.nimaz.data.text
+
+import android.content.Context
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+import com.arshadshah.nimaz.core.text.StringProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Resolves strings against the application `Context` — the one place that holds it. */
+@Singleton
+class AndroidStringProvider @Inject constructor(
+    @ApplicationContext private val context: Context
+) : StringProvider {
+
+    override fun get(@StringRes id: Int, vararg args: Any): String =
+        if (args.isEmpty()) context.getString(id) else context.getString(id, *args)
+
+    override fun quantity(@PluralsRes id: Int, count: Int, vararg args: Any): String =
+        context.resources.getQuantityString(id, count, *args)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/widget/WorkManagerWidgetRefresher.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/widget/WorkManagerWidgetRefresher.kt
@@ -1,0 +1,15 @@
+package com.arshadshah.nimaz.data.widget
+
+import android.content.Context
+import com.arshadshah.nimaz.domain.repository.WidgetRefresher
+import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WorkManagerWidgetRefresher @Inject constructor(
+    @ApplicationContext private val context: Context
+) : WidgetRefresher {
+    override fun refreshPrayerTracker() = PrayerTrackerWorker.enqueueImmediateWork(context)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/AppLocale.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/AppLocale.kt
@@ -1,0 +1,25 @@
+package com.arshadshah.nimaz.domain.repository
+
+/**
+ * Applies the app's language to the platform.
+ *
+ * Persisting the choice and *applying* it are two different things: the preference lives in
+ * `AppSettings.appLanguage`, while the per-app locale is Android state
+ * (`LocaleManager` on 33+, `AppCompatDelegate` below). Only the second needs a `Context`, and
+ * this is the seam that holds it so `SettingsViewModel` does not have to.
+ */
+interface AppLocale {
+    /** Applies [languageCode] (an IETF tag such as `"en"` or `"ar"`) as the app's locale. */
+    fun apply(languageCode: String)
+}
+
+/**
+ * Starts the download of a selected adhan.
+ *
+ * `SettingsViewModel` called `AdhanDownloadService.downloadSelected(context, sound)` — a
+ * ViewModel starting an Android `Service`, and the last thing keeping a `Context` in it.
+ */
+interface AdhanDownloader {
+    /** Begins downloading [adhanSoundName]; a no-op if it is already present. */
+    fun download(adhanSoundName: String)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/CompassSensors.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/CompassSensors.kt
@@ -1,0 +1,51 @@
+package com.arshadshah.nimaz.domain.repository
+
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The device's orientation, as degrees rather than as sensor plumbing.
+ *
+ * `QiblaViewModel` held a `SensorManager` and a `SensorEventListener`, low-pass-filtered the
+ * gravity and geomagnetic vectors itself, and called `SensorManager.getRotationMatrix` /
+ * `getOrientation` — so it needed an `@ApplicationContext` and could not be constructed in a
+ * JVM test.
+ *
+ * The filtering and the rotation-matrix fusion are platform math, and they live behind this
+ * seam. What the ViewModel keeps is the part that is actually about the qibla: unwrapping the
+ * azimuth so the needle does not snap through 360→0, applying magnetic declination, and
+ * deciding when the user is facing the Kaaba.
+ */
+interface CompassSensors {
+
+    /** False when the device has no accelerometer or no magnetometer — no compass is possible. */
+    val isAvailable: Boolean
+
+    /**
+     * Orientation samples while collected; registers on collect and unregisters on cancel, so
+     * the listener's lifetime is the flow's rather than something the caller must remember to
+     * undo.
+     */
+    fun orientation(): Flow<CompassOrientation>
+}
+
+/** A single orientation reading, in degrees, plus how much the magnetometer can be trusted. */
+data class CompassOrientation(
+    /** Heading from **magnetic** north, 0–360. Declination is the caller's to apply. */
+    val azimuthDegrees: Float,
+    val pitchDegrees: Float,
+    val rollDegrees: Float,
+    val accuracy: CompassAccuracy,
+)
+
+/**
+ * A short confirmation buzz.
+ *
+ * Separate from [CompassSensors] because it is an output, not a reading — and because the
+ * qibla screen's haptic is a preference the user can switch off, which is a decision the
+ * ViewModel makes and this seam merely carries out.
+ */
+interface Haptics {
+    /** One brief tap. */
+    fun tap()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/WidgetRefresher.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/WidgetRefresher.kt
@@ -1,0 +1,14 @@
+package com.arshadshah.nimaz.domain.repository
+
+/**
+ * Asks the home-screen widgets to redraw.
+ *
+ * `HomeViewModel` called `PrayerTrackerWorker.enqueueImmediateWork(context)` directly — a
+ * ViewModel reaching into the widget layer's WorkManager plumbing, and one of the reasons it
+ * needed an `@ApplicationContext` at all. What it actually wants to say is "the tracker
+ * changed, redraw"; which worker does that, and how it is scheduled, is not its business.
+ */
+interface WidgetRefresher {
+    /** Redraw the prayer-tracker widget now. */
+    fun refreshPrayerTracker()
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -148,6 +149,9 @@ fun HomeScreen(
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
     ) { viewModel.onEvent(HomeEvent.RefreshPermissions) }
+
+
+
 
     val notificationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
@@ -303,6 +307,7 @@ private fun HomeCompactContent(
     batteryOptimizationLauncher: androidx.activity.result.ActivityResultLauncher<android.content.Intent>,
     viewModel: HomeViewModel,
 ) {
+    val activityContext = LocalContext.current
     val gregorianDate = remember {
         java.time.LocalDate.now().formatFullDate()
     }
@@ -320,7 +325,7 @@ private fun HomeCompactContent(
         notificationPermissionLauncher = notificationPermissionLauncher,
         locationPermissionLauncher = locationPermissionLauncher,
         batteryOptimizationLauncher = batteryOptimizationLauncher,
-        getBatteryIntent = { viewModel.getBatteryOptimizationIntent() },
+        getBatteryIntent = { batteryOptimizationIntent(activityContext) },
     )
 
     LazyColumn(
@@ -469,6 +474,7 @@ private fun HomeTabletContent(
     batteryOptimizationLauncher: androidx.activity.result.ActivityResultLauncher<android.content.Intent>,
     viewModel: HomeViewModel,
 ) {
+    val activityContext = LocalContext.current
     val gregorianDate = remember {
         java.time.LocalDate.now().formatFullDate()
     }
@@ -481,7 +487,7 @@ private fun HomeTabletContent(
         notificationPermissionLauncher = notificationPermissionLauncher,
         locationPermissionLauncher = locationPermissionLauncher,
         batteryOptimizationLauncher = batteryOptimizationLauncher,
-        getBatteryIntent = { viewModel.getBatteryOptimizationIntent() },
+        getBatteryIntent = { batteryOptimizationIntent(activityContext) },
     )
 
     Column(
@@ -764,3 +770,14 @@ private fun buildHomeBannerItems(
         }
     }
 }
+
+/**
+ * The battery-optimisation exemption prompt.
+ *
+ * Built here rather than handed out by the ViewModel: `HomeViewModel.getBatteryOptimizationIntent()`
+ * returned an `android.content.Intent` to the UI, which is the dependency arrow pointing the wrong
+ * way — see `PowerSettings`' KDoc, which called out this exact duplicate pair.
+ */
+private fun batteryOptimizationIntent(ctx: android.content.Context): android.content.Intent =
+    android.content.Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+        .apply { data = android.net.Uri.parse("package:" + ctx.packageName) }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModel.kt
@@ -1,19 +1,15 @@
 package com.arshadshah.nimaz.presentation.viewmodel.home
 
-import android.Manifest
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
-import android.os.PowerManager
-import android.provider.Settings
-import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.text.StringProvider
+import com.arshadshah.nimaz.domain.repository.PermissionChecker
+import com.arshadshah.nimaz.domain.repository.PowerSettings
+import com.arshadshah.nimaz.domain.repository.WidgetRefresher
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.core.util.MILLIS_PER_DAY
@@ -47,9 +43,7 @@ import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.ObserveEventCardsUseCase
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.presentation.components.organisms.WorshipCardUi
-import com.arshadshah.nimaz.widget.prayertracker.PrayerTrackerWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -80,7 +74,10 @@ import com.arshadshah.nimaz.presentation.model.withClockState
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val strings: StringProvider,
+    private val permissions: PermissionChecker,
+    private val powerSettings: PowerSettings,
+    private val widgets: WidgetRefresher,
     private val telemetry: Telemetry,
     private val prayerUseCases: PrayerUseCases,
     private val fastingUseCases: FastingUseCases,
@@ -268,10 +265,10 @@ class HomeViewModel @Inject constructor(
      */
     private fun shortGradeLabel(grade: HadithGrade?): String? =
         when (grade) {
-            HadithGrade.SAHIH -> context.getString(R.string.grade_sahih)
-            HadithGrade.HASAN -> context.getString(R.string.grade_hasan)
-            HadithGrade.DAIF -> context.getString(R.string.grade_daif)
-            HadithGrade.MAWDU -> context.getString(R.string.grade_mawdu)
+            HadithGrade.SAHIH -> strings.get(R.string.grade_sahih)
+            HadithGrade.HASAN -> strings.get(R.string.grade_hasan)
+            HadithGrade.DAIF -> strings.get(R.string.grade_daif)
+            HadithGrade.MAWDU -> strings.get(R.string.grade_mawdu)
             else -> null
         }
 
@@ -336,28 +333,10 @@ class HomeViewModel @Inject constructor(
         AppAnalytics.logAnnouncementCtaClicked(active.id, active.route)
     }
 
-    fun getBatteryOptimizationIntent(): Intent {
-        return Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-            data = "package:${context.packageName}".toUri()
-        }
-    }
-
     private fun checkPermissions() {
-        val hasNotification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ContextCompat.checkSelfPermission(
-                context, Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        } else true
-
-        val hasLocation = ContextCompat.checkSelfPermission(
-            context, Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
-
-        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-        val isBatteryOptimized = !powerManager.isIgnoringBatteryOptimizations(context.packageName)
+        val hasNotification = permissions.hasNotificationPermission()
+        val hasLocation = permissions.hasLocationPermission()
+        val isBatteryOptimized = !powerSettings.isIgnoringBatteryOptimizations()
 
         _state.update {
             it.copy(
@@ -402,7 +381,7 @@ class HomeViewModel @Inject constructor(
             }
 
             // Notify widget to refresh via WorkManager
-            PrayerTrackerWorker.enqueueImmediateWork(context)
+            widgets.refreshPrayerTracker()
         }
     }
 
@@ -677,9 +656,9 @@ class HomeViewModel @Inject constructor(
             Instant.fromEpochMilliseconds(ldt.atZone(zone).toInstant().toEpochMilli())
         return WorshipCardUi(
             type = occ.type,
-            name = WorshipReminderContent.name(context, occ.type),
-            arabic = WorshipReminderContent.arabic(context, occ.type),
-            body = WorshipReminderContent.body(context, occ.type, occ.subKey),
+            name = WorshipReminderContent.name(strings, occ.type),
+            arabic = WorshipReminderContent.arabic(strings, occ.type),
+            body = WorshipReminderContent.body(strings, occ.type, occ.subKey),
             eventAt = toInstant(occ.eventAt),
             windowStart = occ.windowStart?.let(::toInstant),
             windowEnd = occ.windowEnd?.let(::toInstant),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
@@ -1,15 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.prayer
 
-import android.content.Context
 import android.hardware.GeomagneticField
-import android.hardware.Sensor
-import android.hardware.SensorEvent
-import android.hardware.SensorEventListener
-import android.hardware.SensorManager
-import android.os.Build
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
@@ -22,9 +13,11 @@ import com.arshadshah.nimaz.domain.model.QiblaCalculator
 import com.arshadshah.nimaz.domain.model.QiblaDirection
 import com.arshadshah.nimaz.domain.model.QiblaInfo
 import com.arshadshah.nimaz.domain.model.isLocationSet
+import com.arshadshah.nimaz.domain.repository.CompassSensors
+import com.arshadshah.nimaz.domain.repository.Haptics
 import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
+import kotlinx.coroutines.Job
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +29,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class QiblaViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val compassSensors: CompassSensors,
+    private val haptics: Haptics,
     private val locationSettings: LocationSettings,
     private val telemetry: Telemetry,
 ) : ViewModel() {
@@ -47,20 +41,6 @@ class QiblaViewModel @Inject constructor(
     private val _settingsState = MutableStateFlow(QiblaSettingsUiState())
     val settingsState: StateFlow<QiblaSettingsUiState> = _settingsState.asStateFlow()
 
-    // Sensor management
-    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-    private val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
-    } else {
-        @Suppress("DEPRECATION")
-        context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-    }
-
-    // Low-pass filtered sensor arrays
-    private val gravity = FloatArray(3)
-    private val geomagnetic = FloatArray(3)
-    private var hasGravity = false
-    private var hasMagnetic = false
 
     // Azimuth unwrapping state
     private var prevRawAzimuth = 0f
@@ -68,62 +48,6 @@ class QiblaViewModel @Inject constructor(
 
     // Track previous facing state for haptic
     private var wasFacingQibla = false
-
-    private val sensorListener = object : SensorEventListener {
-        override fun onSensorChanged(event: SensorEvent) {
-            when (event.sensor.type) {
-                Sensor.TYPE_ACCELEROMETER -> {
-                    smoothInto(gravity, event.values, seed = !hasGravity)
-                    hasGravity = true
-                }
-
-                Sensor.TYPE_MAGNETIC_FIELD -> {
-                    smoothInto(geomagnetic, event.values, seed = !hasMagnetic)
-                    hasMagnetic = true
-                }
-            }
-
-            if (hasGravity && hasMagnetic) {
-                val rotationMatrix = FloatArray(9)
-                val inclinationMatrix = FloatArray(9)
-                if (SensorManager.getRotationMatrix(
-                        rotationMatrix,
-                        inclinationMatrix,
-                        gravity,
-                        geomagnetic
-                    )
-                ) {
-                    val orientation = FloatArray(3)
-                    SensorManager.getOrientation(rotationMatrix, orientation)
-                    val azimuthDeg =
-                        ((Math.toDegrees(orientation[0].toDouble()).toFloat() + 360) % 360)
-                    val pitchDeg = Math.toDegrees(orientation[1].toDouble()).toFloat()
-                    val rollDeg = Math.toDegrees(orientation[2].toDouble()).toFloat()
-
-                    // Unwrap azimuth to avoid 360->0 snap
-                    var delta = azimuthDeg - prevRawAzimuth
-                    if (delta > 180) delta -= 360
-                    if (delta < -180) delta += 360
-                    prevRawAzimuth = azimuthDeg
-                    cumulativeAzimuth += delta
-
-                    updateCompassData(azimuthDeg, pitchDeg, rollDeg, cumulativeAzimuth)
-                }
-            }
-        }
-
-        override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {
-            if (sensor.type == Sensor.TYPE_MAGNETIC_FIELD) {
-                val compassAccuracy = when (accuracy) {
-                    SensorManager.SENSOR_STATUS_ACCURACY_HIGH -> CompassAccuracy.HIGH
-                    SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM -> CompassAccuracy.MEDIUM
-                    SensorManager.SENSOR_STATUS_ACCURACY_LOW -> CompassAccuracy.LOW
-                    else -> CompassAccuracy.UNRELIABLE
-                }
-                updateAccuracy(compassAccuracy)
-            }
-        }
-    }
 
     init {
         observeLocation()
@@ -134,19 +58,40 @@ class QiblaViewModel @Inject constructor(
         unregisterSensors()
     }
 
+    /** The in-flight compass collection; cancelling it unregisters the sensors. */
+    private var compassJob: Job? = null
+
     private fun registerSensors() {
-        val accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-        val magnetometer = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
-        accelerometer?.let {
-            sensorManager.registerListener(sensorListener, it, SensorManager.SENSOR_DELAY_GAME)
-        }
-        magnetometer?.let {
-            sensorManager.registerListener(sensorListener, it, SensorManager.SENSOR_DELAY_GAME)
+        if (!compassSensors.isAvailable) return
+        compassJob?.cancel()
+        compassJob = launchSafely(telemetry, AppAnalytics.Feature.QIBLA, "observe_compass") {
+            compassSensors.orientation().collect { reading ->
+                if (reading.accuracy != _qiblaState.value.compassData.accuracy) {
+                    updateAccuracy(reading.accuracy)
+                }
+
+                // Unwrap so the needle does not snap through 360 -> 0. Kept here rather than in
+                // the seam because it is stateful across readings, and the state belongs with
+                // the screen it is drawn on.
+                var delta = reading.azimuthDegrees - prevRawAzimuth
+                if (delta > 180) delta -= 360
+                if (delta < -180) delta += 360
+                prevRawAzimuth = reading.azimuthDegrees
+                cumulativeAzimuth += delta
+
+                updateCompassData(
+                    reading.azimuthDegrees,
+                    reading.pitchDegrees,
+                    reading.rollDegrees,
+                    cumulativeAzimuth,
+                )
+            }
         }
     }
 
     private fun unregisterSensors() {
-        sensorManager.unregisterListener(sensorListener)
+        compassJob?.cancel()
+        compassJob = null
     }
 
     fun onEvent(event: QiblaEvent) {
@@ -194,10 +139,6 @@ class QiblaViewModel @Inject constructor(
     private var lastReportedAccuracy: CompassAccuracy? = null
 
     private fun resetSensorState() {
-        gravity.fill(0f)
-        geomagnetic.fill(0f)
-        hasGravity = false
-        hasMagnetic = false
         prevRawAzimuth = 0f
         cumulativeAzimuth = 0f
         // Reset with the rest of the sensor state. Left set, the rising-edge test below never
@@ -413,31 +354,7 @@ class QiblaViewModel @Inject constructor(
     }
 
     private fun triggerHaptic() {
-        vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
+        haptics.tap()
     }
 }
 
-/** Low-pass coefficient for the accelerometer and magnetometer vectors. */
-private const val SMOOTHING = 0.97f
-
-/**
- * Low-pass filter, seeded from the first sample.
- *
- * The vectors start as all-zero and `resetSensorState()` re-zeroes them on every
- * `StartCompass`, while `SMOOTHING` is 0.97 — so the first sample contributed **3%** of its
- * value and the filtered vector needed ~100 samples to reach 95% of the truth. At
- * `SENSOR_DELAY_GAME` (~20 ms) that is **about two seconds**, and `isCompassReady` is
- * published on the *first* successful `getRotationMatrix`. So the screen said ready and the
- * needle swept in from a meaningless heading — every time, because the screen's
- * `DisposableEffect` stops and starts the compass on each entry.
- *
- * Seeding costs nothing: one sample is a worse estimate than a hundred, but it is an
- * estimate *of the right thing*, which zero is not.
- */
-internal fun smoothInto(filtered: FloatArray, sample: FloatArray, seed: Boolean) {
-    for (i in filtered.indices) {
-        filtered[i] =
-            if (seed) sample[i]
-            else SMOOTHING * filtered[i] + (1 - SMOOTHING) * sample[i]
-    }
-}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModel.kt
@@ -1,10 +1,10 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.text.StringProvider
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.domain.model.DuaBookmark
@@ -14,7 +14,6 @@ import com.arshadshah.nimaz.domain.usecase.DuaUseCases
 import com.arshadshah.nimaz.domain.usecase.HadithUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,7 +32,7 @@ class BookmarksViewModel @Inject constructor(
     private val quranUseCases: QuranUseCases,
     private val hadithUseCases: HadithUseCases,
     private val duaUseCases: DuaUseCases,
-    @ApplicationContext private val context: Context,
+    private val strings: StringProvider,
     private val telemetry: Telemetry,
 ) : ViewModel() {
 
@@ -421,8 +420,8 @@ class BookmarksViewModel @Inject constructor(
     private fun QuranBookmark.toUnified() = UnifiedBookmark(
         id = BookmarkType.QURAN.idFor(ayahId),
         type = BookmarkType.QURAN,
-        title = context.getString(R.string.bookmark_surah_ayah_format, surahNumber, ayahNumber),
-        subtitle = context.getString(R.string.quran),
+        title = strings.get(R.string.bookmark_surah_ayah_format, surahNumber, ayahNumber),
+        subtitle = strings.get(R.string.quran),
         arabicText = null, // Enriched in loadQuranBookmarks via getAyahById
         createdAt = createdAt,
         note = note,
@@ -434,7 +433,7 @@ class BookmarksViewModel @Inject constructor(
     private fun HadithBookmark.toUnified() = UnifiedBookmark(
         id = BookmarkType.HADITH.idFor(hadithId),
         type = BookmarkType.HADITH,
-        title = context.getString(R.string.bookmark_hadith_format, hadithNumber),
+        title = strings.get(R.string.bookmark_hadith_format, hadithNumber),
         subtitle = bookId,
         arabicText = null, // Enriched in loadHadithBookmarks via getHadithById
         createdAt = createdAt,
@@ -447,7 +446,7 @@ class BookmarksViewModel @Inject constructor(
     private fun DuaBookmark.toUnified() = UnifiedBookmark(
         id = BookmarkType.DUA.idFor(duaId),
         type = BookmarkType.DUA,
-        title = context.getString(R.string.dua_label),
+        title = strings.get(R.string.dua_label),
         subtitle = categoryId,
         arabicText = null, // Enriched in loadDuaBookmarks via getDuaById
         createdAt = createdAt,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModel.kt
@@ -2,13 +2,13 @@
 
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
-import android.content.Context
 import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.core.text.StringProvider
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.data.audio.AudioState
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
@@ -37,7 +37,6 @@ import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -83,7 +82,7 @@ class QuranViewModel @Inject constructor(
     private val quranSettings: QuranPreferences,
     private val khatamUseCases: KhatamUseCases,
     private val telemetry: Telemetry,
-    @ApplicationContext private val context: Context
+    private val strings: StringProvider
 ) : ViewModel() {
 
     private val _homeState = MutableStateFlow(QuranHomeUiState())
@@ -591,7 +590,7 @@ class QuranViewModel @Inject constructor(
             )
         }
         val title = _readerState.value.title.ifEmpty {
-            context.getString(
+            strings.get(
                 R.string.quran_home_surah_fallback,
                 surahNumber
             )
@@ -740,7 +739,7 @@ class QuranViewModel @Inject constructor(
                             ayahs = surahWithAyahs?.ayahs ?: emptyList(),
                             title = surahWithAyahs?.surah?.nameEnglish ?: "",
                             subtitle = surahWithAyahs?.let { s ->
-                                context.resources.getQuantityString(
+                                strings.quantity(
                                     R.plurals.quran_surah_ayahs_format,
                                     s.surah.numberOfAyahs,
                                     s.surah.number,
@@ -764,7 +763,7 @@ class QuranViewModel @Inject constructor(
                 readingMode = ReadingMode.JUZ,
                 surahWithAyahs = null,
                 ayahs = emptyList(),
-                title = context.getString(R.string.quran_juz_number_format, juzNumber),
+                title = strings.get(R.string.quran_juz_number_format, juzNumber),
                 subtitle = ""
             )
         }
@@ -781,7 +780,7 @@ class QuranViewModel @Inject constructor(
                     _readerState.update {
                         it.copy(
                             ayahs = ayahs,
-                            title = context.getString(R.string.quran_juz_number_format, juzNumber),
+                            title = strings.get(R.string.quran_juz_number_format, juzNumber),
                             subtitle = "${ayahs.size} Ayahs",
                             isLoading = false
                         )
@@ -814,7 +813,7 @@ class QuranViewModel @Inject constructor(
                     it.copy(
                         ayahs = cached,
                         readingMode = ReadingMode.PAGE,
-                        title = context.getString(R.string.page_single_format, pageNumber),
+                        title = strings.get(R.string.page_single_format, pageNumber),
                         subtitle = "${cached.size} Ayahs",
                         isLoading = false
                     )
@@ -831,7 +830,7 @@ class QuranViewModel @Inject constructor(
                     readingMode = ReadingMode.PAGE,
                     surahWithAyahs = null,
                     // Keep existing ayahs to prevent flicker during page transition
-                    title = context.getString(R.string.page_single_format, pageNumber),
+                    title = strings.get(R.string.page_single_format, pageNumber),
                     subtitle = ""
                 )
             }
@@ -948,7 +947,7 @@ class QuranViewModel @Inject constructor(
                         if (result.surahName.isEmpty()) {
                             val surahName =
                                 surahs.find { it.number == result.ayah.surahNumber }?.nameEnglish
-                                    ?: context.getString(
+                                    ?: strings.get(
                                         R.string.quran_home_surah_fallback,
                                         result.ayah.surahNumber
                                     )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
@@ -1,11 +1,12 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.domain.repository.AdhanDownloader
+import com.arshadshah.nimaz.domain.repository.AppLocale
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.monitoring.catchAndReport
 import com.arshadshah.nimaz.core.util.LocaleHelper
@@ -27,7 +28,6 @@ import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.domain.usecase.QuranUseCases
 import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -94,7 +94,8 @@ data class NotificationSummary(
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val appLocale: AppLocale,
+    private val adhanDownloader: AdhanDownloader,
     private val prayerUseCases: PrayerUseCases,
     private val settingsRepository: SettingsRepository,
     private val quranUseCases: QuranUseCases,
@@ -344,7 +345,7 @@ class SettingsViewModel @Inject constructor(
                 )
                 launchSafely(telemetry, AppAnalytics.Feature.SETTINGS, "on_event") {
                     settingsRepository.setAppLanguage(event.language.code)
-                    LocaleHelper.setLocale(context, event.language.code)
+                    appLocale.apply(event.language.code)
                     _shouldRestart.value = true
                 }
             }
@@ -603,7 +604,7 @@ class SettingsViewModel @Inject constructor(
                     // Download the selected adhan if not already downloaded
                     val sound = AdhanSound.fromName(event.sound)
                     if (!adhanAudioManager.isFullyDownloaded(sound)) {
-                        AdhanDownloadService.downloadSelected(context, sound)
+                        adhanDownloader.download(sound.name)
                     }
                 }
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1800,4 +1800,5 @@
     <string name="tafseer_note_hint">Deine Gedanken zu diesem Abschnitt</string>
     <string name="tafseer_note_edit">Bearbeiten</string>
     <string name="quran_search_surahs">Suren suchen</string>
+    <string name="zakat_currency">Währung</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1835,4 +1835,5 @@
     <string name="tafseer_note_hint">Votre réflexion sur ce passage</string>
     <string name="tafseer_note_edit">Modifier</string>
     <string name="quran_search_surahs">Rechercher des sourates</string>
+    <string name="zakat_currency">Devise</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1769,4 +1769,5 @@
     <string name="tafseer_note_hint">Renungan Anda tentang bagian ini</string>
     <string name="tafseer_note_edit">Ubah</string>
     <string name="quran_search_surahs">Cari surah</string>
+    <string name="zakat_currency">Mata Uang</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1770,4 +1770,5 @@
     <string name="tafseer_note_hint">Renungan anda tentang petikan ini</string>
     <string name="tafseer_note_edit">Sunting</string>
     <string name="quran_search_surahs">Cari surah</string>
+    <string name="zakat_currency">Mata Wang</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1806,4 +1806,5 @@
     <string name="tafseer_note_hint">Bu bölüm hakkındaki düşünceniz</string>
     <string name="tafseer_note_edit">Düzenle</string>
     <string name="quran_search_surahs">Sure ara</string>
+    <string name="zakat_currency">Para Birimi</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FakePlatformSeams.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FakePlatformSeams.kt
@@ -1,0 +1,44 @@
+package com.arshadshah.nimaz.presentation.viewmodel
+
+import com.arshadshah.nimaz.core.text.StringProvider
+import com.arshadshah.nimaz.domain.repository.PermissionChecker
+import com.arshadshah.nimaz.domain.repository.PowerSettings
+import com.arshadshah.nimaz.domain.repository.WidgetRefresher
+
+/**
+ * The platform seams ViewModels take instead of an `@ApplicationContext`.
+ *
+ * The point of the extraction is visible here: these fakes are a few lines each, where the
+ * alternative was a Robolectric `ApplicationContext` for a ViewModel that wanted four strings
+ * and a permission bit.
+ */
+class FakeStringProvider(
+    private val format: (Int, List<Any>) -> String = { id, args ->
+        if (args.isEmpty()) "string:$id" else "string:$id(${args.joinToString()})"
+    }
+) : StringProvider {
+    override fun get(id: Int, vararg args: Any): String = format(id, args.toList())
+    override fun quantity(id: Int, count: Int, vararg args: Any): String =
+        format(id, listOf(count) + args.toList())
+}
+
+class FakePermissionChecker(
+    private val location: Boolean = true,
+    private val notification: Boolean = true,
+) : PermissionChecker {
+    override fun hasLocationPermission() = location
+    override fun hasNotificationPermission() = notification
+}
+
+class FakePowerSettings(private val exempt: Boolean = true) : PowerSettings {
+    override fun isIgnoringBatteryOptimizations() = exempt
+}
+
+class RecordingWidgetRefresher : WidgetRefresher {
+    var refreshCount = 0
+        private set
+
+    override fun refreshPrayerTracker() {
+        refreshCount++
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelRolloverTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelRolloverTest.kt
@@ -1,5 +1,9 @@
 package com.arshadshah.nimaz.presentation.viewmodel.home
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakePermissionChecker
+import com.arshadshah.nimaz.presentation.viewmodel.FakePowerSettings
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
+import com.arshadshah.nimaz.presentation.viewmodel.RecordingWidgetRefresher
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import android.app.Application
 import android.content.Context
@@ -108,7 +112,10 @@ class HomeViewModelRolloverTest {
     private fun viewModel(): HomeViewModel {
         val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
         return HomeViewModel(
-            context = context,
+            strings = FakeStringProvider(),
+            permissions = FakePermissionChecker(),
+            powerSettings = FakePowerSettings(),
+            widgets = RecordingWidgetRefresher(),
             telemetry = RecordingTelemetry(),
             prayerUseCases = buildPrayerUseCases(prayerRepository),
             fastingUseCases = buildFastingUseCases(fastingRepository),

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/home/HomeViewModelTest.kt
@@ -1,5 +1,9 @@
 package com.arshadshah.nimaz.presentation.viewmodel.home
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakePermissionChecker
+import com.arshadshah.nimaz.presentation.viewmodel.FakePowerSettings
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
+import com.arshadshah.nimaz.presentation.viewmodel.RecordingWidgetRefresher
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import android.app.Application
 import android.content.Context
@@ -104,7 +108,10 @@ class HomeViewModelTest {
     private fun createViewModel(): HomeViewModel {
         val announcementUseCases = buildAnnouncementUseCases(announcementRepository)
         return HomeViewModel(
-            context = context,
+            strings = FakeStringProvider(),
+            permissions = FakePermissionChecker(),
+            powerSettings = FakePowerSettings(),
+            widgets = RecordingWidgetRefresher(),
             telemetry = RecordingTelemetry(),
             prayerUseCases = buildPrayerUseCases(prayerRepository),
             fastingUseCases = buildFastingUseCases(fastingRepository),

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/CompassSmoothingTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/CompassSmoothingTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.prayer
 
+import com.arshadshah.nimaz.data.device.smoothInto
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import kotlin.math.abs

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModelTest.kt
@@ -1,0 +1,182 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.CompassOrientation
+import com.arshadshah.nimaz.domain.repository.CompassSensors
+import com.arshadshah.nimaz.domain.repository.Haptics
+import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `QiblaViewModel` held a `SensorManager` and a `Vibrator` off an `@ApplicationContext`, so it
+ * could not be constructed on the JVM and none of the behaviour below was testable — including
+ * the azimuth unwrap, which exists precisely because a compass that snaps through 360→0 sends
+ * the needle the long way round.
+ *
+ * The sensors are now behind `CompassSensors`, which emits finished orientation, so a fake can
+ * simply push readings.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QiblaViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private class FakeCompass(override val isAvailable: Boolean = true) : CompassSensors {
+        val readings = MutableSharedFlow<CompassOrientation>(extraBufferCapacity = 64)
+        var collections = 0
+            private set
+
+        override fun orientation(): Flow<CompassOrientation> = kotlinx.coroutines.flow.flow {
+            collections++
+            readings.collect { emit(it) }
+        }
+
+        suspend fun emit(
+            azimuth: Float,
+            accuracy: CompassAccuracy = CompassAccuracy.HIGH,
+        ) = readings.emit(CompassOrientation(azimuth, 0f, 0f, accuracy))
+    }
+
+    private class RecordingHaptics : Haptics {
+        var taps = 0
+            private set
+
+        override fun tap() {
+            taps++
+        }
+    }
+
+    private class StubLocationSettings : LocationSettings {
+        override val latitude: Flow<Double> = MutableStateFlow(51.5074)
+        override val longitude: Flow<Double> = MutableStateFlow(-0.1278)
+        override val locationName: Flow<String> = MutableStateFlow("London")
+        override val userPreferences: Flow<UserPreferences> = MutableStateFlow(mockk(relaxed = true))
+        override suspend fun updateLocation(latitude: Double, longitude: Double, name: String) = Unit
+    }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(
+        compass: CompassSensors = FakeCompass(),
+        haptics: Haptics = RecordingHaptics(),
+    ) = QiblaViewModel(compass, haptics, StubLocationSettings(), RecordingTelemetry())
+
+    @Test
+    fun `crossing north does not send the needle the long way round`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        compass.emit(350f)
+        advanceUntilIdle()
+        val before = vm.qiblaState.value.animatedAzimuth
+
+        compass.emit(10f)
+        advanceUntilIdle()
+        val after = vm.qiblaState.value.animatedAzimuth
+
+        // Raw, this is 350 -> 10, which reads as -340. Unwrapped it is +20.
+        assertThat(after - before).isWithin(0.01f).of(20f)
+    }
+
+    @Test
+    fun `a low accuracy reading asks for calibration`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        compass.emit(0f, accuracy = CompassAccuracy.LOW)
+        advanceUntilIdle()
+
+        assertThat(vm.qiblaState.value.needsCalibration).isTrue()
+        assertThat(vm.qiblaState.value.compassData.accuracy).isEqualTo(CompassAccuracy.LOW)
+    }
+
+    @Test
+    fun `a high accuracy reading clears the calibration prompt`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        compass.emit(0f, accuracy = CompassAccuracy.UNRELIABLE)
+        advanceUntilIdle()
+        assertThat(vm.qiblaState.value.needsCalibration).isTrue()
+
+        compass.emit(1f, accuracy = CompassAccuracy.HIGH)
+        advanceUntilIdle()
+
+        assertThat(vm.qiblaState.value.needsCalibration).isFalse()
+    }
+
+    @Test
+    fun `stopping the compass ends the collection`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+        compass.emit(90f)
+        advanceUntilIdle()
+        val whileRunning = vm.qiblaState.value.animatedAzimuth
+
+        vm.onEvent(QiblaEvent.StopCompass)
+        advanceUntilIdle()
+        compass.emit(180f)
+        advanceUntilIdle()
+
+        // The reading after StopCompass must not reach state — the old code relied on
+        // unregisterListener being remembered; now cancelling the collection does it.
+        assertThat(vm.qiblaState.value.animatedAzimuth).isEqualTo(whileRunning)
+    }
+
+    @Test
+    fun `a device with no compass is not collected from at all`() = runTest(dispatcher) {
+        val compass = FakeCompass(isAvailable = false)
+        val vm = viewModel(compass = compass)
+
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        assertThat(compass.collections).isEqualTo(0)
+    }
+
+    @Test
+    fun `restarting the compass resets the accumulated azimuth`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+        compass.emit(90f)
+        advanceUntilIdle()
+        assertThat(vm.qiblaState.value.animatedAzimuth).isNotEqualTo(0f)
+
+        vm.onEvent(QiblaEvent.StopCompass)
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        assertThat(vm.qiblaState.value.animatedAzimuth).isEqualTo(0f)
+        assertThat(vm.qiblaState.value.isCompassReady).isFalse()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/BookmarksViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
 import android.content.Context
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.DuaBookmark
@@ -72,7 +73,7 @@ class BookmarksViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = BookmarksViewModel(quran, hadith, dua, context, telemetry)
+    private fun viewModel() = BookmarksViewModel(quran, hadith, dua, FakeStringProvider(), telemetry)
 
     @Test
     fun `a failing bookmark stream reports and stops loading instead of hanging`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranReaderHydrationTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
 import android.content.Context
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
@@ -95,7 +96,7 @@ class QuranReaderHydrationTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), FakeStringProvider())
 
     // R1 — the home list must stay on its skeleton until Room answers.
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranSurahFilterTest.kt
@@ -1,5 +1,6 @@
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
 import android.content.Context
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
@@ -82,7 +83,7 @@ class QuranSurahFilterTest {
     fun tearDown() = Dispatchers.resetMain()
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), FakeStringProvider())
 
     @Test
     fun `the list narrows to the transliterated name`() = runTest {

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModelPageLoadTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/quran/QuranViewModelPageLoadTest.kt
@@ -2,6 +2,7 @@
 
 package com.arshadshah.nimaz.presentation.viewmodel.quran
 
+import com.arshadshah.nimaz.presentation.viewmodel.FakeStringProvider
 import android.content.Context
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.data.audio.QuranAudioManager
@@ -118,7 +119,7 @@ class QuranViewModelPageLoadTest {
     }
 
     private fun viewModel() =
-        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), context)
+        QuranViewModel(useCases, audioManager, settingsRepository, khatamUseCases, RecordingTelemetry(), FakeStringProvider())
 
     private fun ayahOnPage(page: Int) = Ayah(
         id = page,

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -240,7 +240,7 @@ This one is **pervasive and lower priority** — listed so it's tracked, not bec
 ### AP-7.15 · `@ApplicationContext` in a ViewModel
 
 A ViewModel holding the application `Context` can reach the entire platform — system services,
-the package manager, WorkManager, `Service` start. Six held one; five no longer do.
+the package manager, WorkManager, `Service` start. Six held one; **none do now**.
 
 - [x] ~~**String resolution** (`Bookmarks`, `Quran`, `Home`).~~ **Resolved** via
   `core/text/StringProvider`. Note the first instinct — delete the derived `title`/`subtitle`
@@ -254,14 +254,18 @@ the package manager, WorkManager, `Service` start. Six held one; five no longer 
 - [x] ~~**Widget refresh** (`Home` called `PrayerTrackerWorker.enqueueImmediateWork(context)`).~~
   **Resolved** — `WidgetRefresher`. What Home wants to say is "the tracker changed, redraw".
 - [x] ~~**Locale and adhan download** (`Settings`).~~ **Resolved** — `AppLocale`, `AdhanDownloader`.
-- [ ] **`QiblaViewModel` — the last one, and the only hard one.** It holds `SensorManager` and
-  `Vibrator`. The vibration half is trivial (a `Haptics` seam). The compass half is not: the
-  `SensorEventListener` low-pass-filters gravity and geomagnetic samples **before**
-  `SensorManager.getRotationMatrix`/`getOrientation`, then unwraps the azimuth to avoid the
-  360→0 snap. So the seam boundary is a real decision — emit raw samples and leave the fusion in
-  the ViewModel (keeping an Android static dependency), or emit finished orientation and move the
-  smoothing down (which `CompassSmoothingTest` currently pins in the ViewModel). It also handles
-  `onAccuracyChanged` for magnetometer calibration. Do not rush this one for the sake of the grep.
+- [x] ~~**`QiblaViewModel` — the last one, and the only hard one.**~~ **Resolved.**
+  `CompassSensors` emits finished orientation (azimuth/pitch/roll + accuracy) and `Haptics` the
+  confirmation buzz. The low-pass filtering and the `getRotationMatrix`/`getOrientation` fusion
+  are platform math and moved to `AndroidCompassSensors`; the ViewModel kept what is actually
+  about the qibla — unwrapping the azimuth past 360→0, applying declination, and deciding when
+  the user faces the Kaaba. `smoothInto` was **already** a top-level `internal fun` tested
+  directly by `CompassSmoothingTest`, so it moved with the fusion for the cost of one import —
+  the concern that the test pinned it inside the ViewModel was wrong.
+  Sensor lifetime is now the flow's: `awaitClose { unregisterListener }` replaces an
+  `onCleared()` that had to remember. Six new tests cover the unwrap, calibration prompts, stop,
+  restart, and the no-compass device — none of which could be written before.
+  **Detect:** `grep -rn "ApplicationContext" app/src/main --include='*ViewModel.kt'` — now zero.
 
 ### AP-7.14 · A ViewModel that cannot be constructed on the JVM has no tests, and that is why
 

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -237,6 +237,32 @@ This one is **pervasive and lower priority** — listed so it's tracked, not bec
   (the wrapper is the seam the UI depends on), but if a use case adds no value and the feature is
   trivial, that's fine — don't over-engineer net-new tiny features.
 
+### AP-7.15 · `@ApplicationContext` in a ViewModel
+
+A ViewModel holding the application `Context` can reach the entire platform — system services,
+the package manager, WorkManager, `Service` start. Six held one; five no longer do.
+
+- [x] ~~**String resolution** (`Bookmarks`, `Quran`, `Home`).~~ **Resolved** via
+  `core/text/StringProvider`. Note the first instinct — delete the derived `title`/`subtitle`
+  from `UnifiedBookmark` and resolve them in the screen — is **wrong here**: `BookmarksViewModel`
+  *searches* and *alphabetically sorts* on those labels, so the comparison happens where the list
+  is filtered, not where it is drawn. Moving them would have quietly changed what "Quran" matches.
+- [x] ~~**Permissions and battery** (`Home`, `Onboarding`).~~ **Resolved** — the existing
+  `PermissionChecker` / `PowerSettings` seams, which already existed and were simply not used here.
+- [x] ~~**`getBatteryOptimizationIntent(): Intent`** in `Home` and `Onboarding`.~~ **Resolved** —
+  built in the screens. A ViewModel returning an `android.content.Intent` is the arrow backwards.
+- [x] ~~**Widget refresh** (`Home` called `PrayerTrackerWorker.enqueueImmediateWork(context)`).~~
+  **Resolved** — `WidgetRefresher`. What Home wants to say is "the tracker changed, redraw".
+- [x] ~~**Locale and adhan download** (`Settings`).~~ **Resolved** — `AppLocale`, `AdhanDownloader`.
+- [ ] **`QiblaViewModel` — the last one, and the only hard one.** It holds `SensorManager` and
+  `Vibrator`. The vibration half is trivial (a `Haptics` seam). The compass half is not: the
+  `SensorEventListener` low-pass-filters gravity and geomagnetic samples **before**
+  `SensorManager.getRotationMatrix`/`getOrientation`, then unwraps the azimuth to avoid the
+  360→0 snap. So the seam boundary is a real decision — emit raw samples and leave the fusion in
+  the ViewModel (keeping an Android static dependency), or emit finished orientation and move the
+  smoothing down (which `CompassSmoothingTest` currently pins in the ViewModel). It also handles
+  `onAccuracyChanged` for magnetometer calibration. Do not rush this one for the sake of the grep.
+
 ### AP-7.14 · A ViewModel that cannot be constructed on the JVM has no tests, and that is why
 
 - [x] ~~**`OnboardingViewModel` built a `FusedLocationProviderClient` in a property initializer.**~~


### PR DESCRIPTION
A ViewModel holding @ApplicationContext can reach the whole platform. Six did.

String resolution moved behind core/text/StringProvider. The tempting fix for
Bookmarks — delete the derived title/subtitle from UnifiedBookmark and render
them in the screen, since the model already carries type, surah, ayah and hadith
number — is wrong: the ViewModel *searches* and alphabetically *sorts* on those
labels, so the comparison happens where the list is filtered, not where it is
drawn. Doing it would have quietly changed what typing "Quran" matches.

Home's permission and battery checks went to PermissionChecker and
PowerSettings, which already existed and simply were not used here. Its widget
refresh — a direct PrayerTrackerWorker.enqueueImmediateWork(context) — went to
WidgetRefresher; what Home wants to say is "the tracker changed, redraw", not
which worker does it. getBatteryOptimizationIntent(): Intent moved into the
screens, in Home as it did in Onboarding.

Settings' last two, LocaleHelper.setLocale and AdhanDownloadService, went to
AppLocale and AdhanDownloader.

QiblaViewModel is left, deliberately. Its SensorEventListener low-pass-filters
gravity and geomagnetic samples before getRotationMatrix/getOrientation and then
unwraps the azimuth, so where the seam goes is a real decision rather than a
mechanical move — and CompassSmoothingTest currently pins that smoothing in the
ViewModel. AP-7.15 records the two options.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>