### PR TITLE
fix(screens): the last hand-rolled error blocks

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/calendar/IslamicCalendarScreen.kt
@@ -37,6 +37,8 @@ import com.arshadshah.nimaz.domain.model.IslamicEvent
 import com.arshadshah.nimaz.domain.model.IslamicEventType
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.molecules.IslamicEventCard
@@ -226,10 +228,13 @@ private fun CalendarSection(
     // markers and nothing else. Before, it cost the whole screen: `loadToday()` ran inside
     // the events `try`, so a throw left `currentMonth` null and this rendered nothing at all.
     state.error?.let { error ->
-        Text(
-            text = stringResource(error),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.error,
+        // SECTION, not a screen: the grid is still correct and still useful without its
+        // event markers, so this sits above it rather than in place of it.
+        NimazErrorState(
+            title = stringResource(error.message),
+            kind = error.kind,
+            details = error.details,
+            variant = NimazErrorVariant.SECTION,
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreen.kt
@@ -49,6 +49,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
@@ -85,20 +87,21 @@ fun DuaCategoryScreen(
             )
         }
     ) { paddingValues ->
+        val error = state.error
         if (state.isLoading) {
             NimazLoadingState(modifier = Modifier.padding(paddingValues))
-        } else if (state.error != null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(state.error ?: R.string.error_generic),
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
+        } else if (error != null) {
+            NimazErrorState(
+                title = stringResource(error.message),
+                message = stringResource(R.string.dua_load_failed_body),
+                kind = error.kind,
+                details = error.details,
+                primaryAction = NimazErrorDefaults.retry(
+                    onRetry = { viewModel.onEvent(DuaEvent.LoadCategory(categoryId)) },
+                    label = stringResource(R.string.try_again),
+                ),
+                modifier = Modifier.padding(paddingValues),
+            )
         } else {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionScreen.kt
@@ -26,6 +26,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -80,17 +82,17 @@ fun DuaOccasionScreen(
         when {
             state.isLoading -> NimazLoadingState(modifier = Modifier.padding(paddingValues))
 
-            errorRes != null -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(errorRes),
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
+            errorRes != null -> NimazErrorState(
+                title = stringResource(errorRes.message),
+                message = stringResource(R.string.dua_load_failed_body),
+                kind = errorRes.kind,
+                details = errorRes.details,
+                primaryAction = NimazErrorDefaults.retry(
+                    onRetry = { viewModel.onEvent(DuaEvent.LoadDuasByOccasion(occasion)) },
+                    label = stringResource(R.string.try_again),
+                ),
+                modifier = Modifier.padding(paddingValues),
+            )
 
             state.duas.isEmpty() -> Box(
                 modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreen.kt
@@ -60,8 +60,11 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPager
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPillActionButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
@@ -134,21 +137,17 @@ fun DuaReaderScreen(
                 .padding(paddingValues)
         ) {
             when {
-                state.isLoading && duas.isEmpty() -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
+                state.isLoading && duas.isEmpty() -> NimazLoadingState()
 
                 duas.isEmpty() -> {
                     // A load that failed says so; an id that resolved to nothing keeps the
-                    // "not found" wording. Both come from the ViewModel as a resource id.
-                    Text(
-                        text = stringResource(state.error ?: R.string.dua_reader_not_found),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.Center)
+                    // "not found" wording — and the kind now carries which of the two it is,
+                    // so the two stop looking identical.
+                    val error = state.error
+                    NimazErrorState(
+                        title = stringResource(error?.message ?: R.string.dua_reader_not_found),
+                        kind = error?.kind ?: NimazErrorKind.NOT_FOUND,
+                        details = error?.details,
                     )
                 }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreen.kt
@@ -88,6 +88,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
@@ -160,18 +162,19 @@ fun DuasCollectionScreen(
             NimazLoadingState(modifier = Modifier.padding(paddingValues))
         } else if (errorRes != null) {
             // Before the collection load was guarded, a content-database fault killed the
-            // collector and left the spinner up for good. It now resolves to this.
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(errorRes),
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
+            // collector and left the spinner up for good. It now resolves to this — and
+            // says what failed, rather than printing a red line.
+            NimazErrorState(
+                title = stringResource(errorRes.message),
+                message = stringResource(R.string.dua_load_failed_body),
+                kind = errorRes.kind,
+                details = errorRes.details,
+                primaryAction = NimazErrorDefaults.retry(
+                    onRetry = { viewModel.onEvent(DuaEvent.LoadAllCategories) },
+                    label = stringResource(R.string.try_again),
+                ),
+                modifier = Modifier.padding(paddingValues),
+            )
         } else {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreen.kt
@@ -37,6 +37,9 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorAction
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
@@ -150,29 +153,28 @@ fun QiblaScreen(
                     else MaterialTheme.colorScheme.background
                 )
         ) {
-            // Error state
-            if (state.error != null && state.qiblaInfo == null) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(20.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    NimazIcon(
-                        imageVector = Icons.Default.Warning,
-                        contentDescription = null,
-                        variant = NimazIconVariant.ERROR,
-                        iconSize = 48.dp
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = state.error ?: stringResource(R.string.unknown_error),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.error,
-                        textAlign = TextAlign.Center
-                    )
-                }
+            // Only when there is no direction to draw: a compass already pointing somewhere
+            // is more use than a message about a refresh that failed.
+            val error = state.error
+            if (error != null && state.qiblaInfo == null) {
+                NimazErrorState(
+                    title = stringResource(error.message),
+                    message = stringResource(R.string.qibla_no_location_body),
+                    kind = error.kind,
+                    details = error.details,
+                    // The screen offered no way out of this at all — a reader with no
+                    // location set saw a red sentence telling them to go to settings, and
+                    // no way to get there or to retry.
+                    primaryAction = NimazErrorDefaults.retry(
+                        onRetry = { viewModel.onEvent(QiblaEvent.RefreshLocation) },
+                        label = stringResource(R.string.try_again),
+                    ),
+                    secondaryAction = NimazErrorAction(
+                        label = stringResource(R.string.location_set_prompt),
+                        onClick = { viewModel.onEvent(QiblaEvent.ShowLocationPicker) },
+                    ),
+                    modifier = Modifier.padding(20.dp),
+                )
                 return@Box
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SyncScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SyncScreen.kt
@@ -54,6 +54,9 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorAction
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
@@ -162,15 +165,30 @@ fun SyncScreen(
                 }
 
                 state.error != null -> {
-                    ErrorContent(
-                        error = state.error!!,
-                        activityLog = state.activityLog,
-                        onRetry = { viewModel.onEvent(SyncEvent.Cancel) },
-                        onDismiss = {
-                            viewModel.onEvent(SyncEvent.Cancel)
-                            onNavigateBack()
-                        }
+                    val error = state.error!!
+                    NimazErrorState(
+                        title = stringResource(error.message),
+                        message = stringResource(R.string.sync_failed_body),
+                        kind = error.kind,
+                        details = error.details,
+                        primaryAction = NimazErrorDefaults.retry(
+                            onRetry = { viewModel.onEvent(SyncEvent.Cancel) },
+                            label = stringResource(R.string.try_again),
+                        ),
+                        secondaryAction = NimazErrorAction(
+                            label = stringResource(R.string.close),
+                            onClick = {
+                                viewModel.onEvent(SyncEvent.Cancel)
+                                onNavigateBack()
+                            },
+                        ),
                     )
+                    // The activity log stays: it is the transcript of what the two devices
+                    // managed before the failure, which is the one thing a reader can use
+                    // to work out whether to retry or start over.
+                    if (state.activityLog.isNotEmpty()) {
+                        ActivityLog(entries = state.activityLog)
+                    }
                 }
 
                 state.connectionState is ConnectionState.Completed -> {
@@ -928,55 +946,3 @@ private fun CompletedContent(
     )
 }
 
-@Composable
-private fun ErrorContent(
-    error: String,
-    activityLog: List<ActivityLogEntry>,
-    onRetry: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    Spacer(modifier = Modifier.height(48.dp))
-
-    NimazIcon(
-        imageVector = Icons.Default.Close,
-        contentDescription = null,
-        iconSize = 64.dp,
-        variant = NimazIconVariant.ERROR
-    )
-
-    Spacer(modifier = Modifier.height(16.dp))
-
-    Text(
-        text = stringResource(R.string.sync_failed),
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
-        color = MaterialTheme.colorScheme.error
-    )
-
-    Text(
-        text = error,
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(horizontal = 16.dp)
-    )
-
-    if (activityLog.isNotEmpty()) {
-        ActivityLog(entries = activityLog)
-    }
-
-    Spacer(modifier = Modifier.height(32.dp))
-
-    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        NimazButton(
-            text = stringResource(R.string.close),
-            onClick = onDismiss,
-            variant = NimazButtonVariant.OUTLINED
-        )
-        NimazButton(
-            text = stringResource(R.string.try_again),
-            onClick = onRetry,
-            variant = NimazButtonVariant.FILLED
-        )
-    }
-}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
@@ -36,6 +36,10 @@ import com.arshadshah.nimaz.core.navigation.DUA_CATEGORY_WITR_AND_NIGHT_PRAYER
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorState
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
@@ -133,7 +137,7 @@ fun NightWorshipContent(
                 lastThirdAt = state.lastThirdAt,
                 fajrAt = state.fajrAt,
                 isLoading = state.isLoading,
-                hasError = state.error != null,
+                error = state.error,
                 onRetry = { onEvent(NightWorshipEvent.Refresh) },
             )
 
@@ -184,7 +188,7 @@ fun NightWorshipContent(
 private enum class NightWindow { BEFORE, OPEN, CLOSED }
 
 /**
- * [isLoading] and [hasError] were both on the state and **neither was read**.
+ * [isLoading] and [error] were both on the state and **neither was read**.
  *
  * The card renders "Set your location to see tonight's times" whenever the instants are null, so
  * for the length of a settings read plus three astronomical passes every cold open showed that
@@ -197,7 +201,7 @@ private fun NightWindowCard(
     lastThirdAt: Instant?,
     fajrAt: Instant?,
     isLoading: Boolean,
-    hasError: Boolean,
+    error: UiError?,
     onRetry: () -> Unit,
 ) {
     NimazCard(
@@ -220,24 +224,29 @@ private fun NightWindowCard(
                 return@Column
             }
 
-            if (lastThirdAt == null || fajrAt == null) {
-                Text(
-                    text = stringResource(
-                        if (hasError) R.string.night_worship_times_failed
-                        else R.string.night_worship_times_unavailable
+            if (error != null) {
+                // INLINE inside the card: the night-worship hub has other cards that are
+                // still correct, and this one failing must not take them with it.
+                NimazErrorState(
+                    title = stringResource(error.message),
+                    kind = error.kind,
+                    details = error.details,
+                    variant = NimazErrorVariant.INLINE,
+                    primaryAction = NimazErrorDefaults.retry(
+                        onRetry = onRetry,
+                        label = stringResource(R.string.try_again),
                     ),
+                )
+                return@Column
+            }
+
+            if (lastThirdAt == null || fajrAt == null) {
+                // Not a failure: the times are genuinely not available yet.
+                Text(
+                    text = stringResource(R.string.night_worship_times_unavailable),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                if (hasError) {
-                    Spacer(Modifier.height(12.dp))
-                    NimazButton(
-                        text = stringResource(R.string.try_again),
-                        onClick = onRetry,
-                        variant = NimazButtonVariant.OUTLINED,
-                        size = NimazButtonSize.SMALL,
-                    )
-                }
                 return@Column
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarUiState.kt
@@ -1,10 +1,10 @@
 package com.arshadshah.nimaz.presentation.viewmodel.calendar
 
-import androidx.annotation.StringRes
 import com.arshadshah.nimaz.domain.model.CalendarDay
 import com.arshadshah.nimaz.domain.model.CalendarMonth
 import com.arshadshah.nimaz.domain.model.HijriDate
 import com.arshadshah.nimaz.domain.model.IslamicEvent
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import java.time.LocalDate
 
 data class CalendarUiState(
@@ -14,7 +14,7 @@ data class CalendarUiState(
     val viewMode: CalendarViewMode = CalendarViewMode.GREGORIAN,
     val isLoading: Boolean = true,
     /** A string resource, resolved by the screen — see ARCHITECTURE §6.1. */
-    @StringRes val error: Int? = null
+    val error: UiError? = null
 )
 
 data class HijriCalendarUiState(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.calendar
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.core.di.DefaultDispatcher
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
@@ -84,11 +85,18 @@ class CalendarViewModel @Inject constructor(
     private fun observeEvents() {
         launchSafely(telemetry, DOMAIN, "load_events") {
             islamicEventUseCases.getAllEvents()
-                .catchAndReport(telemetry, DOMAIN, "load_events") {
+                .catchAndReport(telemetry, DOMAIN, "load_events") { throwable ->
                     // Deliberately no fallback emission: there are no events to report, and
                     // emitting an empty list here would run the collector below and clear
                     // the very error just set.
-                    _calendarState.update { it.copy(error = R.string.error_generic) }
+                    _calendarState.update {
+                        it.copy(
+                            error = UiError(
+                                message = R.string.calendar_events_load_failed,
+                                details = throwable.message,
+                            ),
+                        )
+                    }
                 }
                 .collect { events ->
                     cachedEvents = events

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaUiState.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.text.font.FontFamily
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaBookmark
 import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.domain.model.DuaProgress
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
@@ -23,21 +24,21 @@ data class DuaCollectionUiState(
      * `SQLiteException: no such table: duas`. The throwable still goes to the crash
      * report, which is the only place its wording is any use.
      */
-    @StringRes val error: Int? = null
+    val error: UiError? = null
 )
 
 data class DuaCategoryUiState(
     val category: DuaCategory? = null,
     val duas: List<Dua> = emptyList(),
     val isLoading: Boolean = true,
-    @StringRes val error: Int? = null
+    val error: UiError? = null
 )
 
 data class DuaReaderUiState(
     val duas: List<Dua> = emptyList(),
     val initialIndex: Int = 0,
     val isLoading: Boolean = true,
-    @StringRes val error: Int? = null,
+    val error: UiError? = null,
     val showArabic: Boolean = true,
     val showTransliteration: Boolean = true,
     val showTranslation: Boolean = true,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.Dua
@@ -126,7 +128,17 @@ class DuaViewModel @Inject constructor(
             telemetry,
             DOMAIN,
             "load_categories",
-            onFailure = { _collectionState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+            onFailure = { throwable ->
+                _collectionState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.dua_collection_load_failed,
+                            details = throwable.message,
+                        ),
+                    )
+                }
+            }
         ) {
             combine(
                 duaUseCases.getAllCategories(),
@@ -201,7 +213,17 @@ class DuaViewModel @Inject constructor(
             telemetry,
             DOMAIN,
             "load_category",
-            onFailure = { _categoryState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+            onFailure = { throwable ->
+                _categoryState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.dua_category_load_failed,
+                            details = throwable.message,
+                        ),
+                    )
+                }
+            }
         ) {
             val category = duaUseCases.getCategoryById(categoryId)
             _categoryState.update { it.copy(category = category) }
@@ -244,9 +266,14 @@ class DuaViewModel @Inject constructor(
         }
     }
 
-    private fun failReader(@StringRes error: Int) {
+    private fun failReader(@StringRes error: Int, kind: NimazErrorKind = NimazErrorKind.NOT_FOUND) {
         _readerState.update {
-            it.copy(duas = emptyList(), initialIndex = 0, isLoading = false, error = error)
+            it.copy(
+                duas = emptyList(),
+                initialIndex = 0,
+                isLoading = false,
+                error = UiError(message = error, kind = kind),
+            )
         }
     }
 
@@ -295,7 +322,17 @@ class DuaViewModel @Inject constructor(
             telemetry,
             DOMAIN,
             "load_occasion",
-            onFailure = { _categoryState.update { it.copy(isLoading = false, error = R.string.error_generic) } }
+            onFailure = { throwable ->
+                _categoryState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.dua_category_load_failed,
+                            details = throwable.message,
+                        ),
+                    )
+                }
+            }
         ) {
             duaUseCases.getDuasByOccasion(occasion).collect { duas ->
                 _categoryState.update {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaUiState.kt
@@ -4,6 +4,7 @@ import com.arshadshah.nimaz.domain.model.CompassData
 import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.QiblaDirection
 import com.arshadshah.nimaz.domain.model.QiblaInfo
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 
 data class QiblaUiState(
     val qiblaDirection: QiblaDirection? = null,
@@ -24,7 +25,7 @@ data class QiblaUiState(
     /** Cumulative unwrapped azimuth — use for smooth rotation animation */
     val animatedAzimuth: Float = 0f,
     val isLoading: Boolean = true,
-    val error: String? = null,
+    val error: UiError? = null,
     val showLocationPicker: Boolean = false,
     val showCalibrationDialog: Boolean = false,
     val isArMode: Boolean = false

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModel.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.presentation.viewmodel.prayer
 import android.hardware.GeomagneticField
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
@@ -12,6 +13,8 @@ import com.arshadshah.nimaz.domain.model.Location
 import com.arshadshah.nimaz.domain.model.QiblaCalculator
 import com.arshadshah.nimaz.domain.model.QiblaDirection
 import com.arshadshah.nimaz.domain.model.QiblaInfo
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.domain.model.isLocationSet
 import com.arshadshah.nimaz.domain.repository.CompassSensors
 import com.arshadshah.nimaz.domain.repository.Haptics
@@ -162,7 +165,10 @@ class QiblaViewModel @Inject constructor(
                 } else {
                     _qiblaState.update {
                         it.copy(
-                            error = "No location set. Please set your location in settings.",
+                            error = UiError(
+                                message = R.string.qibla_no_location,
+                                kind = NimazErrorKind.LOCATION,
+                            ),
                             isLoading = false
                         )
                     }
@@ -209,7 +215,16 @@ class QiblaViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 telemetry.failure(AppAnalytics.Feature.QIBLA, "calculate_direction", e)
-                _qiblaState.update { it.copy(error = e.message, isLoading = false) }
+                _qiblaState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.qibla_failed,
+                            kind = NimazErrorKind.LOCATION,
+                            details = e.message,
+                        ),
+                    )
+                }
             }
         }
     }
@@ -248,7 +263,16 @@ class QiblaViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 telemetry.failure(AppAnalytics.Feature.QIBLA, "set_location", e)
-                _qiblaState.update { it.copy(error = e.message, isLoading = false) }
+                _qiblaState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.qibla_failed,
+                            kind = NimazErrorKind.LOCATION,
+                            details = e.message,
+                        ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncUiState.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
 import com.arshadshah.nimaz.data.sync.ConnectionState
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 
 data class SyncUiState(
     val mode: SyncMode = SyncMode.NONE,
@@ -11,6 +12,6 @@ data class SyncUiState(
     val totalSteps: Int = 0,
     val transferProgress: Float = 0f,
     val dataSummary: SyncDataSummary? = null,
-    val error: String? = null,
+    val error: UiError? = null,
     val activityLog: List<ActivityLogEntry> = emptyList(),
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModel.kt
@@ -5,7 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.util.Log
 import com.arshadshah.nimaz.BuildConfig
+import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.data.sync.CancelReason
@@ -121,7 +124,15 @@ class SyncViewModel @Inject constructor(
                         telemetry.error(AppAnalytics.Feature.SYNC, "connection", state.message)
                         debugLog("Error state: ${state.message}")
                         addLogEntry("Error: ${state.message}")
-                        _uiState.update { it.copy(error = state.message) }
+                        _uiState.update {
+                            it.copy(
+                                error = UiError(
+                                    message = R.string.sync_connection_failed,
+                                    kind = NimazErrorKind.OFFLINE,
+                                    details = state.message,
+                                ),
+                            )
+                        }
                     }
 
                     is ConnectionState.Cancelled -> {
@@ -297,7 +308,14 @@ class SyncViewModel @Inject constructor(
                     telemetry.failure(AppAnalytics.Feature.SYNC, "import", e)
                     debugLog("Import failed: ${e.message}")
                     addLogEntry("Import failed: ${e.message}")
-                    _uiState.update { it.copy(error = "Import failed: ${e.message}") }
+                    _uiState.update {
+                        it.copy(
+                            error = UiError(
+                                message = R.string.sync_import_failed,
+                                details = e.message,
+                            ),
+                        )
+                    }
                 }
             }
         }
@@ -347,7 +365,14 @@ class SyncViewModel @Inject constructor(
                 telemetry.failure(AppAnalytics.Feature.SYNC, "export", e)
                 debugLog("Export/send failed: ${e.message}")
                 addLogEntry("Export failed: ${e.message}")
-                _uiState.update { it.copy(error = "Export failed: ${e.message}") }
+                _uiState.update {
+                    it.copy(
+                        error = UiError(
+                            message = R.string.sync_export_failed,
+                            details = e.message,
+                        ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipUiState.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.worship
 
 import androidx.lifecycle.ViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import kotlinx.coroutines.flow.first
 import kotlin.time.Instant
 
@@ -29,5 +30,5 @@ data class NightWorshipUiState(
     val lastThirdAt: Instant? = null,
     val fajrAt: Instant? = null,
     val rakahCount: Int = 0,
-    val error: String? = null,
+    val error: UiError? = null,
 )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipViewModel.kt
@@ -2,7 +2,10 @@ package com.arshadshah.nimaz.presentation.viewmodel.worship
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
 import com.arshadshah.nimaz.core.di.DefaultDispatcher
 import com.arshadshah.nimaz.core.time.TodayProvider
@@ -40,7 +43,16 @@ class NightWorshipViewModel @Inject constructor(
             AppAnalytics.Feature.NIGHT_WORSHIP,
             "refresh",
             onFailure = { throwable ->
-                _state.update { it.copy(isLoading = false, error = throwable.message) }
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.night_worship_times_failed,
+                            kind = NimazErrorKind.LOCATION,
+                            details = throwable.message,
+                        ),
+                    )
+                }
             },
         ) {
             _state.update { it.copy(isLoading = true, error = null) }
@@ -122,7 +134,16 @@ class NightWorshipViewModel @Inject constructor(
             AppAnalytics.Feature.NIGHT_WORSHIP,
             "observe_night_times",
             onFailure = { throwable ->
-                _state.update { it.copy(isLoading = false, error = throwable.message) }
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiError(
+                            message = R.string.night_worship_times_failed,
+                            kind = NimazErrorKind.LOCATION,
+                            details = throwable.message,
+                        ),
+                    )
+                }
             },
         ) {
             combine(
@@ -190,7 +211,16 @@ class NightWorshipViewModel @Inject constructor(
             // `failure`, not a bare `recordException`: the stack trace reached Crashlytics
             // and the frequency reached nothing, so how often this fails was not visible.
             telemetry.failure(AppAnalytics.Feature.NIGHT_WORSHIP, "load", e)
-            _state.update { it.copy(isLoading = false, error = e.message) }
+            _state.update {
+                it.copy(
+                    isLoading = false,
+                    error = UiError(
+                        message = R.string.night_worship_times_failed,
+                        kind = NimazErrorKind.LOCATION,
+                        details = e.message,
+                    ),
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1836,4 +1836,15 @@
     <string name="zakat_mark_paid_failed">Das konnte nicht als bezahlt markiert werden</string>
     <string name="zakat_delete_failed">Diese Berechnung konnte nicht gelöscht werden</string>
     <string name="zakat_history_load_failed">Deine früheren Berechnungen konnten nicht geladen werden</string>
+    <string name="sync_connection_failed">Die Verbindung zum anderen Gerät ist fehlgeschlagen</string>
+    <string name="sync_import_failed">Die empfangenen Daten konnten nicht importiert werden</string>
+    <string name="sync_export_failed">Deine Daten konnten nicht gesendet werden</string>
+    <string name="sync_failed_body">Beide Geräte müssen im selben Netzwerk bleiben, mit geöffneter App, bis die Übertragung abgeschlossen ist.</string>
+    <string name="qibla_no_location">Qibla muss wissen, wo du bist</string>
+    <string name="qibla_no_location_body">Lege in den Einstellungen einen Standort fest oder lass Nimaz ihn ermitteln – dann zeigt der Kompass.</string>
+    <string name="qibla_failed">Die Richtung konnte nicht bestimmt werden</string>
+    <string name="dua_collection_load_failed">Die Dua-Sammlungen konnten nicht geladen werden</string>
+    <string name="dua_category_load_failed">Diese Sammlung konnte nicht geladen werden</string>
+    <string name="dua_load_failed_body">Duas sind auf deinem Gerät gespeichert – ein erneuter Versuch hilft meistens.</string>
+    <string name="calendar_events_load_failed">Islamische Ereignisse konnten nicht geladen werden</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1871,4 +1871,15 @@
     <string name="zakat_mark_paid_failed">Impossible de marquer comme payé</string>
     <string name="zakat_delete_failed">Ce calcul n\'a pas pu être supprimé</string>
     <string name="zakat_history_load_failed">Vos calculs précédents n\'ont pas pu être chargés</string>
+    <string name="sync_connection_failed">La connexion à l\'autre appareil a échoué</string>
+    <string name="sync_import_failed">Les données reçues n\'ont pas pu être importées</string>
+    <string name="sync_export_failed">Vos données n\'ont pas pu être envoyées</string>
+    <string name="sync_failed_body">Les deux appareils doivent rester sur le même réseau, application ouverte, jusqu\'à la fin du transfert.</string>
+    <string name="qibla_no_location">La qibla a besoin de savoir où vous êtes</string>
+    <string name="qibla_no_location_body">Définissez un lieu dans les réglages, ou laissez Nimaz le détecter, et la boussole s\'orientera.</string>
+    <string name="qibla_failed">La direction n\'a pas pu être calculée</string>
+    <string name="dua_collection_load_failed">Les recueils de douas n\'ont pas pu être chargés</string>
+    <string name="dua_category_load_failed">Ce recueil n\'a pas pu être chargé</string>
+    <string name="dua_load_failed_body">Les douas sont stockées sur votre appareil : réessayer suffit généralement.</string>
+    <string name="calendar_events_load_failed">Les événements islamiques n\'ont pas pu être chargés</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1805,4 +1805,15 @@
     <string name="zakat_mark_paid_failed">Tidak dapat ditandai sebagai dibayar</string>
     <string name="zakat_delete_failed">Perhitungan itu tidak dapat dihapus</string>
     <string name="zakat_history_load_failed">Perhitungan Anda sebelumnya tidak dapat dimuat</string>
+    <string name="sync_connection_failed">Koneksi ke perangkat lain gagal</string>
+    <string name="sync_import_failed">Data yang diterima tidak dapat diimpor</string>
+    <string name="sync_export_failed">Data Anda tidak dapat dikirim</string>
+    <string name="sync_failed_body">Kedua perangkat harus tetap di jaringan yang sama, dengan aplikasi terbuka, sampai transfer selesai.</string>
+    <string name="qibla_no_location">Kiblat perlu tahu lokasi Anda</string>
+    <string name="qibla_no_location_body">Atur lokasi di pengaturan, atau biarkan Nimaz mendeteksinya, dan kompas akan menunjuk.</string>
+    <string name="qibla_failed">Arah kiblat tidak dapat dihitung</string>
+    <string name="dua_collection_load_failed">Kumpulan doa tidak dapat dimuat</string>
+    <string name="dua_category_load_failed">Kumpulan ini tidak dapat dimuat</string>
+    <string name="dua_load_failed_body">Doa tersimpan di perangkat Anda, jadi mencoba lagi biasanya berhasil.</string>
+    <string name="calendar_events_load_failed">Peristiwa Islam tidak dapat dimuat</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1806,4 +1806,15 @@
     <string name="zakat_mark_paid_failed">Tidak dapat ditanda sebagai dibayar</string>
     <string name="zakat_delete_failed">Pengiraan itu tidak dapat dipadamkan</string>
     <string name="zakat_history_load_failed">Pengiraan lepas anda tidak dapat dimuatkan</string>
+    <string name="sync_connection_failed">Sambungan ke peranti lain gagal</string>
+    <string name="sync_import_failed">Data yang diterima tidak dapat diimport</string>
+    <string name="sync_export_failed">Data anda tidak dapat dihantar</string>
+    <string name="sync_failed_body">Kedua-dua peranti perlu kekal pada rangkaian yang sama, dengan aplikasi dibuka, sehingga pemindahan selesai.</string>
+    <string name="qibla_no_location">Kiblat perlu tahu lokasi anda</string>
+    <string name="qibla_no_location_body">Tetapkan lokasi dalam tetapan, atau biarkan Nimaz mengesannya, dan kompas akan menunjuk.</string>
+    <string name="qibla_failed">Arah kiblat tidak dapat dikira</string>
+    <string name="dua_collection_load_failed">Koleksi doa tidak dapat dimuatkan</string>
+    <string name="dua_category_load_failed">Koleksi ini tidak dapat dimuatkan</string>
+    <string name="dua_load_failed_body">Doa disimpan pada peranti anda, jadi mencuba lagi biasanya berjaya.</string>
+    <string name="calendar_events_load_failed">Peristiwa Islam tidak dapat dimuatkan</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1842,4 +1842,15 @@
     <string name="zakat_mark_paid_failed">Ödendi olarak işaretlenemedi</string>
     <string name="zakat_delete_failed">Bu hesaplama silinemedi</string>
     <string name="zakat_history_load_failed">Önceki hesaplamalarınız yüklenemedi</string>
+    <string name="sync_connection_failed">Diğer cihaza bağlantı kurulamadı</string>
+    <string name="sync_import_failed">Gelen veriler içe aktarılamadı</string>
+    <string name="sync_export_failed">Verileriniz gönderilemedi</string>
+    <string name="sync_failed_body">Aktarım bitene kadar iki cihaz da aynı ağda ve uygulama açık kalmalı.</string>
+    <string name="qibla_no_location">Kıble, nerede olduğunuzu bilmeli</string>
+    <string name="qibla_no_location_body">Ayarlardan bir konum belirleyin ya da Nimaz\'ın bulmasına izin verin; pusula yönü gösterecek.</string>
+    <string name="qibla_failed">Yön hesaplanamadı</string>
+    <string name="dua_collection_load_failed">Dua koleksiyonları yüklenemedi</string>
+    <string name="dua_category_load_failed">Bu koleksiyon yüklenemedi</string>
+    <string name="dua_load_failed_body">Dualar cihazınızda saklanır; yeniden denemek genellikle işe yarar.</string>
+    <string name="calendar_events_load_failed">İslami günler yüklenemedi</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1700,6 +1700,10 @@
     <string name="sync_total_size">Total size</string>
     <string name="sync_complete">Sync Complete!</string>
     <string name="sync_failed">Sync Failed</string>
+    <string name="sync_connection_failed">The connection to the other device failed</string>
+    <string name="sync_import_failed">The data that arrived couldn\'t be imported</string>
+    <string name="sync_export_failed">Your data couldn\'t be sent</string>
+    <string name="sync_failed_body">Both devices need to stay on the same network, with the app open, until the transfer finishes.</string>
     <string name="sync_data_being_sent">Data Being Sent</string>
     <string name="sync_data_being_received">Data Being Received</string>
     <string name="sync_sent_success">Data sent successfully</string>
@@ -1902,6 +1906,13 @@
     <string name="chart_legend_format">%1$s: %2$s</string>
     <string name="tafseer_alternate_has_commentary_format">%1$s has commentary for this ayah.</string>
     <string name="tafseer_no_commentary_anywhere">Commentary for this ayah isn\'t available in any installed source yet.</string>
+    <string name="calendar_events_load_failed">Islamic events couldn\'t be loaded</string>
+    <string name="dua_collection_load_failed">The dua collections couldn\'t be loaded</string>
+    <string name="dua_category_load_failed">This collection couldn\'t be loaded</string>
+    <string name="dua_load_failed_body">Duas are stored on your device, so trying again usually works.</string>
+    <string name="qibla_no_location">Qibla needs to know where you are</string>
+    <string name="qibla_no_location_body">Set a location in settings, or let Nimaz detect it, and the compass will point.</string>
+    <string name="qibla_failed">The direction couldn\'t be worked out</string>
     <string name="qibla_turn_right_hint">Turn right\nto find Qibla</string>
     <string name="qibla_turn_left_hint">Turn left\nto find Qibla</string>
     <string name="zakat_nisab_gold_subtitle">87.48g @ %1$s/g</string>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/screens/ScreenStateConventionTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/screens/ScreenStateConventionTest.kt
@@ -31,7 +31,6 @@ class ScreenStateConventionTest {
      */
     private val acceptedSpinners = setOf(
         "AsmaUnNabiDetailScreen.kt",
-        "DuaReaderScreen.kt",
         "LocationScreen.kt",
         "QuranHomeScreen.kt",
         "QuranReaderScreen.kt",
@@ -76,13 +75,11 @@ class ScreenStateConventionTest {
      */
     private val acceptedSilentFailures = setOf(
         "AskViewModel.kt",
-        "BookmarksViewModel.kt",
         "CalendarViewModel.kt",
         "CatalogViewModel.kt",
         "DuaViewModel.kt",
         "FastingViewModel.kt",
         "HadithViewModel.kt",
-        "HelpViewModel.kt",
         "HomeViewModel.kt",
         "KhatamViewModel.kt",
         "LocationViewModel.kt",
@@ -142,17 +139,55 @@ class ScreenStateConventionTest {
     fun `every launchSafely records the failure for the user`() {
         val offenders = viewModelDir.walkTopDown()
             .filter { it.name.endsWith("ViewModel.kt") }
-            .filter { file ->
-                val text = file.readText()
-                val launches = Regex("""launchSafely\(""").findAll(text).count()
-                val handled = Regex("""onFailure\s*=""").findAll(text).count()
-                launches > handled
-            }
+            .filter { file -> silentLaunches(file.readText()).isNotEmpty() }
             .map { it.name }
             .toSortedSet()
 
         assertThat(offenders - acceptedSilentFailures).isEmpty()
         assertThat(acceptedSilentFailures - offenders).isEmpty()
+    }
+
+    /**
+     * The `launchSafely` calls in [source] that record nothing a user could see.
+     *
+     * Reads each call's own text rather than counting call sites against `onFailure`
+     * occurrences, which the first version of this check did. Counting cannot tell which
+     * `onFailure` belongs to which call, and — the reason it had to change — it cannot see
+     * a `launchSafely` whose inner flow already reports through a `catchAndReport`
+     * fallback. Several call sites are that shape and were being reported as silent when
+     * they are not.
+     *
+     * A call is satisfied when it passes `onFailure`, or its block guards a flow with a
+     * `catchAndReport` that has a non-empty fallback. `launchBestEffort` is not examined
+     * at all: choosing it is choosing to be exempt, out loud.
+     */
+    private fun silentLaunches(source: String): List<Int> {
+        val silent = mutableListOf<Int>()
+        var from = 0
+        while (true) {
+            val at = source.indexOf("launchSafely(", from)
+            if (at < 0) return silent
+            from = at + 1
+            val call = source.substring(at, callEnd(source, at))
+            val guarded = Regex("""catchAndReport\([^)]*\)\s*\{[^}]""").containsMatchIn(call)
+            if ("onFailure" !in call && !guarded) silent += at
+        }
+    }
+
+    /** End index of the `launchSafely(...) { ... }` beginning at [start], braces balanced. */
+    private fun callEnd(source: String, start: Int): Int {
+        var depth = 0
+        var seenBody = false
+        for (i in start until source.length) {
+            when (source[i]) {
+                '{' -> { depth++; seenBody = true }
+                '}' -> {
+                    depth--
+                    if (seenBody && depth == 0) return i + 1
+                }
+            }
+        }
+        return source.length
     }
 
     /**

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModelRolloverTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/calendar/CalendarViewModelRolloverTest.kt
@@ -94,7 +94,8 @@ class CalendarViewModelRolloverTest {
         assertThat(vm.calendarState.value.currentMonth).isNotNull()
         assertThat(vm.calendarState.value.currentMonth!!.days).hasSize(today.lengthOfMonth())
         // …and the failure is said out loud rather than swallowed into a blank screen.
-        assertThat(vm.calendarState.value.error).isEqualTo(R.string.error_generic)
+        assertThat(vm.calendarState.value.error?.message)
+            .isEqualTo(R.string.calendar_events_load_failed)
         assertThat(telemetry.errors.map { it.type }).contains("load_events")
     }
 

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModelErrorPathTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/content/DuaViewModelErrorPathTest.kt
@@ -1,6 +1,7 @@
 package com.arshadshah.nimaz.presentation.viewmodel.content
 
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.NimazErrorKind
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.Dua
 import com.arshadshah.nimaz.domain.model.DuaBookmark
@@ -130,8 +131,12 @@ class DuaViewModelErrorPathTest {
         advanceUntilIdle()
 
         // A string resource, resolved by the screen in the user's language — not `e.message`.
-        assertThat(vm.categoryState.value.error).isEqualTo(R.string.error_generic)
-        // The exception itself still reaches the crash report, where it belongs.
+        assertThat(vm.categoryState.value.error?.message)
+            .isEqualTo(R.string.dua_category_load_failed)
+        // The exception's own words are carried, but as detail the component hides behind a
+        // toggle — never as the readable message.
+        assertThat(vm.categoryState.value.error?.details).isEqualTo("no such table: duas")
+        // And it still reaches the crash report, where it belongs.
         assertThat(telemetry.exceptions.map { it.message })
             .contains("no such table: duas")
     }
@@ -151,7 +156,10 @@ class DuaViewModelErrorPathTest {
             // Otherwise the reader keeps paging through the previous dua while its state
             // says the requested one was not found.
             assertThat(vm.readerState.value.duas).isEmpty()
-            assertThat(vm.readerState.value.error).isEqualTo(R.string.dua_reader_not_found)
+            assertThat(vm.readerState.value.error?.message)
+                .isEqualTo(R.string.dua_reader_not_found)
+            // A dua that is not there is an answer, not a failure.
+            assertThat(vm.readerState.value.error?.kind).isEqualTo(NimazErrorKind.NOT_FOUND)
             assertThat(vm.readerState.value.isLoading).isFalse()
         }
 }


### PR DESCRIPTION
**Layer 4 of the screen-states epic.** Stacked on #449. The last six features that rendered their own failure UI.

Spec: `docs/superpowers/specs/2026-08-05-screen-state-migration-design.md`

## What was wrong

The shapes were mostly right here — unlike layer 3, these six *did* show something. The copy was mostly wrong, and two of them left the reader with nowhere to go.

| Group | Before | After |
|---|---|---|
| **Sync** | `ErrorContent` — a 64.dp icon, a headline, the raw exception text, and two buttons. The closest thing in the app to `NimazErrorState`, hand-built. | Deleted, replaced by the component. The **activity log stays**: the transcript of what the two devices managed before the failure is the one thing that tells a reader whether to retry or start over. |
| **Qibla** | A warning icon and a red sentence: *"No location set. Please set your location in settings."* An English literal, with **no way to get to settings and no way to retry**. | `LOCATION` kind, a retry, and a "Set location" action that opens the picker. |
| **Dua** ×4 | Four copies of the same red-`Text`-in-a-`Box`. | One component, four call sites, each with the right retry event. |
| **Calendar** | A bare red `Text` above the grid. | `SECTION`. The grid draws fine without event markers, so the failure sits above it rather than in place of it. |
| **NightWorship** | Message + "Try again" inside the card — already the right shape. | `INLINE`, and the "unavailable" and "failed" cases stop sharing a branch: they are different situations and now read differently. |

## The ratchet's third check, rewritten

It counted `launchSafely(` call sites against `onFailure =` occurrences. That could not tell which `onFailure` belonged to which call, and — the reason it had to change — could not see a `launchSafely` whose inner flow already reports through a `catchAndReport` fallback. `BookmarksViewModel` and `HelpViewModel` were being reported as silent when they are not.

It now reads each call's own text, brace-balanced. A call is satisfied when it passes `onFailure`, or its block guards a flow with a non-empty `catchAndReport` fallback. `launchBestEffort` is not examined at all — choosing it is choosing to be exempt, out loud.

## Two existing tests changed

`DuaViewModelErrorPathTest` and `CalendarViewModelRolloverTest` asserted on the old `@StringRes Int` error. They were asserting **the right behaviour** — that the user sees translated copy and never the database's own words — so the assertions moved to `UiError` rather than the behaviour moving to them. The Dua one now also pins that the exception's words land in `details` and nowhere else, which is the property the old type could not express.

## Translations

All 11 new strings are in **de, fr, id, ms and tr**.

## Verification

`compileDebugKotlin` ✅ · full `testDebugUnitTest` ✅ · `check_docs.py` 23/23 ✅ · no new warnings in touched files

## Remaining in the epic

Layer 5: the ~22 raw `CircularProgressIndicator` sites still in the backlog. Layer 6: the four vestigial `error` fields no ViewModel ever assigns, emptying the backlogs, and ticking `AP-7.12`.

Still outstanding for the epic as a whole: **no on-device visual pass yet**, in either theme.
