### PR TITLE
fix(components): a gradient card no longer stretches to its parent's height

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -305,7 +304,13 @@ fun NimazCard(
                     )
             ) {
                 CompositionLocalProvider(LocalContentColor provides contentColor) {
-                    Column(modifier = Modifier.fillMaxSize(), content = content)
+                    // Width, never height. `fillMaxSize` here made the card as tall as whatever
+                    // height its parent offered, which is a no-op inside a scrollable (the
+                    // constraint is infinite) but stretches the card to the full viewport in a
+                    // bounded parent — how the zakat hero came to eat the whole calculator screen.
+                    // The other styles delegate to Material's `Card`, whose column wraps its
+                    // content; this branch has to say so itself.
+                    Column(modifier = Modifier.fillMaxWidth(), content = content)
                 }
             }
         }


### PR DESCRIPTION
`NimazCardStyle.GRADIENT` is the one card style that builds its own container
instead of delegating to Material's `Card`, and its inner column was declared
`fillMaxSize()`. Inside a scrollable the height constraint is infinite, so that
was a no-op and every existing gradient card looked right. In a bounded parent
it is not: the column takes the full height offered and the wrapping `Box` sizes
to it.

The zakat calculator moved its hero out of the `LazyColumn` and into the bounded
`Column` above it, so the hero could stay visible while the form scrolls. That
put a gradient card under a real height constraint for the first time and it
filled the whole viewport, leaving the form squeezed underneath.

Fill width, not size — matching what Material's `Card` column does for the other
four styles.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XZRJNHKd3hhxn2vvjyu1Tf