### PR TITLE
ci: make the lanes run, the build faster, and coverage visible (audit PR 1/12)

### DIFF
--- a/.github/workflows/android_instrumented_tests.yml
+++ b/.github/workflows/android_instrumented_tests.yml
@@ -4,7 +4,9 @@ name: Android Instrumentation Tests (emulator.wtf)
 # (DB / notifications / workers / preferences / navigation flows) on emulator.wtf.
 #
 # Triggers:
-#  - push to main           → the canonical lane.
+#  - push to dev            → the canonical lane. This said `main` until 2026-08-10, and
+#    since this repository's branches are `dev` and `master`, it had never once fired —
+#    only `pull_request` was doing anything. See #461.
 #  - pull_request (any base) → so it validates this branch's PR (and every future PR).
 #
 # The debug build needs no secrets: google-services.json is only required for the
@@ -14,7 +16,7 @@ name: Android Instrumentation Tests (emulator.wtf)
 # warning) instead of failing.
 on:
   push:
-    branches: [ main ]
+    branches: [ dev ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/internal_testing.yml
+++ b/.github/workflows/internal_testing.yml
@@ -39,6 +39,10 @@ on:
       - 'claude/**'
       - 'feature/**'
       - 'fix/**'
+      # An epic's integration branch is validated on a real device before it opens a
+      # PR to dev, so it needs this lane too. Without the pattern the `[deploy]`
+      # marker commit produces no failure and no build — it just does nothing. (#462)
+      - 'epic/**'
 
 # One internal upload at a time — two concurrent runs would race for the next versionCode.
 concurrency:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    # pull-requests: write is for the sticky coverage comment below. Without it the
+    # comment step fails on a repository whose default token is read-only.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       # The content artifact lives in a private repository. Mint a short-lived
       # installation token for it rather than carrying a long-lived PAT: the token
@@ -57,6 +62,28 @@ jobs:
 
       - name: Run Tests and Lint
         run: bundle exec fastlane android test
+
+      # Coverage is reported, never gated. jacocoTestReport already depends on
+      # testDebugUnitTest, which the step above has run, so this is close to free.
+      # `always()` on all three: when a test fails is exactly when you want to see
+      # what coverage did.
+      - name: Coverage report
+        if: always()
+        run: ./gradlew :app:jacocoTestReport
+
+      - name: Summarise coverage
+        if: always()
+        run: |
+          python3 scripts/coverage_summary.py \
+            app/build/reports/jacoco/jacocoTestReport.xml > coverage.md
+          cat coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment coverage on the PR
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          path: coverage.md
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -40,19 +40,14 @@ Core content and functionality are designed to remain available without constant
 
 ## Tech Stack
 
-- Android Gradle Plugin 8.12.0
-- Kotlin 2.3.0
-- Jetpack Compose BOM 2026.01.00
-- Hilt 2.57.1
-- Room 2.8.4
-- Navigation Compose 2.9.6
-- Coroutines 1.10.2
-- Media3 1.9.0
-- WorkManager 2.11.0
+Kotlin and Jetpack Compose, Clean Architecture with MVVM + UDF, Hilt, Room, DataStore,
+Media3, WorkManager and Glance.
 
-For the full dependency catalog, see:
-
-- `gradle/libs.versions.toml`
+**Versions are not duplicated here.** The version catalog is the single source of truth —
+see [`gradle/libs.versions.toml`](gradle/libs.versions.toml). A hand-maintained list lived
+in this section until eight of its nine entries had drifted from the catalog, and
+`scripts/check_docs.py` enforces 23 documentation obligations but none of them cover this
+file, so nothing could have caught it.
 
 ## Repository Structure
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -384,31 +384,39 @@ val coverageExclusions = listOf(
     "**/*Hilt_*.*",
 )
 
-val kotlinDebugClassesDir = layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile
+// Where the debug classes live, which is not where it used to be.
+//
+// These tasks pointed at `tmp/kotlin-classes/debug` alone. AGP 9 does not write there
+// — compiled classes land under `intermediates/classes/debug/…` — so the directory
+// simply did not exist, `classDirectories` resolved to nothing, and every one of the
+// four jacoco reports came out as a 237-byte file containing a `sessioninfo` and no
+// classes at all. Coverage was not merely unreported (#464); it was not being measured.
+//
+// Both paths are listed so the report is correct on either AGP, and so this cannot
+// fail silently again: an empty report is indistinguishable from 0% at a glance.
+val debugClassRoots = listOf(
+    layout.buildDirectory.dir("intermediates/classes/debug").get().asFile,
+    layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile,
+)
 val buildOutputDir = layout.buildDirectory.get().asFile
 
-fun atomsClassTree(): ConfigurableFileTree =
-    fileTree(kotlinDebugClassesDir) {
-        include("**/presentation/components/atoms/**")
-        exclude(coverageExclusions)
-    }
+fun classTree(vararg includes: String): FileCollection =
+    files(
+        debugClassRoots.map { root ->
+            fileTree(root) {
+                if (includes.isNotEmpty()) include(*includes)
+                exclude(coverageExclusions)
+            }
+        }
+    )
 
-fun moleculesClassTree(): ConfigurableFileTree =
-    fileTree(kotlinDebugClassesDir) {
-        include("**/presentation/components/molecules/**")
-        exclude(coverageExclusions)
-    }
+fun atomsClassTree(): FileCollection = classTree("**/presentation/components/atoms/**")
 
-fun organismsClassTree(): ConfigurableFileTree =
-    fileTree(kotlinDebugClassesDir) {
-        include("**/presentation/components/organisms/**")
-        exclude(coverageExclusions)
-    }
+fun moleculesClassTree(): FileCollection = classTree("**/presentation/components/molecules/**")
 
-fun debugClassTree(): ConfigurableFileTree =
-    fileTree(kotlinDebugClassesDir) {
-        exclude(coverageExclusions)
-    }
+fun organismsClassTree(): FileCollection = classTree("**/presentation/components/organisms/**")
+
+fun debugClassTree(): FileCollection = classTree()
 
 fun coverageExecutionData(): ConfigurableFileTree =
     fileTree(buildOutputDir) {
@@ -427,6 +435,11 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         html.required.set(true)
         xml.required.set(true)
         csv.required.set(false)
+        // Pinned: the default XML destination is derived from the task name, and
+        // scripts/coverage_summary.py (wired into pr_checks.yml) reads this path.
+        xml.outputLocation.set(
+            layout.buildDirectory.file("reports/jacoco/jacocoTestReport.xml")
+        )
     }
 
     classDirectories.setFrom(debugClassTree())

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,25 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+# 4g, not 2g: 2048m was tight for a 965-file Kotlin module running KSP, and a
+# daemon that GCs its way through a build is slower than one that does not.
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+
+# ── Build performance (#463) ─────────────────────────────────────────────────
+# parallel: safe here — this is effectively a single-module build (:app).
+# caching: reuses task outputs across builds and branches.
+org.gradle.parallel=true
+org.gradle.caching=true
+
+# The configuration cache is NOT enabled, and the reason is specific rather than
+# cautionary: `:app:fetchNimazData` (gradle/nimaz-data.gradle.kts) does its work in a
+# `doLast` block that calls script-level helpers — sha256Of, resolveDataToken,
+# githubApi — and Gradle cannot serialize script object references. Enabling it fails
+# the build with "1 problem was found storing the configuration cache".
+#
+# It is worth having: measured on this branch, a no-op :app:compileDebugKotlin goes
+# from 7.95s to 0.85s. Getting there means converting that task to a typed task class,
+# which is its own change with its own risk — see the follow-up issue on #460.
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Print a Markdown coverage summary from a JaCoCo XML report.
+
+Deliberately non-failing. A missing or malformed report prints a note and exits 0,
+because this runs on every pull request and must never be the reason one goes red:
+the audit epic (#460) lands eleven PRs of new tests, and a coverage gate would have
+blocked all of them until the last one merged.
+
+Reported, not gated — the number is there so a reviewer can see it move.
+
+Usage: coverage_summary.py <path-to-jacoco-xml>
+"""
+
+import sys
+import xml.etree.ElementTree as ET  # trusted input: JaCoCo output from our own build
+from pathlib import Path
+
+# Ordered most-useful-first; a JaCoCo report may not carry all of them.
+COUNTERS = [
+    ("LINE", "Lines"),
+    ("BRANCH", "Branches"),
+    ("INSTRUCTION", "Instructions"),
+]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: coverage_summary.py <jacoco-xml>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print("### Coverage\n\n_No coverage report was produced for this run._")
+        return 0
+
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        print(f"### Coverage\n\n_The coverage report could not be read: {exc}_")
+        return 0
+
+    totals = {
+        counter.get("type"): (
+            int(counter.get("missed", 0)),
+            int(counter.get("covered", 0)),
+        )
+        for counter in root.findall("counter")
+    }
+
+    if not totals:
+        # This is not a hypothetical. Before #464, all four jacoco tasks pointed at
+        # `tmp/kotlin-classes/debug`, which AGP 9 does not write — so every report was
+        # a 237-byte file with a sessioninfo and no classes. An empty table looks like
+        # a formatting glitch; say plainly that nothing was measured.
+        print(
+            "### Coverage\n\n"
+            "**The report contains no classes.** Coverage was not measured — this "
+            "usually means the jacoco `classDirectories` no longer match where the "
+            "build writes compiled classes. See `app/build.gradle.kts`."
+        )
+        return 0
+
+    lines = ["### Coverage", "", "| Metric | Covered | Total | % |", "|---|---:|---:|---:|"]
+    for key, label in COUNTERS:
+        if key not in totals:
+            continue
+        missed, covered = totals[key]
+        total = missed + covered
+        pct = (covered / total * 100) if total else 0.0
+        lines.append(f"| {label} | {covered} | {total} | {pct:.1f}% |")
+
+    lines += ["", "_Reported, not gated — see #464._"]
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_coverage_summary.py
+++ b/scripts/test_coverage_summary.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/coverage_summary.py.
+
+Run: python3 -m pytest scripts/test_coverage_summary.py -v
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "coverage_summary.py"
+
+FIXTURE = textwrap.dedent(
+    """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <report name="app">
+      <counter type="INSTRUCTION" missed="300" covered="700"/>
+      <counter type="BRANCH" missed="40" covered="60"/>
+      <counter type="LINE" missed="25" covered="75"/>
+    </report>
+    """
+)
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], capture_output=True, text=True
+    )
+
+
+def test_summary_reports_each_counter_as_a_percentage(tmp_path: Path):
+    xml = tmp_path / "jacocoTestReport.xml"
+    xml.write_text(FIXTURE)
+
+    result = _run(str(xml))
+
+    assert result.returncode == 0, result.stderr
+    assert "75.0%" in result.stdout  # lines: 75 covered of 100
+    assert "60.0%" in result.stdout  # branches: 60 covered of 100
+    assert "70.0%" in result.stdout  # instructions: 700 covered of 1000
+
+
+def test_summary_never_fails_on_a_missing_report(tmp_path: Path):
+    """A PR must not go red because coverage did not run."""
+    result = _run(str(tmp_path / "nope.xml"))
+
+    assert result.returncode == 0
+    assert "no coverage report" in result.stdout.lower()
+
+
+def test_a_report_with_no_classes_says_so_loudly(tmp_path: Path):
+    """The exact shape jacoco produced here for months: a sessioninfo and nothing else.
+
+    An empty table reads as a formatting glitch, so it has to name the cause.
+    """
+    xml = tmp_path / "empty.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><report name="app">'
+        '<sessioninfo id="x" start="0" dump="1"/></report>'
+    )
+
+    result = _run(str(xml))
+
+    assert result.returncode == 0
+    assert "no classes" in result.stdout.lower()
+    assert "classDirectories" in result.stdout
+
+
+def test_summary_does_not_divide_by_zero(tmp_path: Path):
+    xml = tmp_path / "zero.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><report name="app">'
+        '<counter type="LINE" missed="0" covered="0"/></report>'
+    )
+
+    result = _run(str(xml))
+
+    assert result.returncode == 0
+    assert "0.0%" in result.stdout


### PR DESCRIPTION
**Stacked PR 1 of 12** in the code-audit epic #460. Targets `epic/audit`, not `dev` — nothing reaches `dev` until the whole stack is validated on the Play internal track.

Five config changes, no production Kotlin touched. Every claim below is measured on this branch.

Closes #461, #462, #463, #464, #465.

---

## Two workflow triggers that never fired

**`android_instrumented_tests.yml` triggered on `push: branches: [main]`.** This repository's branches are `dev` and `master`:

```
$ gh run list --workflow=android_instrumented_tests.yml --event=push --limit 20
(no output)

$ git branch -r | grep -E 'origin/(main|dev|master)$'
  origin/dev
  origin/master
```

Zero runs, ever. Only `pull_request` was doing anything, while the file's own header comment called push-to-main "the canonical lane". Now `dev`, and the comment says what happened so it does not get quietly reverted.

**`internal_testing.yml` did not list `epic/**`.** Its push filter covered `claude/**`, `feature/**` and `fix/**`. The plan for this epic is to validate `epic/audit` on a real device with an empty `chore: internal build [deploy]` commit — which would have produced no build, no error, and no upload. Found while writing the plan, not while debugging it at the worst possible moment.

## Build performance

| | before | after |
|---|---:|---:|
| no-op `:app:compileDebugKotlin` | 7.95s | 0.85s |

`org.gradle.parallel` was commented out; `caching` and `configuration-cache` were unset. Parallel and the build cache are now on, and the daemon heap goes 2g → 4g (2048m is tight for a 965-file Kotlin module running KSP).

**The configuration cache is deliberately left off**, and the reason is specific rather than cautionary:

```
1 problem was found storing the configuration cache.
- Task `:app:fetchNimazData` of type `org.gradle.api.DefaultTask`: cannot serialize
  Gradle script object references as these are not supported with the configuration cache.
```

`gradle/nimaz-data.gradle.kts:135` registers that task with an ad-hoc `doLast` block calling script-level helpers (`sha256Of`, `resolveDataToken`, `githubApi`), and those closures capture the script object. The 7.95s → 0.85s figure above is *with* the configuration cache, so the win is real and worth chasing — but it means converting a task that fetches a 170 MB artifact over an authenticated API with sha256 verification into a typed task class, which is its own change with its own failure modes. Filed as #503 rather than folded in here.

## Coverage — two problems, not one

The audit found that no coverage number ever reaches a PR: `pr_checks.yml` runs `bundle exec fastlane android test`, which is `gradle test` plus `gradle lint`, while four jacoco tasks and a 90% rule sit unused in `app/build.gradle.kts`.

Wiring it up surfaced the larger problem. **The reports were empty.** All four tasks resolved `classDirectories` from `build/tmp/kotlin-classes/debug`, which AGP 9 does not write — compiled classes land under `build/intermediates/classes/debug`. The directory did not exist, `classDirectories` resolved to nothing, and every report was a 237-byte file containing a `sessioninfo` and no classes:

```
$ ls -la app/build/reports/jacoco/jacocoTestReport.xml
.rw-r--r-- 237 …
$ python3 -c "…; print([c.attrib for c in root.findall('counter')])"
[]
```

Coverage was not merely unreported. It was not being measured, and had not been for as long as this project has been on AGP 9.

Both roots are now listed so the report is correct on either AGP. **The real baseline:**

| Metric | Covered | Total | % |
|---|---:|---:|---:|
| Lines | 22347 | 64321 | 34.7% |
| Branches | 11282 | 54978 | 20.5% |
| Instructions | 190964 | 660687 | 28.9% |

That is the number the remaining eleven PRs move.

**Reported, not gated.** `jacocoAtomsCoverageVerification` already exists with a 90% rule scoped to the atoms package and deliberately kept out of the `check` graph; that decision is untouched. A global threshold here would fail every one of the eleven test-adding PRs until the last one merged. `scripts/coverage_summary.py` posts a sticky comment, and says loudly when a report contains no classes — so this exact regression cannot hide as a silent empty table again. It has its own tests (`scripts/test_coverage_summary.py`, 4 passing).

## README

Eight of the nine versions listed under `## Tech Stack` had drifted:

| | README | actual |
|---|---|---|
| AGP | 8.12.0 | 9.2.1 |
| Kotlin | 2.3.0 | 2.3.21 |
| Compose BOM | 2026.01.00 | 2026.05.01 |
| Hilt | 2.57.1 | 2.59.2 |
| Navigation Compose | 2.9.6 | 2.9.8 |
| Coroutines | 1.10.2 | 1.11.0 |
| Media3 | 1.9.0 | 1.10.1 |
| WorkManager | 2.11.0 | 2.11.2 |
| Room | 2.8.4 | 2.8.4 ✓ |

The audit flagged five; three more had gone unnoticed. `check_docs.py` enforces 23 obligations and none cover the README, so a list here cannot be kept honest — it now points at `gradle/libs.versions.toml`.

---

## Verification

```
./gradlew :app:compileDebugKotlin    BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest     BUILD SUCCESSFUL (--rerun-tasks, 2m)
./gradlew :app:lintDebug             BUILD SUCCESSFUL
python3 scripts/check_docs.py        All 23 documentation checks passed
python3 -m pytest scripts/test_coverage_summary.py    4 passed
```
