### PR TITLE
fix(audio): cancelling a download now cancels it, and two forever-loops stop (audit PR 3/12)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
@@ -16,13 +16,19 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.net.URL
@@ -156,6 +162,12 @@ class QuranAudioManager @Inject constructor(
     }
 
     companion object {
+        /** How often playback position is republished. See [startPositionTracking]. */
+        private const val POSITION_TICK_MS = 400L
+
+        /** Concurrent ayah downloads. Enough to saturate a connection, few enough to share it. */
+        private const val MAX_PARALLEL_DOWNLOADS = 5
+
         // CDN identifiers and bitrates from https://api.alquran.cloud/v1/edition?format=audio&type=versebyverse
         // Pair: (cdnId, bitrate) - some reciters only have 64kbps, others have 128kbps.
         //
@@ -284,23 +296,41 @@ class QuranAudioManager @Inject constructor(
         }
     }
 
+    /**
+     * Publish playback position while something is listening.
+     *
+     * This used to tick every 100 ms unconditionally — ten wake-ups a second, forever,
+     * including with the screen off during background playback, and including while
+     * *paused*, because `isPlaying` guarded only the state update and not the delay.
+     * Each tick recomputes [computeTotalPosition] and [computeTotalDuration] across the
+     * whole playlist, which is not free on a 286-ayah surah.
+     *
+     * Now 400 ms, and only while a collector is attached. A progress bar animating
+     * between 400 ms ticks looks smoother than one snapping to 100 ms ones, so this is
+     * not a quality trade.
+     */
     private fun startPositionTracking() {
         positionTrackingJob?.cancel()
         positionTrackingJob = scope.launch {
-            while (true) {
-                delay(100) // More frequent updates for smoother progress
-                val p = player ?: break
-                if (p.isPlaying) {
-                    val totalPos = computeTotalPosition(p)
-                    val totalDur = computeTotalDuration()
-                    _audioState.update {
-                        it.copy(
-                            position = totalPos,
-                            duration = if (totalDur > 0) totalDur else it.duration
-                        )
+            _audioState.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { hasCollectors ->
+                    if (!hasCollectors) return@collectLatest
+                    while (true) {
+                        delay(POSITION_TICK_MS)
+                        val p = player ?: break
+                        if (!p.isPlaying) continue
+                        val totalPos = computeTotalPosition(p)
+                        val totalDur = computeTotalDuration()
+                        _audioState.update {
+                            it.copy(
+                                position = totalPos,
+                                duration = if (totalDur > 0) totalDur else it.duration
+                            )
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -334,28 +364,40 @@ class QuranAudioManager @Inject constructor(
             )
         }
 
-        // Download files with parallel downloads (limit concurrency to avoid overwhelming network)
         val downloadedCount = java.util.concurrent.atomic.AtomicInteger(0)
 
+        // `coroutineScope { launch { … } }`, not `scope.launch { … }`.
+        //
+        // These used to be started on the manager's own `scope`, which made them
+        // *siblings* of `downloadJob` rather than children of it. So `downloadJob.cancel()`
+        // stopped the waiting and left every download running: they kept writing
+        // `downloadedCount` and `downloadProgress` into the shared audio state, so
+        // switching surah mid-download let the old surah's progress overwrite the new
+        // one's and then jump backwards. Children inherit cancellation; siblings do not.
+        //
+        // A Semaphore rather than `chunked(5) + join`: the old shape waited for the
+        // slowest file in each group of five before starting the next group, so one slow
+        // connection idled four others. This keeps five in flight at all times.
         withContext(Dispatchers.IO) {
-            // Use chunked parallel downloads - 5 concurrent downloads at a time
-            toDownload.chunked(5).forEach { chunk ->
-                ensureActive() // Bail out if user cancelled
-                val jobs = chunk.map { (ayah, file) ->
-                    scope.launch(Dispatchers.IO) {
-                        val url =
-                            "https://cdn.islamic.network/quran/audio/$reciterBitrate/$reciterCdnId/${ayah.ayahGlobalId}.mp3"
-                        downloadFileSilent(url, file)
-                        val count = downloadedCount.incrementAndGet()
-                        _audioState.update {
-                            it.copy(
-                                downloadedCount = count,
-                                downloadProgress = count.toFloat() / toDownload.size
-                            )
+            val slots = Semaphore(MAX_PARALLEL_DOWNLOADS)
+            coroutineScope {
+                toDownload.forEach { (ayah, file) ->
+                    ensureActive() // Bail out if the user cancelled.
+                    launch {
+                        slots.withPermit {
+                            val url =
+                                "https://cdn.islamic.network/quran/audio/$reciterBitrate/$reciterCdnId/${ayah.ayahGlobalId}.mp3"
+                            downloadFileSilent(url, file)
+                            val count = downloadedCount.incrementAndGet()
+                            _audioState.update {
+                                it.copy(
+                                    downloadedCount = count,
+                                    downloadProgress = count.toFloat() / toDownload.size
+                                )
+                            }
                         }
                     }
                 }
-                jobs.forEach { it.join() }
             }
         }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/PrayerSkyScene.kt
@@ -6,12 +6,6 @@ import android.graphics.Paint
 import android.graphics.RadialGradient
 import android.graphics.RectF
 import android.graphics.Shader
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +25,10 @@ import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -66,6 +64,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.GlassBackdrop
 import com.arshadshah.nimaz.presentation.components.atoms.GlassIconButton
@@ -121,16 +120,25 @@ fun SkyBackground(
     sunriseFraction: Float = SUNRISE_T,
     sunsetFraction: Float = SUNSET_T,
 ) {
-    val drift = rememberInfiniteTransition(label = "sky")
-    val cloudPhase by drift.animateFloat(
-        initialValue = 0f,
-        targetValue = if (cloudsEnabled) 1f else 0f,
-        animationSpec = infiniteRepeatable(
-            tween(120_000, easing = LinearEasing),
-            RepeatMode.Restart
-        ),
-        label = "clouds",
-    )
+    // Cloud drift, without holding the frame clock open.
+    //
+    // This was a `rememberInfiniteTransition` + `animateFloat`, which requests a frame
+    // *every frame, forever*, for as long as Home is composed — and it ran even with
+    // `cloudsEnabled` false, animating 0f → 0f. The drawing itself is already cheap
+    // (`drawWithCache` over baked sprite layers), so the animation was the cost.
+    //
+    // The cycle is 120 seconds. Advancing the phase once a second is 120 steps across
+    // it — invisible at that speed — and it lets the compositor idle in between. When
+    // clouds are off nothing is started at all.
+    var cloudPhase by remember { mutableFloatStateOf(0f) }
+    if (cloudsEnabled) {
+        LaunchedEffect(Unit) {
+            while (true) {
+                delay(CLOUD_TICK_MS)
+                cloudPhase = (cloudPhase + CLOUD_TICK_MS.toFloat() / CLOUD_CYCLE_MS) % 1f
+            }
+        }
+    }
 
     Box(
         modifier = modifier
@@ -318,6 +326,10 @@ private val LocationPillMaxWidth = 260.dp
 
 /** A soft drop shadow so overlaid glass text stays crisp over bright sky. */
 private val GlassTextShadow = Shadow(Color.Black.copy(alpha = 0.35f), Offset(0f, 1f), 4f)
+
+/** One cloud-drift step. 120 steps across the cycle — invisible, and lets the compositor idle. */
+private const val CLOUD_TICK_MS = 1_000L
+private const val CLOUD_CYCLE_MS = 120_000f
 
 private const val SPRITE_SCALE = 0.6f
 private const val SUNRISE_T = 0.27f

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -201,6 +201,27 @@ completion awards stars and unlocks the next lesson. `QaidaReaderViewModel` coll
 and calls `markCellHeard` from there; `playLine` starts playback and writes no progress at all.
 (Tapping a single cell still marks eagerly — one tap, one clip, one intent.)
 
+**Download concurrency and cancellation.** `downloadAllAyahs` runs at most
+`MAX_PARALLEL_DOWNLOADS` (5) at a time, held by a `Semaphore` inside a `coroutineScope`.
+Both details are load-bearing and both replaced something broken:
+
+- The per-file jobs were started on the manager's own `scope`, which made them **siblings**
+  of `downloadJob` rather than children. `downloadJob.cancel()` therefore stopped the
+  waiting and left every download running, still writing `downloadedCount` and
+  `downloadProgress` into the shared `AudioState` — so switching surah mid-download let the
+  old surah's progress overwrite the new one's and then jump backwards. Anything launched
+  here must be a **child** of the download job.
+- The old shape was `chunked(5)` followed by `jobs.forEach { it.join() }`, a barrier that
+  waited for the slowest file in each group of five before starting the next, so one slow
+  connection idled four others. The semaphore keeps five in flight throughout.
+
+**Position tracking.** `startPositionTracking` republishes position every
+`POSITION_TICK_MS` (400 ms) and **only while `_audioState` has collectors**. It previously
+ticked every 100 ms unconditionally — ten wake-ups a second, forever, including with the
+screen off during background playback and including while paused, since `isPlaying` guarded
+only the state update and not the delay. Each tick recomputes `computeTotalPosition` and
+`computeTotalDuration` across the whole playlist, which is not free on a 286-ayah surah.
+
 **Gotchas.**
 - Two player APIs: ExoPlayer everywhere **except** `AdhanAudioManager.preview()` (legacy `MediaPlayer`).
 - `QuranAudioManager.stop()` deliberately does **not** send a stop intent to the service — it sets `isActive=false` and lets the service's state-observer self-stop after a 500 ms debounce, avoiding a start/stop race.


### PR DESCRIPTION
**Stacked PR 3 of 12** in the code-audit epic #460. Targets `epic/audit-02-baseline-profile`.

Closes #468, #470, #471. **#469 (streaming) is deliberately not here** — see the bottom.

---

## The live bug: cancelling a download did not cancel it

`QuranAudioManager.downloadAllAyahs` started its per-file jobs like this:

```kotlin
withContext(Dispatchers.IO) {
    toDownload.chunked(5).forEach { chunk ->
        val jobs = chunk.map { scope.launch(Dispatchers.IO) { … } }
        jobs.forEach { it.join() }
    }
}
```

`scope` is the manager's own `CoroutineScope(SupervisorJob() + Dispatchers.Main)`. Launching on it inside a `withContext` makes those jobs **siblings** of `downloadJob`, not children of it.

So `downloadJob?.cancel()` — called at three sites, including the top of `playAyahsSequentially` — stopped the *waiting* and left every download running. They carried on writing `downloadedCount` and `downloadProgress` into the shared `AudioState`. Switch surah mid-download and the old surah's progress overwrites the new one's, then jumps backwards.

Now `coroutineScope { launch { … } }`, so the jobs are children and cancellation propagates.

Worth noting where this was hiding: the tech-debt registry's audio entry is about *encapsulation* — making `audioManager` private — and nobody looked at what the manager does. It was in the class the registry had already marked handled.

## The concurrency was barrier-shaped

`chunked(5)` + `jobs.forEach { it.join() }` waits for the slowest file in each group of five before starting the next group, so one slow connection leaves four idle. Replaced with a `Semaphore(5)`, which keeps five in flight throughout.

## Position tracking ticked ten times a second, forever

```kotlin
while (true) {
    delay(100)
    val p = player ?: break
    if (p.isPlaying) { … }
}
```

`isPlaying` guards only the state update, **not the delay** — so this spins at 10 Hz while paused too, and it never stops for as long as a player exists, including with the screen off during background playback. Each tick recomputes `computeTotalPosition` and `computeTotalDuration` across the whole playlist, which is not free on a 286-ayah surah.

Now 400 ms, and only while `_audioState` actually has collectors. A progress bar animating between 400 ms ticks looks smoother than one snapping to 100 ms ones, so this is not a quality trade.

## `PrayerSkyScene` held the frame clock open

`SkyBackground` drove cloud drift from a `rememberInfiniteTransition` with a 120-second `tween`. That requests a frame **every frame, forever**, for as long as Home is composed — and it ran with `cloudsEnabled` false too, animating `0f → 0f`.

The drawing was never the problem: it is `drawWithCache` over baked sprite layers, so the animation was the entire cost. The phase now advances once a second from a `LaunchedEffect` — 120 steps across the cycle, invisible at that speed — and nothing is started at all when clouds are off.

---

## Why #469 (streaming) is not in this PR

The audit's §2.1 is real: `downloadAllAyahs` downloads *every* file before playback starts — 286 for Al-Baqarah — and the fix is to delete it and let Media3 stream through a `CacheDataSource.Factory` over a `SimpleCache`.

That is not a bug fix, it is a rewrite of how every ayah is fetched, cached, prefetched and reported on. And right now `QuranAudioManager` has **zero tests** (#478 is the issue that adds them), while verifying playback needs a device with a network — so nothing in the local gate can tell a working player from a broken one.

Rewriting the fetch path with no coverage and no way to run it is how you ship a player that compiles and does not play. Re-sequenced to land after #478, which also carries the cancel-and-assert-no-writes regression test for the defect fixed above. Nothing else in the stack depends on it. Recorded on #469.

---

## Verification

```
./gradlew :app:compileDebugKotlin     BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest      BUILD SUCCESSFUL
./gradlew :app:lintDebug              BUILD SUCCESSFUL
python3 scripts/check_docs.py         All 23 documentation checks passed
```

`docs/SUBSYSTEMS.md` §1 gains the download-concurrency and position-tracking contracts, both stated as *what must stay true* rather than as a changelog — the sibling-vs-child rule is the kind of thing that gets reintroduced by the next person who adds a parallel fetch there.
