### PR TITLE
feat(content): make a stuck content install visible, so empty Arabic search stops being invisible (audit PR 4/12)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/DatabaseModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.core.di
 import android.content.Context
 import android.util.Log
 import androidx.room.Room
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.data.local.content.ContentArtifactInstaller
 import com.arshadshah.nimaz.data.local.content.ContentArtifactStore
 import com.arshadshah.nimaz.data.local.content.SharedPreferencesContentArtifactStore
@@ -69,6 +70,24 @@ object DatabaseModule {
     ): NimazDatabase {
         val outcome = ContentArtifactInstaller(context, contentArtifactStore).installIfChanged()
         Log.i("DatabaseModule", "content artifact: $outcome")
+
+        // Also to Crashlytics, not only logcat. Whether a release actually reached a device is
+        // the first question to ask about any "the app still shows the old content" report — and
+        // about Arabic search returning nothing, since the FTS index arrives inside the artifact
+        // and an install that never takes one falls back to LIKE, which matches no Arabic at all.
+        // Until now the outcome was computed and thrown away at `Log.i`, so that question had no
+        // answer in production.
+        CrashReporter.setCustomKey(
+            "content_artifact_outcome",
+            outcome::class.java.simpleName,
+        )
+        CrashReporter.setCustomKey(
+            "content_artifact_deferrals",
+            contentArtifactStore.consecutiveDeferrals(),
+        )
+        if (outcome is ContentArtifactInstaller.Outcome.Failed) {
+            CrashReporter.log("content artifact install failed: ${outcome.reason}")
+        }
 
         return Room.databaseBuilder(
             context,

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/content/ContentArtifactInstaller.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/content/ContentArtifactInstaller.kt
@@ -69,6 +69,15 @@ class ContentArtifactInstaller(
     private val context: Context,
     private val store: ContentArtifactStore,
     private val installedArtifact: String = com.arshadshah.nimaz.BuildConfig.CONTENT_ARTIFACT_SHA256,
+    /**
+     * Called once when a device looks stuck rather than merely deferred.
+     *
+     * A lambda rather than a direct `CrashReporter` call so a test can assert it fired —
+     * `CrashReporter` is an `object` with a static `Context` and no seam, which is why no test
+     * in this repo can currently assert that anything was reported. The general fix for that is
+     * the injectable `Telemetry` seam in #359; this is the local version of it.
+     */
+    private val reportStuck: (String) -> Unit = { CrashReporter.log(it) },
 ) {
 
     /**
@@ -85,11 +94,15 @@ class ContentArtifactInstaller(
         // artifact it copies is this one. Recording it now is what makes the *next* release a
         // comparison rather than a guess.
         if (!database.exists()) {
+            store.clearDeferrals()
             store.setInstalledArtifact(installedArtifact)
             return Outcome.FreshInstall
         }
 
-        if (store.installedArtifact() == installedArtifact) return Outcome.AlreadyCurrent
+        if (store.installedArtifact() == installedArtifact) {
+            store.clearDeferrals()
+            return Outcome.AlreadyCurrent
+        }
 
         // The order matters: ask the cheap flag first. Once the copy has run, the rows in the
         // content database are a spare copy and reading the file to find them is wasted work on
@@ -102,6 +115,7 @@ class ContentArtifactInstaller(
                 // the next launch replaces. One launch of delay, for the shrinking set of installs
                 // that predate schemaVersion 23, against destroying the only copy of their data.
                 Log.i(TAG, "holding off the content replace: $blocker still has un-copied rows")
+                noteDeferral(blocker)
                 return Outcome.DeferredForLegacyData(blocker)
             }
         }
@@ -113,6 +127,7 @@ class ContentArtifactInstaller(
             if (!deleted && database.exists()) {
                 Outcome.Failed("deleteDatabase returned false and the file is still there")
             } else {
+                store.clearDeferrals()
                 store.setInstalledArtifact(installedArtifact)
                 Outcome.Replaced
             }
@@ -122,6 +137,27 @@ class ContentArtifactInstaller(
             // artifact is deliberately *not* updated, so the next launch tries again.
             CrashReporter.recordException(e)
             Outcome.Failed(e.message ?: e::class.java.simpleName)
+        }
+    }
+
+    /**
+     * Count this deferral, and report once when the count says the device is stuck.
+     *
+     * One deferral is by design. Repeated ones are not: they mean this install has stopped
+     * receiving content releases entirely — no new content, and no FTS index, so every Arabic
+     * search on it returns zero rows against a corpus where الله alone appears in 1,746 verses.
+     * Reported exactly once, at the threshold, so a stuck device does not become a repeating
+     * report for the rest of its life.
+     */
+    private fun noteDeferral(blocker: String) {
+        store.recordDeferral()
+        val deferrals = store.consecutiveDeferrals()
+        if (deferrals == STUCK_AFTER_DEFERRALS) {
+            reportStuck(
+                "content artifact deferred $deferrals launches running; " +
+                    "\"$blocker\" still holds un-copied rows and the legacy import has not " +
+                    "completed — this install is no longer receiving content or a search index"
+            )
         }
     }
 
@@ -175,8 +211,17 @@ class ContentArtifactInstaller(
         data class Failed(val reason: String) : Outcome
     }
 
-    private companion object {
-        const val TAG = "ContentArtifactInstaller"
+    companion object {
+        /**
+         * Consecutive deferrals before this install is treated as stuck rather than waiting.
+         *
+         * Three, not one: a single deferral is the designed path, and two can legitimately
+         * happen if the first launch was killed before `UserDataMigrator` finished. Three in a
+         * row is not a slow migration, it is a migration that is not completing.
+         */
+        const val STUCK_AFTER_DEFERRALS = 3
+
+        private const val TAG = "ContentArtifactInstaller"
 
         /**
          * Tables the app writes to at runtime. Mirrors `user_tables` in the data console's
@@ -187,7 +232,7 @@ class ContentArtifactInstaller(
          * in the artifact. The list survives here for the one case where they *are* still on
          * disk: an install that predates that split and has not yet had its rows copied out.
          */
-        val USER_TABLES = setOf(
+        private val USER_TABLES = setOf(
             "reading_progress", "quran_bookmarks", "quran_favorites", "hadith_bookmarks",
             "dua_bookmarks", "dua_progress", "prayer_records", "fast_records", "makeup_fasts",
             "khatams", "khatam_ayahs", "khatam_daily_log", "tasbih_sessions", "zakat_history",

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/content/ContentArtifactStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/content/ContentArtifactStore.kt
@@ -31,6 +31,23 @@ interface ContentArtifactStore {
     fun legacyImportComplete(): Boolean
 
     fun setLegacyImportComplete()
+
+    /**
+     * How many launches in a row have deferred the content replace.
+     *
+     * A deferral is meant to last exactly one launch — `UserDataMigrator` runs every launch and
+     * is awaited before the splash lifts, so the copy completes during that session. A count that
+     * keeps climbing means the device has stopped receiving content releases altogether: the
+     * migrator is failing, or the content database cannot be read at all (`legacyDataBlocking`
+     * treats any read failure as "something is there", which is the safe answer but an
+     * indefinitely sticky one). Such a device also never receives an FTS index, which is why
+     * Arabic search returns nothing on it.
+     */
+    fun consecutiveDeferrals(): Int
+
+    fun recordDeferral()
+
+    fun clearDeferrals()
 }
 
 class SharedPreferencesContentArtifactStore(
@@ -57,9 +74,22 @@ class SharedPreferencesContentArtifactStore(
         prefs.edit(commit = true) { putBoolean(LEGACY_KEY, true) }
     }
 
+    override fun consecutiveDeferrals(): Int = prefs.getInt(DEFERRAL_KEY, 0)
+
+    override fun recordDeferral() {
+        // `apply`, not `commit`: unlike the other two writes nothing is destroyed by losing this
+        // one. A dropped increment under-counts a stuck device; it cannot cause a bad replace.
+        prefs.edit { putInt(DEFERRAL_KEY, consecutiveDeferrals() + 1) }
+    }
+
+    override fun clearDeferrals() {
+        prefs.edit { remove(DEFERRAL_KEY) }
+    }
+
     private companion object {
         const val FILE = "nimaz_content_artifact"
         const val KEY = "installed_artifact_sha256"
         const val LEGACY_KEY = "legacy_user_data_import_complete"
+        const val DEFERRAL_KEY = "consecutive_deferrals"
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/content/ContentArtifactInstallerTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/content/ContentArtifactInstallerTest.kt
@@ -184,6 +184,76 @@ class ContentArtifactInstallerTest {
         assertThat(databaseFile().exists()).isTrue()
     }
 
+    // ── Stuck-deferral detection (#472, #473) ────────────────────────────────────
+    //
+    // A deferral is meant to last exactly one launch: `UserDataMigrator` runs on every
+    // launch and is awaited before the splash lifts, so the copy completes during that
+    // session and the next launch replaces. The failure that is *not* designed for is a
+    // deferral that repeats — a migrator that keeps failing, or a database that cannot be
+    // read (`legacyDataBlocking` treats any read failure as "something is there"). Such a
+    // device silently stops receiving content releases altogether, which also means it
+    // never receives an FTS index, which is why Arabic search returns nothing on it.
+    //
+    // Nothing reported that. These tests are what make it reportable.
+
+    @Test
+    fun `a deferral is counted`() {
+        writeContentDatabase("v22 content")
+        addLegacyUserTable("quran_bookmarks", rows = 3)
+        store.setInstalledArtifact("sha-v7")
+
+        installer("sha-v8").installIfChanged()
+
+        assertThat(store.consecutiveDeferrals()).isEqualTo(1)
+    }
+
+    @Test
+    fun `a successful replace clears the deferral count`() {
+        writeContentDatabase("v22 content")
+        addLegacyUserTable("quran_bookmarks", rows = 3)
+        store.setInstalledArtifact("sha-v7")
+        installer("sha-v8").installIfChanged()
+        assertThat(store.consecutiveDeferrals()).isEqualTo(1)
+
+        // The migrator has now run, which is what unblocks it.
+        store.setLegacyImportComplete()
+        val outcome = installer("sha-v8").installIfChanged()
+
+        assertThat(outcome).isEqualTo(ContentArtifactInstaller.Outcome.Replaced)
+        assertThat(store.consecutiveDeferrals()).isEqualTo(0)
+    }
+
+    @Test
+    fun `a deferral that repeats past the threshold is reported`() {
+        writeContentDatabase("v22 content")
+        addLegacyUserTable("quran_bookmarks", rows = 3)
+        store.setInstalledArtifact("sha-v7")
+
+        val reported = mutableListOf<String>()
+        repeat(ContentArtifactInstaller.STUCK_AFTER_DEFERRALS) {
+            ContentArtifactInstaller(
+                context, store, installedArtifact = "sha-v8", reportStuck = reported::add,
+            ).installIfChanged()
+        }
+
+        assertThat(reported).hasSize(1)
+        assertThat(reported.single()).contains("quran_bookmarks")
+    }
+
+    @Test
+    fun `a single deferral is not reported`() {
+        writeContentDatabase("v22 content")
+        addLegacyUserTable("quran_bookmarks", rows = 3)
+        store.setInstalledArtifact("sha-v7")
+
+        val reported = mutableListOf<String>()
+        ContentArtifactInstaller(
+            context, store, installedArtifact = "sha-v8", reportStuck = reported::add,
+        ).installIfChanged()
+
+        assertThat(reported).isEmpty()
+    }
+
     private class FakeStore : ContentArtifactStore {
         private var value: String? = null
         private var legacyDone = false
@@ -195,6 +265,16 @@ class ContentArtifactInstallerTest {
         override fun legacyImportComplete(): Boolean = legacyDone
         override fun setLegacyImportComplete() {
             legacyDone = true
+        }
+
+        private var deferrals = 0
+        override fun consecutiveDeferrals(): Int = deferrals
+        override fun recordDeferral() {
+            deferrals++
+        }
+
+        override fun clearDeferrals() {
+            deferrals = 0
         }
     }
 }

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -1079,6 +1079,29 @@ Three things make deleting it safe, and the third is the one that bites on a rea
    delay, against destroying the only copy of somebody's data. The check reads the *file*, not a
    "migration done" flag, because what is in the file is what a delete would destroy.
 
+**When the deferral does not end.** One deferral is the design. Repeated ones are not — and the
+failure is silent in a way that matters: an install whose `UserDataMigrator` keeps failing, or
+whose content database cannot be read at all (`legacyDataBlocking` treats *any* read failure as
+"something is there", which is the safe answer but an indefinitely sticky one), simply stops
+receiving content releases. It also never receives an **FTS index**, because the index ships
+inside the artifact; `ContentSearchIndex.status()` returns `Absent` and search falls back to
+`LIKE`, which matches no Arabic at all. الله appears in 1,746 verses and returns nothing, and an
+empty result list reads as "no results", so nobody reports it.
+
+`ContentArtifactStore` therefore counts consecutive deferrals, cleared by any outcome that is not
+one. At `ContentArtifactInstaller.STUCK_AFTER_DEFERRALS` (3 — one is designed, two can happen if a
+launch was killed mid-migration, three is a migration that is not completing) the installer
+reports **once**, so a stuck device does not become a repeating report for the rest of its life.
+The threshold is reported through an injectable `reportStuck` lambda rather than calling
+`CrashReporter` directly, because `CrashReporter` is an `object` with a static `Context` and no
+seam — this is the local version of the injectable `Telemetry` seam that #359 introduces generally.
+
+`DatabaseModule` additionally publishes `content_artifact_outcome` and
+`content_artifact_deferrals` as Crashlytics custom keys on every launch. Before this the outcome
+was computed and thrown away at a `Log.i`, so "did this release actually reach the device" had no
+answer in production — which is the first question to ask about both stale content and empty
+Arabic search.
+
 **What this retired.** `ContentPatchSeeder` existed because content had to reach existing installs
 *without* replacing the file, and it had a hard limit: `nz patch emit` cannot express a table the
 baseline lacks — it files those under `out_of_scope` and emits nothing. So a newly added table


### PR DESCRIPTION
**Stacked PR 4 of 12** in the code-audit epic #460. Targets `epic/audit-03-audio`.

Closes #472, #473.

---

## The audit's prescription was wrong, and the real bug is a different one

§6.1 says installs made before the folded FTS index shipped never get one, and prescribes building the index on-device in a `WorkManager` job over 150k documents.

**The app has no index-building code and should not acquire any.** `ContentSearchIndex` only *probes* — `Ready` / `Absent` / `Mismatched`, keyed on `search_meta.fold_version` against `ArabicSearchNormaliser.FOLD_VERSION` — and reads. The index is compiled by nimaz-data (`nimaz_data/build/search.py`, stage 5 of the pipeline; FTS4 rather than FTS5 because AOSP has never enabled the FTS5 module) and ships **inside the content artifact**. `ContentArtifactInstaller.installIfChanged()` already replaces the content database on update, for existing installs too. A `WorkManager` indexer would be a second implementation of a path that already works.

Reading the installer closely, `DeferredForLegacyData` is not a permanent block either — it is **designed to last exactly one launch**, because `UserDataMigrator` runs every launch and is awaited before the splash lifts.

So what is actually exposed is narrower and less obvious:

> `legacyDataBlocking` treats **any** failure to read the content database as *"something is there"*. That is the correct, safe answer — refusing to delete is always recoverable — but it is an indefinitely sticky one. An install whose migrator keeps failing, or whose content database cannot be read at all, defers **forever**, and silently stops receiving content releases altogether.

Such a device never receives a new artifact, so it never receives an FTS index either. `status()` returns `Absent`, search falls back to `LIKE`, and `LIKE` matches no Arabic at all — الله appears in 1,746 verses and returns nothing. An empty result list reads as "no results", so nobody reports it.

## And nothing reported any of it

```kotlin
val outcome = ContentArtifactInstaller(context, contentArtifactStore).installIfChanged()
Log.i("DatabaseModule", "content artifact: $outcome")
```

Computed, and thrown away to logcat. *"Did this release actually reach the device"* had no answer in production — which is the first question to ask about both stale content and empty Arabic search.

## What this PR does

**Counts consecutive deferrals.** `ContentArtifactStore` gains `consecutiveDeferrals()` / `recordDeferral()` / `clearDeferrals()`. Every outcome that is not a deferral clears the count, so only a *run* of them accumulates.

**Reports once at the threshold.** `STUCK_AFTER_DEFERRALS = 3` — one is the designed path, two can legitimately happen if a launch was killed before the migration finished, three is a migration that is not completing. Reported **once**, at the threshold, so a stuck device does not become a repeating report for the rest of its life.

**Publishes the outcome.** `DatabaseModule` sets `content_artifact_outcome` and `content_artifact_deferrals` as Crashlytics custom keys on every launch, and logs the reason on `Failed`.

**A note on the seam.** The stuck report goes through an injectable `reportStuck: (String) -> Unit` rather than calling `CrashReporter` directly. `CrashReporter` is an `object` with a static `Context` and no seam, which is precisely why no test in this repo can currently assert that anything was reported — the registry's own R2 note makes this point. This is the local version of the injectable `Telemetry` seam #359 introduces generally; when that lands, this should collapse into it.

The `apply`-vs-`commit` choice differs from its neighbours on purpose: the other two writes in that store use `commit` because losing them causes a 176 MB re-copy or a lost content release. Losing a deferral increment only under-counts a stuck device — it cannot cause a bad replace — so `apply` is right here.

## Honest limitation

**This makes a stuck install visible. It does not unblock one.**

Without telemetry there is no way to know whether that population is 0.1% or 5%, or whether the cause is a failing migrator, an unreadable file, or something else — and inventing a repair for an unobserved cause is guessing. Once this reaches the internal track and real numbers come back, the repair (if one is warranted) is a follow-up with evidence behind it.

## Tests

Four added to the existing Robolectric suite, 13 total, all passing:

```
PASS  a deferral is counted
PASS  a successful replace clears the deferral count
PASS  a deferral that repeats past the threshold is reported
PASS  a single deferral is not reported
```

---

## Verification

```
./gradlew :app:compileDebugKotlin     BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest      BUILD SUCCESSFUL  (13/13 in this suite)
./gradlew :app:lintDebug              BUILD SUCCESSFUL
python3 scripts/check_docs.py         All 23 documentation checks passed
```

`docs/SUBSYSTEMS.md` §7 gains the "when the deferral does not end" contract, stated as what must stay true rather than as a changelog.
