### PR TITLE
test(boot): the reboot reschedule gets a seam and six tests (audit PR 5/12)

### DIFF
--- a/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/work/WidgetWorkersTest.kt
@@ -11,6 +11,7 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.arshadshah.nimaz.data.audio.AdhanDownloadWorker
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.widget.khatam.KhatamWorker
 import com.arshadshah.nimaz.widget.hijricalendar.HijriCalendarWorker
 import com.arshadshah.nimaz.widget.hijridate.HijriDateWorker
 import com.arshadshah.nimaz.widget.nextprayer.NextPrayerWorker
@@ -27,8 +28,18 @@ import org.junit.runner.RunWith
 import javax.inject.Inject
 
 /**
- * Drives every background [androidx.work.CoroutineWorker] the app ships through its
- * `doWork()` once, built by the real [HiltWorkerFactory].
+ * Builds every background [androidx.work.CoroutineWorker] the app ships with the real
+ * [HiltWorkerFactory] and runs `doWork()` once.
+ *
+ * **Read what this does and does not prove.** A test device has no widgets on its home screen,
+ * so `GlanceAppWidgetManager.getGlanceIds(...)` is empty and every widget worker returns
+ * `Result.success()` from its first branch without touching a repository or writing a widget
+ * state. So this suite proves the `@AssistedInject` graph resolves and `doWork()` does not throw
+ * — worth having, and genuinely all it is. It does **not** prove a worker computes or writes the
+ * right thing; a worker that returned Success having updated nothing would pass every test here.
+ *
+ * Covering the actual work means lifting the computation out from behind the Glance plumbing so
+ * it can be asserted on the JVM. That is #474.
  *
  * What this proves:
  *  - Each `@HiltWorker` can actually be instantiated by the factory — i.e. its
@@ -93,6 +104,9 @@ class WidgetWorkersTest {
 
     @Test
     fun hijriCalendarWorker_runs() = assertNotFailure(runWorker<HijriCalendarWorker>())
+
+    @Test
+    fun khatamWorker_runs() = assertNotFailure(runWorker<KhatamWorker>())
 
     @Test
     fun adhanDownloadWorker_isConstructableByFactory() {

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/BootReceiver.kt
@@ -46,6 +46,9 @@ class BootReceiver : BroadcastReceiver() {
     lateinit var prayerRepository: PrayerRepository
 
     @Inject
+    lateinit var prayerRescheduler: PrayerRescheduler
+
+    @Inject
     lateinit var khatamRepository: KhatamRepository
 
     @Inject
@@ -90,66 +93,25 @@ class BootReceiver : BroadcastReceiver() {
         }
     }
 
+    /**
+     * Re-arm today's notifications after a reboot.
+     *
+     * The day has not changed, so past prayers are left alone: marking them missed here would
+     * overwrite what the user actually recorded.
+     */
     private fun reschedulePrayerNotifications() {
-        scope.launch {
-            try {
-                val prefs = preferencesDataStore.userPreferences.first()
-                val notificationsEnabled = prefs.prayerNotificationsEnabled
-                val latitude = prefs.latitude
-                val longitude = prefs.longitude
-
-                val enabledPrayers = preferencesDataStore.enabledPrayerTypes()
-                val preReminders = preferencesDataStore.preReminderMinutesByPrayer()
-                val fridayReminderEnabled = preferencesDataStore.fridayReminderEnabled.first()
-                val fridayReminderMinutes = preferencesDataStore.fridayReminderMinutes.first()
-
-                prayerNotificationScheduler.scheduleTodaysPrayerNotifications(
-                    latitude = latitude,
-                    longitude = longitude,
-                    notificationsEnabled = notificationsEnabled,
-                    enabledPrayers = enabledPrayers,
-                    preReminders = preReminders,
-                    fridayReminderEnabled = fridayReminderEnabled,
-                    fridayReminderMinutes = fridayReminderMinutes
-                )
-            } catch (e: Exception) {
-                CrashReporter.log("BootReceiver reschedule failed")
-                CrashReporter.recordException(e)
-                e.printStackTrace()
-            }
-        }
+        scope.launch { prayerRescheduler.rescheduleToday(markPastAsMissed = false) }
     }
 
+    /**
+     * Re-arm across a date change or timezone shift, marking anything already past as missed.
+     *
+     * This and [reschedulePrayerNotifications] used to be the same twenty-odd lines written out
+     * twice — two copies of the code that decides whether a user is reminded to pray. See
+     * [PrayerRescheduler].
+     */
     private fun markMissedPrayersAndReschedule() {
-        scope.launch {
-            try {
-                prayerRepository.markPastPrayersAsMissed()
-
-                val prefs = preferencesDataStore.userPreferences.first()
-                val notificationsEnabled = prefs.prayerNotificationsEnabled
-                val latitude = prefs.latitude
-                val longitude = prefs.longitude
-
-                val enabledPrayers = preferencesDataStore.enabledPrayerTypes()
-                val preReminders = preferencesDataStore.preReminderMinutesByPrayer()
-                val fridayReminderEnabled = preferencesDataStore.fridayReminderEnabled.first()
-                val fridayReminderMinutes = preferencesDataStore.fridayReminderMinutes.first()
-
-                prayerNotificationScheduler.scheduleTodaysPrayerNotifications(
-                    latitude = latitude,
-                    longitude = longitude,
-                    notificationsEnabled = notificationsEnabled,
-                    enabledPrayers = enabledPrayers,
-                    preReminders = preReminders,
-                    fridayReminderEnabled = fridayReminderEnabled,
-                    fridayReminderMinutes = fridayReminderMinutes
-                )
-            } catch (e: Exception) {
-                CrashReporter.log("BootReceiver markMissedPrayersAndReschedule failed")
-                CrashReporter.recordException(e)
-                e.printStackTrace()
-            }
-        }
+        scope.launch { prayerRescheduler.rescheduleToday(markPastAsMissed = true) }
     }
 
     private fun handlePrayerNotification(context: Context, intent: Intent) {

--- a/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerRescheduler.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/util/PrayerRescheduler.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.core.util
+
+import com.arshadshah.nimaz.core.monitoring.CrashReporter
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Re-arms today's prayer notifications from the current preferences.
+ *
+ * Extracted from [BootReceiver], where it existed twice. `reschedulePrayerNotifications` and
+ * `markMissedPrayersAndReschedule` were the same twenty-odd lines — read seven preferences, call
+ * `scheduleTodaysPrayerNotifications` with all of them — differing only in the
+ * `markPastPrayersAsMissed()` call at the top of the second and the string in its catch block.
+ * Two copies of the code that decides whether a user is reminded to pray, free to drift apart.
+ *
+ * It is a class rather than a private helper because of what depends on it: after a reboot,
+ * **nothing re-arms an alarm except this**. If it regresses, prayer notifications simply stop,
+ * and they stop *silently* — there is no crash, no error state, and no screen that shows an
+ * alarm was expected. A user notices weeks later, if at all. `BootReceiver` is 851 lines with a
+ * `BroadcastReceiver` at the top of it and cannot be unit-tested; this can.
+ *
+ * Typed to [SettingsRepository], not the concrete `PreferencesDataStore` the receiver injects:
+ * the extension functions it calls (`enabledPrayerTypes`, `preReminderMinutesByPrayer`) are
+ * declared on the interface anyway, and depending on the interface is both the house rule and
+ * what lets a test hand it a fake instead of a DataStore.
+ */
+@Singleton
+class PrayerRescheduler @Inject constructor(
+    private val preferences: SettingsRepository,
+    private val scheduler: PrayerNotificationScheduler,
+    private val prayerRepository: PrayerRepository,
+) {
+
+    /**
+     * Re-arm today's notifications.
+     *
+     * @param markPastAsMissed first mark prayers whose time has passed as missed. True on a
+     *   date change or a timezone shift, where the day being re-armed is not the day that was
+     *   scheduled; false after a reboot, where the day has not changed and marking would
+     *   overwrite what the user actually did.
+     * @return true when the reschedule completed. Failures are reported and swallowed — a
+     *   receiver has nowhere to propagate to, and crashing on boot is worse than one missed
+     *   re-arm — so the return value exists for tests and callers that want to know.
+     */
+    suspend fun rescheduleToday(markPastAsMissed: Boolean = false): Boolean = try {
+        if (markPastAsMissed) {
+            prayerRepository.markPastPrayersAsMissed()
+        }
+
+        val prefs = preferences.userPreferences.first()
+
+        scheduler.scheduleTodaysPrayerNotifications(
+            latitude = prefs.latitude,
+            longitude = prefs.longitude,
+            notificationsEnabled = prefs.prayerNotificationsEnabled,
+            enabledPrayers = preferences.enabledPrayerTypes(),
+            preReminders = preferences.preReminderMinutesByPrayer(),
+            fridayReminderEnabled = preferences.fridayReminderEnabled.first(),
+            fridayReminderMinutes = preferences.fridayReminderMinutes.first(),
+        )
+        true
+    } catch (e: Exception) {
+        CrashReporter.log(
+            "prayer reschedule failed (markPastAsMissed=$markPastAsMissed)"
+        )
+        CrashReporter.recordException(e)
+        false
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerReschedulerTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/core/util/PrayerReschedulerTest.kt
@@ -1,0 +1,178 @@
+package com.arshadshah.nimaz.core.util
+
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * After a reboot, **nothing re-arms a prayer alarm except this**.
+ *
+ * If it regresses, prayer notifications stop — silently. There is no crash, no error state and
+ * no screen that shows an alarm was expected, so a user notices weeks later if at all. That is
+ * the failure these tests exist for, and why the logic was lifted out of `BootReceiver` (851
+ * lines, a `BroadcastReceiver`, untestable) to somewhere it could have them.
+ */
+class PrayerReschedulerTest {
+
+    private lateinit var settings: SettingsRepository
+    private lateinit var scheduler: PrayerNotificationScheduler
+    private lateinit var prayers: PrayerRepository
+
+    @Before
+    fun setUp() {
+        scheduler = mockk(relaxed = true)
+        prayers = mockk(relaxed = true)
+        settings = mockk(relaxed = true) {
+            every { userPreferences } returns flowOf(
+                mockk(relaxed = true) {
+                    every { latitude } returns 51.5
+                    every { longitude } returns -0.12
+                    every { prayerNotificationsEnabled } returns true
+                }
+            )
+            // enabledPrayerTypes() reads these six flags one by one.
+            every { fajrNotificationEnabled } returns flowOf(true)
+            every { sunriseNotificationEnabled } returns flowOf(false)
+            every { dhuhrNotificationEnabled } returns flowOf(true)
+            every { asrNotificationEnabled } returns flowOf(false)
+            every { maghribNotificationEnabled } returns flowOf(true)
+            every { ishaNotificationEnabled } returns flowOf(false)
+            every { fridayReminderEnabled } returns flowOf(true)
+            every { fridayReminderMinutes } returns flowOf(30)
+            // preReminderMinutesByPrayer() — nothing enabled, so no reminders.
+            every { prayerReminderEnabled(any()) } returns flowOf(false)
+            every { prayerReminderMinutes(any()) } returns flowOf(0)
+        }
+    }
+
+    private fun rescheduler() = PrayerRescheduler(settings, scheduler, prayers)
+
+    @Test
+    fun `a reboot reschedules today from the stored preferences`() = runTest {
+        val ok = rescheduler().rescheduleToday(markPastAsMissed = false)
+
+        assertThat(ok).isTrue()
+        verify(exactly = 1) {
+            scheduler.scheduleTodaysPrayerNotifications(
+                latitude = 51.5,
+                longitude = -0.12,
+                notificationsEnabled = true,
+                enabledPrayers = setOf(PrayerType.FAJR, PrayerType.DHUHR, PrayerType.MAGHRIB),
+                preReminders = emptyMap(),
+                fridayReminderEnabled = true,
+                fridayReminderMinutes = 30,
+            )
+        }
+    }
+
+    /**
+     * A reboot must not touch prayer records. The day has not changed, so marking past prayers
+     * missed here would overwrite what the user actually recorded.
+     */
+    @Test
+    fun `a reboot does not mark past prayers as missed`() = runTest {
+        rescheduler().rescheduleToday(markPastAsMissed = false)
+
+        coVerify(exactly = 0) { prayers.markPastPrayersAsMissed() }
+    }
+
+    /** A date change or timezone shift is the case where marking *is* correct. */
+    @Test
+    fun `a date change marks past prayers missed before rescheduling`() = runTest {
+        rescheduler().rescheduleToday(markPastAsMissed = true)
+
+        coVerify(exactly = 1) { prayers.markPastPrayersAsMissed() }
+        // Named rather than positional: the scheduler takes eleven parameters, six of them
+        // defaulted, so a positional any()-list silently stops matching the moment one is added.
+        verify(exactly = 1) {
+            scheduler.scheduleTodaysPrayerNotifications(
+                latitude = 51.5,
+                longitude = -0.12,
+                notificationsEnabled = true,
+                enabledPrayers = setOf(PrayerType.FAJR, PrayerType.DHUHR, PrayerType.MAGHRIB),
+                preReminders = emptyMap(),
+                fridayReminderEnabled = true,
+                fridayReminderMinutes = 30,
+            )
+        }
+    }
+
+    /** Notifications switched off must reach the scheduler as off, not as "skip the call". */
+    @Test
+    fun `notifications disabled still reschedules, with the flag off`() = runTest {
+        every { settings.userPreferences } returns flowOf(
+            mockk(relaxed = true) {
+                every { latitude } returns 51.5
+                every { longitude } returns -0.12
+                every { prayerNotificationsEnabled } returns false
+            }
+        )
+
+        rescheduler().rescheduleToday()
+
+        verify(exactly = 1) {
+            scheduler.scheduleTodaysPrayerNotifications(
+                latitude = any(),
+                longitude = any(),
+                notificationsEnabled = false,
+                enabledPrayers = any(),
+                preReminders = any(),
+                fridayReminderEnabled = any(),
+                fridayReminderMinutes = any(),
+            )
+        }
+    }
+
+    /**
+     * A receiver has nowhere to propagate to, and crashing on boot is worse than one missed
+     * re-arm — so a failure is reported and swallowed. It must not escape.
+     */
+    @Test
+    fun `a scheduler failure is reported, not thrown`() = runTest {
+        // `every`, not `coEvery` — scheduleTodaysPrayerNotifications is not a suspend function.
+        every {
+            scheduler.scheduleTodaysPrayerNotifications(
+                latitude = any(),
+                longitude = any(),
+                notificationsEnabled = any(),
+                enabledPrayers = any(),
+                preReminders = any(),
+                fridayReminderEnabled = any(),
+                fridayReminderMinutes = any(),
+            )
+        } throws IllegalStateException("alarm manager said no")
+
+        val ok = rescheduler().rescheduleToday()
+
+        assertThat(ok).isFalse()
+    }
+
+    @Test
+    fun `a preferences failure is reported, not thrown`() = runTest {
+        every { settings.userPreferences } throws IllegalStateException("datastore corrupt")
+
+        val ok = rescheduler().rescheduleToday()
+
+        assertThat(ok).isFalse()
+        verify(exactly = 0) {
+            scheduler.scheduleTodaysPrayerNotifications(
+                latitude = any(),
+                longitude = any(),
+                notificationsEnabled = any(),
+                enabledPrayers = any(),
+                preReminders = any(),
+                fridayReminderEnabled = any(),
+                fridayReminderMinutes = any(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
**Stacked PR 5 of 12** in the code-audit epic #460. Targets `epic/audit-04-content-artifact`.

Closes #475. **#474 is rescoped, not closed** — see the bottom.

---

## The failure this is about

After a reboot, **nothing re-arms a prayer alarm except `BootReceiver`**. If it regresses, prayer notifications stop — and they stop *silently*. There is no crash, no error state, and no screen anywhere that shows an alarm was expected. A user notices weeks later, if at all, and what they report is "the app stopped working", not a bug you can act on.

It was 851 lines with a `BroadcastReceiver` at the top of it and no tests. `PrayerNotificationScheduler` (910 lines) *is* tested, which makes the gap worse rather than better.

## The clone was in the worst possible place

`reschedulePrayerNotifications` and `markMissedPrayersAndReschedule` were the same twenty-odd lines written out twice — read seven preferences, call `scheduleTodaysPrayerNotifications` with all of them — differing only in a `markPastPrayersAsMissed()` call at the top of the second, and the string in its catch block.

Two copies of the code that decides whether a user is reminded to pray, free to drift apart, in the file nothing tests.

Both now delegate to **`PrayerRescheduler`**, which takes the difference as a parameter:

```kotlin
suspend fun rescheduleToday(markPastAsMissed: Boolean = false): Boolean
```

Typed to `SettingsRepository`, not the concrete `PreferencesDataStore` the receiver injects. The extension functions it calls (`enabledPrayerTypes`, `preReminderMinutesByPrayer`) are declared on the interface anyway, depending on the interface is the house rule, and it is what lets a test hand it a fake instead of a DataStore.

`BootReceiver` 851 → 813 lines.

## Six tests, covering what actually breaks

```
PASS  a reboot reschedules today from the stored preferences
PASS  a reboot does not mark past prayers as missed
PASS  a date change marks past prayers missed before rescheduling
PASS  notifications disabled still reschedules, with the flag off
PASS  a scheduler failure is reported, not thrown
PASS  a preferences failure is reported, not thrown
```

Two of those encode decisions that are easy to get wrong later:

- **A reboot must not mark past prayers missed.** The day has not changed, so marking would overwrite what the user actually recorded. Only a date change or timezone shift should.
- **Notifications switched off must still reach the scheduler, with the flag off** — not be short-circuited into skipping the call, which is how a stale alarm survives a settings change.

And the failure paths assert that nothing escapes: a receiver has nowhere to propagate to, and crashing on boot is worse than one missed re-arm.

The verifications are written with **named** arguments rather than a positional `any()` list. `scheduleTodaysPrayerNotifications` takes eleven parameters, six of them defaulted; a positional list silently stops matching the moment somebody adds a twelfth.

---

## #474 is rescoped: the worker tests exist, and they prove nothing

The audit says "seven Workers, zero tested". **Six have tests** — `WidgetWorkersTest` has been running on the emulator.wtf lane on every PR, `EW_API_TOKEN` exists, and the last five runs are green.

But every widget worker opens `doWork()` like this:

```kotlin
val glanceIds = manager.getGlanceIds(XWidget::class.java)
if (glanceIds.isEmpty()) return Result.success()
```

Confirmed in all six. **A test device has no widgets on its home screen**, so `glanceIds` is empty, every worker returns success from that first branch, and `assertThat(result).isNotInstanceOf(Failure::class.java)` passes without a repository being touched or a widget state being written.

The suite proves `HiltWorkerFactory` can construct these classes — worth having, it catches a broken `@AssistedInject` graph. It does not prove a worker computes or writes the right thing. A worker that returned `Success` having updated nothing passes today, which is exactly the failure the audit was worried about: *"when one fails the user sees a stale widget and never files a bug."*

That is worse than being untested. Untested is visible in a coverage report; a green suite exercising an early return is invisible, which is why it has passed for a year unexamined.

**This PR** adds the missing `KhatamWorker` for parity, and rewrites the suite's KDoc, which claimed to "drive every worker through its `doWork()`" — it now states plainly what it proves and what it does not.

**Fixing it properly** means lifting the computation out from behind the Glance plumbing so `doWork()` becomes *get ids → compute → write*, and the compute half is a JVM test running in seconds on every local gate. That is a seven-worker refactor, so it gets its own PR rather than being folded in beside a receiver test.

---

## Verification

```
./gradlew :app:compileDebugKotlin              BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin   BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest               BUILD SUCCESSFUL  (6/6 new)
./gradlew :app:lintDebug                       BUILD SUCCESSFUL
python3 scripts/check_docs.py                  All 23 documentation checks passed
```
