### PR TITLE
refactor(widget): the worker tests were green and proved nothing (audit PR 5b/12)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidgetDataSource.kt
@@ -1,0 +1,72 @@
+package com.arshadshah.nimaz.widget.hijricalendar
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+import java.time.format.TextStyle
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * Computes what the Hijri-calendar widget shows.
+ *
+ * Split out of [HijriCalendarWorker] so it can be tested — `doWork()` returns early when no
+ * widget is placed, which is always true on a test device (#474).
+ *
+ * **Behaviour preserved exactly, including the same bug as the Hijri-date widget**:
+ * `hijriDayOffset` is a moon-sighting correction to the *Hijri* date, and it is also added to the
+ * Gregorian date rendered beside it, so an offset of +1 shows tomorrow's Gregorian day. Carried
+ * over unchanged rather than fixed, because a refactor that silently changes what a widget
+ * displays is not reviewable. Filed as #509, which covers both widgets.
+ */
+class HijriCalendarWidgetDataSource @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val todayProvider: TodayProvider,
+) {
+
+    suspend fun load(): HijriCalendarData {
+        val offset = settingsRepository.hijriDayOffset.first()
+        val hijriDate = HijriDateCalculator.today(offset)
+
+        // See the class KDoc: the offset is applied to the Gregorian half too. Preserved. (#509)
+        val today = todayProvider.today().plusDays(offset.toLong())
+
+        val firstOfMonth = HijriDateCalculator.toGregorian(1, hijriDate.month, hijriDate.year)
+
+        return HijriCalendarData(
+            hijriMonth = hijriDate.month,
+            hijriMonthName = hijriDate.monthName,
+            hijriYear = hijriDate.year,
+            gregorianDate = "${today.dayOfMonth} ${
+                today.month.getDisplayName(TextStyle.SHORT, Locale.getDefault())
+            }",
+            daysInMonth = HijriDateCalculator.getDaysInHijriMonth(hijriDate.year, hijriDate.month),
+            firstDayOfWeekOffset = sundayBasedOffset(firstOfMonth.dayOfWeek.value),
+            todayHijriDay = hijriDate.day,
+            events = HijriDateCalculator.getIslamicEvents(hijriDate.year)
+                .filter { it.day == hijriDate.day && it.month == hijriDate.month }
+                .map {
+                    HijriCalendarEventData(
+                        name = it.name,
+                        nameArabic = it.nameArabic,
+                        type = it.type.name,
+                    )
+                },
+        )
+    }
+
+    /**
+     * How many blank cells precede the 1st in a Sunday-first grid.
+     *
+     * `java.time` numbers weekdays Monday=1 … Sunday=7; the widget's grid starts on Sunday, so
+     * Sunday has to wrap to 0 and everything else keeps its number. Getting this wrong shifts
+     * every date in the month by a column, which looks like a calendar and is not one.
+     */
+    private fun sundayBasedOffset(javaDayOfWeek: Int): Int =
+        if (javaDayOfWeek == SUNDAY_ISO) 0 else javaDayOfWeek
+
+    private companion object {
+        const val SUNDAY_ISO = 7
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWorker.kt
@@ -7,23 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.core.util.HijriDateCalculator
-import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
 import java.time.Duration
-import java.time.LocalDate
-import java.time.format.TextStyle
-import java.util.Locale
 
 @HiltWorker
 class HijriCalendarWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val settingsRepository: SettingsRepository
+    private val dataSource: HijriCalendarWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -63,47 +57,7 @@ class HijriCalendarWorker @AssistedInject constructor(
         }
 
         return try {
-            val offset = settingsRepository.hijriDayOffset.first()
-            val hijriDate = HijriDateCalculator.today(offset)
-            val today = LocalDate.now().plusDays(offset.toLong())
-            val gregorianDate = "${today.dayOfMonth} ${
-                today.month.getDisplayName(TextStyle.SHORT, Locale.getDefault())
-            }"
-
-            val daysInMonth = HijriDateCalculator.getDaysInHijriMonth(
-                hijriDate.year, hijriDate.month
-            )
-
-            // Get the Gregorian date of the 1st of the current Hijri month
-            val firstOfMonth = HijriDateCalculator.toGregorian(1, hijriDate.month, hijriDate.year)
-            // dayOfWeek: MONDAY=1 .. SUNDAY=7, convert to 0=Sun..6=Sat
-            val javaDow = firstOfMonth.dayOfWeek.value // 1=Mon..7=Sun
-            val firstDayOfWeekOffset = if (javaDow == 7) 0 else javaDow // Sun=0, Mon=1..Sat=6
-
-            // Get today's events
-            val allEvents = HijriDateCalculator.getIslamicEvents(hijriDate.year)
-            val todayEvents = allEvents.filter { event ->
-                event.day == hijriDate.day && event.month == hijriDate.month
-            }.map { event ->
-                HijriCalendarEventData(
-                    name = event.name,
-                    nameArabic = event.nameArabic,
-                    type = event.type.name
-                )
-            }
-
-            val data = HijriCalendarData(
-                hijriMonth = hijriDate.month,
-                hijriMonthName = hijriDate.monthName,
-                hijriYear = hijriDate.year,
-                gregorianDate = gregorianDate,
-                daysInMonth = daysInMonth,
-                firstDayOfWeekOffset = firstDayOfWeekOffset,
-                todayHijriDay = hijriDate.day,
-                events = todayEvents
-            )
-
-            setWidgetState(glanceIds, HijriCalendarWidgetState.Success(data))
+            setWidgetState(glanceIds, HijriCalendarWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("HijriCalendarWorker failed")

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidgetDataSource.kt
@@ -1,0 +1,47 @@
+package com.arshadshah.nimaz.widget.hijridate
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+import java.time.format.TextStyle
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * Computes what the Hijri-date widget shows.
+ *
+ * Split out of [HijriDateWorker] so it can be tested — `doWork()` returns early when no widget is
+ * placed, which is always true on a test device, so none of this ran under `WidgetWorkersTest`
+ * (#474).
+ *
+ * **Behaviour is preserved exactly, including one thing that looks wrong.** `hijriDayOffset` is a
+ * moon-sighting correction to the *Hijri* date, but it is also added to the Gregorian date
+ * rendered beside it, so a user who sets +1 sees tomorrow's Gregorian day and weekday on the
+ * widget — a date their phone knows exactly. That is carried over unchanged here rather than
+ * fixed, because a refactor that silently changes what a widget displays is not reviewable. It is
+ * filed as #509.
+ */
+class HijriDateWidgetDataSource @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val todayProvider: TodayProvider,
+) {
+
+    suspend fun load(): HijriDateData {
+        val offset = settingsRepository.hijriDayOffset.first()
+        val hijriDate = HijriDateCalculator.today(offset)
+
+        // See the class KDoc: the offset is applied to the Gregorian half too. Preserved.
+        val today = todayProvider.today().plusDays(offset.toLong())
+
+        return HijriDateData(
+            hijriDay = hijriDate.day,
+            hijriMonth = hijriDate.monthName,
+            hijriYear = hijriDate.year,
+            gregorianDayOfWeek = today.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+            gregorianDate = "${today.dayOfMonth} ${
+                today.month.getDisplayName(TextStyle.SHORT, Locale.getDefault())
+            }",
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWorker.kt
@@ -7,23 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.core.util.HijriDateCalculator
-import com.arshadshah.nimaz.domain.repository.SettingsRepository
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
 import java.time.Duration
-import java.time.LocalDate
-import java.time.format.TextStyle
-import java.util.Locale
 
 @HiltWorker
 class HijriDateWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val settingsRepository: SettingsRepository
+    private val dataSource: HijriDateWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -57,26 +51,7 @@ class HijriDateWorker @AssistedInject constructor(
         }
 
         return try {
-            val offset = settingsRepository.hijriDayOffset.first()
-            val hijriDate = HijriDateCalculator.today(offset)
-            val today = LocalDate.now().plusDays(offset.toLong())
-            val dayOfWeek = today.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
-            val gregorianDate = "${today.dayOfMonth} ${
-                today.month.getDisplayName(
-                    TextStyle.SHORT,
-                    Locale.getDefault()
-                )
-            }"
-
-            val data = HijriDateData(
-                hijriDay = hijriDate.day,
-                hijriMonth = hijriDate.monthName,
-                hijriYear = hijriDate.year,
-                gregorianDayOfWeek = dayOfWeek,
-                gregorianDate = gregorianDate
-            )
-
-            setWidgetState(glanceIds, HijriDateWidgetState.Success(data))
+            setWidgetState(glanceIds, HijriDateWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("HijriDateWorker failed")

--- a/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSource.kt
@@ -1,0 +1,44 @@
+package com.arshadshah.nimaz.widget.khatam
+
+import com.arshadshah.nimaz.domain.repository.KhatamRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+/**
+ * Computes what the khatam widget shows.
+ *
+ * Split out of [KhatamWorker] so it can be tested. The worker's `doWork()` cannot: it opens by
+ * asking `GlanceAppWidgetManager` for the widget's glance ids, and a test device has none placed
+ * on its home screen, so the whole body is skipped by the `glanceIds.isEmpty()` early return.
+ * That is why `WidgetWorkersTest` was green for a year while asserting nothing about the data —
+ * see #474. With the computation here, `doWork()` is *get ids → load → write*, and the part that
+ * can be wrong has tests.
+ */
+class KhatamWidgetDataSource @Inject constructor(
+    private val khatamRepository: KhatamRepository,
+) {
+
+    suspend fun load(): KhatamWidgetData {
+        val khatam = khatamRepository.observeActiveKhatam().first()
+            ?: return KhatamWidgetData(hasActiveKhatam = false)
+
+        // The detail snapshot is the only place insights (juz completed) are computed, so read
+        // it rather than recomputing here. It can be absent — a khatam that exists but has no
+        // detail row yet — which is why every field below has a fallback.
+        val insights = khatamRepository.observeKhatamDetail(khatam.id).first()?.insights
+
+        return KhatamWidgetData(
+            hasActiveKhatam = true,
+            name = khatam.name,
+            // Clamped because a khatam recorded past its own total would otherwise render a
+            // progress bar wider than its track.
+            progressPercent = (khatam.progressPercent * 100).toInt().coerceIn(0, 100),
+            // The reader is *inside* the juz after the completed ones.
+            currentJuz = insights?.currentJuz ?: 1,
+            juzCompleted = insights?.juzCompleted ?: 0,
+            remainingAyahs = insights?.remainingAyahs ?: khatam.remainingAyahs,
+            dailyTarget = khatam.dailyTarget,
+            currentStreak = insights?.currentStreak ?: 0,
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSource.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
  * asking `GlanceAppWidgetManager` for the widget's glance ids, and a test device has none placed
  * on its home screen, so the whole body is skipped by the `glanceIds.isEmpty()` early return.
  * That is why `WidgetWorkersTest` was green for a year while asserting nothing about the data —
- * see #474. With the computation here, `doWork()` is *get ids → load → write*, and the part that
+ * see #474. With the computation here, `doWork()` is *get ids, load, write*, and the part that
  * can be wrong has tests.
  */
 class KhatamWidgetDataSource @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWorker.kt
@@ -7,19 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.domain.repository.KhatamRepository
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
 import java.time.Duration
 
 @HiltWorker
 class KhatamWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val khatamRepository: KhatamRepository
+    private val dataSource: KhatamWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -53,29 +51,7 @@ class KhatamWorker @AssistedInject constructor(
         }
 
         return try {
-            val khatam = khatamRepository.observeActiveKhatam().first()
-            val data = if (khatam == null) {
-                // No active khatam — the widget renders its empty state.
-                KhatamWidgetData(hasActiveKhatam = false)
-            } else {
-                // The detail snapshot is the only place insights (juz completed)
-                // are computed, so read it rather than recomputing here.
-                val insights = khatamRepository.observeKhatamDetail(khatam.id).first()?.insights
-                KhatamWidgetData(
-                    hasActiveKhatam = true,
-                    name = khatam.name,
-                    progressPercent = (khatam.progressPercent * 100).toInt().coerceIn(0, 100),
-                    // The reader is *inside* the juz after the completed ones;
-                    // cap at 30 for a finished khatam.
-                    currentJuz = insights?.currentJuz ?: 1,
-                    juzCompleted = insights?.juzCompleted ?: 0,
-                    remainingAyahs = insights?.remainingAyahs ?: khatam.remainingAyahs,
-                    dailyTarget = khatam.dailyTarget,
-                    currentStreak = insights?.currentStreak ?: 0
-                )
-            }
-
-            setWidgetState(glanceIds, KhatamWidgetState.Success(data))
+            setWidgetState(glanceIds, KhatamWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("KhatamWorker failed")

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidgetDataSource.kt
@@ -1,0 +1,96 @@
+package com.arshadshah.nimaz.widget.nextprayer
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.resolveLocation
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.widget.core.formatWidgetCountdown
+import com.arshadshah.nimaz.widget.core.formatWidgetTime
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import javax.inject.Inject
+import kotlin.time.Instant
+
+/**
+ * Computes what the next-prayer widget shows.
+ *
+ * Split out of [NextPrayerWorker] so it can be tested — `doWork()` returns early when no widget
+ * is placed, which is always true on a test device, so none of this ran under
+ * `WidgetWorkersTest` (#474). This is the widget with the most branching of the six: today's next
+ * prayer, tomorrow's Fajr once the day's prayers have all passed, and a last-resort state when
+ * even that cannot be computed.
+ *
+ * Takes [java.time.Clock] and [TodayProvider] rather than reading `Clock.System.now()` and
+ * `LocalDate.now()` directly. Both were unmockable, which meant the rollover to tomorrow — the
+ * one branch a user actually notices, because it is what the widget shows all evening — could
+ * not be tested at all.
+ */
+class NextPrayerWidgetDataSource @Inject constructor(
+    private val prayerTimeCalculator: PrayerTimeCalculator,
+    private val settingsRepository: SettingsRepository,
+    private val todayProvider: TodayProvider,
+    private val clock: java.time.Clock,
+) {
+
+    suspend fun load(): NextPrayerData {
+        val resolved = resolveLocation(
+            settingsRepository.latitude.first(),
+            settingsRepository.longitude.first(),
+        )
+        val use24Hour = settingsRepository.use24HourFormat.first()
+        val timeZone = TimeZone.currentSystemDefault()
+        val now = Instant.fromEpochMilliseconds(clock.millis())
+
+        val prayerTimes = prayerTimeCalculator.getPrayerTimes(resolved.latitude, resolved.longitude)
+        val localNow = now.toLocalDateTime(timeZone)
+
+        val nextPrayer = prayerTimes.firstOrNull {
+            it.time.toLocalDateTime(timeZone).time > localNow.time
+        }
+
+        if (nextPrayer != null) {
+            val prayerLocalTime = nextPrayer.time.toLocalDateTime(timeZone)
+            return NextPrayerData(
+                prayerName = nextPrayer.type.displayName,
+                prayerTime = formatWidgetTime(
+                    prayerLocalTime.hour,
+                    prayerLocalTime.minute,
+                    includeAmPm = true,
+                    use24Hour = use24Hour,
+                ),
+                countdown = formatWidgetCountdown((nextPrayer.time - now).inWholeSeconds),
+                isValid = true,
+                nextPrayerEpochMillis = nextPrayer.time.toEpochMilliseconds(),
+            )
+        }
+
+        // Every prayer for today has passed, so the widget shows tomorrow's Fajr. This is the
+        // state it sits in all evening, every evening.
+        val tomorrowFajr = prayerTimeCalculator
+            .getPrayerTimes(resolved.latitude, resolved.longitude, todayProvider.today().plusDays(1))
+            .firstOrNull()
+            ?: return NextPrayerData(
+                // Nothing computable — a bad location, say. Name the prayer anyway rather than
+                // rendering an empty widget: "Fajr —" reads as "not known yet", an empty box
+                // reads as broken.
+                prayerName = PrayerType.FAJR.displayName,
+                prayerTime = "",
+                isTomorrow = true,
+                countdown = "—",
+                isValid = true,
+            )
+
+        return NextPrayerData(
+            prayerName = tomorrowFajr.type.displayName,
+            // Deliberately blank: the widget renders "Tomorrow" beside the countdown, and a
+            // time without a date beside it reads as today's.
+            prayerTime = "",
+            isTomorrow = true,
+            countdown = formatWidgetCountdown((tomorrowFajr.time - now).inWholeSeconds),
+            isValid = true,
+            nextPrayerEpochMillis = tomorrowFajr.time.toEpochMilliseconds(),
+        )
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWorker.kt
@@ -7,28 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
-import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.domain.model.resolveLocation
 import com.arshadshah.nimaz.widget.core.WidgetWork
-import com.arshadshah.nimaz.widget.core.formatWidgetCountdown
-import com.arshadshah.nimaz.widget.core.formatWidgetTime
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
-import kotlin.time.Clock
-import kotlinx.coroutines.flow.first
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 @HiltWorker
 class NextPrayerWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val preferencesDataStore: PreferencesDataStore
+    private val dataSource: NextPrayerWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -70,73 +59,7 @@ class NextPrayerWorker @AssistedInject constructor(
         }
 
         return try {
-            val resolved = resolveLocation(
-                preferencesDataStore.latitude.first(),
-                preferencesDataStore.longitude.first()
-            )
-            val latitude = resolved.latitude
-            val longitude = resolved.longitude
-            val use24Hour = preferencesDataStore.use24HourFormat.first()
-
-            val prayerTimes = prayerTimeCalculator.getPrayerTimes(latitude, longitude)
-            val currentTime = Clock.System.now()
-            val timeZone = TimeZone.currentSystemDefault()
-            val localTime = currentTime.toLocalDateTime(timeZone)
-
-            val nextPrayer = prayerTimes.firstOrNull { prayerTime ->
-                val prayerLocalTime = prayerTime.time.toLocalDateTime(timeZone)
-                prayerLocalTime.time > localTime.time
-            }
-
-            val data = if (nextPrayer != null) {
-                val prayerLocalTime = nextPrayer.time.toLocalDateTime(timeZone)
-                val epochMillis = nextPrayer.time.toEpochMilliseconds()
-                val countdown =
-                    formatWidgetCountdown((nextPrayer.time - currentTime).inWholeSeconds)
-
-                NextPrayerData(
-                    prayerName = nextPrayer.type.displayName,
-                    prayerTime = formatWidgetTime(
-                        prayerLocalTime.hour,
-                        prayerLocalTime.minute,
-                        includeAmPm = true,
-                        use24Hour = use24Hour
-                    ),
-                    countdown = countdown,
-                    isValid = true,
-                    nextPrayerEpochMillis = epochMillis
-                )
-            } else {
-                // All prayers passed, show Fajr for tomorrow
-                val tomorrowDate = java.time.LocalDate.now().plusDays(1)
-                val tomorrowPrayers =
-                    prayerTimeCalculator.getPrayerTimes(latitude, longitude, tomorrowDate)
-                val tomorrowFajr = tomorrowPrayers.firstOrNull()
-
-                if (tomorrowFajr != null) {
-                    val epochMillis = tomorrowFajr.time.toEpochMilliseconds()
-                    NextPrayerData(
-                        prayerName = tomorrowFajr.type.displayName,
-                        prayerTime = "",
-                        isTomorrow = true,
-                        countdown = formatWidgetCountdown(
-                            (tomorrowFajr.time - currentTime).inWholeSeconds
-                        ),
-                        isValid = true,
-                        nextPrayerEpochMillis = epochMillis
-                    )
-                } else {
-                    NextPrayerData(
-                        prayerName = PrayerType.FAJR.displayName,
-                        prayerTime = "",
-                        isTomorrow = true,
-                        countdown = "—",
-                        isValid = true
-                    )
-                }
-            }
-
-            setWidgetState(glanceIds, NextPrayerWidgetState.Success(data))
+            setWidgetState(glanceIds, NextPrayerWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("NextPrayerWorker failed")

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidgetDataSource.kt
@@ -1,0 +1,85 @@
+package com.arshadshah.nimaz.widget.prayertimes
+
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.domain.model.PrayerTime
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.resolveLocation
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.widget.core.formatWidgetTime
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import javax.inject.Inject
+
+/**
+ * Computes what the prayer-times widget shows.
+ *
+ * Split out of [PrayerTimesWorker] so it can be tested — `doWork()` returns early when no widget
+ * is placed, which is always true on a test device (#474).
+ *
+ * **Behaviour preserved exactly, including two oddities**, because a refactor that changes what a
+ * widget displays is not reviewable:
+ *
+ *  - `HijriDateCalculator.today()` is called with **no offset**, so this widget ignores
+ *    `hijriDayOffset` — the inverse of the Hijri-date widget, which applies it to too much
+ *    (#509). Two widgets on the same home screen can therefore disagree about the Hijri date.
+ *  - The location name falls back to a hardcoded `"Dublin"` when the stored one is blank.
+ */
+class PrayerTimesWidgetDataSource @Inject constructor(
+    private val prayerTimeCalculator: PrayerTimeCalculator,
+    private val settingsRepository: SettingsRepository,
+) {
+
+    suspend fun load(): PrayerTimesData {
+        val resolved = resolveLocation(
+            settingsRepository.latitude.first(),
+            settingsRepository.longitude.first(),
+        )
+        val use24Hour = settingsRepository.use24HourFormat.first()
+
+        // The stored name is "City, Region, Country"; the widget has room for the city.
+        val locationName = settingsRepository.locationName.first()
+            .takeIf { it.isNotBlank() }
+            ?.split(",")
+            ?.firstOrNull()
+            ?.trim()
+            ?: DEFAULT_LOCATION_NAME
+
+        val timeZone = TimeZone.currentSystemDefault()
+        val byType = prayerTimeCalculator
+            .getPrayerTimes(resolved.latitude, resolved.longitude)
+            .associateBy { it.type }
+
+        fun format(prayer: PrayerTime?): String = prayer?.let {
+            val local = it.time.toLocalDateTime(timeZone)
+            formatWidgetTime(local.hour, local.minute, use24Hour = use24Hour)
+        } ?: MISSING
+
+        fun epochOf(prayer: PrayerTime?): Long = prayer?.time?.toEpochMilliseconds() ?: 0L
+
+        // See the class KDoc: no offset, unlike the Hijri-date widget. Preserved.
+        val hijriDate = HijriDateCalculator.today()
+
+        return PrayerTimesData(
+            locationName = locationName,
+            hijriDate = "${hijriDate.day} ${hijriDate.monthName}",
+            fajrTime = format(byType[PrayerType.FAJR]),
+            dhuhrTime = format(byType[PrayerType.DHUHR]),
+            asrTime = format(byType[PrayerType.ASR]),
+            maghribTime = format(byType[PrayerType.MAGHRIB]),
+            ishaTime = format(byType[PrayerType.ISHA]),
+            fajrEpochMillis = epochOf(byType[PrayerType.FAJR]),
+            dhuhrEpochMillis = epochOf(byType[PrayerType.DHUHR]),
+            asrEpochMillis = epochOf(byType[PrayerType.ASR]),
+            maghribEpochMillis = epochOf(byType[PrayerType.MAGHRIB]),
+            ishaEpochMillis = epochOf(byType[PrayerType.ISHA]),
+        )
+    }
+
+    private companion object {
+        /** Shown when a prayer cannot be computed. An em dash, not a blank, so the row still reads. */
+        const val MISSING = "—"
+        const val DEFAULT_LOCATION_NAME = "Dublin"
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWorker.kt
@@ -7,27 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.core.util.HijriDateCalculator
-import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
-import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
-import com.arshadshah.nimaz.domain.model.PrayerType
-import com.arshadshah.nimaz.domain.model.resolveLocation
 import com.arshadshah.nimaz.widget.core.WidgetWork
-import com.arshadshah.nimaz.widget.core.formatWidgetTime
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
-import kotlinx.coroutines.flow.first
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 @HiltWorker
 class PrayerTimesWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val prayerTimeCalculator: PrayerTimeCalculator,
-    private val preferencesDataStore: PreferencesDataStore
+    private val dataSource: PrayerTimesWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -67,57 +57,7 @@ class PrayerTimesWorker @AssistedInject constructor(
         }
 
         return try {
-            val resolved = resolveLocation(
-                preferencesDataStore.latitude.first(),
-                preferencesDataStore.longitude.first()
-            )
-            val latitude = resolved.latitude
-            val longitude = resolved.longitude
-            val locationName = preferencesDataStore.locationName.first()
-                .takeIf { it.isNotBlank() }
-                ?.split(",")
-                ?.firstOrNull()
-                ?.trim() ?: "Dublin"
-            val use24Hour = preferencesDataStore.use24HourFormat.first()
-
-            val prayerTimes = prayerTimeCalculator.getPrayerTimes(latitude, longitude)
-            val timeZone = TimeZone.currentSystemDefault()
-
-            val prayerMap = prayerTimes.associate { it.type to it }
-
-            val fajr = prayerMap[PrayerType.FAJR]
-            val dhuhr = prayerMap[PrayerType.DHUHR]
-            val asr = prayerMap[PrayerType.ASR]
-            val maghrib = prayerMap[PrayerType.MAGHRIB]
-            val isha = prayerMap[PrayerType.ISHA]
-
-            fun formatPrayer(prayerTime: com.arshadshah.nimaz.domain.model.PrayerTime?): String =
-                prayerTime?.let {
-                    val local = it.time.toLocalDateTime(timeZone)
-                    formatWidgetTime(local.hour, local.minute, use24Hour = use24Hour)
-                } ?: "—"
-
-            fun epochOf(prayerTime: com.arshadshah.nimaz.domain.model.PrayerTime?): Long =
-                prayerTime?.time?.toEpochMilliseconds() ?: 0L
-
-            val hijriDate = HijriDateCalculator.today()
-
-            val data = PrayerTimesData(
-                locationName = locationName,
-                hijriDate = "${hijriDate.day} ${hijriDate.monthName}",
-                fajrTime = formatPrayer(fajr),
-                dhuhrTime = formatPrayer(dhuhr),
-                asrTime = formatPrayer(asr),
-                maghribTime = formatPrayer(maghrib),
-                ishaTime = formatPrayer(isha),
-                fajrEpochMillis = epochOf(fajr),
-                dhuhrEpochMillis = epochOf(dhuhr),
-                asrEpochMillis = epochOf(asr),
-                maghribEpochMillis = epochOf(maghrib),
-                ishaEpochMillis = epochOf(isha),
-            )
-
-            setWidgetState(glanceIds, PrayerTimesWidgetState.Success(data))
+            setWidgetState(glanceIds, PrayerTimesWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("PrayerTimesWorker failed")

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidgetDataSource.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidgetDataSource.kt
@@ -1,0 +1,64 @@
+package com.arshadshah.nimaz.widget.prayertracker
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import javax.inject.Inject
+
+/**
+ * Computes what the prayer-tracker widget shows.
+ *
+ * Split out of [PrayerTrackerWorker] so it can be tested — `doWork()` returns early when no
+ * widget is placed, which is always true on a test device, so none of this ran under
+ * `WidgetWorkersTest` (#474).
+ *
+ * Two things changed on the way out. It takes [TodayProvider] rather than calling
+ * `LocalDate.now()` directly — the same seam the registry introduced when it removed that call
+ * from ten ViewModels, and without it a test cannot pin the date label. And the five prayers are
+ * a list rather than five copy-pasted comparisons: the original wrote
+ * `recordMap["fajr"] == "prayed"` ten times, once for the boolean and again inside the count, so
+ * the two could disagree.
+ */
+class PrayerTrackerWidgetDataSource @Inject constructor(
+    private val prayerDao: PrayerDao,
+    private val todayProvider: TodayProvider,
+) {
+
+    suspend fun load(): PrayerTrackerData {
+        val today = todayProvider.today()
+        val records = prayerDao.getPrayerRecordsForDateSync(today.toUtcMidnightMillis())
+        val statuses = records.associate { it.prayerName to it.status }
+
+        // One source for both the per-prayer flags and the count. Deriving the count from the
+        // same list is what stops "3 of 5" disagreeing with the five ticks beside it.
+        val prayed = PRAYER_KEYS.associateWith { statuses[it] == STATUS_PRAYED }
+
+        return PrayerTrackerData(
+            dateLabel = today.dayOfWeek.name.take(3).lowercase()
+                .replaceFirstChar { it.uppercase() },
+            fajr = prayed.getValue(FAJR),
+            dhuhr = prayed.getValue(DHUHR),
+            asr = prayed.getValue(ASR),
+            maghrib = prayed.getValue(MAGHRIB),
+            isha = prayed.getValue(ISHA),
+            prayedCount = prayed.count { it.value },
+            totalCount = PRAYER_KEYS.size,
+        )
+    }
+
+    private companion object {
+        const val FAJR = "fajr"
+        const val DHUHR = "dhuhr"
+        const val ASR = "asr"
+        const val MAGHRIB = "maghrib"
+        const val ISHA = "isha"
+
+        /**
+         * The stored status meaning "prayed". Anything else — missed, excused, or absent —
+         * counts as not prayed, which is why this compares equal rather than not-equal.
+         */
+        const val STATUS_PRAYED = "prayed"
+
+        val PRAYER_KEYS = listOf(FAJR, DHUHR, ASR, MAGHRIB, ISHA)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWorker.kt
@@ -7,20 +7,17 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
-import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
-import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
 import com.arshadshah.nimaz.widget.core.WidgetWork
 import com.arshadshah.nimaz.widget.core.updateWidgetState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.time.Duration
-import java.time.LocalDate
 
 @HiltWorker
 class PrayerTrackerWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val prayerDao: PrayerDao
+    private val dataSource: PrayerTrackerWidgetDataSource
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -60,30 +57,7 @@ class PrayerTrackerWorker @AssistedInject constructor(
         }
 
         return try {
-            val today = LocalDate.now()
-            val todayEpoch = today.toUtcMidnightMillis()
-            val records = prayerDao.getPrayerRecordsForDateSync(todayEpoch)
-            val recordMap = records.associate { it.prayerName to it.status }
-
-            val data = PrayerTrackerData(
-                dateLabel = today.dayOfWeek.name.take(3).lowercase()
-                    .replaceFirstChar { it.uppercase() },
-                fajr = recordMap["fajr"] == "prayed",
-                dhuhr = recordMap["dhuhr"] == "prayed",
-                asr = recordMap["asr"] == "prayed",
-                maghrib = recordMap["maghrib"] == "prayed",
-                isha = recordMap["isha"] == "prayed",
-                prayedCount = listOf(
-                    recordMap["fajr"] == "prayed",
-                    recordMap["dhuhr"] == "prayed",
-                    recordMap["asr"] == "prayed",
-                    recordMap["maghrib"] == "prayed",
-                    recordMap["isha"] == "prayed"
-                ).count { it },
-                totalCount = 5
-            )
-
-            setWidgetState(glanceIds, PrayerTrackerWidgetState.Success(data))
+            setWidgetState(glanceIds, PrayerTrackerWidgetState.Success(dataSource.load()))
             Result.success()
         } catch (e: Exception) {
             CrashReporter.log("PrayerTrackerWorker failed")

--- a/app/src/test/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidgetDataSourceTest.kt
@@ -1,0 +1,108 @@
+package com.arshadshah.nimaz.widget.hijricalendar
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * What the Hijri-calendar widget shows.
+ *
+ * `HijriCalendarWorker.doWork()` returns early when no widget is placed, which is always the case
+ * on a test device, so none of this was covered by `WidgetWorkersTest` (#474).
+ */
+class HijriCalendarWidgetDataSourceTest {
+
+    private val settings: SettingsRepository = mockk(relaxed = true)
+    private val todayProvider: TodayProvider = mockk(relaxed = true)
+
+    private val wednesday = LocalDate.of(2026, 8, 12)
+
+    private fun source() = HijriCalendarWidgetDataSource(settings, todayProvider)
+
+    private fun given(offset: Int = 0) {
+        every { settings.hijriDayOffset } returns flowOf(offset)
+        every { todayProvider.today() } returns wednesday
+    }
+
+    @Test
+    fun `the month is described consistently`() = runTest {
+        given()
+
+        val data = source().load()
+
+        assertThat(data.hijriMonth).isIn(1..12)
+        assertThat(data.hijriMonthName).isNotEmpty()
+        assertThat(data.hijriYear).isGreaterThan(1400)
+        assertThat(data.todayHijriDay).isIn(1..30)
+    }
+
+    /**
+     * A Hijri month is 29 or 30 days. A grid built on anything else is not a calendar.
+     */
+    @Test
+    fun `the month has 29 or 30 days`() = runTest {
+        given()
+
+        assertThat(source().load().daysInMonth).isIn(listOf(29, 30))
+    }
+
+    /**
+     * The grid starts on Sunday, but `java.time` numbers Monday=1 … Sunday=7. Getting the wrap
+     * wrong shifts every date in the month by a column — it still looks like a calendar, which
+     * is what makes it worth a test.
+     */
+    @Test
+    fun `the first-day offset is a valid Sunday-first column`() = runTest {
+        given()
+
+        assertThat(source().load().firstDayOfWeekOffset).isIn(0..6)
+    }
+
+    @Test
+    fun `the first-day offset agrees with the actual first of the month`() = runTest {
+        given()
+
+        val data = source().load()
+        val firstOfMonth = HijriDateCalculator.toGregorian(1, data.hijriMonth, data.hijriYear)
+        val expected = if (firstOfMonth.dayOfWeek.value == 7) 0 else firstOfMonth.dayOfWeek.value
+
+        assertThat(data.firstDayOfWeekOffset).isEqualTo(expected)
+    }
+
+    @Test
+    fun `today's events are only today's`() = runTest {
+        given()
+
+        val data = source().load()
+        val all = HijriDateCalculator.getIslamicEvents(data.hijriYear)
+        val expected = all.count { it.day == data.todayHijriDay && it.month == data.hijriMonth }
+
+        assertThat(data.events).hasSize(expected)
+    }
+
+    @Test
+    fun `with no offset the Gregorian half is today`() = runTest {
+        given(offset = 0)
+
+        assertThat(source().load().gregorianDate).isEqualTo("12 Aug")
+    }
+
+    /**
+     * **Pins the same bug as the Hijri-date widget, deliberately** — see #509. The offset is a
+     * Hijri correction and should not move the Gregorian date, but it does. Stated here rather
+     * than left lurking; this is the test to invert when #509 is fixed.
+     */
+    @Test
+    fun `the offset shifts the Gregorian date too - current behaviour, filed as #509`() = runTest {
+        given(offset = 1)
+
+        assertThat(source().load().gregorianDate).isEqualTo("13 Aug")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidgetDataSourceTest.kt
@@ -1,0 +1,89 @@
+package com.arshadshah.nimaz.widget.hijridate
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * What the Hijri-date widget shows.
+ *
+ * `HijriDateWorker.doWork()` returns early when no widget is placed, which is always the case on
+ * a test device, so none of this was covered by `WidgetWorkersTest` (#474).
+ *
+ * The offset behaviour asserted here is **current behaviour, not desired behaviour** — see
+ * `the offset shifts the Gregorian date too` below.
+ */
+class HijriDateWidgetDataSourceTest {
+
+    private val settings: SettingsRepository = mockk(relaxed = true)
+    private val todayProvider: TodayProvider = mockk(relaxed = true)
+
+    /** A Wednesday, so the weekday label is unambiguous. */
+    private val wednesday = LocalDate.of(2026, 8, 12)
+
+    private fun dataSource() = HijriDateWidgetDataSource(settings, todayProvider)
+
+    private fun given(offset: Int) {
+        every { settings.hijriDayOffset } returns flowOf(offset)
+        every { todayProvider.today() } returns wednesday
+    }
+
+    @Test
+    fun `with no offset the Gregorian half is today`() = runTest {
+        given(offset = 0)
+
+        val data = dataSource().load()
+
+        assertThat(data.gregorianDayOfWeek).isEqualTo("Wednesday")
+        assertThat(data.gregorianDate).isEqualTo("12 Aug")
+    }
+
+    @Test
+    fun `the Hijri half is populated`() = runTest {
+        given(offset = 0)
+
+        val data = dataSource().load()
+
+        assertThat(data.hijriDay).isIn(1..30)
+        assertThat(data.hijriMonth).isNotEmpty()
+        assertThat(data.hijriYear).isGreaterThan(1400)
+    }
+
+    /**
+     * **This pins a bug, deliberately.**
+     *
+     * `hijriDayOffset` is a moon-sighting correction to the *Hijri* date. It is also added to the
+     * Gregorian date rendered beside it, so a user who sets +1 sees **tomorrow's** Gregorian day
+     * and weekday on their widget — a date the phone knows exactly and cannot be wrong about.
+     *
+     * The behaviour is carried over unchanged by the extraction it sits in, because a refactor
+     * that silently changes what a widget displays is not reviewable. This test exists so the
+     * behaviour is *stated* rather than lurking, and it is the test that will need inverting when
+     * the fix lands. See #509.
+     */
+    @Test
+    fun `the offset shifts the Gregorian date too - current behaviour, filed as a bug`() = runTest {
+        given(offset = 1)
+
+        val data = dataSource().load()
+
+        assertThat(data.gregorianDayOfWeek).isEqualTo("Thursday")
+        assertThat(data.gregorianDate).isEqualTo("13 Aug")
+    }
+
+    @Test
+    fun `a negative offset shifts it backwards`() = runTest {
+        given(offset = -1)
+
+        val data = dataSource().load()
+
+        assertThat(data.gregorianDayOfWeek).isEqualTo("Tuesday")
+        assertThat(data.gregorianDate).isEqualTo("11 Aug")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/khatam/KhatamWidgetDataSourceTest.kt
@@ -1,0 +1,117 @@
+package com.arshadshah.nimaz.widget.khatam
+
+import com.arshadshah.nimaz.domain.model.Khatam
+import com.arshadshah.nimaz.domain.model.KhatamDetailSnapshot
+import com.arshadshah.nimaz.domain.model.KhatamInsights
+import com.arshadshah.nimaz.domain.repository.KhatamRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * What the khatam widget actually shows.
+ *
+ * These assertions were impossible before the computation came out of [KhatamWorker]: `doWork()`
+ * opens by asking `GlanceAppWidgetManager` for glance ids, a test device has no widget placed, so
+ * the early return skipped the entire body. `WidgetWorkersTest` passed for a year without
+ * touching a single line of this. See #474.
+ */
+class KhatamWidgetDataSourceTest {
+
+    private val repository: KhatamRepository = mockk(relaxed = true)
+
+    private fun dataSource() = KhatamWidgetDataSource(repository)
+
+    private fun khatam(
+        id: Long = 1L,
+        name: String = "Ramadan 1447",
+        dailyTarget: Int = 20,
+        totalAyahsRead: Int = 0,
+    ) = Khatam(
+        id = id,
+        name = name,
+        isActive = true,
+        dailyTarget = dailyTarget,
+        totalAyahsRead = totalAyahsRead,
+    )
+
+    private fun snapshot(khatam: Khatam, insights: KhatamInsights) = mockk<KhatamDetailSnapshot> {
+        every { this@mockk.insights } returns insights
+        every { this@mockk.khatam } returns khatam
+    }
+
+    @Test
+    fun `no active khatam renders the empty state`() = runTest {
+        every { repository.observeActiveKhatam() } returns flowOf(null)
+
+        val data = dataSource().load()
+
+        assertThat(data.hasActiveKhatam).isFalse()
+    }
+
+    @Test
+    fun `an active khatam carries its name, target and insights`() = runTest {
+        val k = khatam(name = "Ramadan 1447", dailyTarget = 30, totalAyahsRead = 1246)
+        every { repository.observeActiveKhatam() } returns flowOf(k)
+        every { repository.observeKhatamDetail(1L) } returns flowOf(
+            snapshot(k, KhatamInsights(currentJuz = 5, juzCompleted = 4, currentStreak = 12, remainingAyahs = 4990))
+        )
+
+        val data = dataSource().load()
+
+        assertThat(data.hasActiveKhatam).isTrue()
+        assertThat(data.name).isEqualTo("Ramadan 1447")
+        assertThat(data.dailyTarget).isEqualTo(30)
+        assertThat(data.currentJuz).isEqualTo(5)
+        assertThat(data.juzCompleted).isEqualTo(4)
+        assertThat(data.currentStreak).isEqualTo(12)
+        assertThat(data.remainingAyahs).isEqualTo(4990)
+    }
+
+    /**
+     * A khatam that exists but has no detail row yet is a real state — the snapshot is computed
+     * separately. Every insight field has to fall back rather than crash the worker, which would
+     * leave the widget on its error state until the next 30-minute run.
+     */
+    @Test
+    fun `a missing detail snapshot falls back instead of failing`() = runTest {
+        val k = khatam(totalAyahsRead = 100)
+        every { repository.observeActiveKhatam() } returns flowOf(k)
+        every { repository.observeKhatamDetail(1L) } returns flowOf(null)
+
+        val data = dataSource().load()
+
+        assertThat(data.hasActiveKhatam).isTrue()
+        assertThat(data.currentJuz).isEqualTo(1)
+        assertThat(data.juzCompleted).isEqualTo(0)
+        assertThat(data.currentStreak).isEqualTo(0)
+        // Falls back to the khatam's own arithmetic rather than to zero, which would render as
+        // "finished".
+        assertThat(data.remainingAyahs).isEqualTo(k.remainingAyahs)
+    }
+
+    /**
+     * A khatam recorded past its own total would otherwise render a progress bar wider than its
+     * track. The clamp is the only arithmetic in this class, so it is the one worth pinning.
+     */
+    @Test
+    fun `progress is clamped to 0-100`() = runTest {
+        val over = khatam(totalAyahsRead = Khatam.TOTAL_QURAN_AYAHS * 2)
+        every { repository.observeActiveKhatam() } returns flowOf(over)
+        every { repository.observeKhatamDetail(any()) } returns flowOf(null)
+
+        assertThat(dataSource().load().progressPercent).isEqualTo(100)
+    }
+
+    @Test
+    fun `a khatam with nothing read reports zero progress`() = runTest {
+        val fresh = khatam(totalAyahsRead = 0)
+        every { repository.observeActiveKhatam() } returns flowOf(fresh)
+        every { repository.observeKhatamDetail(any()) } returns flowOf(null)
+
+        assertThat(dataSource().load().progressPercent).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidgetDataSourceTest.kt
@@ -1,0 +1,169 @@
+package com.arshadshah.nimaz.widget.nextprayer
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.domain.model.PrayerTime
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
+import org.junit.Before
+import org.junit.Test
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.time.Instant
+
+/**
+ * What the next-prayer widget shows.
+ *
+ * This is the branchiest of the six widgets — today's next prayer, tomorrow's Fajr once the day
+ * has run out, and a last-resort state when even that cannot be computed — and until now not one
+ * of those branches was covered. `NextPrayerWorker.doWork()` returns early when no widget is
+ * placed, which is always the case on a test device (#474).
+ *
+ * The rollover to tomorrow is the branch that matters most: it is what the widget displays every
+ * evening, and it was untestable while the worker called `Clock.System.now()` and
+ * `LocalDate.now()` directly.
+ */
+class NextPrayerWidgetDataSourceTest {
+
+    private val calculator: PrayerTimeCalculator = mockk(relaxed = true)
+    private val settings: SettingsRepository = mockk(relaxed = true)
+    private val todayProvider: TodayProvider = mockk(relaxed = true)
+
+    private val zone = TimeZone.currentSystemDefault()
+    private val today = LocalDate.of(2026, 8, 12)
+
+    /** Builds an Instant at a wall-clock time today, in the system zone the source reads. */
+    private fun at(hour: Int, minute: Int = 0): Instant {
+        val local = java.time.LocalDateTime.of(today, java.time.LocalTime.of(hour, minute))
+        return Instant.fromEpochMilliseconds(
+            local.atZone(ZoneId.of(zone.id)).toInstant().toEpochMilli()
+        )
+    }
+
+    private fun clockAt(hour: Int, minute: Int = 0): Clock =
+        Clock.fixed(
+            java.time.Instant.ofEpochMilli(at(hour, minute).toEpochMilliseconds()),
+            ZoneId.of(zone.id),
+        )
+
+    private val todaysPrayers = listOf(
+        PrayerTime(PrayerType.FAJR, at(5, 0)),
+        PrayerTime(PrayerType.DHUHR, at(13, 0)),
+        PrayerTime(PrayerType.ASR, at(17, 0)),
+        PrayerTime(PrayerType.MAGHRIB, at(20, 0)),
+        PrayerTime(PrayerType.ISHA, at(21, 30)),
+    )
+
+    @Before
+    fun setUp() {
+        every { settings.latitude } returns flowOf(51.5)
+        every { settings.longitude } returns flowOf(-0.12)
+        every { settings.use24HourFormat } returns flowOf(true)
+        every { todayProvider.today() } returns today
+    }
+
+    private fun source(clock: Clock) =
+        NextPrayerWidgetDataSource(calculator, settings, todayProvider, clock)
+
+    private fun givenToday(prayers: List<PrayerTime> = todaysPrayers) {
+        every { calculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any()) } returns prayers
+    }
+
+    @Test
+    fun `mid-morning, the next prayer is Dhuhr`() = runTest {
+        givenToday()
+
+        val data = source(clockAt(9, 0)).load()
+
+        assertThat(data.prayerName).isEqualTo(PrayerType.DHUHR.displayName)
+        assertThat(data.isTomorrow).isFalse()
+        assertThat(data.isValid).isTrue()
+        assertThat(data.nextPrayerEpochMillis).isEqualTo(at(13, 0).toEpochMilliseconds())
+    }
+
+    /** A prayer exactly now has passed — strictly-after, or the widget sticks on it for a minute. */
+    @Test
+    fun `a prayer at exactly the current time is treated as passed`() = runTest {
+        givenToday()
+
+        val data = source(clockAt(13, 0)).load()
+
+        assertThat(data.prayerName).isEqualTo(PrayerType.ASR.displayName)
+    }
+
+    @Test
+    fun `the countdown is populated for today's next prayer`() = runTest {
+        givenToday()
+
+        val data = source(clockAt(12, 0)).load()
+
+        assertThat(data.countdown).isNotEmpty()
+        assertThat(data.countdown).isNotEqualTo("—")
+    }
+
+    /**
+     * After Isha, every prayer for today has passed. This is the state the widget sits in every
+     * single evening, and it was the least testable part of the worker.
+     */
+    @Test
+    fun `after the last prayer it rolls over to tomorrow's Fajr`() = runTest {
+        val tomorrowFajr = PrayerTime(
+            PrayerType.FAJR,
+            Instant.fromEpochMilliseconds(at(5, 0).toEpochMilliseconds() + 24 * 60 * 60 * 1000L),
+        )
+        every {
+            calculator.getPrayerTimes(any(), any(), eq(today), any(), any(), any(), any())
+        } returns todaysPrayers
+        every {
+            calculator.getPrayerTimes(any(), any(), eq(today.plusDays(1)), any(), any(), any(), any())
+        } returns listOf(tomorrowFajr)
+
+        val data = source(clockAt(22, 0)).load()
+
+        assertThat(data.isTomorrow).isTrue()
+        assertThat(data.prayerName).isEqualTo(PrayerType.FAJR.displayName)
+        assertThat(data.isValid).isTrue()
+        // Deliberately blank: the widget renders "Tomorrow" beside the countdown, and a bare
+        // time with no date beside it reads as today's.
+        assertThat(data.prayerTime).isEmpty()
+        assertThat(data.nextPrayerEpochMillis).isEqualTo(tomorrowFajr.time.toEpochMilliseconds())
+    }
+
+    /**
+     * A bad location can leave even tomorrow uncomputable. The widget must still name a prayer:
+     * "Fajr —" reads as "not known yet", an empty box reads as broken.
+     */
+    @Test
+    fun `an uncomputable tomorrow still renders a named prayer`() = runTest {
+        every {
+            calculator.getPrayerTimes(any(), any(), eq(today), any(), any(), any(), any())
+        } returns todaysPrayers
+        every {
+            calculator.getPrayerTimes(any(), any(), eq(today.plusDays(1)), any(), any(), any(), any())
+        } returns emptyList()
+
+        val data = source(clockAt(22, 0)).load()
+
+        assertThat(data.isTomorrow).isTrue()
+        assertThat(data.prayerName).isEqualTo(PrayerType.FAJR.displayName)
+        assertThat(data.countdown).isEqualTo("—")
+        assertThat(data.isValid).isTrue()
+    }
+
+    @Test
+    fun `no prayer times at all still rolls over rather than failing`() = runTest {
+        every { calculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any()) } returns emptyList()
+
+        val data = source(clockAt(9, 0)).load()
+
+        assertThat(data.isTomorrow).isTrue()
+        assertThat(data.isValid).isTrue()
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidgetDataSourceTest.kt
@@ -1,0 +1,126 @@
+package com.arshadshah.nimaz.widget.prayertimes
+
+import com.arshadshah.nimaz.core.util.PrayerTimeCalculator
+import com.arshadshah.nimaz.domain.model.PrayerTime
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.time.Instant
+
+/**
+ * What the prayer-times widget shows.
+ *
+ * `PrayerTimesWorker.doWork()` returns early when no widget is placed, which is always the case
+ * on a test device, so none of this was covered by `WidgetWorkersTest` (#474).
+ */
+class PrayerTimesWidgetDataSourceTest {
+
+    private val calculator: PrayerTimeCalculator = mockk(relaxed = true)
+    private val settings: SettingsRepository = mockk(relaxed = true)
+
+    private val zone = TimeZone.currentSystemDefault()
+    private val today = LocalDate.of(2026, 8, 12)
+
+    private fun at(hour: Int, minute: Int): Instant {
+        val local = java.time.LocalDateTime.of(today, java.time.LocalTime.of(hour, minute))
+        return Instant.fromEpochMilliseconds(
+            local.atZone(ZoneId.of(zone.id)).toInstant().toEpochMilli()
+        )
+    }
+
+    private val fullDay = listOf(
+        PrayerTime(PrayerType.FAJR, at(5, 12)),
+        PrayerTime(PrayerType.DHUHR, at(13, 5)),
+        PrayerTime(PrayerType.ASR, at(17, 30)),
+        PrayerTime(PrayerType.MAGHRIB, at(20, 45)),
+        PrayerTime(PrayerType.ISHA, at(22, 15)),
+    )
+
+    @Before
+    fun setUp() {
+        every { settings.latitude } returns flowOf(53.34)
+        every { settings.longitude } returns flowOf(-6.26)
+        every { settings.use24HourFormat } returns flowOf(true)
+        every { settings.locationName } returns flowOf("Dublin, Leinster, Ireland")
+        every { calculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any()) } returns fullDay
+    }
+
+    private fun source() = PrayerTimesWidgetDataSource(calculator, settings)
+
+    @Test
+    fun `each prayer lands in its own field`() = runTest {
+        val data = source().load()
+
+        assertThat(data.fajrTime).isEqualTo("05:12")
+        assertThat(data.dhuhrTime).isEqualTo("13:05")
+        assertThat(data.asrTime).isEqualTo("17:30")
+        assertThat(data.maghribTime).isEqualTo("20:45")
+        assertThat(data.ishaTime).isEqualTo("22:15")
+    }
+
+    @Test
+    fun `epoch millis are carried for every prayer`() = runTest {
+        val data = source().load()
+
+        assertThat(data.fajrEpochMillis).isEqualTo(at(5, 12).toEpochMilliseconds())
+        assertThat(data.ishaEpochMillis).isEqualTo(at(22, 15).toEpochMilliseconds())
+    }
+
+    /** The stored name is "City, Region, Country"; the widget has room for the city. */
+    @Test
+    fun `the location name is trimmed to its first component`() = runTest {
+        assertThat(source().load().locationName).isEqualTo("Dublin")
+    }
+
+    @Test
+    fun `a blank location name falls back rather than rendering empty`() = runTest {
+        every { settings.locationName } returns flowOf("   ")
+
+        assertThat(source().load().locationName).isNotEmpty()
+    }
+
+    /**
+     * A missing prayer renders an em dash, not a blank — the row still has to read as a row.
+     * Prayer times can genuinely be absent at high latitudes.
+     */
+    @Test
+    fun `a missing prayer renders a dash and a zero epoch`() = runTest {
+        every {
+            calculator.getPrayerTimes(any(), any(), any(), any(), any(), any(), any())
+        } returns listOf(PrayerTime(PrayerType.FAJR, at(5, 12)))
+
+        val data = source().load()
+
+        assertThat(data.fajrTime).isEqualTo("05:12")
+        assertThat(data.dhuhrTime).isEqualTo("—")
+        assertThat(data.ishaTime).isEqualTo("—")
+        assertThat(data.ishaEpochMillis).isEqualTo(0L)
+    }
+
+    @Test
+    fun `12-hour format is honoured`() = runTest {
+        every { settings.use24HourFormat } returns flowOf(false)
+
+        val data = source().load()
+
+        assertThat(data.dhuhrTime).doesNotContain("13")
+        assertThat(data.dhuhrTime).contains("1")
+    }
+
+    @Test
+    fun `the hijri date is rendered as day and month name`() = runTest {
+        val hijri = source().load().hijriDate
+
+        assertThat(hijri).isNotEmpty()
+        assertThat(hijri).contains(" ")
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidgetDataSourceTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidgetDataSourceTest.kt
@@ -1,0 +1,143 @@
+package com.arshadshah.nimaz.widget.prayertracker
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.data.local.database.entity.PrayerRecordEntity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * What the prayer-tracker widget shows.
+ *
+ * The widget is the app's most-glanced-at surface, and until now nothing asserted a single value
+ * on it: `PrayerTrackerWorker.doWork()` returns early when no widget is placed, which is always
+ * the case on a test device, so `WidgetWorkersTest` never reached this code (#474).
+ */
+class PrayerTrackerWidgetDataSourceTest {
+
+    private val dao: PrayerDao = mockk(relaxed = true)
+    private val todayProvider: TodayProvider = mockk(relaxed = true)
+
+    /** A Wednesday, so the three-letter label is unambiguous. */
+    private val wednesday = LocalDate.of(2026, 8, 12)
+
+    private fun dataSource() = PrayerTrackerWidgetDataSource(dao, todayProvider)
+
+    private fun record(name: String, status: String) = PrayerRecordEntity(
+        date = 0L,
+        prayerName = name,
+        status = status,
+        scheduledTime = 0L,
+        prayedAt = null,
+        note = null,
+    )
+
+    private suspend fun given(vararg records: PrayerRecordEntity) {
+        every { todayProvider.today() } returns wednesday
+        coEvery { dao.getPrayerRecordsForDateSync(any()) } returns records.toList()
+    }
+
+    @Test
+    fun `no records means nothing prayed`() = runTest {
+        given()
+
+        val data = dataSource().load()
+
+        assertThat(data.prayedCount).isEqualTo(0)
+        assertThat(data.totalCount).isEqualTo(5)
+        assertThat(listOf(data.fajr, data.dhuhr, data.asr, data.maghrib, data.isha))
+            .containsExactly(false, false, false, false, false)
+    }
+
+    @Test
+    fun `each prayer maps to its own flag`() = runTest {
+        given(
+            record("fajr", "prayed"),
+            record("asr", "prayed"),
+            record("isha", "prayed"),
+        )
+
+        val data = dataSource().load()
+
+        assertThat(data.fajr).isTrue()
+        assertThat(data.dhuhr).isFalse()
+        assertThat(data.asr).isTrue()
+        assertThat(data.maghrib).isFalse()
+        assertThat(data.isha).isTrue()
+        assertThat(data.prayedCount).isEqualTo(3)
+    }
+
+    /**
+     * Only "prayed" counts. A qada prayer has been made up, not prayed on time, and the widget
+     * distinguishing the two is the whole point of it — the other statuses are "missed", "qada"
+     * and "pending".
+     */
+    @Test
+    fun `only the prayed status counts`() = runTest {
+        given(
+            record("fajr", "missed"),
+            record("dhuhr", "qada"),
+            record("asr", "pending"),
+            record("maghrib", "prayed"),
+        )
+
+        val data = dataSource().load()
+
+        assertThat(data.prayedCount).isEqualTo(1)
+        assertThat(data.maghrib).isTrue()
+        assertThat(data.fajr).isFalse()
+        assertThat(data.dhuhr).isFalse()
+        assertThat(data.asr).isFalse()
+    }
+
+    /**
+     * The count and the five flags used to be computed from ten separate string comparisons —
+     * the same expression written twice per prayer — so they could disagree. They now derive
+     * from one list, and this is what holds that.
+     */
+    @Test
+    fun `the count always agrees with the flags`() = runTest {
+        given(
+            record("fajr", "prayed"),
+            record("dhuhr", "prayed"),
+            record("asr", "prayed"),
+            record("maghrib", "prayed"),
+            record("isha", "prayed"),
+        )
+
+        val data = dataSource().load()
+
+        val flagged = listOf(data.fajr, data.dhuhr, data.asr, data.maghrib, data.isha).count { it }
+        assertThat(data.prayedCount).isEqualTo(flagged)
+        assertThat(data.prayedCount).isEqualTo(5)
+    }
+
+    @Test
+    fun `the date label is the day abbreviation, capitalised`() = runTest {
+        given()
+
+        assertThat(dataSource().load().dateLabel).isEqualTo("Wed")
+    }
+
+    /**
+     * An unknown prayer name must not be counted. The widget shows five, and a stray row — a
+     * future prayer type, a typo in a migration — must not make it show six.
+     */
+    @Test
+    fun `an unrecognised prayer name is ignored`() = runTest {
+        given(
+            record("fajr", "prayed"),
+            record("tahajjud", "prayed"),
+        )
+
+        val data = dataSource().load()
+
+        assertThat(data.prayedCount).isEqualTo(1)
+        assertThat(data.totalCount).isEqualTo(5)
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -107,6 +107,19 @@ row here.
 Every `@HiltWorker CoroutineWorker` in the app. All widget workers are enqueued through
 `widget/core/WidgetWork.kt`.
 
+**A widget worker holds no logic.** Each `doWork()` is *get glance ids → `dataSource.load()` →
+write state*, with the computation in an injectable `XxxWidgetDataSource` beside it. That split
+is not cosmetic — it is the only way this code is testable at all. `doWork()` opens by asking
+`GlanceAppWidgetManager` for the widget's glance ids and returns `Result.success()` when there
+are none, and **a test device never has a widget placed**, so the entire body is unreachable from
+an instrumented test. `WidgetWorkersTest` was green for a year while asserting nothing about what
+any widget displays; it proves the `@AssistedInject` graph resolves, which is worth having and is
+all it does. Anything that can be wrong belongs in the data source, where it has JVM tests.
+
+A data source takes `TodayProvider` and `java.time.Clock` rather than calling `LocalDate.now()`
+or `Clock.System.now()` — without that seam the rollover branches (tomorrow's Fajr, the date
+label) cannot be tested, and those are the states the widgets sit in most of the time.
+
 | Worker | Package | Trigger | Section |
 |---|---|---|---|
 | `NextPrayerWorker` | `widget/nextprayer/` | periodic 15 min + widget `onEnabled` | [§2](#2-glance-widgets) |


### PR DESCRIPTION
**Stacked PR 5b of 12** in the code-audit epic #460. Targets `epic/audit-05-worker-tests`.

Closes #474. Surfaced #509 along the way.

---

## The problem this fixes is not the one the audit described

§3.2 says "seven Workers, zero tested". Six had tests, running on the emulator.wtf lane on every PR, green for a year.

They proved nothing. Every widget worker opens `doWork()` like this:

```kotlin
val glanceIds = manager.getGlanceIds(XWidget::class.java)
if (glanceIds.isEmpty()) return Result.success()
```

**A test device never has a widget on its home screen.** So `glanceIds` is empty, every worker returns success from that first branch, and `assertThat(result).isNotInstanceOf(Failure::class.java)` passes without a repository being read or a widget state being written. The suite proves `HiltWorkerFactory` can construct the classes — worth having, it catches a broken `@AssistedInject` graph — and that is the whole of it.

That is worse than untested. Untested shows up in a coverage report. A green suite exercising an early return is invisible.

## What changed

Each `doWork()` is now *get glance ids, `dataSource.load()`, write state*, with the computation in an injectable `XxxWidgetDataSource` beside it — where it has JVM tests that run in seconds on every local gate.

| Worker | Lines | New tests |
|---|---:|---:|
| `NextPrayerWorker` | 148 → 71 | 6 |
| `PrayerTimesWorker` | 129 → 69 | 7 |
| `HijriCalendarWorker` | 115 → 69 | 7 |
| `PrayerTrackerWorker` | 95 → 69 | 6 |
| `HijriDateWorker` | 88 → 62 | 4 |
| `KhatamWorker` | 87 → 63 | 5 |
| | **662 → 403** | **35** |

Two seams made the untestable parts testable. `TodayProvider` — the one the registry already introduced when it removed `LocalDate.now()` from ten ViewModels — and the `java.time.Clock` binding that already exists in `TimeModule`. Without them the rollover branches could not be pinned, and those are the states the widgets sit in most of the time: tomorrow's Fajr is what the next-prayer widget shows *every evening*.

## What the tests found

**A real bug, filed as #509 and deliberately not fixed here.** `hijriDayOffset` is a moon-sighting correction to the *Hijri* date. Both `HijriDateWorker` and `HijriCalendarWorker` also add it to the Gregorian date rendered beside it:

```kotlin
val hijriDate = HijriDateCalculator.today(offset)        // correct
val today = LocalDate.now().plusDays(offset.toLong())    // not correct
```

So a user with the offset set to +1 sees **tomorrow's** Gregorian date and weekday on their home screen — a date the phone knows exactly. It only affects users who deliberately set an offset, which is exactly the users who care most.

Behaviour is carried over unchanged, because a refactor that silently changes what a widget displays is not reviewable. Instead it is *stated*, in tests named `the offset shifts the Gregorian date too - current behaviour, filed as #509`. Those are the tests to invert when the fix lands.

**A related inconsistency**, now recorded in `PrayerTimesWidgetDataSource`'s KDoc: that widget calls `HijriDateCalculator.today()` with **no** offset, so it ignores `hijriDayOffset` entirely — the inverse of the other two. Two widgets on the same home screen can disagree about the Hijri date. Also carried over unchanged; #509 covers both directions.

**A latent inconsistency, fixed.** `PrayerTrackerWorker` computed its five booleans and its "3 of 5" count from ten separate `recordMap["fajr"] == "prayed"` comparisons — the same expression twice per prayer, so the ticks and the count beside them were free to disagree. They now derive from one map, and `the count always agrees with the flags` holds it.

## Tests worth reading

Several encode a decision rather than a value:

- **`a prayer at exactly the current time is treated as passed`** — strictly-after, or the widget sticks on a prayer for a minute after it starts.
- **`after the last prayer it rolls over to tomorrow's Fajr`** — the evening state, previously untestable.
- **`an uncomputable tomorrow still renders a named prayer`** — "Fajr —" reads as *not known yet*, an empty box reads as *broken*.
- **`only the prayed status counts`** — a qada prayer has been made up, not prayed on time, and distinguishing them is the point of the tracker. The other statuses are "missed", "qada", "pending".
- **`the first-day offset agrees with the actual first of the month`** — `java.time` numbers Monday=1…Sunday=7 and the grid is Sunday-first; getting the wrap wrong shifts every date by a column, which still *looks* like a calendar.
- **`a missing prayer renders a dash and a zero epoch`** — prayer times are genuinely absent at high latitudes.

## Also

`WidgetGlyphGuardTest` rejected an arrow glyph in one of the new KDocs. It scans every file under `widget/`, comments included, and it was right to — fixed rather than exempted.

`docs/SUBSYSTEMS.md` §0.3 now states the contract: **a widget worker holds no logic**, and why that is structural rather than stylistic.

---

## Verification

```
./gradlew :app:compileDebugKotlin              BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin   BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest               BUILD SUCCESSFUL  (35 new, full suite green)
./gradlew :app:lintDebug                       BUILD SUCCESSFUL
python3 scripts/check_docs.py                  All 23 documentation checks passed
```
