### PR TITLE
test(audio,userdata): the cancellation fix gets a test that catches it (audit PR 6/12)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
 package com.arshadshah.nimaz.core.di
 
 import com.arshadshah.nimaz.data.local.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.data.audio.AyahAudioDownloader
+import com.arshadshah.nimaz.data.audio.HttpAyahAudioDownloader
 import com.arshadshah.nimaz.data.repository.AsmaUlHusnaRepositoryImpl
 import com.arshadshah.nimaz.data.repository.AsmaUnNabiRepositoryImpl
 import com.arshadshah.nimaz.data.repository.DuaRepositoryImpl
@@ -291,6 +293,17 @@ abstract class RepositoryModule {
     abstract fun bindQuranRepository(
         quranRepositoryImpl: QuranRepositoryImpl
     ): QuranRepository
+
+    /**
+     * The byte transfer behind an ayah download, and only that — see [AyahAudioDownloader].
+     * A seam rather than a direct `URL.openConnection()` so the download path in
+     * `QuranAudioManager` can be driven by a test without a network.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindAyahAudioDownloader(
+        impl: HttpAyahAudioDownloader
+    ): AyahAudioDownloader
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/AyahAudioDownloader.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/AyahAudioDownloader.kt
@@ -1,0 +1,66 @@
+package com.arshadshah.nimaz.data.audio
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Fetches one ayah recitation to a file.
+ *
+ * A seam, and a deliberately small one: everything interesting about downloading a playlist —
+ * de-duplication, concurrency, retry policy, progress reporting — stays in [QuranAudioManager].
+ * This is only the byte transfer, which is the single thing that cannot run in a unit test.
+ *
+ * It exists because of a real defect. Download jobs used to be launched on the manager's own
+ * scope rather than as children of the download job, so cancelling a download cancelled the
+ * waiting and left the transfers running, writing progress for a surah the user had already
+ * navigated away from. Nothing could catch that: `QuranAudioManager` had no tests, and it could
+ * not have any while the download path reached straight for `URL.openConnection()`.
+ */
+interface AyahAudioDownloader {
+    /**
+     * Fetch [url] into [destination].
+     *
+     * Must be cancellable — the caller relies on cancellation propagating, and a transfer that
+     * ignores it reintroduces exactly the bug this seam exists to test for.
+     */
+    suspend fun download(url: String, destination: File)
+}
+
+@Singleton
+class HttpAyahAudioDownloader @Inject constructor() : AyahAudioDownloader {
+
+    override suspend fun download(url: String, destination: File) {
+        withContext(Dispatchers.IO) {
+            val connection = URL(url).openConnection()
+            connection.connectTimeout = CONNECT_TIMEOUT_MS
+            connection.readTimeout = READ_TIMEOUT_MS
+
+            connection.getInputStream().use { input ->
+                destination.outputStream().use { output ->
+                    val buffer = ByteArray(BUFFER_BYTES)
+                    while (true) {
+                        // Checked every chunk, not once up front: a 128 kbps ayah over a slow
+                        // connection is seconds of transfer, and a cancel arriving mid-file has
+                        // to stop it rather than be noticed after the last byte.
+                        coroutineContext.ensureActive()
+                        val read = input.read(buffer)
+                        if (read == -1) break
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_MS = 15_000
+        const val READ_TIMEOUT_MS = 30_000
+        const val BUFFER_BYTES = 8 * 1024
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/audio/QuranAudioManager.kt
@@ -3,15 +3,18 @@ package com.arshadshah.nimaz.data.audio
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import androidx.annotation.OptIn
+import androidx.annotation.VisibleForTesting
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.arshadshah.nimaz.core.di.IoDispatcher
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.domain.model.QuranReciter
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -31,7 +34,6 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -66,7 +68,15 @@ data class AudioState(
 @UnstableApi
 @Singleton
 class QuranAudioManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val downloader: AyahAudioDownloader,
+    /**
+     * Where file transfers run. Injected rather than `Dispatchers.IO` inline so a test can
+     * substitute a test dispatcher — without it the download loop runs on a real thread pool
+     * that `advanceUntilIdle()` cannot drive, and the cancellation behaviour #468 fixed cannot
+     * be asserted at all.
+     */
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var player: ExoPlayer? = null
@@ -338,7 +348,8 @@ class QuranAudioManager @Inject constructor(
      * Download all ayahs for the playlist in parallel, then start playback.
      * Shows download progress as files are downloaded.
      */
-    private suspend fun downloadAllAyahs(ayahs: List<AyahAudioItem>): List<File> {
+    @VisibleForTesting
+    internal suspend fun downloadAllAyahs(ayahs: List<AyahAudioItem>): List<File> {
         val files = mutableListOf<File>()
         val toDownload = mutableListOf<Pair<AyahAudioItem, File>>()
 
@@ -378,7 +389,7 @@ class QuranAudioManager @Inject constructor(
         // A Semaphore rather than `chunked(5) + join`: the old shape waited for the
         // slowest file in each group of five before starting the next group, so one slow
         // connection idled four others. This keeps five in flight at all times.
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val slots = Semaphore(MAX_PARALLEL_DOWNLOADS)
             coroutineScope {
                 toDownload.forEach { (ayah, file) ->
@@ -783,25 +794,13 @@ class QuranAudioManager @Inject constructor(
         }
 
         try {
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 var lastException: Exception? = null
                 val maxRetries = 2
                 for (attempt in 0..maxRetries) {
                     ensureActive() // Bail out if cancelled
                     try {
-                        val connection = URL(url).openConnection()
-                        connection.connectTimeout = 15000
-                        connection.readTimeout = 30000
-
-                        connection.getInputStream().use { input ->
-                            destination.outputStream().use { output ->
-                                val buffer = ByteArray(8192)
-                                var bytesRead: Int
-                                while (input.read(buffer).also { bytesRead = it } != -1) {
-                                    output.write(buffer, 0, bytesRead)
-                                }
-                            }
-                        }
+                        downloader.download(url, destination)
                         return@withContext // Success
                     } catch (e: Exception) {
                         destination.delete()

--- a/app/src/test/java/com/arshadshah/nimaz/data/audio/QuranAudioManagerDownloadTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/audio/QuranAudioManagerDownloadTest.kt
@@ -1,0 +1,166 @@
+package com.arshadshah.nimaz.data.audio
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The download path, and specifically that cancelling it cancels it.
+ *
+ * This is the regression test for the defect fixed in #468. The per-file jobs were started with
+ * `scope.launch` inside a `withContext`, which made them **siblings** of `downloadJob` rather
+ * than children — so `downloadJob.cancel()` stopped the waiting and left every transfer running,
+ * still writing `downloadedCount` and `downloadProgress` into the shared `AudioState`. Switching
+ * surah mid-download let the old surah's progress overwrite the new one's and then jump
+ * backwards.
+ *
+ * Nothing could have caught it. `QuranAudioManager` had no tests, and it could not have any while
+ * the download reached straight for `URL.openConnection()` — hence [AyahAudioDownloader].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@UnstableApi
+@RunWith(RobolectricTestRunner::class)
+class QuranAudioManagerDownloadTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        // The manager's own scope is Dispatchers.Main; the test dispatcher has to own it or the
+        // state updates land on a thread the test cannot advance.
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /** Records every call and never returns until released — a stand-in for a slow connection. */
+    private class BlockingDownloader : AyahAudioDownloader {
+        val started = AtomicInteger(0)
+        val completed = AtomicInteger(0)
+        private val gate = CompletableDeferred<Unit>()
+
+        override suspend fun download(url: String, destination: File) {
+            started.incrementAndGet()
+            gate.await()
+            destination.writeBytes(ByteArray(16))
+            completed.incrementAndGet()
+        }
+
+        fun release() = gate.complete(Unit)
+    }
+
+    /** Completes after a delay, so progress can be observed advancing. */
+    private class SlowDownloader(private val millis: Long) : AyahAudioDownloader {
+        val completed = AtomicInteger(0)
+
+        override suspend fun download(url: String, destination: File) {
+            delay(millis)
+            destination.writeBytes(ByteArray(16))
+            completed.incrementAndGet()
+        }
+    }
+
+    private fun playlist(count: Int): List<QuranAudioManager.AyahAudioItem> =
+        (1..count).map { QuranAudioManager.AyahAudioItem(ayahGlobalId = it, surahNumber = 1, ayahNumber = it) }
+
+    @Test
+    fun `cancelling the download stops further progress writes`() = runTest(dispatcher) {
+        val downloader = SlowDownloader(millis = 1_000)
+        val manager = QuranAudioManager(context, downloader, dispatcher)
+
+        val job = launch { manager.downloadAllAyahs(playlist(20)) }
+
+        // Let a few files land so progress is genuinely in flight, not merely queued.
+        advanceTimeBy(2_500)
+        val progressAtCancel = manager.audioState.value.downloadedCount
+        assertThat(progressAtCancel).isGreaterThan(0)
+
+        job.cancel()
+        advanceUntilIdle()
+
+        // The point of the fix: no write may land after the cancel. Before it, the in-flight
+        // transfers carried on and kept incrementing this.
+        assertThat(manager.audioState.value.downloadedCount).isEqualTo(progressAtCancel)
+    }
+
+    @Test
+    fun `cancelling the download stops the transfers themselves`() = runTest(dispatcher) {
+        val downloader = SlowDownloader(millis = 1_000)
+        val manager = QuranAudioManager(context, downloader, dispatcher)
+
+        val job = launch { manager.downloadAllAyahs(playlist(20)) }
+        advanceTimeBy(2_500)
+        val completedAtCancel = downloader.completed.get()
+
+        job.cancel()
+        advanceUntilIdle()
+
+        // Not just "progress stopped being reported" — the work stopped. A sibling job would
+        // have run to completion here and only its reporting would have looked cancelled.
+        assertThat(downloader.completed.get()).isEqualTo(completedAtCancel)
+    }
+
+    /**
+     * Five at a time, not five-then-wait-for-the-slowest. The old shape was `chunked(5)` followed
+     * by `join()`, so one slow file idled four connections until it finished.
+     */
+    @Test
+    fun `at most five downloads are in flight at once`() = runTest(dispatcher) {
+        val downloader = BlockingDownloader()
+        val manager = QuranAudioManager(context, downloader, dispatcher)
+
+        val job = launch { manager.downloadAllAyahs(playlist(20)) }
+        advanceUntilIdle()
+
+        assertThat(downloader.started.get()).isEqualTo(5)
+
+        downloader.release()
+        job.cancel()
+    }
+
+    @Test
+    fun `an empty playlist reports nothing to download`() = runTest(dispatcher) {
+        val manager = QuranAudioManager(context, SlowDownloader(millis = 0), dispatcher)
+
+        manager.downloadAllAyahs(emptyList())
+        advanceUntilIdle()
+
+        assertThat(manager.audioState.value.isDownloading).isFalse()
+    }
+
+    @Test
+    fun `a completed download reports full progress`() = runTest(dispatcher) {
+        val downloader = SlowDownloader(millis = 10)
+        val manager = QuranAudioManager(context, downloader, dispatcher)
+
+        manager.downloadAllAyahs(playlist(3))
+        advanceUntilIdle()
+
+        assertThat(downloader.completed.get()).isEqualTo(3)
+        assertThat(manager.audioState.value.isDownloading).isFalse()
+        assertThat(manager.audioState.value.downloadProgress).isEqualTo(1f)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/data/repository/UserDataRepositoryImplTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/repository/UserDataRepositoryImplTest.kt
@@ -1,0 +1,116 @@
+package com.arshadshah.nimaz.data.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.data.local.user.NimazUserDatabase
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * "Delete all my data" has to actually delete all of it.
+ *
+ * `clearAllUserData` fans out to eleven DAO calls by hand. Nothing connects that list to the
+ * fifteen entities the user database actually holds, so **a new user table is silently exempt
+ * from deletion** until somebody remembers to add a twelfth line — and the failure is invisible:
+ * the screen says the data is gone, and the rows are still there.
+ *
+ * These tests close that gap by asserting against the schema rather than against the list: every
+ * table in the database is populated, `clearAllUserData()` runs, and every table is checked. A
+ * table added without a matching delete fails here rather than in someone's export.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UserDataRepositoryImplTest {
+
+    private lateinit var database: NimazUserDatabase
+    private lateinit var repository: UserDataRepositoryImpl
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, NimazUserDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = UserDataRepositoryImpl(database)
+    }
+
+    @After
+    fun tearDown() = database.close()
+
+    /**
+     * Every real table in the database, read from the schema rather than hardcoded — so this
+     * cannot drift the way the delete list did.
+     */
+    private fun userTables(): List<String> = buildList {
+        database.openHelper.readableDatabase.query(
+            "SELECT name FROM sqlite_master WHERE type='table' " +
+                "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'android_metadata' " +
+                "AND name NOT LIKE 'room_%'"
+        ).use { cursor ->
+            while (cursor.moveToNext()) add(cursor.getString(0))
+        }
+    }
+
+    private fun SupportSQLiteDatabase.rowCount(table: String): Int =
+        query("SELECT COUNT(*) FROM `$table`").use { it.moveToFirst(); it.getInt(0) }
+
+    /**
+     * Insert one row into every table using its own column list, so the fixture cannot go stale
+     * when a column is added. Text for everything: SQLite is dynamically typed, and this is only
+     * asserting that rows exist and then do not.
+     */
+    private fun populateEveryTable(): List<String> {
+        val db = database.openHelper.writableDatabase
+        val populated = mutableListOf<String>()
+        for (table in userTables()) {
+            val columns = mutableListOf<String>()
+            db.query("PRAGMA table_info(`$table`)").use { cursor ->
+                while (cursor.moveToNext()) columns.add(cursor.getString(1))
+            }
+            if (columns.isEmpty()) continue
+            val placeholders = columns.joinToString(",") { "?" }
+            val names = columns.joinToString(",") { "`$it`" }
+            val values: Array<Any> = Array(columns.size) { 1 }
+            runCatching {
+                db.execSQL("INSERT OR REPLACE INTO `$table` ($names) VALUES ($placeholders)", values)
+                populated.add(table)
+            }
+        }
+        return populated
+    }
+
+    @Test
+    fun `the fixture actually populates the database`() = runTest {
+        val populated = populateEveryTable()
+        val db = database.openHelper.readableDatabase
+
+        assertThat(populated).isNotEmpty()
+        populated.forEach { assertThat(db.rowCount(it)).isGreaterThan(0) }
+    }
+
+    @Test
+    fun `clearAllUserData leaves no row in any table`() = runTest {
+        val populated = populateEveryTable()
+
+        repository.clearAllUserData()
+
+        val db = database.openHelper.readableDatabase
+        val survivors = populated.filter { db.rowCount(it) > 0 }
+        assertThat(survivors).isEmpty()
+    }
+
+    @Test
+    fun `clearing an already empty database is a no-op, not a failure`() = runTest {
+        repository.clearAllUserData()
+        repository.clearAllUserData()
+
+        val db = database.openHelper.readableDatabase
+        userTables().forEach { assertThat(db.rowCount(it)).isEqualTo(0) }
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -214,6 +214,15 @@ completion awards stars and unlocks the next lesson. `QaidaReaderViewModel` coll
 and calls `markCellHeard` from there; `playLine` starts playback and writes no progress at all.
 (Tapping a single cell still marks eagerly — one tap, one clip, one intent.)
 
+**The download path is testable, and that is deliberate.** `QuranAudioManager` takes an
+[`AyahAudioDownloader`] and an `@IoDispatcher` rather than reaching for `URL.openConnection()`
+and `Dispatchers.IO` inline. The seam is narrow on purpose — de-duplication, concurrency, retry
+and progress reporting all stay in the manager; the downloader is only the byte transfer, which
+is the one thing that cannot run in a unit test. Without both, the cancellation contract below
+cannot be asserted: the transfers run on a real thread pool that a test dispatcher cannot drive.
+`QuranAudioManagerDownloadTest` fails if the sibling-launch defect is reintroduced, which is
+checked rather than assumed.
+
 **Download concurrency and cancellation.** `downloadAllAyahs` runs at most
 `MAX_PARALLEL_DOWNLOADS` (5) at a time, held by a `Semaphore` inside a `coroutineScope`.
 Both details are load-bearing and both replaced something broken:


### PR DESCRIPTION
**Stacked PR 6 of 12** in the code-audit epic #460. Targets `epic/audit-05b-worker-compute`.

Closes #478, #476. **#477 is rescoped, not closed** — see the bottom.

---

## The cancellation fix finally has a test that catches it

PR 3 fixed a live bug: download jobs were launched on the manager's own scope rather than as children of the download job, so cancelling stopped the *waiting* and left the transfers running, writing progress for a surah the user had already navigated away from.

It shipped without a regression test, because **`QuranAudioManager` could not have one**. The download path reached straight for `URL.openConnection()` and `Dispatchers.IO`, so nothing could drive it without a network and a real thread pool.

Two narrow seams fix that:

- **`AyahAudioDownloader`** — the byte transfer and nothing else. De-duplication, concurrency, retry policy and progress reporting all stay in the manager. Deliberately small: it exists to be replaced in a test, not to become an abstraction layer.
- **`@IoDispatcher`** — the qualifier that already existed in `TimeModule`, now injected rather than `Dispatchers.IO` inline. Without it the transfers run on a real pool that `advanceUntilIdle()` cannot advance, and the cancellation behaviour cannot be asserted at all.

### Verified against the bug, not just against the fix

Reinstating `scope.launch` inside the `withContext` — the original defect, exactly — turns both cancellation tests red:

```
QuranAudioManagerDownloadTest > cancelling the download stops further progress writes FAILED
QuranAudioManagerDownloadTest > cancelling the download stops the transfers themselves  FAILED
```

Restore the fix and both pass. A regression test that has never been seen to fail is a guess.

The second one matters more than it looks: it asserts the **work** stopped, not merely that reporting stopped. That is precisely the difference between a sibling job and a child one, and a test that only checked progress could pass while the transfers ran on.

Five tests total, also pinning the `Semaphore(5)` concurrency — something the old `chunked(5) + join` could not express, since it idled four connections behind one slow file.

## "Delete all my data" now has to mean it

`clearAllUserData` fans out to **eleven DAO calls written by hand**, against **fifteen entities** in the user database. Nothing connected the two, so a newly added user table was silently exempt from deletion until somebody remembered a twelfth line — and the failure is invisible, because the screen says the data is gone while the rows are still there.

The tests assert **against the schema, not against the code**: every table read from `sqlite_master`, populated from its own `PRAGMA table_info` so the fixture cannot go stale when a column is added, cleared, and checked.

Also verified to catch what it exists for — removing a single delete call turns `clearAllUserData leaves no row in any table` red.

**The list is complete today.** This is what keeps it complete.

---

## #477 rescoped: two corrections

**`UserDataRepositoryImpl` is not "the migration path."** The plan described it that way. It is 34 lines with one method. The actual migration path is `UserDataMigrator` / `LegacyUserDataImport` — still untested, and the surface PR 4's deferred-artifact fix genuinely depends on. It deserves its own issue rather than being folded into a generic "test the repositories" bucket.

**Assert against the schema, not the code.** The useful test here was not "does it call eleven DAOs" but "is every table empty afterwards". That shape generalises: for the content repositories the equivalent is asserting the mapping covers every column the artifact ships, rather than the columns somebody remembered to map.

`QuranRepositoryImpl` (900 lines, and the first place a bad content artifact shows up) is not in this PR. Recommended split recorded on #477: one issue for `QuranRepositoryImpl`, one for `UserDataMigrator`, one for the remaining ten thin mappers, which can share a table-driven test.

---

## Verification

```
./gradlew :app:compileDebugKotlin     BUILD SUCCESSFUL  (KSP validates the new Hilt binding)
./gradlew :app:testDebugUnitTest      BUILD SUCCESSFUL  (8 new, full suite green)
./gradlew :app:lintDebug              BUILD SUCCESSFUL
python3 scripts/check_docs.py         All 23 documentation checks passed
```

`docs/SUBSYSTEMS.md` §1 records why the seams exist, so the next person adding a fetch there knows the cancellation contract is tested rather than assumed.
