### PR TITLE
test(search): cover the state machine behind empty Arabic search (audit PR 7/12)

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazScrollSpyIndex.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/NimazScrollSpyIndex.kt
@@ -61,7 +61,11 @@ fun NimazScrollSpyIndex(
                 contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                itemsIndexed(labels) { index, label ->
+                // Keyed by label, not position: the row is rebuilt whenever the section list
+                // changes, and a position key would hand one chip's selection state to another.
+                // Labels are section headings, which have to be distinct for scroll-to to mean
+                // anything, so they are a safe identity.
+                itemsIndexed(labels, key = { _, label -> label }) { index, label ->
                     NimazChip(
                         text = label,
                         selected = index == selectedIndex,

--- a/app/src/test/java/com/arshadshah/nimaz/data/local/search/ContentSearchIndexTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/data/local/search/ContentSearchIndexTest.kt
@@ -1,0 +1,132 @@
+package com.arshadshah.nimaz.data.local.search
+
+import androidx.sqlite.db.SimpleSQLiteQuery
+import com.arshadshah.nimaz.domain.search.ArabicSearchNormaliser
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The three states behind "Arabic search returns nothing".
+ *
+ * The FTS index ships inside the content artifact. When it is absent or stamped with a fold
+ * version this build does not speak, search falls back to `LIKE` — and `LIKE` matches no Arabic
+ * at all: الله appears in 1,746 verses and returns zero rows. An empty result list reads as "no
+ * results", so nobody reports it, which is why #472/#473 had to make the artifact install
+ * *visible*.
+ *
+ * This is the state machine that decides which of those a device is in, and it had no tests.
+ */
+class ContentSearchIndexTest {
+
+    /** A stand-in for the artifact's `search_meta` table. */
+    private class FakeDao(
+        private var meta: List<SearchIndexMetaRow>?,
+        private val refs: List<SearchIndexRefRow> = emptyList(),
+    ) : SearchIndexDao {
+        val metaReads = AtomicInteger(0)
+
+        override suspend fun rawRefs(query: SimpleSQLiteQuery): List<SearchIndexRefRow> = refs
+
+        override suspend fun rawMeta(query: SimpleSQLiteQuery): List<SearchIndexMetaRow> {
+            metaReads.incrementAndGet()
+            // Room throws "no such table: search_meta" on an artifact that predates the index.
+            return meta ?: throw android.database.sqlite.SQLiteException("no such table: search_meta")
+        }
+    }
+
+    private fun meta(
+        foldVersion: String = ArabicSearchNormaliser.FOLD_VERSION.toString(),
+        documents: String = "150000",
+        flavour: String = "fts4",
+    ) = listOf(
+        SearchIndexMetaRow("fold_version", foldVersion),
+        SearchIndexMetaRow("documents", documents),
+        SearchIndexMetaRow("flavour", flavour),
+    )
+
+    @Test
+    fun `a matching fold version is Ready`() = runTest {
+        val index = ContentSearchIndex(FakeDao(meta()))
+
+        val status = index.status()
+
+        assertThat(status).isInstanceOf(ContentSearchIndex.Status.Ready::class.java)
+        assertThat((status as ContentSearchIndex.Status.Ready).documents).isEqualTo(150_000)
+        assertThat(status.flavour).isEqualTo("fts4")
+        assertThat(index.isAvailable()).isTrue()
+    }
+
+    /**
+     * The state every install that predates the index is in — and the one an install stuck on a
+     * deferred content replace stays in indefinitely (#473).
+     */
+    @Test
+    fun `a missing search_meta table is Absent, not an error`() = runTest {
+        val index = ContentSearchIndex(FakeDao(meta = null))
+
+        assertThat(index.status()).isEqualTo(ContentSearchIndex.Status.Absent)
+        assertThat(index.isAvailable()).isFalse()
+    }
+
+    /**
+     * An index folded by a different normaliser version would match the wrong things, so it is
+     * refused rather than used. Refusing is the safe answer and also a silent one — hence the
+     * telemetry in #472.
+     */
+    @Test
+    fun `a fold version this build does not speak is Mismatched`() = runTest {
+        val index = ContentSearchIndex(FakeDao(meta(foldVersion = "-1")))
+
+        val status = index.status()
+
+        assertThat(status).isInstanceOf(ContentSearchIndex.Status.Mismatched::class.java)
+        assertThat((status as ContentSearchIndex.Status.Mismatched).stamped).isEqualTo("-1")
+        assertThat(index.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `an absent fold version is Mismatched rather than assumed compatible`() = runTest {
+        val index = ContentSearchIndex(FakeDao(listOf(SearchIndexMetaRow("documents", "10"))))
+
+        assertThat(index.status()).isInstanceOf(ContentSearchIndex.Status.Mismatched::class.java)
+        assertThat(index.isAvailable()).isFalse()
+    }
+
+    /**
+     * Probed once per process — the answer is a property of the file on disk, and the file does
+     * not change under a running app. `ContentArtifactInstaller` replaces it *before* Room opens
+     * it, so a swap always comes with a fresh process.
+     */
+    @Test
+    fun `the status is probed once and cached`() = runTest {
+        val dao = FakeDao(meta())
+        val index = ContentSearchIndex(dao)
+
+        repeat(5) { index.status() }
+        index.isAvailable()
+
+        assertThat(dao.metaReads.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `an absent index is cached too, not retried on every search`() = runTest {
+        val dao = FakeDao(meta = null)
+        val index = ContentSearchIndex(dao)
+
+        repeat(5) { index.status() }
+
+        assertThat(dao.metaReads.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `a malformed document count degrades to zero rather than failing`() = runTest {
+        val index = ContentSearchIndex(FakeDao(meta(documents = "not-a-number")))
+
+        val status = index.status()
+
+        assertThat(status).isInstanceOf(ContentSearchIndex.Status.Ready::class.java)
+        assertThat((status as ContentSearchIndex.Status.Ready).documents).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/LazyListKeyGuardTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/LazyListKeyGuardTest.kt
@@ -16,15 +16,20 @@ import java.io.File
  *
  * The `items(count)` and `items(list.size)` overloads take an index and have no key parameter,
  * so they are excluded.
+ *
+ * `itemsIndexed` is checked too. It was not, and the gap was invisible: an audit counting
+ * `items(` on a single line reported 22 keyless sites here, all of which turned out to be
+ * multi-line calls whose `key =` sat on the next line — while the one genuinely keyless call in
+ * the presentation layer was an `itemsIndexed` the guard never looked at.
  */
 class LazyListKeyGuardTest {
 
     @Test
-    fun `lazy list items declare a stable key`() {
+    fun `lazy list items and itemsIndexed declare a stable key`() {
         val dir = File("src/main/java/com/arshadshah/nimaz/presentation")
         assert(dir.isDirectory) { "Presentation source dir not found at ${dir.absolutePath}" }
 
-        val callStart = Regex("""(?<![A-Za-z0-9_])items\s*\(""")
+        val callStart = Regex("""(?<![A-Za-z0-9_])items(?:Indexed)?\s*\(""")
         val hasKey = Regex("""\bkey\s*=""")
         val countOverload = Regex("""^\d+$|^[\w.]+\.size$""")
 
@@ -36,7 +41,7 @@ class LazyListKeyGuardTest {
                 if (hasKey.containsMatchIn(args)) return@forEach
                 if (countOverload.matches(args.trim())) return@forEach
                 val line = text.substring(0, match.range.first).count { it == '\n' } + 1
-                offenders += "${file.name}:$line  items(${args.trim().take(60)})"
+                offenders += "${file.name}:$line  ${match.value}${args.trim().take(60)})"
             }
         }
 


### PR DESCRIPTION
**Stacked PR 7 of 12** in the code-audit epic #460. Targets `epic/audit-06-repo-tests`.

Closes #480, #482. **#479 and #481 are rescoped** — see below.

---

## The state machine behind empty Arabic search

`ContentSearchIndex` decides whether a device has a usable FTS index. That decision is the whole of #472/#473: when it answers `Absent` or `Mismatched`, search falls back to `LIKE`, and `LIKE` matches no Arabic at all — الله appears in **1,746 verses** and returns zero rows, which reads as "no results" rather than as a fault.

It had no tests. Seven now, over the three states and the caching.

Two are about **refusing rather than guessing**: an index folded by a normaliser version this build does not speak is `Mismatched` and goes unused, and an *absent* `fold_version` is `Mismatched` rather than assumed compatible. Both are the safe answer, and both are silent — which is exactly why PR 4 added the artifact telemetry.

Two pin that the probe happens **once per process**, including when the answer is `Absent`, so a device without an index does not re-query on every keystroke. That is only safe because `ContentArtifactInstaller` replaces the file *before* Room opens it, so a swap always arrives with a fresh process — a coupling worth having a test hold.

`SearchIndexDao` itself is 41 lines of `@RawQuery` pass-through with no logic in it. The logic is here, and that is where the tests are.

## The key guard now checks `itemsIndexed`

The audit reported **22 of 62** `items(` calls without a stable key. All 22 turned out to be multi-line calls whose `key =` sat on the following line — the count came from grepping a single line, and `LazyListKeyGuardTest` already enforced this and was already green.

What it did *not* check was `itemsIndexed`, which takes the same `key` parameter and has the same failure mode. Extending the regex found exactly one genuinely keyless lazy list in the entire presentation layer:

```
Lazy list items() without a stable key (1 site(s)):
NimazScrollSpyIndex.kt:64  itemsIndexed(labels)
```

Now keyed by label rather than position: the chip row rebuilds whenever the section list changes, and a position key hands one chip's selection state to another. Section headings must be distinct for scroll-to to mean anything, so they are a safe identity.

---

## #479 rescoped: three of the seven were never untested

`AsmaUlHusnaViewModel`, `AsmaUnNabiViewModel` and `ProphetViewModel` have no `XTest.kt`, which is what the audit counted. Each is ~37 lines that do nothing but extend `CatalogViewModel<T>`:

```kotlin
class AsmaUlHusnaViewModel @Inject constructor(
    useCases: AsmaUlHusnaUseCases,
    telemetry: Telemetry,
) : CatalogViewModel<AsmaUlHusna>(…)
```

That base has **three** test files — `CatalogViewModelTest`, `CatalogDetailRaceTest`, `CatalogSearchTelemetryTest` — the last two covering genuinely subtle behaviour, including a detail-load race where a cancelled coroutine still completes its block and writes one item's story under another item's route.

The behaviour is tested once rather than three times, which is the right arrangement; three per-subclass files would assert that a constructor passes its arguments. **This also means the epic's "byte-for-byte identical ViewModels" finding is already resolved** — they were unified into the base, and §1.3 is now only about the *screens*.

The real gap is the other four, which are substantial and genuinely untested: `HadithViewModel`, `KhatamViewModel`, `TasbihViewModel`, `SurahThematicViewModel`. Recorded on #479.

**#481** (`WidgetUpdateScheduler`, `NimazMessagingService`, `AdhanPlaybackService`, `QuranAudioService`) is untouched here and still open.

---

## Verification

```
./gradlew :app:compileDebugKotlin     BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest      BUILD SUCCESSFUL  (8 new, full suite green)
./gradlew :app:lintDebug              BUILD SUCCESSFUL
python3 scripts/check_docs.py         All 23 documentation checks passed
```
