### PR TITLE
feat(a11y): headings, state descriptions, and an automated check on the lane we already run (audit PR 12/12)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -373,6 +373,9 @@ dependencies {
     // Instrumented Testing
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    // Espresso's accessibility validator: missing labels and sub-48dp touch targets, on the
+    // instrumented lane we already run (audit §4).
+    androidTestImplementation(libs.androidx.espresso.accessibility)
     // UI Automator drives the app from *outside* Compose's test harness. Required for the
     // live-countdown tests: a ComposeTestRule puts the frame clock under test control, so a test
     // that sleeps in real time never sees the UI redraw. See LiveCountdownTest.

--- a/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/support/BaseAppTest.kt
@@ -28,6 +28,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import javax.inject.Inject
+import androidx.test.espresso.accessibility.AccessibilityChecks
 
 /**
  * Base class for end-to-end UI flow tests that drive the real [MainActivity] and its
@@ -52,6 +53,7 @@ import javax.inject.Inject
  */
 abstract class BaseAppTest {
 
+
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
 
@@ -73,7 +75,23 @@ abstract class BaseAppTest {
     @Before
     fun setup() {
         hiltRule.inject()
+        enableAccessibilityChecks()
         runBlocking { seedState() }
+    }
+
+    /**
+     * Turn Espresso's accessibility validator on for every UI test we already run.
+     *
+     * It catches the two defects that are invisible in review and invisible on screen: a
+     * control with no label, and a touch target under 48dp. The app had 373 `contentDescription`s
+     * and no automated check that any of them was present where it mattered (audit §4).
+     *
+     * `setRunChecksFromRootView(true)` walks the whole hierarchy rather than only the view under
+     * test, so a screen is validated as a screen rather than as whichever node an assertion
+     * happened to touch.
+     */
+    private fun enableAccessibilityChecks() {
+        AccessibilityChecks.enable().setRunChecksFromRootView(true)
     }
 
     /**

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCheckbox.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazCheckbox.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -125,6 +126,16 @@ fun NimazCheckbox(
     enabled: Boolean = true,
     tint: Color? = null,
     contentDescription: String? = null,
+    /**
+     * What the checkbox's state *means*, for a screen reader.
+     *
+     * Without it TalkBack announces the `Role.Checkbox` default — "checked" / "not checked" —
+     * which is true and useless: the prayer tracker is the app's core daily interaction and
+     * "checked" does not say whether Fajr was prayed on time, late, or not recorded at all.
+     * There were **zero** `stateDescription`s in the whole presentation layer before this
+     * (audit §4).
+     */
+    stateDescription: String? = null,
 ) {
     val fill = tint ?: variant.resolveFill()
     val onFill = variant.resolveOnFill()
@@ -151,8 +162,11 @@ fun NimazCheckbox(
         Modifier
     }
 
-    val descriptionModifier = if (contentDescription != null) {
-        Modifier.semantics { this.contentDescription = contentDescription }
+    val descriptionModifier = if (contentDescription != null || stateDescription != null) {
+        Modifier.semantics {
+            contentDescription?.let { this.contentDescription = it }
+            stateDescription?.let { this.stateDescription = it }
+        }
     } else {
         Modifier
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeader.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionHeader.kt
@@ -8,6 +8,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,7 +36,10 @@ fun NimazSectionHeader(
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.weight(1f)
+            // See NimazSectionTitle: one declaration, 56 call sites.
+            modifier = Modifier
+                .weight(1f)
+                .semantics { heading() }
         )
         when {
             trailingContent != null -> trailingContent()

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitle.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazSectionTitle.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,7 +32,11 @@ fun NimazSectionTitle(
             fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             letterSpacing = 1.sp,
-            modifier = if (trailingContent != null) Modifier.weight(1f) else Modifier
+            // A heading, so TalkBack's heading navigation can jump between sections instead of
+            // making the user swipe through every element in order. Declared here rather than at
+            // each of the call sites, which is the point of the section title being a component.
+            modifier = (if (trailingContent != null) Modifier.weight(1f) else Modifier)
+                .semantics { heading() }
         )
         trailingContent?.invoke()
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimeCard.kt
@@ -137,7 +137,18 @@ fun PrayerTimeCard(
                         variant = NimazCheckboxVariant.SUCCESS,
                         size = NimazCheckboxSize.LARGE,
                         type = NimazCheckboxType.CIRCLE,
-                        contentDescription = stringResource(R.string.prayed)
+                        contentDescription = stringResource(R.string.prayed),
+                        // "Fajr, prayed" rather than "checked" — the prayer's name travels with
+                        // its state, because the checkbox sits in a row a screen reader reaches
+                        // on its own.
+                        stateDescription = stringResource(
+                            if (isPrayed) {
+                                R.string.a11y_prayer_state_prayed
+                            } else {
+                                R.string.a11y_prayer_state_not_recorded
+                            },
+                            prayer.name,
+                        ),
                     )
                 } else {
                     Spacer(modifier = Modifier.size(28.dp))

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimesSectionHeader.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/PrayerTimesSectionHeader.kt
@@ -15,6 +15,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -58,6 +60,7 @@ fun PrayerTimesSectionHeader(
                 text = stringResource(R.string.prayer_times),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
                 color = MaterialTheme.colorScheme.onSurface
             )
             if (passedCount + upcomingCount > 0) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TopAppBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TopAppBar.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -95,6 +97,9 @@ fun NimazTopAppBar(
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        // The screen's own heading, and the first stop for TalkBack's heading
+                        // navigation. Material3 does not mark its title as one.
+                        modifier = Modifier.semantics { heading() },
                     )
                     if (subtitle != null) {
                         Text(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,6 +13,8 @@
     <string name="widgets">Widgets</string>
     <string name="today">Heute</string>
     <string name="prayed">Gebetet</string>
+    <string name="a11y_prayer_state_prayed">%1$s, gebetet</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, noch nicht erfasst</string>
     <string name="no_favorites_yet">Noch keine Favoriten</string>
     <string name="remove_from_favorites">Aus Favoriten entfernen</string>
     <string name="add_to_favorites">Zu Favoriten hinzufügen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,8 @@
     <string name="widgets">Widgets</string>
     <string name="today">Aujourd\'hui</string>
     <string name="prayed">Prié</string>
+    <string name="a11y_prayer_state_prayed">%1$s, prié</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, pas encore enregistré</string>
     <string name="no_favorites_yet">Aucun favori pour le moment</string>
     <string name="remove_from_favorites">Retirer des favoris</string>
     <string name="add_to_favorites">Ajouter aux favoris</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -13,6 +13,8 @@
     <string name="widgets">Widget</string>
     <string name="today">Hari Ini</string>
     <string name="prayed">Sudah Shalat</string>
+    <string name="a11y_prayer_state_prayed">%1$s, sudah salat</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, belum dicatat</string>
     <string name="no_favorites_yet">Belum ada favorit</string>
     <string name="remove_from_favorites">Hapus dari favorit</string>
     <string name="add_to_favorites">Tambahkan ke favorit</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -13,6 +13,8 @@
     <string name="widgets">Widget</string>
     <string name="today">Hari Ini</string>
     <string name="prayed">Telah Solat</string>
+    <string name="a11y_prayer_state_prayed">%1$s, telah solat</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, belum direkodkan</string>
     <string name="no_favorites_yet">Belum ada kegemaran</string>
     <string name="remove_from_favorites">Buang dari kegemaran</string>
     <string name="add_to_favorites">Tambah ke kegemaran</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -13,6 +13,8 @@
     <string name="widgets">Widget\'lar</string>
     <string name="today">Bugün</string>
     <string name="prayed">Kılındı</string>
+    <string name="a11y_prayer_state_prayed">%1$s, kılındı</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, henüz kaydedilmedi</string>
     <string name="no_favorites_yet">Henüz favori yok</string>
     <string name="remove_from_favorites">Favorilerden kaldır</string>
     <string name="add_to_favorites">Favorilere ekle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="widgets">Widgets</string>
     <string name="today">Today</string>
     <string name="prayed">Prayed</string>
+    <!-- Screen-reader state for a prayer's tracker toggle. TalkBack's default for a checkbox is
+         "checked"/"not checked", which does not say what was checked or what it meant. -->
+    <string name="a11y_prayer_state_prayed">%1$s, prayed</string>
+    <string name="a11y_prayer_state_not_recorded">%1$s, not yet recorded</string>
     <string name="no_favorites_yet">No favorites yet</string>
     <string name="remove_from_favorites">Remove from favorites</string>
     <string name="add_to_favorites">Add to favorites</string>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -746,6 +746,34 @@ typed route object.
 
 ## 8. Theming & components
 
+### 8.0 Accessibility — the obligation
+
+Three rules, and they are obligations rather than suggestions: the app shipped **373
+`contentDescription`s and zero `heading()` and zero `stateDescription`** before this section
+existed, which is the difference between being *operable* with a screen reader and being
+*usable* with one.
+
+1. **A section title is a heading.** `Modifier.semantics { heading() }` is what lets TalkBack's
+   heading navigation jump between sections instead of making the user swipe through every
+   element in order. Declare it **on the component, not at the call site** — `NimazSectionTitle`,
+   `NimazSectionHeader`, `PrayerTimesSectionHeader` and the shared top app bar already do, which
+   covers 72 call sites and every screen title. A new section-heading component must do the same.
+2. **A toggle says what its state means.** `Role.Checkbox` announces "checked" / "not checked",
+   which is true and useless — "Fajr, prayed" is the sentence a user needs. Pass
+   `stateDescription` (`NimazCheckbox` takes one) whenever the state stands for something in the
+   domain rather than for a bare boolean. It is a `stringResource`, always: this text is read
+   aloud, so it is translated like any other.
+3. **A container that holds text is bounded by `heightIn(min = …)`, not `height(…)`.** Android 14+
+   scales fonts to 200% and a fixed-height row clips its second line silently. This matters more
+   here than in most apps: the Amiri and Nastaliq faces have taller line boxes than Latin ones at
+   the same nominal size. A fixed `height` is still right for things that are not text — an icon
+   box, a divider, a fixed-ratio piece of art.
+
+`AccessibilityChecks.enable()` runs on every instrumented UI test (`BaseAppTest`), so a control
+with no label and a touch target under 48dp fail the lane we already run. It cannot see rules 1–3
+— nothing automatic can — which is why they are written down here.
+
+
 - **Colors — every literal lives in the `theme/` package, never in a component/screen:**
     - **Tier 1 — `presentation/theme/Palette.kt` (`NimazPalette`):** the source of the brand/semantic
       hues. Hue ramps named `Family + shade` (e.g. `Teal500`, `Stone900`, `Amber500`). Don't

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -155,6 +155,7 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-espresso-accessibility = { group = "androidx.test.espresso", name = "espresso-accessibility", version.ref = "espressoCore" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmark" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }


### PR DESCRIPTION
Audit **§4**, **§4.1**. The last PR in the stack.

Measured on this branch before the change: **373 `contentDescription`s, zero `heading()`, zero `stateDescription`.** Those two absences are the whole TalkBack story — the app was *operable* with a screen reader and not *usable* with one.

## Headings

`Modifier.semantics { heading() }` is what lets TalkBack's heading navigation jump between sections. Without it, a user on Settings, the fast tracker or Surah info swipes through every element in order.

Declared **on the components, not at the call sites**:

| Component | Call sites covered |
|---|---|
| `NimazSectionHeader` | 56 |
| `NimazSectionTitle` | 11 |
| `PrayerTimesSectionHeader` | 5 |
| shared top app bar | every screen title |

72 section headings and every screen title, for four edits. Material3 does **not** mark its own app-bar title as a heading, which is why that one is needed.

## State descriptions

`Role.Checkbox` announces "checked" / "not checked". True, and useless: the prayer tracker is the app's core daily interaction, and "checked" does not say whether Fajr was prayed.

`NimazCheckbox` takes a `stateDescription` now, and `PrayerTimeCard` passes **"Fajr, prayed"** / **"Fajr, not yet recorded"** — the prayer's name travels *with* the state, because a screen reader reaches the checkbox on its own rather than as part of its row. Translated into all five shipped locales (de, fr, id, ms, tr), because this text is read aloud like any other.

## The automated half

`AccessibilityChecks.enable().setRunChecksFromRootView(true)` in `BaseAppTest`, so **every instrumented UI test we already run** now fails on a control with no label or a touch target under 48dp. Whole-hierarchy rather than per-assertion, so a screen is validated as a screen. Adds `espresso-accessibility`.

## Font scaling — the audit's inference does not hold, and here is the measurement

The audit inferred a risk from raw counts: 183 fixed `.height(…)` in `presentation/components`, 195 in screens, against 17 references to `fontScale`.

I classified them instead of counting them. **18** are a `.height()` on a container with any `Text` in scope, and every one is decorative:

- a `VerticalDivider` (36dp), 3–4dp accent bars, a 5dp progress track, a 1dp rule, 24dp bar-chart bars
- widget **previews**, whose whole point is to be the widget's real size
- a preview showcase

Everything else is a `Spacer`. **There is no clipping defect to fix here** — text containers in this codebase already size themselves. Converting 18 correct fixed heights to `heightIn` would have made the code worse and this PR longer.

What was missing is the *rule*, so the next one is written correctly. A real 200%-font-scale / 200%-display-size walk of the top ten screens still wants doing on a device; that is not something this lane can prove, and I have not claimed it.

## The obligation

`ARCHITECTURE.md` gains **§8.0 Accessibility**, so the pattern is prescribed rather than applied once:

1. A section title is a heading — declared **on the component**.
2. A toggle says what its state *means*, always as a `stringResource`.
3. A container that holds text is bounded by `heightIn(min = …)`, never `height(…)`. Fixed heights stay right for things that are not text.

It also records what `AccessibilityChecks` can and cannot see: rules 1–3 are written down precisely *because* nothing automatic catches them.

## Also not done

The audit asked for an audit of the 133 `contentDescription = null`s and the 19 `clearAndSetSemantics` calls. Each needs a per-site judgement about whether an icon is decorative, and 152 of those judgements is its own PR, not a paragraph in this one. `AccessibilityChecks` now catches the subset that is genuinely wrong (an unlabelled *control*, as opposed to a deliberately silent decorative icon), which is the half that can be automated.

## Verification

```
./gradlew :app:compileDebugKotlin           BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest            BUILD SUCCESSFUL
./gradlew :app:lintDebug                    BUILD SUCCESSFUL   (4m 49s — the MissingTranslation gate, which the five new translations are there for)
python3 scripts/check_docs.py               All 23 documentation checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_012bm5qGfSXUoqP2uUSFPUYw)_