### PR TITLE
feat(search): make the four hidden search constants user-controlled

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/di/RepositoryModule.kt
@@ -60,6 +60,7 @@ import com.arshadshah.nimaz.domain.repository.settings.QuranPreferences
 import com.arshadshah.nimaz.domain.repository.settings.TasbihSettings
 import com.arshadshah.nimaz.domain.repository.settings.MoreSettings
 import com.arshadshah.nimaz.domain.repository.settings.HijriSettings
+import com.arshadshah.nimaz.domain.repository.settings.SearchSettings
 import com.arshadshah.nimaz.domain.repository.settings.ZakatSettings
 import com.arshadshah.nimaz.domain.repository.TafseerRepository
 import com.arshadshah.nimaz.domain.repository.TasbihRepository
@@ -471,6 +472,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindHijriSettings(impl: PreferencesDataStore): HijriSettings
+
+    @Binds
+    abstract fun bindSearchSettings(impl: PreferencesDataStore): SearchSettings
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferenceCodec.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferenceCodec.kt
@@ -137,6 +137,13 @@ internal object PreferenceCodec {
         "ai_history_enabled" to PrefType.BOOLEAN,
         "ai_ask_hint_dismissed" to PrefType.BOOLEAN,
         "ai_question_history" to PrefType.STRING,
+        "search_results_per_source" to PrefType.INT,
+        // A comma-separated list of LibrarySource names, not a STRING_SET, for the same reason
+        // as the shortcuts below: an empty value is meaningful here (it means "every source,
+        // including ones added later"), and a Set gives no way to tell it from unset.
+        "search_sources" to PrefType.STRING,
+        "search_strictness" to PrefType.STRING,
+        "search_default_scope" to PrefType.STRING,
         // A delimited string of PinnedShortcut keys, not a STRING_SET: the row's order is what
         // the user arranged, and a Set discards it.
         "more_pinned_shortcuts" to PrefType.STRING,

--- a/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/local/datastore/PreferencesDataStore.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+import com.arshadshah.nimaz.domain.model.SearchPreferences
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "nimaz_preferences")
 
@@ -197,6 +199,12 @@ class PreferencesDataStore @Inject constructor(
         val LOCATION_NAME = stringPreferencesKey("location_name")
 
         // AI — Ask with Proof (opt-in; all off/neutral by default)
+        // Search behaviour, user-controlled since the four caps stopped being constants.
+        val SEARCH_RESULTS_PER_SOURCE = intPreferencesKey("search_results_per_source")
+        val SEARCH_SOURCES = stringPreferencesKey("search_sources")
+        val SEARCH_STRICTNESS = stringPreferencesKey("search_strictness")
+        val SEARCH_DEFAULT_SCOPE = stringPreferencesKey("search_default_scope")
+
         val AI_ASK_ENABLED = booleanPreferencesKey("ai_ask_enabled")
         val AI_CONSENT_TIMESTAMP = longPreferencesKey("ai_consent_timestamp")
         val AI_HISTORY_ENABLED = booleanPreferencesKey("ai_history_enabled")
@@ -893,6 +901,34 @@ class PreferencesDataStore @Inject constructor(
     }
 
     // AI — Ask with Proof
+    // --- search behaviour -------------------------------------------------------------
+
+    override val searchResultsPerSource: Flow<Int> =
+        preference(PreferencesKeys.SEARCH_RESULTS_PER_SOURCE, SearchPreferences.DEFAULT_RESULTS_PER_SOURCE)
+
+    override suspend fun setSearchResultsPerSource(count: Int) =
+        put(PreferencesKeys.SEARCH_RESULTS_PER_SOURCE, count)
+
+    // Empty string, not a joined list of every source: "the user has not chosen" and "the user
+    // chose all of them" look the same today but stop being the same the moment a source is
+    // added, and the unset case should pick that one up.
+    override val searchSources: Flow<String> = preference(PreferencesKeys.SEARCH_SOURCES, "")
+
+    override suspend fun setSearchSources(sources: String) =
+        put(PreferencesKeys.SEARCH_SOURCES, sources)
+
+    override val searchStrictness: Flow<String> =
+        preference(PreferencesKeys.SEARCH_STRICTNESS, MatchStrictness.BALANCED.name)
+
+    override suspend fun setSearchStrictness(strictness: String) =
+        put(PreferencesKeys.SEARCH_STRICTNESS, strictness)
+
+    override val searchDefaultScope: Flow<String> =
+        preference(PreferencesKeys.SEARCH_DEFAULT_SCOPE, "")
+
+    override suspend fun setSearchDefaultScope(scope: String) =
+        put(PreferencesKeys.SEARCH_DEFAULT_SCOPE, scope)
+
     override val aiAskEnabled: Flow<Boolean> = preference(PreferencesKeys.AI_ASK_ENABLED, false)
 
     override suspend fun setAiAskEnabled(enabled: Boolean) =

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/SearchPreferences.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/SearchPreferences.kt
@@ -1,0 +1,85 @@
+package com.arshadshah.nimaz.domain.model
+
+/**
+ * What the user has decided about how search behaves.
+ *
+ * All four of these were compile-time constants in `SearchLibraryUseCase`, which meant the
+ * only way to discover them was to hit one: a search for الله returned 180 results and looked
+ * like a defect, when it was three sources each returning a full 60. A cap you cannot see and
+ * cannot change reads as a bug every time.
+ */
+data class SearchPreferences(
+    /** How many results each source may contribute. Was a hardcoded 60. */
+    val resultsPerSource: Int = DEFAULT_RESULTS_PER_SOURCE,
+    /** Which sources are searched at all. Empty is not allowed — see [sanitised]. */
+    val sources: Set<LibrarySource> = LibrarySource.entries.toSet(),
+    /** How hard a multi-word query tries. Was a hardcoded eight word passes. */
+    val strictness: MatchStrictness = MatchStrictness.BALANCED,
+    /** Which source the search screen opens filtered to; null means "everything". */
+    val defaultScope: LibrarySource? = null,
+) {
+
+    /**
+     * The same preferences with the values that would break search corrected.
+     *
+     * A user cannot reach these states through the settings screen, but a preference file can:
+     * it survives an app downgrade, a restore from a backup written by a newer version, and a
+     * hand-edit. Search returning nothing at all because the persisted source set was empty is
+     * not a state worth honouring faithfully.
+     */
+    val sanitised: SearchPreferences
+        get() = copy(
+            resultsPerSource = resultsPerSource.coerceIn(MIN_RESULTS_PER_SOURCE, MAX_RESULTS_PER_SOURCE),
+            sources = sources.ifEmpty { LibrarySource.entries.toSet() },
+            // A scope pointing at a source that is switched off would silently show nothing.
+            defaultScope = defaultScope?.takeIf { it in sources },
+        )
+
+    companion object {
+        const val DEFAULT_RESULTS_PER_SOURCE = 60
+        const val MIN_RESULTS_PER_SOURCE = 10
+        const val MAX_RESULTS_PER_SOURCE = 200
+    }
+}
+
+/**
+ * A body of content search can look in.
+ *
+ * One entry per thing a user would think of as a separate place to look, which is why surah
+ * names are not their own source: "search the Qur'an but not its surah names" is not a
+ * distinction anyone wants, and offering it would make the settings screen longer without
+ * making it more useful. The order is the reading order of the library, and it is the order
+ * results appear in.
+ *
+ * Adding a source here is enough to make it selectable — the settings screen and the search
+ * screen's filter chips are both built from [entries] — but the query itself has to be added
+ * to `SearchLibraryUseCase` in the same change, or the new source is a switch that does
+ * nothing.
+ */
+enum class LibrarySource {
+    /** Ayat and their translations, plus surah names. */
+    QURAN,
+    HADITH,
+    DUAS,
+}
+
+/**
+ * How aggressively a multi-word query is broken into single-word passes.
+ *
+ * The whole phrase is always searched and always outranks a word hit. This governs only the
+ * *extra* passes: "patience in hardship" as three more searches whose hits are merged and
+ * ranked by how many words they match.
+ *
+ * More passes means more recall and more noise, and each pass is a query per source — so this
+ * is also the setting that decides how much work a long query does.
+ */
+enum class MatchStrictness(val wordPasses: Int) {
+    /** The phrase only. A search means exactly what it says. */
+    EXACT(0),
+
+    /** Up to eight word passes — what the app did before this was a setting. */
+    BALANCED(8),
+
+    /** Up to twenty, for someone who would rather sift than miss something. */
+    BROAD(20),
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/SettingsRepository.kt
@@ -10,6 +10,7 @@ import com.arshadshah.nimaz.domain.repository.settings.MoreSettings
 import com.arshadshah.nimaz.domain.repository.settings.QuranPreferences
 import com.arshadshah.nimaz.domain.repository.settings.TasbihSettings
 import com.arshadshah.nimaz.domain.repository.settings.HijriSettings
+import com.arshadshah.nimaz.domain.repository.settings.SearchSettings
 import com.arshadshah.nimaz.domain.repository.settings.ZakatSettings
 import kotlinx.coroutines.flow.Flow
 
@@ -28,6 +29,7 @@ interface SettingsRepository :
     TasbihSettings,
     ZakatSettings,
     HijriSettings,
+    SearchSettings,
     AiSettings,
     LocationSettings,
     MoreSettings,

--- a/app/src/main/java/com/arshadshah/nimaz/domain/repository/settings/SettingsSeams.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/repository/settings/SettingsSeams.kt
@@ -202,3 +202,31 @@ interface HijriSettings {
      */
     val hijriDayOffset: Flow<Int>
 }
+
+/**
+ * How search behaves, as the user has set it.
+ *
+ * Primitives rather than the [com.arshadshah.nimaz.domain.model.SearchPreferences] model,
+ * like every other seam here: the store persists values, and
+ * `ObserveSearchPreferencesUseCase` is where they become a typed model with its invariants
+ * applied. Keeping the mapping out of the store means a preference file written by a newer
+ * build — an unknown source name, a strictness that no longer exists — degrades to the
+ * default instead of throwing on read.
+ */
+interface SearchSettings {
+    /** How many results each source may contribute. */
+    val searchResultsPerSource: Flow<Int>
+    suspend fun setSearchResultsPerSource(count: Int)
+
+    /** Comma-separated `LibrarySource` names. Empty string means "everything". */
+    val searchSources: Flow<String>
+    suspend fun setSearchSources(sources: String)
+
+    /** A `MatchStrictness` name. */
+    val searchStrictness: Flow<String>
+    suspend fun setSearchStrictness(strictness: String)
+
+    /** A `LibrarySource` name, or empty for "everything". */
+    val searchDefaultScope: Flow<String>
+    suspend fun setSearchDefaultScope(scope: String)
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ObserveSearchPreferencesUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/ObserveSearchPreferencesUseCase.kt
@@ -1,0 +1,57 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+import com.arshadshah.nimaz.domain.model.SearchPreferences
+import com.arshadshah.nimaz.domain.repository.settings.SearchSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+/**
+ * The stored search preferences, as a typed model with its invariants applied.
+ *
+ * This is where the four persisted primitives become [SearchPreferences], and where a value
+ * the app no longer understands stops being a crash. A preferences file outlives the build
+ * that wrote it — a downgrade, a restore from a device on a newer version, a hand-edit — so
+ * an unknown `LibrarySource` name or a `MatchStrictness` that has been renamed has to degrade
+ * to the default rather than throw on the first search anyone runs.
+ */
+class ObserveSearchPreferencesUseCase @Inject constructor(
+    private val settings: SearchSettings,
+) {
+    operator fun invoke(): Flow<SearchPreferences> = combine(
+        settings.searchResultsPerSource,
+        settings.searchSources,
+        settings.searchStrictness,
+        settings.searchDefaultScope,
+    ) { perSource, sources, strictness, scope ->
+        SearchPreferences(
+            resultsPerSource = perSource,
+            sources = parseSources(sources),
+            strictness = parseStrictness(strictness),
+            defaultScope = parseSource(scope),
+        ).sanitised
+    }
+
+    private fun parseSources(stored: String): Set<LibrarySource> {
+        // Empty means "not chosen", which is every source — including any added since the
+        // preference was written, which is the reason it is not stored as a full list.
+        if (stored.isBlank()) return LibrarySource.entries.toSet()
+        return stored.split(SEPARATOR).mapNotNull(::parseSource).toSet()
+    }
+
+    private fun parseSource(name: String): LibrarySource? =
+        LibrarySource.entries.firstOrNull { it.name == name.trim() }
+
+    private fun parseStrictness(name: String): MatchStrictness =
+        MatchStrictness.entries.firstOrNull { it.name == name.trim() } ?: MatchStrictness.BALANCED
+
+    companion object {
+        const val SEPARATOR = ","
+
+        /** How a source set is written down. The inverse of [parseSources]. */
+        fun encode(sources: Set<LibrarySource>): String =
+            if (sources == LibrarySource.entries.toSet()) "" else sources.joinToString(SEPARATOR) { it.name }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/SearchLibraryUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/SearchLibraryUseCase.kt
@@ -3,6 +3,7 @@ package com.arshadshah.nimaz.domain.usecase
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.model.LibrarySearchResults
+import com.arshadshah.nimaz.domain.model.LibrarySource
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase.Companion.PHRASE_SCORE
@@ -44,6 +45,7 @@ class SearchLibraryUseCase @Inject constructor(
     private val quranUseCases: QuranUseCases,
     private val hadithUseCases: HadithUseCases,
     private val duaUseCases: DuaUseCases,
+    private val searchPreferences: ObserveSearchPreferencesUseCase,
 ) {
     suspend operator fun invoke(
         query: String,
@@ -77,6 +79,10 @@ class SearchLibraryUseCase @Inject constructor(
         wordQueries: List<String>,
         translatorId: String,
     ): LibrarySearchResults {
+        // Read once per search rather than collected: a preference change mid-query would
+        // otherwise mean half the passes ran under the old settings and half under the new.
+        val prefs = searchPreferences().first()
+
         val quran = Ranked<Int, QuranSearchResult>()
         val surahs = Ranked<Int, Surah>()
         val hadith = Ranked<String, HadithSearchResult>()
@@ -84,25 +90,34 @@ class SearchLibraryUseCase @Inject constructor(
 
         val passes = buildList {
             if (phrase != null) add(phrase to PHRASE_SCORE)
-            addAll(wordQueries.take(MAX_WORD_QUERIES).map { it to 1 })
+            addAll(wordQueries.take(prefs.strictness.wordPasses).map { it to 1 })
         }
 
         for ((term, score) in passes) {
-            quranUseCases.searchQuran(term, translatorId).first()
-                .forEach { quran.add(it.ayah.id, it, score) }
-            quranUseCases.getSurahList.search(term).first()
-                .forEach { surahs.add(it.number, it, score) }
-            hadithUseCases.searchHadiths(term).first()
-                .forEach { hadith.add(it.hadith.id, it, score) }
-            duaUseCases.searchDuas(term).first()
-                .forEach { duas.add(it.dua.id, it, score) }
+            // A source the user switched off is not queried at all — the cost of a search is
+            // one query per source per pass, so this is the setting that makes a long query
+            // cheaper as well as the one that makes its results narrower.
+            if (LibrarySource.QURAN in prefs.sources) {
+                quranUseCases.searchQuran(term, translatorId).first()
+                    .forEach { quran.add(it.ayah.id, it, score) }
+                quranUseCases.getSurahList.search(term).first()
+                    .forEach { surahs.add(it.number, it, score) }
+            }
+            if (LibrarySource.HADITH in prefs.sources) {
+                hadithUseCases.searchHadiths(term).first()
+                    .forEach { hadith.add(it.hadith.id, it, score) }
+            }
+            if (LibrarySource.DUAS in prefs.sources) {
+                duaUseCases.searchDuas(term).first()
+                    .forEach { duas.add(it.dua.id, it, score) }
+            }
         }
 
         return LibrarySearchResults(
-            quran = quran.top(MAX_PER_SOURCE),
-            surahs = surahs.top(MAX_PER_SOURCE),
-            hadith = hadith.top(MAX_PER_SOURCE),
-            duas = duas.top(MAX_PER_SOURCE),
+            quran = quran.top(prefs.resultsPerSource),
+            surahs = surahs.top(prefs.resultsPerSource),
+            hadith = hadith.top(prefs.resultsPerSource),
+            duas = duas.top(prefs.resultsPerSource),
         )
     }
 
@@ -132,8 +147,10 @@ class SearchLibraryUseCase @Inject constructor(
         private const val PHRASE_SCORE = 100
 
         /** Bound the per-source DB work for very long queries/term lists. */
-        private const val MAX_WORD_QUERIES = 8
-        private const val MAX_PER_SOURCE = 60
+        // MAX_WORD_QUERIES and MAX_PER_SOURCE used to live here as 8 and 60. They are
+        // SearchPreferences.strictness and .resultsPerSource now: the 60 was invisible and
+        // unchangeable, so a search for الله returning 180 results — three sources at their
+        // cap — read as a defect rather than as a setting.
 
         private val NON_WORD = Regex("[^\\p{L}\\p{N}']+")
         private val STOPWORDS = setOf(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.annotation.StringRes
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -29,6 +30,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+import com.arshadshah.nimaz.domain.model.SearchPreferences
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
@@ -38,8 +42,12 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogDestructiveButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazListPicker
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
+import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
+import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SearchSettingsEvent
@@ -54,6 +62,8 @@ fun SearchSettingsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     var showClearHistoryDialog by remember { mutableStateOf(false) }
+    var showStrictnessPicker by remember { mutableStateOf(false) }
+    var showScopePicker by remember { mutableStateOf(false) }
 
     NimazScreenScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -72,6 +82,86 @@ fun SearchSettingsScreen(
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            // ── Local search ──────────────────────────────────────────────
+            // First, and above the AI section, because this is the search everyone has:
+            // "Ask with Proof" is off by default and stays off for most installs.
+            item { NimazSectionHeader(title = stringResource(R.string.search_results_section)) }
+            item {
+                NimazMenuGroup {
+                    NimazNumberStepper(
+                        value = state.search.resultsPerSource,
+                        onValueChange = {
+                            viewModel.onEvent(SearchSettingsEvent.SetResultsPerSource(it))
+                        },
+                        variant = NimazNumberStepperVariant.INLINE,
+                        label = stringResource(R.string.search_results_per_source),
+                        minValue = SearchPreferences.MIN_RESULTS_PER_SOURCE,
+                        maxValue = SearchPreferences.MAX_RESULTS_PER_SOURCE,
+                        step = 10,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                    Text(
+                        text = stringResource(
+                            R.string.search_results_per_source_subtitle,
+                            state.search.resultsPerSource * state.search.sources.size,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .padding(bottom = 12.dp),
+                    )
+                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazSettingsItem(
+                        title = stringResource(R.string.search_strictness),
+                        subtitle = stringResource(strictnessDescription(state.search.strictness)),
+                        value = stringResource(strictnessLabel(state.search.strictness)),
+                        onClick = { showStrictnessPicker = true },
+                        showArrow = true,
+                    )
+                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazSettingsItem(
+                        title = stringResource(R.string.search_default_scope),
+                        subtitle = stringResource(R.string.search_default_scope_subtitle),
+                        value = state.search.defaultScope
+                            ?.let { stringResource(sourceLabel(it)) }
+                            ?: stringResource(R.string.search_scope_everything),
+                        onClick = { showScopePicker = true },
+                        showArrow = true,
+                    )
+                }
+            }
+
+            // ── Where to search ───────────────────────────────────────────
+            item { NimazSectionHeader(title = stringResource(R.string.search_sources_section)) }
+            item {
+                NimazMenuGroup {
+                    LibrarySource.entries.forEachIndexed { index, source ->
+                        if (index > 0) {
+                            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                        }
+                        val isOn = source in state.search.sources
+                        // The last source left on cannot be switched off: an empty set is a
+                        // search that returns nothing for every query, and the sanitiser would
+                        // read it straight back as "everything" — a switch that flips itself.
+                        val isLastOn = isOn && state.search.sources.size == 1
+                        NimazSettingsItem(
+                            title = stringResource(sourceLabel(source)),
+                            subtitle = if (isLastOn) {
+                                stringResource(R.string.search_source_last_one)
+                            } else {
+                                stringResource(sourceDescription(source))
+                            },
+                            checked = isOn,
+                            enabled = !isLastOn,
+                            onCheckedChange = {
+                                viewModel.onEvent(SearchSettingsEvent.ToggleSource(source))
+                            },
+                        )
+                    }
+                }
+            }
+
             // ── AI answers ────────────────────────────────────────────────
             item { NimazSectionHeader(title = stringResource(R.string.ai_answers)) }
             item {
@@ -123,6 +213,53 @@ fun SearchSettingsScreen(
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
+    }
+
+    if (showStrictnessPicker) {
+        NimazListPicker(
+            title = stringResource(R.string.search_strictness),
+            items = MatchStrictness.entries.map { strictness ->
+                NimazPickerItem(
+                    value = strictness,
+                    title = stringResource(strictnessLabel(strictness)),
+                    description = stringResource(strictnessDescription(strictness)),
+                )
+            },
+            selected = state.search.strictness,
+            onSelected = { viewModel.onEvent(SearchSettingsEvent.SetStrictness(it)) },
+            onDismiss = { showStrictnessPicker = false },
+        )
+    }
+
+    if (showScopePicker) {
+        // "Everything" is not a source, so it cannot come from LibrarySource.entries — it is
+        // the absence of a scope, and the picker models that as a nullable value.
+        NimazListPicker(
+            title = stringResource(R.string.search_default_scope),
+            items = buildList<NimazPickerItem<LibrarySource?>> {
+                add(
+                    NimazPickerItem(
+                        value = null,
+                        title = stringResource(R.string.search_scope_everything),
+                        description = stringResource(R.string.search_scope_everything_desc),
+                    )
+                )
+                // Only sources that are actually searched: opening filtered to a switched-off
+                // source would show an empty list that reads as "nothing matched".
+                state.search.sources.forEach { source ->
+                    add(
+                        NimazPickerItem(
+                            value = source,
+                            title = stringResource(sourceLabel(source)),
+                            description = stringResource(sourceDescription(source)),
+                        )
+                    )
+                }
+            },
+            selected = state.search.defaultScope,
+            onSelected = { viewModel.onEvent(SearchSettingsEvent.SetDefaultScope(it)) },
+            onDismiss = { showScopePicker = false },
+        )
     }
 
     if (showClearHistoryDialog) {
@@ -212,4 +349,37 @@ fun SearchSettingsScreen(
             }
         }
     }
+}
+
+// ── enum → string resource ────────────────────────────────────────────────────
+// Exhaustive `when`s rather than a name-keyed lookup: adding a source or a strictness level
+// stops this file compiling until it has been given a label, which is the only thing that
+// keeps a new option from shipping as a blank row.
+
+@StringRes
+private fun sourceLabel(source: LibrarySource): Int = when (source) {
+    LibrarySource.QURAN -> R.string.quran
+    LibrarySource.HADITH -> R.string.hadith
+    LibrarySource.DUAS -> R.string.duas
+}
+
+@StringRes
+private fun sourceDescription(source: LibrarySource): Int = when (source) {
+    LibrarySource.QURAN -> R.string.search_source_quran_desc
+    LibrarySource.HADITH -> R.string.search_source_hadith_desc
+    LibrarySource.DUAS -> R.string.search_source_duas_desc
+}
+
+@StringRes
+private fun strictnessLabel(strictness: MatchStrictness): Int = when (strictness) {
+    MatchStrictness.EXACT -> R.string.search_strictness_exact
+    MatchStrictness.BALANCED -> R.string.search_strictness_balanced
+    MatchStrictness.BROAD -> R.string.search_strictness_broad
+}
+
+@StringRes
+private fun strictnessDescription(strictness: MatchStrictness): Int = when (strictness) {
+    MatchStrictness.EXACT -> R.string.search_strictness_exact_desc
+    MatchStrictness.BALANCED -> R.string.search_strictness_balanced_desc
+    MatchStrictness.BROAD -> R.string.search_strictness_broad_desc
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModel.kt
@@ -8,8 +8,10 @@ import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.domain.model.DuaSearchResult
 import com.arshadshah.nimaz.domain.model.HadithSearchResult
 import com.arshadshah.nimaz.domain.model.LibrarySearchResults
+import com.arshadshah.nimaz.domain.model.LibrarySource
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.usecase.ObserveSearchPreferencesUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase
 import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +20,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,6 +30,19 @@ enum class SearchFilter {
     ALL, QURAN, HADITH, DUA
 }
 
+/**
+ * The chip that corresponds to a [LibrarySource], with `null` — "no default" — as [ALL].
+ *
+ * Exhaustive on purpose: a source added to [LibrarySource] stops this compiling until it has
+ * a chip to filter by, which is the only thing that keeps the two lists from drifting.
+ */
+private fun LibrarySource?.asFilter(): SearchFilter = when (this) {
+    LibrarySource.QURAN -> SearchFilter.QURAN
+    LibrarySource.HADITH -> SearchFilter.HADITH
+    LibrarySource.DUAS -> SearchFilter.DUA
+    null -> SearchFilter.ALL
+}
+
 /** Idle time after the last keystroke before a search-as-you-type lookup fires. */
 private const val SEARCH_DEBOUNCE_MS = 300L
 private const val DOMAIN = "global_search"
@@ -34,6 +50,7 @@ private const val DOMAIN = "global_search"
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val searchLibrary: SearchLibraryUseCase,
+    private val searchPreferences: ObserveSearchPreferencesUseCase,
     private val telemetry: Telemetry,
 ) : ViewModel() {
 
@@ -49,6 +66,26 @@ class SearchViewModel @Inject constructor(
     // new query so stale results never clobber newer ones.
     private var searchJob: Job? = null
 
+    /**
+     * Whether a filter has been chosen for *this* screen — by a tap, or by the screen being
+     * opened scoped (Duas → search passes `initialFilter`).
+     *
+     * The stored default scope is read asynchronously, so without this it would race the
+     * screen's `LaunchedEffect(initialFilter)` and sometimes overwrite it. The precedence is
+     * not in doubt — "search duas", said by opening search from duas, beats "usually start on
+     * hadith", said once in settings — so the flag settles it rather than the scheduler.
+     */
+    private var filterChosenForThisScreen = false
+
+    init {
+        viewModelScope.launch {
+            val defaultScope = searchPreferences().first().defaultScope
+            if (!filterChosenForThisScreen && defaultScope != null) {
+                setFilter(defaultScope.asFilter())
+            }
+        }
+    }
+
     fun onEvent(event: SearchEvent) {
         when (event) {
             is SearchEvent.UpdateQuery -> updateQuery(event.query)
@@ -56,6 +93,7 @@ class SearchViewModel @Inject constructor(
             // without recording what they typed — which of Qur'an, hadith or dua they narrow
             // to is the shape, and it was not recorded at all.
             is SearchEvent.SetFilter -> {
+                filterChosenForThisScreen = true
                 telemetry.featureUsed(DOMAIN, "set_filter_" + event.filter.name.lowercase())
                 setFilter(event.filter)
             }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsEvent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsEvent.kt
@@ -1,6 +1,18 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+
 sealed interface SearchSettingsEvent {
+    data class SetResultsPerSource(val count: Int) : SearchSettingsEvent
+
+    /** Switch one source on or off. Switching off the last one is refused, not obeyed. */
+    data class ToggleSource(val source: LibrarySource) : SearchSettingsEvent
+    data class SetStrictness(val strictness: MatchStrictness) : SearchSettingsEvent
+
+    /** `null` opens search unfiltered. */
+    data class SetDefaultScope(val source: LibrarySource?) : SearchSettingsEvent
+
     /** Master toggle tapped. Enabling first opens the consent sheet. */
     data object ToggleAiRequested : SearchSettingsEvent
     data object ConsentAccepted : SearchSettingsEvent

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsUiState.kt
@@ -1,6 +1,14 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
+import com.arshadshah.nimaz.domain.model.SearchPreferences
+
 data class SearchSettingsUiState(
+    /**
+     * How local search behaves. All four of these were compile-time constants, which is how a
+     * search for الله came to return exactly 180 results — three sources each capped at a
+     * hidden 60 — and read as a defect.
+     */
+    val search: SearchPreferences = SearchPreferences(),
     val aiEnabled: Boolean = false,
     val historyEnabled: Boolean = false,
     /** Persisted recent questions — shown in the clear-history confirm dialog. */

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsViewModel.kt
@@ -5,13 +5,18 @@ import androidx.lifecycle.viewModelScope
 import com.arshadshah.nimaz.core.monitoring.AppAnalytics
 import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.SearchPreferences
 import com.arshadshah.nimaz.domain.repository.settings.AiSettings
+import com.arshadshah.nimaz.domain.repository.settings.SearchSettings
+import com.arshadshah.nimaz.domain.usecase.ObserveSearchPreferencesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -22,6 +27,8 @@ import com.arshadshah.nimaz.presentation.viewmodel.ai.AskViewModel
 @HiltViewModel
 class SearchSettingsViewModel @Inject constructor(
     private val aiSettings: AiSettings,
+    private val searchSettings: SearchSettings,
+    searchPreferences: ObserveSearchPreferencesUseCase,
     private val telemetry: Telemetry,
 ) : ViewModel() {
 
@@ -44,6 +51,13 @@ class SearchSettingsViewModel @Inject constructor(
                 )
             }
         }.launchIn(viewModelScope)
+
+        // The same use case search itself reads, so the screen can never show a value search
+        // is not using — including the corrections `sanitised` makes to a preferences file
+        // written by some other build.
+        searchPreferences()
+            .onEach { prefs -> _uiState.update { it.copy(search = prefs) } }
+            .launchIn(viewModelScope)
     }
 
     // Same wire format as AskViewModel's encodeHistory: a JSON string list.
@@ -58,6 +72,37 @@ class SearchSettingsViewModel @Inject constructor(
 
     fun onEvent(event: SearchSettingsEvent) {
         when (event) {
+            is SearchSettingsEvent.SetResultsPerSource ->
+                launchSafely(telemetry, SEARCH_DOMAIN, "set_results_per_source") {
+                    searchSettings.setSearchResultsPerSource(
+                        event.count.coerceIn(
+                            SearchPreferences.MIN_RESULTS_PER_SOURCE,
+                            SearchPreferences.MAX_RESULTS_PER_SOURCE,
+                        )
+                    )
+                    telemetry.settingChanged("search_results_per_source", event.count.toString())
+                }
+
+            is SearchSettingsEvent.ToggleSource -> onToggleSource(event.source)
+
+            is SearchSettingsEvent.SetStrictness ->
+                launchSafely(telemetry, SEARCH_DOMAIN, "set_strictness") {
+                    searchSettings.setSearchStrictness(event.strictness.name)
+                    telemetry.settingChanged(
+                        "search_strictness",
+                        event.strictness.name.lowercase(),
+                    )
+                }
+
+            is SearchSettingsEvent.SetDefaultScope ->
+                launchSafely(telemetry, SEARCH_DOMAIN, "set_default_scope") {
+                    searchSettings.setSearchDefaultScope(event.source?.name.orEmpty())
+                    telemetry.settingChanged(
+                        "search_default_scope",
+                        event.source?.name?.lowercase() ?: "all",
+                    )
+                }
+
             SearchSettingsEvent.ToggleAiRequested -> onToggleRequested()
             SearchSettingsEvent.ConsentAccepted -> onConsentAccepted()
             SearchSettingsEvent.ConsentDismissed ->
@@ -78,6 +123,38 @@ class SearchSettingsViewModel @Inject constructor(
                     aiSettings.setAiQuestionHistory("")
                     telemetry.featureUsed(DOMAIN, "history_cleared")
                 }
+        }
+    }
+
+    /**
+     * Switching a source on or off — except the last one on, which is refused.
+     *
+     * An empty source set is search that returns nothing for every query. `sanitised` would
+     * quietly read it back as "everything", so obeying the tap would show a switch that turns
+     * itself back on; the screen disables the last remaining switch instead, and this is the
+     * guard behind it.
+     *
+     * The default scope follows: it is stored as a source name, and a scope pointing at a
+     * source that is no longer searched opens the results list already filtered to nothing.
+     */
+    private fun onToggleSource(source: LibrarySource) {
+        val current = _uiState.value.search
+        val updated = if (source in current.sources) {
+            current.sources - source
+        } else {
+            current.sources + source
+        }
+        if (updated.isEmpty()) return
+
+        launchSafely(telemetry, SEARCH_DOMAIN, "toggle_source") {
+            searchSettings.setSearchSources(ObserveSearchPreferencesUseCase.encode(updated))
+            if (current.defaultScope != null && current.defaultScope !in updated) {
+                searchSettings.setSearchDefaultScope("")
+            }
+            telemetry.settingChanged(
+                "search_source_" + source.name.lowercase(),
+                if (source in updated) "on" else "off",
+            )
         }
     }
 
@@ -119,5 +196,8 @@ class SearchSettingsViewModel @Inject constructor(
 
     private companion object {
         private const val DOMAIN = AppAnalytics.Feature.AI_ASK
+
+        /** Local search is not the AI feature — its telemetry does not belong under it. */
+        private const val SEARCH_DOMAIN = "global_search"
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1438,7 +1438,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Suche &amp; KI</string>
-    <string name="search_settings_subtitle">KI-Antworten und Datenschutz</string>
+    <string name="search_settings_subtitle">Ergebnisse, Quellen, KI-Antworten und Datenschutz</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Ergebnisse</string>
+    <string name="search_results_per_source">Ergebnisse pro Quelle</string>
+    <string name="search_results_per_source_subtitle">Bis zu %1$d Ergebnisse insgesamt über die durchsuchten Quellen.</string>
+    <string name="search_sources_section">Wo gesucht wird</string>
+    <string name="search_source_quran_desc">Verse, Übersetzungen und Surennamen</string>
+    <string name="search_source_hadith_desc">Überlieferungen aus den Hadith-Sammlungen</string>
+    <string name="search_source_duas_desc">Bittgebete und ihre Übersetzungen</string>
+    <string name="search_source_last_one">Die Suche braucht mindestens eine Quelle</string>
+    <string name="search_strictness">Genauigkeit der Treffer</string>
+    <string name="search_strictness_exact">Genau</string>
+    <string name="search_strictness_exact_desc">Nur den eingegebenen Ausdruck als Ganzes suchen</string>
+    <string name="search_strictness_balanced">Ausgewogen</string>
+    <string name="search_strictness_balanced_desc">Auch einzelne Wörter suchen; Treffer mit mehr passenden Wörtern stehen weiter oben</string>
+    <string name="search_strictness_broad">Weit</string>
+    <string name="search_strictness_broad_desc">So viele Wörter wie möglich suchen. Mehr zu sichten und langsamer bei langen Fragen</string>
+    <string name="search_default_scope">Suche beginnen in</string>
+    <string name="search_default_scope_subtitle">Mit welchem Filter die Suche öffnet</string>
+    <string name="search_scope_everything">Alles</string>
+    <string name="search_scope_everything_desc">Ergebnisse aus allen durchsuchten Quellen anzeigen</string>
     <string name="ai_answers">KI-Antworten</string>
     <string name="ai_answers_enable">KI-Antworten aktivieren</string>
     <string name="ai_answers_enable_subtitle">Stelle eine Frage und erhalte eine Antwort mit Versen und Hadithen aus deiner Bibliothek als Beleg</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1466,7 +1466,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Recherche &amp; IA</string>
-    <string name="search_settings_subtitle">Réponses IA et confidentialité</string>
+    <string name="search_settings_subtitle">Résultats, sources, réponses IA et confidentialité</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Résultats</string>
+    <string name="search_results_per_source">Résultats par source</string>
+    <string name="search_results_per_source_subtitle">Jusqu\'à %1$d résultats au total sur les sources consultées.</string>
+    <string name="search_sources_section">Où chercher</string>
+    <string name="search_source_quran_desc">Versets, traductions et noms des sourates</string>
+    <string name="search_source_hadith_desc">Narrations dans les recueils de hadiths</string>
+    <string name="search_source_duas_desc">Invocations et leurs traductions</string>
+    <string name="search_source_last_one">La recherche a besoin d\'au moins une source</string>
+    <string name="search_strictness">Précision des correspondances</string>
+    <string name="search_strictness_exact">Exact</string>
+    <string name="search_strictness_exact_desc">Chercher uniquement la phrase saisie, telle quelle</string>
+    <string name="search_strictness_balanced">Équilibré</string>
+    <string name="search_strictness_balanced_desc">Chercher aussi les mots isolés ; les résultats correspondant à plus de mots passent devant</string>
+    <string name="search_strictness_broad">Large</string>
+    <string name="search_strictness_broad_desc">Chercher le plus de mots possible. Plus de résultats à trier, et plus lent sur les questions longues</string>
+    <string name="search_default_scope">Commencer la recherche dans</string>
+    <string name="search_default_scope_subtitle">Le filtre actif à l\'ouverture de la recherche</string>
+    <string name="search_scope_everything">Tout</string>
+    <string name="search_scope_everything_desc">Afficher les résultats de toutes les sources consultées</string>
     <string name="ai_answers">Réponses de l\'IA</string>
     <string name="ai_answers_enable">Activer les réponses de l\'IA</string>
     <string name="ai_answers_enable_subtitle">Posez une question et obtenez une réponse avec des versets et des hadiths de votre bibliothèque comme preuve</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1415,7 +1415,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Pencarian &amp; AI</string>
-    <string name="search_settings_subtitle">Jawaban AI dan privasi</string>
+    <string name="search_settings_subtitle">Hasil, sumber, jawaban AI, dan privasi</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Hasil</string>
+    <string name="search_results_per_source">Hasil per sumber</string>
+    <string name="search_results_per_source_subtitle">Hingga %1$d hasil secara keseluruhan dari sumber yang dicari.</string>
+    <string name="search_sources_section">Tempat pencarian</string>
+    <string name="search_source_quran_desc">Ayat, terjemahan, dan nama surah</string>
+    <string name="search_source_hadith_desc">Riwayat dari kitab-kitab hadis</string>
+    <string name="search_source_duas_desc">Doa beserta terjemahannya</string>
+    <string name="search_source_last_one">Pencarian membutuhkan setidaknya satu sumber</string>
+    <string name="search_strictness">Ketepatan pencocokan</string>
+    <string name="search_strictness_exact">Tepat</string>
+    <string name="search_strictness_exact_desc">Cocokkan seluruh frasa yang Anda ketik, tanpa pelonggaran</string>
+    <string name="search_strictness_balanced">Seimbang</string>
+    <string name="search_strictness_balanced_desc">Cocokkan juga kata per kata; hasil yang cocok dengan lebih banyak kata diurutkan lebih dulu</string>
+    <string name="search_strictness_broad">Luas</string>
+    <string name="search_strictness_broad_desc">Cocokkan sebanyak mungkin kata. Lebih banyak yang harus disaring, dan lebih lambat untuk pertanyaan panjang</string>
+    <string name="search_default_scope">Mulai pencarian di</string>
+    <string name="search_default_scope_subtitle">Filter yang aktif saat pencarian dibuka</string>
+    <string name="search_scope_everything">Semua</string>
+    <string name="search_scope_everything_desc">Tampilkan hasil dari setiap sumber yang dicari</string>
     <string name="ai_answers">Jawaban AI</string>
     <string name="ai_answers_enable">Aktifkan jawaban AI</string>
     <string name="ai_answers_enable_subtitle">Ajukan pertanyaan dan dapatkan jawaban dengan ayat dan hadis dari pustaka Anda sebagai bukti</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1416,7 +1416,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Carian &amp; AI</string>
-    <string name="search_settings_subtitle">Jawapan AI dan privasi</string>
+    <string name="search_settings_subtitle">Keputusan, sumber, jawapan AI dan privasi</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Keputusan</string>
+    <string name="search_results_per_source">Keputusan setiap sumber</string>
+    <string name="search_results_per_source_subtitle">Sehingga %1$d keputusan kesemuanya merentas sumber yang dicari.</string>
+    <string name="search_sources_section">Tempat carian</string>
+    <string name="search_source_quran_desc">Ayat, terjemahan dan nama surah</string>
+    <string name="search_source_hadith_desc">Riwayat daripada koleksi hadis</string>
+    <string name="search_source_duas_desc">Doa dan terjemahannya</string>
+    <string name="search_source_last_one">Carian memerlukan sekurang-kurangnya satu sumber</string>
+    <string name="search_strictness">Ketepatan padanan</string>
+    <string name="search_strictness_exact">Tepat</string>
+    <string name="search_strictness_exact_desc">Padankan keseluruhan frasa yang anda taip sahaja</string>
+    <string name="search_strictness_balanced">Seimbang</string>
+    <string name="search_strictness_balanced_desc">Padankan juga perkataan tunggal; keputusan yang memadankan lebih banyak perkataan didahulukan</string>
+    <string name="search_strictness_broad">Luas</string>
+    <string name="search_strictness_broad_desc">Padankan seberapa banyak perkataan yang boleh. Lebih banyak untuk disaring, dan lebih perlahan bagi soalan panjang</string>
+    <string name="search_default_scope">Mula carian dalam</string>
+    <string name="search_default_scope_subtitle">Penapis yang aktif apabila carian dibuka</string>
+    <string name="search_scope_everything">Semua</string>
+    <string name="search_scope_everything_desc">Tunjukkan keputusan daripada setiap sumber yang dicari</string>
     <string name="ai_answers">Jawapan AI</string>
     <string name="ai_answers_enable">Dayakan jawapan AI</string>
     <string name="ai_answers_enable_subtitle">Ajukan soalan dan dapatkan jawapan dengan ayat dan hadis daripada pustaka anda sebagai bukti</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1444,7 +1444,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Arama &amp; Yapay Zekâ</string>
-    <string name="search_settings_subtitle">Yapay zekâ yanıtları ve gizlilik</string>
+    <string name="search_settings_subtitle">Sonuçlar, kaynaklar, yapay zekâ yanıtları ve gizlilik</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Sonuçlar</string>
+    <string name="search_results_per_source">Kaynak başına sonuç</string>
+    <string name="search_results_per_source_subtitle">Aranan kaynaklar genelinde toplam en fazla %1$d sonuç.</string>
+    <string name="search_sources_section">Nerede aranacak</string>
+    <string name="search_source_quran_desc">Ayetler, mealler ve sûre adları</string>
+    <string name="search_source_hadith_desc">Hadis külliyatındaki rivayetler</string>
+    <string name="search_source_duas_desc">Dualar ve çevirileri</string>
+    <string name="search_source_last_one">Arama için en az bir kaynak gerekir</string>
+    <string name="search_strictness">Eşleşme sıkılığı</string>
+    <string name="search_strictness_exact">Tam</string>
+    <string name="search_strictness_exact_desc">Yalnızca yazdığınız ifadenin tamamını eşleştir</string>
+    <string name="search_strictness_balanced">Dengeli</string>
+    <string name="search_strictness_balanced_desc">Tek tek kelimeleri de eşleştir; daha çok kelimeyi tutturan sonuçlar üste çıkar</string>
+    <string name="search_strictness_broad">Geniş</string>
+    <string name="search_strictness_broad_desc">Olabildiğince çok kelimeyi eşleştir. Elemesi daha uzun sürer ve uzun sorularda yavaşlar</string>
+    <string name="search_default_scope">Aramaya şurada başla</string>
+    <string name="search_default_scope_subtitle">Arama açıldığında hangi filtrenin seçili olacağı</string>
+    <string name="search_scope_everything">Her şey</string>
+    <string name="search_scope_everything_desc">Aranan her kaynaktan sonuç göster</string>
     <string name="ai_answers">Yapay zekâ yanıtları</string>
     <string name="ai_answers_enable">Yapay zekâ yanıtlarını etkinleştir</string>
     <string name="ai_answers_enable_subtitle">Bir soru sorun, kitaplığınızdaki ayet ve hadislerle kanıtlanmış bir yanıt alın</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1831,7 +1831,28 @@
 
     <!-- Search & AI (Ask with Proof) -->
     <string name="search_settings">Search &amp; AI</string>
-    <string name="search_settings_subtitle">AI answers and privacy</string>
+    <string name="search_settings_subtitle">Results, sources, AI answers and privacy</string>
+
+    <!-- Local search behaviour -->
+    <string name="search_results_section">Results</string>
+    <string name="search_results_per_source">Results per source</string>
+    <string name="search_results_per_source_subtitle">Up to %1$d results in total across the sources you search.</string>
+    <string name="search_sources_section">Where to search</string>
+    <string name="search_source_quran_desc">Verses, translations and surah names</string>
+    <string name="search_source_hadith_desc">Narrations across the hadith collections</string>
+    <string name="search_source_duas_desc">Supplications and their translations</string>
+    <string name="search_source_last_one">Search needs at least one source</string>
+    <string name="search_strictness">How closely to match</string>
+    <string name="search_strictness_exact">Exact</string>
+    <string name="search_strictness_exact_desc">Match the whole phrase you typed and nothing looser</string>
+    <string name="search_strictness_balanced">Balanced</string>
+    <string name="search_strictness_balanced_desc">Also match individual words, ranking results that match more of them higher</string>
+    <string name="search_strictness_broad">Broad</string>
+    <string name="search_strictness_broad_desc">Match as many words as possible. More to look through, and slower on long questions</string>
+    <string name="search_default_scope">Start search in</string>
+    <string name="search_default_scope_subtitle">Which filter search opens on</string>
+    <string name="search_scope_everything">Everything</string>
+    <string name="search_scope_everything_desc">Show results from every source you search</string>
     <string name="ai_answers">AI answers</string>
     <string name="ai_answers_enable">Enable AI answers</string>
     <string name="ai_answers_enable_subtitle">Ask a question and get an answer with verses and hadiths from your library as proof</string>

--- a/app/src/test/java/com/arshadshah/nimaz/domain/model/SearchPreferencesTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/model/SearchPreferencesTest.kt
@@ -1,0 +1,78 @@
+package com.arshadshah.nimaz.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The states a preferences file can hold that the settings screen cannot produce.
+ *
+ * Everything here is reachable without a bug in the app: a preferences file survives a
+ * downgrade, a restore from a device running a newer build, and a hand-edit. `sanitised` is
+ * the boundary where those become something search can run under.
+ */
+class SearchPreferencesTest {
+
+    @Test
+    fun `an empty source set would return nothing, so it means everything`() {
+        val stored = SearchPreferences(sources = emptySet())
+
+        assertThat(stored.sanitised.sources).isEqualTo(LibrarySource.entries.toSet())
+    }
+
+    @Test
+    fun `a result cap outside the allowed range is clamped, not honoured`() {
+        // 0 would make every search look broken; 100_000 would make one hang the UI.
+        assertThat(SearchPreferences(resultsPerSource = 0).sanitised.resultsPerSource)
+            .isEqualTo(SearchPreferences.MIN_RESULTS_PER_SOURCE)
+        assertThat(SearchPreferences(resultsPerSource = 100_000).sanitised.resultsPerSource)
+            .isEqualTo(SearchPreferences.MAX_RESULTS_PER_SOURCE)
+    }
+
+    @Test
+    fun `a default scope pointing at a switched-off source is dropped`() {
+        // Otherwise the search screen opens focused on a source it will never query, and
+        // shows an empty result list that looks like "nothing matched".
+        val stored = SearchPreferences(
+            sources = setOf(LibrarySource.QURAN),
+            defaultScope = LibrarySource.HADITH,
+        )
+
+        assertThat(stored.sanitised.defaultScope).isNull()
+    }
+
+    @Test
+    fun `a default scope inside the chosen sources survives`() {
+        val stored = SearchPreferences(
+            sources = setOf(LibrarySource.QURAN, LibrarySource.HADITH),
+            defaultScope = LibrarySource.HADITH,
+        )
+
+        assertThat(stored.sanitised.defaultScope).isEqualTo(LibrarySource.HADITH)
+    }
+
+    @Test
+    fun `sanitising is idempotent`() {
+        val once = SearchPreferences(resultsPerSource = 0, sources = emptySet()).sanitised
+
+        assertThat(once.sanitised).isEqualTo(once)
+    }
+
+    @Test
+    fun `the defaults are what the app did before any of this was a setting`() {
+        val defaults = SearchPreferences()
+
+        assertThat(defaults.resultsPerSource).isEqualTo(60)
+        assertThat(defaults.strictness.wordPasses).isEqualTo(8)
+        assertThat(defaults.sources).isEqualTo(LibrarySource.entries.toSet())
+        assertThat(defaults.defaultScope).isNull()
+    }
+
+    @Test
+    fun `strictness orders the way its names claim`() {
+        assertThat(MatchStrictness.EXACT.wordPasses).isEqualTo(0)
+        assertThat(MatchStrictness.EXACT.wordPasses)
+            .isLessThan(MatchStrictness.BALANCED.wordPasses)
+        assertThat(MatchStrictness.BALANCED.wordPasses)
+            .isLessThan(MatchStrictness.BROAD.wordPasses)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveLocalEventsUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveLocalEventsUseCaseTest.kt
@@ -83,6 +83,14 @@ private class FakeSettings(private val offset: Int) : SettingsRepository {
     override suspend fun setUseHijriPrimary(enabled: Boolean) {}
     override val hijriDayOffset: Flow<Int> = flowOf(offset)
     override suspend fun setHijriDayOffset(days: Int) {}
+    override val searchResultsPerSource: Flow<Int> = flowOf(60)
+    override suspend fun setSearchResultsPerSource(count: Int) {}
+    override val searchSources: Flow<String> = flowOf("")
+    override suspend fun setSearchSources(sources: String) {}
+    override val searchStrictness: Flow<String> = flowOf("BALANCED")
+    override suspend fun setSearchStrictness(strictness: String) {}
+    override val searchDefaultScope: Flow<String> = flowOf("")
+    override suspend fun setSearchDefaultScope(scope: String) {}
     override val appLanguage: Flow<String> = flowOf("en")
     override suspend fun setAppLanguage(language: String) {}
     override val tasbihBeadMode: Flow<Boolean> = flowOf(false)

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveSearchPreferencesUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/ObserveSearchPreferencesUseCaseTest.kt
@@ -1,0 +1,100 @@
+package com.arshadshah.nimaz.domain.usecase
+
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+import com.arshadshah.nimaz.presentation.viewmodel.FakeSearchSettings
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * The boundary between four stored primitives and the typed model search runs on.
+ *
+ * A preferences file outlives the build that wrote it — a downgrade, a restore from a device on
+ * a newer version, a hand-edit — so everything here is about what happens when the stored text
+ * is not something this build would have written.
+ */
+class ObserveSearchPreferencesUseCaseTest {
+
+    private suspend fun preferencesFrom(settings: FakeSearchSettings) =
+        ObserveSearchPreferencesUseCase(settings)().first()
+
+    @Test
+    fun `an unwritten preferences file is the defaults`() = runTest {
+        val prefs = preferencesFrom(FakeSearchSettings())
+
+        assertThat(prefs.resultsPerSource).isEqualTo(60)
+        assertThat(prefs.sources).isEqualTo(LibrarySource.entries.toSet())
+        assertThat(prefs.strictness).isEqualTo(MatchStrictness.BALANCED)
+        assertThat(prefs.defaultScope).isNull()
+    }
+
+    @Test
+    fun `a chosen subset round-trips through the stored form`() = runTest {
+        val chosen = setOf(LibrarySource.QURAN, LibrarySource.DUAS)
+
+        val prefs = preferencesFrom(
+            FakeSearchSettings(sources = ObserveSearchPreferencesUseCase.encode(chosen))
+        )
+
+        assertThat(prefs.sources).isEqualTo(chosen)
+    }
+
+    @Test
+    fun `everything-selected is stored as empty, so a later source is included too`() {
+        // If the full set were written out by name, a build that adds an eighth source would
+        // read back seven and silently stop searching the new one for existing users.
+        assertThat(ObserveSearchPreferencesUseCase.encode(LibrarySource.entries.toSet()))
+            .isEmpty()
+    }
+
+    @Test
+    fun `a source name this build does not know is dropped, not fatal`() = runTest {
+        val prefs = preferencesFrom(FakeSearchSettings(sources = "QURAN,TAFSIR,DUAS"))
+
+        assertThat(prefs.sources).containsExactly(LibrarySource.QURAN, LibrarySource.DUAS)
+    }
+
+    @Test
+    fun `a source list that is entirely unknown falls back to everything`() = runTest {
+        // Dropping all of them would leave an empty set, which is search returning nothing.
+        val prefs = preferencesFrom(FakeSearchSettings(sources = "TAFSIR,SEERAH"))
+
+        assertThat(prefs.sources).isEqualTo(LibrarySource.entries.toSet())
+    }
+
+    @Test
+    fun `an unrecognised strictness degrades to the default rather than throwing`() = runTest {
+        val prefs = preferencesFrom(FakeSearchSettings(strictness = "PEDANTIC"))
+
+        assertThat(prefs.strictness).isEqualTo(MatchStrictness.BALANCED)
+    }
+
+    @Test
+    fun `a stored value out of range is clamped on the way out`() = runTest {
+        val prefs = preferencesFrom(FakeSearchSettings(resultsPerSource = 100_000))
+
+        assertThat(prefs.resultsPerSource).isEqualTo(200)
+    }
+
+    @Test
+    fun `the default scope is dropped when it points outside the chosen sources`() = runTest {
+        val prefs = preferencesFrom(
+            FakeSearchSettings(sources = "QURAN", defaultScope = "HADITH")
+        )
+
+        assertThat(prefs.defaultScope).isNull()
+    }
+
+    @Test
+    fun `changing a stored value re-emits`() = runTest {
+        // The settings screen writes; search reads on its next query. Both go through here.
+        val settings = FakeSearchSettings()
+        val preferences = ObserveSearchPreferencesUseCase(settings)
+
+        assertThat(preferences().first().resultsPerSource).isEqualTo(60)
+        settings.setSearchResultsPerSource(25)
+        assertThat(preferences().first().resultsPerSource).isEqualTo(25)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/SearchLibraryUseCaseTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/SearchLibraryUseCaseTest.kt
@@ -1,8 +1,11 @@
 package com.arshadshah.nimaz.domain.usecase
 
 import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
 import com.arshadshah.nimaz.domain.model.QuranSearchResult
 import com.arshadshah.nimaz.domain.model.SearchType
+import com.arshadshah.nimaz.presentation.viewmodel.FakeSearchSettings
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -39,8 +42,16 @@ class SearchLibraryUseCaseTest {
         every { searchHadithsUC.invoke(any()) } returns flowOf(emptyList())
         every { searchDuasUC.invoke(any()) } returns flowOf(emptyList())
 
-        useCase = SearchLibraryUseCase(quranUseCases, hadithUseCases, duaUseCases)
+        useCase = searchingUnder(FakeSearchSettings())
     }
+
+    /** The same use case reading a given set of stored preferences. */
+    private fun searchingUnder(settings: FakeSearchSettings) = SearchLibraryUseCase(
+        quranUseCases,
+        hadithUseCases,
+        duaUseCases,
+        ObserveSearchPreferencesUseCase(settings),
+    )
 
     @Test
     fun `multi-word query finds per-word matches the phrase search misses`() = runTest {
@@ -112,6 +123,66 @@ class SearchLibraryUseCaseTest {
         assertThat(results.quran).hasSize(2)
         // The record matched by both terms ranks first.
         assertThat(results.quran.first().ayah.surahNumber).isEqualTo(2)
+    }
+
+    // ── what the four settings actually change ────────────────────────────────
+
+    @Test
+    fun `EXACT strictness runs the phrase and nothing else`() = runTest {
+        val exact = searchingUnder(
+            FakeSearchSettings(strictness = MatchStrictness.EXACT.name)
+        )
+
+        exact("patience during hardship")
+
+        verify(exactly = 1) { searchQuranUC.invoke("patience during hardship", any()) }
+        verify(exactly = 0) { searchQuranUC.invoke("patience", any()) }
+        verify(exactly = 0) { searchQuranUC.invoke("hardship", any()) }
+    }
+
+    @Test
+    fun `a switched-off source is not queried at all`() = runTest {
+        // Not merely filtered out of the results: the query is the expensive part, and the
+        // point of the setting is that narrowing search also makes it faster.
+        val quranOnly = searchingUnder(
+            FakeSearchSettings(
+                sources = ObserveSearchPreferencesUseCase.encode(setOf(LibrarySource.QURAN))
+            )
+        )
+
+        quranOnly("patience")
+
+        verify(exactly = 1) { searchQuranUC.invoke("patience", any()) }
+        // Surah names are part of the Qur'an source, not a source of their own — "search the
+        // Qur'an but not its surah names" is not a distinction worth a switch.
+        verify(exactly = 1) { getSurahListUC.search("patience") }
+        verify(exactly = 0) { searchHadithsUC.invoke(any()) }
+        verify(exactly = 0) { searchDuasUC.invoke(any()) }
+    }
+
+    @Test
+    fun `the per-source cap is the setting, not a constant`() = runTest {
+        // The 180-results-for-الله report: three sources each capped at a hardcoded 60.
+        val hits = (1..100).map { quranResult(2, it) }
+        every { searchQuranUC.invoke("patience", any()) } returns flowOf(hits)
+
+        val narrow = searchingUnder(FakeSearchSettings(resultsPerSource = 25))
+        assertThat(narrow("patience").quran).hasSize(25)
+
+        val wide = searchingUnder(FakeSearchSettings(resultsPerSource = 100))
+        assertThat(wide("patience").quran).hasSize(100)
+    }
+
+    @Test
+    fun `a preferences file that would return nothing still searches everything`() = runTest {
+        // An empty stored source set is reachable by a downgrade or a restore; honouring it
+        // literally would make every search look broken.
+        val empty = searchingUnder(FakeSearchSettings(sources = "NOT_A_SOURCE"))
+
+        empty("patience")
+
+        verify(exactly = 1) { searchQuranUC.invoke("patience", any()) }
+        verify(exactly = 1) { searchHadithsUC.invoke("patience") }
     }
 
     @Test

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FakePlatformSeams.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/FakePlatformSeams.kt
@@ -1,11 +1,14 @@
 package com.arshadshah.nimaz.presentation.viewmodel
 
 import com.arshadshah.nimaz.core.text.StringProvider
+import com.arshadshah.nimaz.domain.model.MatchStrictness
 import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.SearchPreferences
 import com.arshadshah.nimaz.domain.repository.PermissionChecker
 import com.arshadshah.nimaz.domain.repository.PowerSettings
 import com.arshadshah.nimaz.domain.repository.WidgetRefresher
 import com.arshadshah.nimaz.domain.repository.settings.HijriSettings
+import com.arshadshah.nimaz.domain.repository.settings.SearchSettings
 import com.arshadshah.nimaz.domain.repository.settings.ZakatSettings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -99,4 +102,42 @@ class FakeZakatSettings(
  */
 class FakeHijriSettings(offset: Int = 0) : HijriSettings {
     override val hijriDayOffset: Flow<Int> = MutableStateFlow(offset)
+}
+
+/**
+ * The four stored search preferences, writable.
+ *
+ * Writable rather than fixed because the settings screen's whole job is writing them, so a test
+ * of it has to be able to read back what it wrote.
+ */
+class FakeSearchSettings(
+    resultsPerSource: Int = SearchPreferences.DEFAULT_RESULTS_PER_SOURCE,
+    sources: String = "",
+    strictness: String = MatchStrictness.BALANCED.name,
+    defaultScope: String = "",
+) : SearchSettings {
+    private val perSourceFlow = MutableStateFlow(resultsPerSource)
+    private val sourcesFlow = MutableStateFlow(sources)
+    private val strictnessFlow = MutableStateFlow(strictness)
+    private val scopeFlow = MutableStateFlow(defaultScope)
+
+    override val searchResultsPerSource: Flow<Int> = perSourceFlow
+    override suspend fun setSearchResultsPerSource(count: Int) {
+        perSourceFlow.value = count
+    }
+
+    override val searchSources: Flow<String> = sourcesFlow
+    override suspend fun setSearchSources(sources: String) {
+        sourcesFlow.value = sources
+    }
+
+    override val searchStrictness: Flow<String> = strictnessFlow
+    override suspend fun setSearchStrictness(strictness: String) {
+        strictnessFlow.value = strictness
+    }
+
+    override val searchDefaultScope: Flow<String> = scopeFlow
+    override suspend fun setSearchDefaultScope(scope: String) {
+        scopeFlow.value = scope
+    }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/search/SearchViewModelTest.kt
@@ -2,7 +2,10 @@ package com.arshadshah.nimaz.presentation.viewmodel.search
 
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
 import com.arshadshah.nimaz.domain.model.LibrarySearchResults
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.usecase.ObserveSearchPreferencesUseCase
 import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase
+import com.arshadshah.nimaz.presentation.viewmodel.FakeSearchSettings
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,7 +38,12 @@ class SearchViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = SearchViewModel(searchLibrary, RecordingTelemetry())
+    private fun viewModel(settings: FakeSearchSettings = FakeSearchSettings()) =
+        SearchViewModel(
+            searchLibrary,
+            ObserveSearchPreferencesUseCase(settings),
+            RecordingTelemetry(),
+        )
 
     @Test
     fun `typing a query runs the search without pressing enter`() = runTest {
@@ -106,5 +114,35 @@ class SearchViewModelTest {
         vm.onEvent(SearchEvent.SetFilter(SearchFilter.HADITH))
         assertThat(vm.statsState.value.totalResults).isEqualTo(3)
         assertThat(vm.searchState.value.filteredResults).hasSize(3)
+    }
+
+    // ── the stored default scope ──────────────────────────────────────────────
+
+    @Test
+    fun `search opens on the filter the user made their default`() = runTest {
+        val vm = viewModel(FakeSearchSettings(defaultScope = LibrarySource.HADITH.name))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.selectedFilter).isEqualTo(SearchFilter.HADITH)
+    }
+
+    @Test
+    fun `no stored default leaves search on everything`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.selectedFilter).isEqualTo(SearchFilter.ALL)
+    }
+
+    @Test
+    fun `a filter chosen on this screen wins over the stored default`() = runTest {
+        // The preference is read asynchronously, so this is the race: opening search *from*
+        // duas passes an initial filter, and the settings value must not land on top of it.
+        // "Search duas", said now, beats "usually start on hadith", said once in settings.
+        val vm = viewModel(FakeSearchSettings(defaultScope = LibrarySource.HADITH.name))
+        vm.onEvent(SearchEvent.SetFilter(SearchFilter.DUA))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.selectedFilter).isEqualTo(SearchFilter.DUA)
     }
 }

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/settings/SearchSettingsViewModelTest.kt
@@ -1,7 +1,11 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
 import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.ObserveSearchPreferencesUseCase
+import com.arshadshah.nimaz.presentation.viewmodel.FakeSearchSettings
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,6 +39,7 @@ class SearchSettingsViewModelTest {
 
     private val dispatcher = StandardTestDispatcher()
     private val settings = mockk<SettingsRepository>(relaxed = true)
+    private val searchSettings = FakeSearchSettings()
     private val telemetry = RecordingTelemetry()
 
     private val aiEnabled = MutableStateFlow(false)
@@ -52,7 +57,13 @@ class SearchSettingsViewModelTest {
     @After
     fun tearDown() = Dispatchers.resetMain()
 
-    private fun viewModel() = SearchSettingsViewModel(settings, telemetry)
+    private fun viewModel(search: FakeSearchSettings = searchSettings) =
+        SearchSettingsViewModel(
+            settings,
+            search,
+            ObserveSearchPreferencesUseCase(search),
+            telemetry,
+        )
 
     @Test
     fun `asking to enable opens the consent sheet rather than enabling anything`() = runTest {
@@ -154,4 +165,80 @@ class SearchSettingsViewModelTest {
             assertThat(vm.uiState.value.showConsentSheet).isFalse()
             assertThat(vm.uiState.value.consentFailed).isFalse()
         }
+
+    // ── local search settings ─────────────────────────────────────────────────
+
+    @Test
+    fun `switching a source off removes it and leaves the rest`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ToggleSource(LibrarySource.HADITH))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.sources)
+            .containsExactly(LibrarySource.QURAN, LibrarySource.DUAS)
+    }
+
+    @Test
+    fun `the last source on cannot be switched off`() = runTest {
+        // Obeying would store an empty set, which the sanitiser reads straight back as
+        // "everything" — the switch would turn itself on again with no explanation.
+        val vm = viewModel(FakeSearchSettings(sources = LibrarySource.QURAN.name))
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ToggleSource(LibrarySource.QURAN))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.sources).containsExactly(LibrarySource.QURAN)
+    }
+
+    @Test
+    fun `switching off the source the default scope points at clears the scope`() = runTest {
+        // Otherwise search opens filtered to a source it will never query, and the empty
+        // results list reads as "nothing matched".
+        val vm = viewModel(FakeSearchSettings(defaultScope = LibrarySource.HADITH.name))
+        advanceUntilIdle()
+        assertThat(vm.uiState.value.search.defaultScope).isEqualTo(LibrarySource.HADITH)
+
+        vm.onEvent(SearchSettingsEvent.ToggleSource(LibrarySource.HADITH))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.defaultScope).isNull()
+    }
+
+    @Test
+    fun `switching off some other source leaves the default scope alone`() = runTest {
+        val vm = viewModel(FakeSearchSettings(defaultScope = LibrarySource.HADITH.name))
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.ToggleSource(LibrarySource.DUAS))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.defaultScope).isEqualTo(LibrarySource.HADITH)
+    }
+
+    @Test
+    fun `a result cap outside the allowed range never reaches storage`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.SetResultsPerSource(100_000))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.resultsPerSource).isEqualTo(200)
+    }
+
+    @Test
+    fun `strictness and scope round-trip through the screen`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(SearchSettingsEvent.SetStrictness(MatchStrictness.BROAD))
+        vm.onEvent(SearchSettingsEvent.SetDefaultScope(LibrarySource.DUAS))
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.search.strictness).isEqualTo(MatchStrictness.BROAD)
+        assertThat(vm.uiState.value.search.defaultScope).isEqualTo(LibrarySource.DUAS)
+    }
 }

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -1050,6 +1050,25 @@ newer build is **dropped**, so a future pin cannot crash an older install's More
 explicitly saved empty value means *no pins* and is honoured rather than reset to the defaults,
 or unpinning the last shortcut would not stick. Read through the `MoreSettings` seam.
 
+**Local search behaviour.** `search_results_per_source: Int` (default 60, clamped to 10–200),
+`search_sources: String` (comma-separated `LibrarySource` names, **empty = every source**),
+`search_strictness: String` (a `MatchStrictness` name, default `BALANCED`) and
+`search_default_scope: String` (a `LibrarySource` name, empty = no scope). All four were
+compile-time constants in `SearchLibraryUseCase` until a search for الله returned exactly 180
+results — three sources each capped at a hidden 60 — and was reported as a defect.
+
+Read through the **`SearchSettings`** seam (four flows and four setters, not the 179 members of
+`SettingsRepository`) and turned into the typed `SearchPreferences` by
+`ObserveSearchPreferencesUseCase`, which is where a value this build cannot parse degrades to
+the default instead of throwing on the first search anyone runs. Stored as raw names for the
+usual reason — a payload from a newer build's sync (§10) must not crash an older install — and
+`search_sources` is a delimited string rather than a `stringSetPreferencesKey` because *empty*
+is meaningful here: it means "every source, including any added later", so a build that adds a
+source starts searching it for existing users rather than silently leaving it out. Written from
+`SearchSettingsScreen`; the invariants (a non-empty source set, a scope that points at a source
+still being searched) are applied in `SearchPreferences.sanitised` on every read. See
+[`docs/ai-ask-with-proof.md`](ai-ask-with-proof.md#smart-local-search-searchlibraryusecase).
+
 **Mushaf script / layout.** `quran_mushaf_script: String` (a `MushafScript` enum name, default `MADANI`) selects the Mushaf edition the page reader renders — ayah-flow Uthmani/Madani (604 pages) vs a line-accurate IndoPak edition (16-line/548, 15-line/610 or 13-line/847; #270). Stored raw and mapped to the domain enum at the boundary (mirrors `quran_arabic_font`/`pattern_style`); read by `QuranViewModel` (drives `useLineAccurateLayout` + script-aware page counts) and written from the "Mushaf Script" dropdown in `QuranSettingsScreen`. Off by default. See §5 (16-line renderer).
 
 **One `SettingsViewModel` per screen — so settings state must be *collected*, not snapshotted.**

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -235,11 +235,55 @@ use case now:
 
 `SearchViewModel` uses it for search-as-you-type, submits, and `ApplyAiTerms`.
 
+### What the user controls (`SearchPreferences`)
+
+Four numbers in that description used to be compile-time constants, and one of them was
+reported as a bug: a search for الله returned exactly 180 results, which is three sources
+each returning a hidden cap of 60. A cap you cannot see and cannot change reads as a defect
+every time someone hits it.
+
+They are now `domain/model/SearchPreferences`, read once per search from
+`ObserveSearchPreferencesUseCase` (reading once, rather than collecting, so a preference
+changed mid-query cannot leave half the passes on the old settings):
+
+| Preference | Was | Now |
+| --- | --- | --- |
+| `resultsPerSource` | `MAX_PER_SOURCE = 60` | 10–200, stepped by 10 |
+| `sources` | all, always | any non-empty subset of `LibrarySource`; a source that is off is **not queried**, so narrowing is faster as well as narrower |
+| `strictness` | `MAX_WORD_QUERIES = 8` | `MatchStrictness` — `EXACT` (0 word passes), `BALANCED` (8, the old behaviour), `BROAD` (20) |
+| `defaultScope` | always "All" | which filter chip `SearchScreen` opens on; `null` is everything |
+
+`LibrarySource` is `QURAN` (ayat, translations **and** surah names), `HADITH`, `DUAS`. Surah
+names are not a separate source: "search the Qur'an but not its surah names" is not a
+distinction anyone wants.
+
+Two invariants are enforced in `SearchPreferences.sanitised` rather than trusted, because a
+preferences file outlives the build that wrote it (a downgrade, a restore from a device on a
+newer version, a hand-edit):
+
+- an **empty** source set means everything, since honouring it literally is a search that
+  returns nothing for every query;
+- a `defaultScope` pointing at a source that is switched off is dropped, since it would open
+  the results list filtered to a source that is never queried — an empty list that reads as
+  "nothing matched".
+
+The source set is stored as a comma-separated list of names with **empty meaning "all"**, so
+a build that adds a source picks it up for existing users instead of silently leaving it
+unsearched. Names this build does not recognise are dropped rather than fatal.
+
 ## Settings & consent behaviour
 
 Search Settings (`Route.SearchSettings`, reachable from the Global Search top-bar
 action and the Settings hub):
 
+- **Results** — "Results per source" (a `NimazNumberStepper`, 10–200 by 10, with the resulting
+  total across the selected sources shown underneath so the number is not a mystery),
+  "How closely to match" (`MatchStrictness`) and "Start search in" (`defaultScope`). The scope
+  picker only offers sources that are switched on, plus "Everything".
+- **Where to search** — one switch per `LibrarySource`. The **last** switch left on is
+  disabled and says so: obeying it would store an empty set, which `sanitised` reads straight
+  back as "everything", so the switch would appear to turn itself on again. Switching off the
+  source the default scope points at clears the scope in the same write.
 - **AI answers** — master toggle. Turning it **on** first opens a consent
   `ModalBottomSheet` stating exactly what is shared (**only the question text**
   → Nimaz server on Cloudflare → Anthropic Claude), that the cited verses and


### PR DESCRIPTION
## Why

A search for الله returned exactly **180** results and was reported as a bug. It wasn't one: `SearchLibraryUseCase` capped every source at a hardcoded `MAX_PER_SOURCE = 60`, and three sources × 60 = 180. A cap you cannot see and cannot change reads as a defect every time somebody hits it.

Four compile-time constants shaped every search. This makes all four settings.

## What

`domain/model/SearchPreferences`:

| Preference | Was | Now |
| --- | --- | --- |
| `resultsPerSource` | `MAX_PER_SOURCE = 60` | 10–200, stepped by 10 |
| `sources` | all, always | any non-empty subset of `LibrarySource` |
| `strictness` | `MAX_WORD_QUERIES = 8` | `EXACT` (0 word passes) / `BALANCED` (8, the old behaviour) / `BROAD` (20) |
| `defaultScope` | always "All" | which filter chip search opens on |

Defaults reproduce the previous behaviour exactly, so an install that never opens the screen searches as it did before.

A source that is switched off **is not queried at all** rather than filtered out afterwards — the query is the expensive part, so narrowing search makes it faster as well as narrower.

`LibrarySource` is `QURAN` (ayat, translations *and* surah names), `HADITH`, `DUAS`. Surah names are not their own source: "search the Qur'an but not its surah names" is not a distinction anyone wants, and offering it would make the screen longer without making it more useful.

## The states the screen cannot produce, but a preferences file can

A preferences file outlives the build that wrote it — a downgrade, a restore from a device on a newer version, a hand-edit. Two invariants are enforced in `SearchPreferences.sanitised` rather than trusted:

- an **empty source set** means everything, since honouring it literally is a search that returns nothing for every query;
- a **default scope pointing at a switched-off source** is dropped, since it would open the results list filtered to something never queried, and the empty list would read as "nothing matched".

The screen backs the first one up by disabling the last source switch left on. Obeying that tap would store the empty set the sanitiser reads straight back as "everything" — a switch that appears to flip itself on again.

`search_sources` is a delimited string with **empty meaning "all"**, not a `stringSetPreferencesKey`, so a build that adds a source starts searching it for existing users instead of silently leaving it out. Unrecognised names degrade rather than throw.

## Two things the existing tests caught

- **`PreferenceCodecTest`** failed on the four new keys missing from `PreferenceCodec.TYPES`. That registry exists because the sync wire loses the type and reading a DataStore key at the wrong type *crashes on next read* — so this would have been a crash after any device sync, not a wrong value.
- Merging surah search under `QURAN` invalidated an assertion I'd written the other way round; fixed rather than relaxed.

## Ordering

Preferences are read **once per search** rather than collected, so a change made mid-query cannot leave half the passes on the old settings.

The default scope is applied in `SearchViewModel`'s init behind a flag rather than a race. Opening search *from* duas passes an explicit `initialFilter`, and the preference read is async — "search duas", said now, beats "usually start on hadith", said once in settings.

## Tests

| Suite | New | Covers |
| --- | --- | --- |
| `SearchPreferencesTest` | 7 | the sanitiser's invariants and idempotence |
| `ObserveSearchPreferencesUseCaseTest` | 9 | parsing, round-trip, forward-compat, degradation |
| `SearchLibraryUseCaseTest` | 4 | what each setting changes at the query layer |
| `SearchViewModelTest` | 3 | default-scope precedence |
| `SearchSettingsViewModelTest` | 6 | last-source guard, scope cascade, clamping |

All 1826 unit tests pass.

## Gates

- `:app:compileDebugKotlin` ✅
- `:app:testDebugUnitTest` ✅ 1826 tests, 0 failures
- `:app:lintDebug` ✅ (strings translated into de/fr/id/ms/tr, so no `MissingTranslation`)
- `scripts/check_docs.py` ✅ 23/23

## Docs (same commit)

- `docs/SUBSYSTEMS.md` §6 — the four keys, the `SearchSettings` seam, why the source list is a string
- `docs/ai-ask-with-proof.md` — "What the user controls", and the settings screen's new sections

## Follow-up

This is the first of two PRs for the combined-Names work. The second adds the three name catalogs as `LibrarySource` entries — which existing users get automatically, because "all selected" is stored as empty.

---
_Generated by [Claude Code](https://claude.ai/code/session_012bm5qGfSXUoqP2uUSFPUYw)_