### PR TITLE
refactor: share the widget frame and reader typography, move the Ramadan cards

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/fasting/CountUnloggedRamadanDaysUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/fasting/CountUnloggedRamadanDaysUseCase.kt
@@ -1,0 +1,47 @@
+package com.arshadshah.nimaz.domain.usecase.fasting
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.FastRecord
+import java.time.LocalDate
+import javax.inject.Inject
+
+/**
+ * How many days of the current Ramadan have gone by with nothing logged against them.
+ *
+ * **Why this is a use case and not arithmetic inside a card.** It was six lines inside
+ * `RamadanMissedFastsTracker`, a private composable, computed from `LocalDate.now()` read at
+ * composition — so nothing could test it, and the count went stale the moment the screen was
+ * left open across midnight. Issue #492 moves that card to the shared component layer, which
+ * makes both problems everyone's rather than one screen's.
+ *
+ * "Unlogged" is not "missed": a day the user explicitly recorded as not fasted is logged, and
+ * the card is prompting for the days with no record at all.
+ */
+class CountUnloggedRamadanDaysUseCase @Inject constructor(
+    private val todayProvider: TodayProvider,
+) {
+
+    /**
+     * @param currentDay today's day of Ramadan, 1..30.
+     * @param records the fast records for this Ramadan.
+     */
+    operator fun invoke(currentDay: Int, records: List<FastRecord>): Int {
+        val today = todayProvider.today()
+        // Today is still in progress, so it cannot be behind on anything.
+        val daysElapsed = currentDay - 1
+        if (daysElapsed <= 0) return 0
+
+        val recorded = records.count { record ->
+            val recordDate = LocalDate.ofEpochDay(
+                record.date / MILLIS_PER_DAY
+            )
+            recordDate.isBefore(today) && HijriDateCalculator.isRamadan(recordDate)
+        }
+        return (daysElapsed - recorded).coerceAtLeast(0)
+    }
+
+    private companion object {
+        const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/domain/usecase/fasting/GetRamadanCountdownUseCase.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/usecase/fasting/GetRamadanCountdownUseCase.kt
@@ -1,0 +1,55 @@
+package com.arshadshah.nimaz.domain.usecase.fasting
+
+import com.arshadshah.nimaz.core.time.TodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import java.time.LocalDate
+import javax.inject.Inject
+
+/** How far away the next Ramadan is, and when it starts. */
+data class RamadanCountdown(
+    val daysAway: Int,
+    val startsOn: LocalDate,
+)
+
+/**
+ * The countdown to the next Ramadan.
+ *
+ * **Why this is a use case and not two calls inside a composable.** `RamadanCountdownCard` did
+ * its own `HijriDateCalculator.daysUntilNextRamadan()` and `HijriDateCalculator.today()` at
+ * composition, and `FastTrackerScreen` called `daysUntilNextRamadan()` a third time just to
+ * decide whether to show the card at all. That is the pattern [TodayProvider] exists to
+ * remove — a screen composed just before midnight keeps counting down to yesterday's answer
+ * for as long as it stays open — and it was about to be made worse: issue #492 moves that card
+ * into the shared component layer, where a composable that reads the clock is a defect every
+ * future caller inherits.
+ *
+ * Same shape as [GetDaysUntilAyyamAlBeedUseCase], for the same reasons, including
+ * [offsetDays]: a user who shifted their Hijri date to match a local moon sighting should see
+ * that reflected here as well as everywhere else (registry Open #10).
+ */
+class GetRamadanCountdownUseCase @Inject constructor(
+    private val todayProvider: TodayProvider,
+) {
+
+    /** @param offsetDays the user's `hijriDayOffset`, applied the way `HijriDateCalculator.today` applies it. */
+    operator fun invoke(offsetDays: Int = 0): RamadanCountdown {
+        val today = todayProvider.today().plusDays(offsetDays.toLong())
+        val hijriToday = HijriDateCalculator.toHijri(today)
+
+        // Past Ramadan this Hijri year, so the next one is next year's. Month 9 itself counts
+        // as "this year" — the countdown reads zero rather than jumping eleven months.
+        val targetYear = if (hijriToday.month > RAMADAN) hijriToday.year + 1 else hijriToday.year
+        val startsOn = HijriDateCalculator.getFirstDayOfRamadan(targetYear)
+
+        return RamadanCountdown(
+            daysAway = java.time.temporal.ChronoUnit.DAYS.between(today, startsOn)
+                .toInt()
+                .coerceAtLeast(0),
+            startsOn = startsOn,
+        )
+    }
+
+    private companion object {
+        const val RAMADAN = 9
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/RamadanCards.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/RamadanCards.kt
@@ -1,0 +1,254 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.util.formatLongDate
+import com.arshadshah.nimaz.presentation.components.atoms.GradientCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.theme.NimazColors
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import java.time.LocalDate
+
+/**
+ * The three Ramadan cards.
+ *
+ * They were private composables inside `FastTrackerScreen.kt` (issue #492). A Ramadan
+ * countdown is not fasting-tab-specific — the home screen and the calendar have as much claim
+ * on one — so the only thing keeping them there was the file they happened to be written in.
+ *
+ * **They were also not pure, and moving them is what made that matter.** The countdown called
+ * `HijriDateCalculator.daysUntilNextRamadan()` and `today()` at composition, and the tracker
+ * called `LocalDate.now()` and did its own arithmetic. A composable that reads the clock is a
+ * screen open across midnight showing yesterday's answer; shared, it is that defect in every
+ * future caller. So the values arrive as parameters now, from
+ * `GetRamadanCountdownUseCase` and `CountUnloggedRamadanDaysUseCase`, which take the
+ * `TodayProvider` seam and can be tested.
+ */
+
+/** Progress through Ramadan: which day it is, and how many of them have been fasted. */
+@Composable
+fun RamadanBanner(
+    fastedDays: Int,
+    totalDays: Int,
+    currentDay: Int,
+    modifier: Modifier = Modifier,
+) {
+    GradientCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        gradientColors = listOf(
+            NimazColors.FastingColors.Ramadan,
+            NimazColors.FastingColors.Ramadan.copy(alpha = 0.85f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = stringResource(R.string.fasting_current),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.8f),
+                letterSpacing = 1.sp
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.fasting_ramadan_day, currentDay),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                LinearProgressIndicator(
+                    progress = { if (totalDays > 0) fastedDays.toFloat() / totalDays else 0f },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                    color = Color.White,
+                    trackColor = Color.White.copy(alpha = 0.2f)
+                )
+                Text(
+                    text = "$fastedDays/$totalDays",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}
+
+/**
+ * How long until Ramadan begins.
+ *
+ * @param daysAway from `GetRamadanCountdownUseCase`, not from the clock at composition.
+ */
+@Composable
+fun RamadanCountdownCard(
+    daysAway: Int,
+    startsOn: LocalDate,
+    modifier: Modifier = Modifier,
+) {
+    GradientCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        gradientColors = listOf(
+            NimazColors.FastingColors.Ramadan,
+            NimazColors.FastingColors.Ramadan.copy(alpha = 0.8f)
+        )
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.fasting_ramadan_starts_in),
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White.copy(alpha = 0.8f),
+                letterSpacing = 2.sp
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "$daysAway",
+                style = MaterialTheme.typography.displayLarge.copy(
+                    fontWeight = FontWeight.Bold
+                ),
+                color = Color.White
+            )
+            Text(
+                text = if (daysAway == 1) {
+                    stringResource(R.string.fasting_day)
+                } else {
+                    stringResource(R.string.fasting_days)
+                },
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White.copy(alpha = 0.9f)
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = startsOn.formatLongDate(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White.copy(alpha = 0.8f)
+            )
+        }
+    }
+}
+
+/**
+ * A nudge about days of Ramadan that have gone by with nothing recorded against them.
+ *
+ * Renders nothing when there are none, so a caller can place it unconditionally.
+ *
+ * @param unloggedDays from `CountUnloggedRamadanDaysUseCase`.
+ */
+@Composable
+fun RamadanMissedFastsTracker(
+    unloggedDays: Int,
+    modifier: Modifier = Modifier,
+) {
+    if (unloggedDays <= 0) return
+
+    NimazCard(
+        modifier = modifier.fillMaxWidth(),
+        style = NimazCardStyle.OUTLINED,
+        shape = RoundedCornerShape(14.dp),
+        colors = NimazCardDefaults.colors(
+            container = NimazColors.PrayerColors.Maghrib.copy(alpha = 0.1f),
+            border = NimazColors.PrayerColors.Maghrib.copy(alpha = 0.3f),
+            borderWidth = 1.dp
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(15.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(NimazColors.PrayerColors.Maghrib.copy(alpha = 0.2f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "$unloggedDays",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = NimazColors.PrayerColors.Maghrib
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (unloggedDays == 1) {
+                        stringResource(R.string.fasting_unlogged_day)
+                    } else {
+                        stringResource(R.string.fasting_unlogged_days)
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(R.string.fasting_log_calendar_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RamadanBannerPreview() {
+    NimazTheme {
+        RamadanBanner(fastedDays = 15, totalDays = 30, currentDay = 16)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RamadanCountdownCardPreview() {
+    NimazTheme {
+        // A fixed date, because a preview that reads the clock renders differently every day.
+        RamadanCountdownCard(daysAway = 42, startsOn = LocalDate.of(2027, 2, 8))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RamadanMissedFastsTrackerPreview() {
+    NimazTheme {
+        RamadanMissedFastsTracker(unloggedDays = 3)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ReaderTypographySettings.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ReaderTypographySettings.kt
@@ -1,0 +1,96 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
+import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
+import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+
+/**
+ * The "how the text looks" half of a reader's settings screen: Arabic size, Arabic font, and
+ * translation size.
+ *
+ * `DuaSettingsScreen` and `HadithSettingsScreen` had this identically, twice (#488) — same
+ * three controls, same ranges, same strings, differing only in which preference each wrote.
+ * The two screens keep everything that makes them different: the live preview at the top and
+ * their own display toggles at the bottom, including the grade badge and chain of narration
+ * that only hadith has.
+ *
+ * `QuranSettingsScreen` has the same three controls but interleaved with its own script and
+ * translator pickers, so it is deliberately **not** a caller: making it one would mean
+ * reordering that screen to suit this function, which is the tail wagging the dog.
+ *
+ * A `LazyListScope` extension rather than a composable because the sections are separate list
+ * items — folding them into one item would make the whole block a single scroll unit and
+ * change how the list recycles.
+ */
+fun LazyListScope.readerTypographySettings(
+    arabicFontSize: Float,
+    onArabicFontSize: (Float) -> Unit,
+    selectedFont: QuranArabicFont,
+    onArabicFont: (String) -> Unit,
+    translationFontSize: Float,
+    onTranslationFontSize: (Float) -> Unit,
+) {
+    item { NimazSectionHeader(title = stringResource(R.string.arabic_text)) }
+    item {
+        NimazMenuGroup {
+            NimazSettingsSlider(
+                title = stringResource(R.string.arabic_font_size),
+                valueLabel = stringResource(
+                    R.string.arabic_font_size_value,
+                    arabicFontSize.toInt()
+                ),
+                value = arabicFontSize,
+                onValueChange = onArabicFontSize,
+                valueRange = ARABIC_RANGE,
+                contentDescription = stringResource(R.string.arabic_font_size)
+            )
+
+            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
+            Column(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 14.dp)
+            ) {
+                NimazDropdownField(
+                    label = stringResource(R.string.arabic_font),
+                    items = QuranArabicFont.entries.map { font ->
+                        NimazDropdownItem(
+                            value = font.id,
+                            label = font.displayName,
+                            textFontFamily = font.fontFamily,
+                        )
+                    },
+                    selected = selectedFont.id,
+                    onSelected = onArabicFont
+                )
+            }
+        }
+    }
+
+    item { NimazSectionHeader(title = stringResource(R.string.translation)) }
+    item {
+        NimazMenuGroup {
+            NimazSettingsSlider(
+                title = stringResource(R.string.translation_font_size),
+                valueLabel = stringResource(
+                    R.string.arabic_font_size_value,
+                    translationFontSize.toInt()
+                ),
+                value = translationFontSize,
+                onValueChange = onTranslationFontSize,
+                valueRange = TRANSLATION_RANGE,
+                contentDescription = stringResource(R.string.translation_font_size)
+            )
+        }
+    }
+}
+
+/** Both readers used these, and a reader whose Arabic can shrink further than another's is a bug. */
+private val ARABIC_RANGE = 18f..42f
+private val TRANSLATION_RANGE = 12f..28f

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreen.kt
@@ -36,6 +36,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownField
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.molecules.readerTypographySettings
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsSlider
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -90,65 +91,14 @@ fun DuaSettingsScreen(
                 )
             }
 
-            // Arabic text — size + font
-            item { NimazSectionHeader(title = stringResource(R.string.arabic_text)) }
-            item {
-                NimazMenuGroup {
-                    NimazSettingsSlider(
-                        title = stringResource(R.string.arabic_font_size),
-                        valueLabel = stringResource(
-                            R.string.arabic_font_size_value,
-                            duaState.arabicFontSize.toInt()
-                        ),
-                        value = duaState.arabicFontSize,
-                        onValueChange = { viewModel.onEvent(SettingsEvent.SetDuaArabicFontSize(it)) },
-                        valueRange = 18f..42f,
-                        contentDescription = stringResource(R.string.arabic_font_size)
-                    )
-
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
-
-                    Column(
-                        modifier = Modifier.padding(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 12.dp,
-                            bottom = 14.dp
-                        )
-                    ) {
-                        NimazDropdownField(
-                            label = stringResource(R.string.arabic_font),
-                            items = QuranArabicFont.entries.map { font ->
-                                NimazDropdownItem(
-                                    value = font.id,
-                                    label = font.displayName,
-                                    textFontFamily = font.fontFamily,
-                                )
-                            },
-                            selected = selectedFont.id,
-                            onSelected = { viewModel.onEvent(SettingsEvent.SetDuaArabicFont(it)) }
-                        )
-                    }
-                }
-            }
-
-            // Translation size
-            item { NimazSectionHeader(title = stringResource(R.string.translation)) }
-            item {
-                NimazMenuGroup {
-                    NimazSettingsSlider(
-                        title = stringResource(R.string.translation_font_size),
-                        valueLabel = stringResource(
-                            R.string.arabic_font_size_value,
-                            duaState.translationFontSize.toInt()
-                        ),
-                        value = duaState.translationFontSize,
-                        onValueChange = { viewModel.onEvent(SettingsEvent.SetDuaTranslationFontSize(it)) },
-                        valueRange = 12f..28f,
-                        contentDescription = stringResource(R.string.translation_font_size)
-                    )
-                }
-            }
+            readerTypographySettings(
+                arabicFontSize = duaState.arabicFontSize,
+                onArabicFontSize = { viewModel.onEvent(SettingsEvent.SetDuaArabicFontSize(it)) },
+                selectedFont = selectedFont,
+                onArabicFont = { viewModel.onEvent(SettingsEvent.SetDuaArabicFont(it)) },
+                translationFontSize = duaState.translationFontSize,
+                onTranslationFontSize = { viewModel.onEvent(SettingsEvent.SetDuaTranslationFontSize(it)) },
+            )
 
             // Display options
             item { NimazSectionHeader(title = stringResource(R.string.display_options)) }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
@@ -92,6 +92,9 @@ import com.arshadshah.nimaz.presentation.components.atoms.countdownText
 import com.arshadshah.nimaz.presentation.components.atoms.rememberCountdownTo
 import com.arshadshah.nimaz.presentation.components.atoms.rememberNow
 import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.molecules.RamadanBanner
+import com.arshadshah.nimaz.presentation.components.molecules.RamadanCountdownCard
+import com.arshadshah.nimaz.presentation.components.molecules.RamadanMissedFastsTracker
 import com.arshadshah.nimaz.presentation.components.molecules.calendar.CalendarDayState
 import com.arshadshah.nimaz.presentation.components.molecules.calendar.CalendarLegendItem
 import com.arshadshah.nimaz.presentation.components.molecules.calendar.NimazCalendar
@@ -256,16 +259,23 @@ fun FastTrackerScreen(
 
                             // Missed Fasts Alert (if any days are missed/not logged)
                             item {
+                                // Renders nothing when there is nothing owing, so it does
+                                // not need the `if` the old private version had inside it.
                                 RamadanMissedFastsTracker(
-                                    currentDay = ramadanState.currentDay,
-                                    fastedDays = ramadanState.fastedDays,
-                                    records = calendarState.records
+                                    unloggedDays = ramadanState.unloggedDays
                                 )
                             }
-                        } else if (HijriDateCalculator.daysUntilNextRamadan() <= RamadanCardWindowDays) {
-                            // Ramadan approaching (within 30 days) - show countdown
-                            item {
-                                RamadanCountdownCard()
+                        } else if (ramadanState.daysUntilRamadan <= RamadanCardWindowDays) {
+                            // Ramadan approaching (within 30 days) — show the countdown. The
+                            // days come from the ViewModel now; this used to be a third call
+                            // to the calculator at composition (#492).
+                            ramadanState.ramadanStartsOn?.let { startsOn ->
+                                item {
+                                    RamadanCountdownCard(
+                                        daysAway = ramadanState.daysUntilRamadan,
+                                        startsOn = startsOn,
+                                    )
+                                }
                             }
                         }
 
@@ -341,7 +351,7 @@ fun FastTrackerScreen(
                                 currency = makeupState.currency,
                                 isRamadan = ramadanState.isRamadan,
                                 ramadanDay = ramadanState.currentDay,
-                                daysUntilRamadan = HijriDateCalculator.daysUntilNextRamadan(),
+                                daysUntilRamadan = ramadanState.daysUntilRamadan,
                                 calendarExpanded = showCalendar,
                                 recommendedExpanded = showRecommended,
                                 onToggleCalendar = { showCalendar = !showCalendar },
@@ -382,189 +392,6 @@ fun FastTrackerScreen(
                     }
                 }
 
-            }
-        }
-    }
-}
-
-@Composable
-private fun RamadanBanner(
-    fastedDays: Int,
-    totalDays: Int,
-    currentDay: Int,
-    modifier: Modifier = Modifier
-) {
-    GradientCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        gradientColors = listOf(
-            NimazColors.FastingColors.Ramadan,
-            NimazColors.FastingColors.Ramadan.copy(alpha = 0.85f)
-        )
-    ) {
-        Column(modifier = Modifier.padding(20.dp)) {
-            Text(
-                text = stringResource(R.string.fasting_current),
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White.copy(alpha = 0.8f),
-                letterSpacing = 1.sp
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.fasting_ramadan_day, currentDay),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = Color.White
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                LinearProgressIndicator(
-                    progress = { if (totalDays > 0) fastedDays.toFloat() / totalDays else 0f },
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(8.dp)
-                        .clip(RoundedCornerShape(4.dp)),
-                    color = Color.White,
-                    trackColor = Color.White.copy(alpha = 0.2f)
-                )
-                Text(
-                    text = "$fastedDays/$totalDays",
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color.White
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RamadanCountdownCard(
-    modifier: Modifier = Modifier
-) {
-    val daysUntilRamadan = HijriDateCalculator.daysUntilNextRamadan()
-    val hijriToday = HijriDateCalculator.today()
-
-    // Get the target Ramadan year
-    val targetYear = if (hijriToday.month >= 9) hijriToday.year + 1 else hijriToday.year
-    val ramadanStart = HijriDateCalculator.getFirstDayOfRamadan(targetYear)
-
-    GradientCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        gradientColors = listOf(
-            NimazColors.FastingColors.Ramadan,
-            NimazColors.FastingColors.Ramadan.copy(alpha = 0.8f)
-        )
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.fasting_ramadan_starts_in),
-                style = MaterialTheme.typography.labelMedium,
-                color = Color.White.copy(alpha = 0.8f),
-                letterSpacing = 2.sp
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "$daysUntilRamadan",
-                style = MaterialTheme.typography.displayLarge.copy(
-                    fontWeight = FontWeight.Bold
-                ),
-                color = Color.White
-            )
-            Text(
-                text = if (daysUntilRamadan == 1) stringResource(R.string.fasting_day) else stringResource(
-                    R.string.fasting_days
-                ),
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White.copy(alpha = 0.9f)
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = ramadanStart.formatLongDate(),
-                style = MaterialTheme.typography.bodyMedium,
-                color = Color.White.copy(alpha = 0.8f)
-            )
-        }
-    }
-}
-
-@Composable
-private fun RamadanMissedFastsTracker(
-    currentDay: Int,
-    fastedDays: Int,
-    records: List<FastRecord>,
-    modifier: Modifier = Modifier
-) {
-    val today = LocalDate.now()
-
-    // Calculate how many past Ramadan days have no logged fast
-    // currentDay is the current day of Ramadan (1-30)
-    // fastedDays is the number of days logged as fasted
-    // Past days without a record are considered missed
-
-    val pastDaysInRamadan = currentDay - 1 // Days before today in Ramadan
-    val recordedDays = records.count { record ->
-        val recordDate = LocalDate.ofEpochDay(record.date / (24 * 60 * 60 * 1000))
-        recordDate.isBefore(today) && HijriDateCalculator.isRamadan(recordDate)
-    }
-
-    val unloggedDays = (pastDaysInRamadan - recordedDays).coerceAtLeast(0)
-
-    if (unloggedDays > 0) {
-        NimazCard(
-            modifier = modifier.fillMaxWidth(),
-            style = NimazCardStyle.OUTLINED,
-            shape = RoundedCornerShape(14.dp),
-            colors = NimazCardDefaults.colors(
-                container = NimazColors.PrayerColors.Maghrib.copy(alpha = 0.1f),
-                border = NimazColors.PrayerColors.Maghrib.copy(alpha = 0.3f),
-                borderWidth = 1.dp
-            )
-        ) {
-            Row(
-                modifier = Modifier.padding(15.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(NimazColors.PrayerColors.Maghrib.copy(alpha = 0.2f)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "$unloggedDays",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = NimazColors.PrayerColors.Maghrib
-                    )
-                }
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = if (unloggedDays == 1) stringResource(R.string.fasting_unlogged_day) else stringResource(
-                            R.string.fasting_unlogged_days
-                        ),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Text(
-                        text = stringResource(R.string.fasting_log_calendar_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
             }
         }
     }
@@ -1416,20 +1243,7 @@ private fun MakeupSectionHeaderPreview() {
     }
 }
 
-@Preview(showBackground = true, widthDp = 400, name = "Ramadan Countdown Card")
-@Composable
-private fun RamadanCountdownCardPreview() {
-    NimazTheme {
-        RamadanCountdownCard()
-    }
-}
-
-@Preview(showBackground = true, widthDp = 400, name = "Ramadan Banner")
-@Composable
-private fun RamadanBannerPreview() {
-    NimazTheme {
-        RamadanBanner(fastedDays = 15, totalDays = 30, currentDay = 16)
-    }
-}
+// The Ramadan previews moved with their components, to
+// `presentation/components/molecules/RamadanCards.kt` (#492).
 
 // endregion

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreen.kt
@@ -37,6 +37,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownField
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
+import com.arshadshah.nimaz.presentation.components.molecules.readerTypographySettings
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsSlider
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -90,63 +91,14 @@ fun HadithSettingsScreen(
                 )
             }
 
-            item { NimazSectionHeader(title = stringResource(R.string.arabic_text)) }
-            item {
-                NimazMenuGroup {
-                    NimazSettingsSlider(
-                        title = stringResource(R.string.arabic_font_size),
-                        valueLabel = stringResource(
-                            R.string.arabic_font_size_value,
-                            hadithState.arabicFontSize.toInt()
-                        ),
-                        value = hadithState.arabicFontSize,
-                        onValueChange = { viewModel.onEvent(SettingsEvent.SetHadithArabicFontSize(it)) },
-                        valueRange = 18f..42f,
-                        contentDescription = stringResource(R.string.arabic_font_size)
-                    )
-
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
-
-                    Column(
-                        modifier = Modifier.padding(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 12.dp,
-                            bottom = 14.dp
-                        )
-                    ) {
-                        NimazDropdownField(
-                            label = stringResource(R.string.arabic_font),
-                            items = QuranArabicFont.entries.map { font ->
-                                NimazDropdownItem(
-                                    value = font.id,
-                                    label = font.displayName,
-                                    textFontFamily = font.fontFamily,
-                                )
-                            },
-                            selected = selectedFont.id,
-                            onSelected = { viewModel.onEvent(SettingsEvent.SetHadithArabicFont(it)) }
-                        )
-                    }
-                }
-            }
-
-            item { NimazSectionHeader(title = stringResource(R.string.translation)) }
-            item {
-                NimazMenuGroup {
-                    NimazSettingsSlider(
-                        title = stringResource(R.string.translation_font_size),
-                        valueLabel = stringResource(
-                            R.string.arabic_font_size_value,
-                            hadithState.translationFontSize.toInt()
-                        ),
-                        value = hadithState.translationFontSize,
-                        onValueChange = { viewModel.onEvent(SettingsEvent.SetHadithTranslationFontSize(it)) },
-                        valueRange = 12f..28f,
-                        contentDescription = stringResource(R.string.translation_font_size)
-                    )
-                }
-            }
+            readerTypographySettings(
+                arabicFontSize = hadithState.arabicFontSize,
+                onArabicFontSize = { viewModel.onEvent(SettingsEvent.SetHadithArabicFontSize(it)) },
+                selectedFont = selectedFont,
+                onArabicFont = { viewModel.onEvent(SettingsEvent.SetHadithArabicFont(it)) },
+                translationFontSize = hadithState.translationFontSize,
+                onTranslationFontSize = { viewModel.onEvent(SettingsEvent.SetHadithTranslationFontSize(it)) },
+            )
 
             item { NimazSectionHeader(title = stringResource(R.string.display_options)) }
             item {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingUiState.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingUiState.kt
@@ -60,6 +60,20 @@ data class RamadanTrackerUiState(
      * user's `hijriDayOffset` while everything else honoured it (registry Open #10).
      */
     val daysUntilAyyamAlBeed: Int = 0,
+    /**
+     * Days until the next Ramadan, and the day it starts.
+     *
+     * Here for the same reason as [daysUntilAyyamAlBeed]: `RamadanCountdownCard` used to call
+     * `HijriDateCalculator.daysUntilNextRamadan()` at composition, and the screen called it a
+     * second time just to decide whether to show the card (#492).
+     */
+    val daysUntilRamadan: Int = 0,
+    val ramadanStartsOn: LocalDate? = null,
+    /**
+     * Days of this Ramadan gone by with no fast record at all — not the same as [missedDays],
+     * which counts days explicitly recorded as not fasted.
+     */
+    val unloggedDays: Int = 0,
     val isLoading: Boolean = true
 )
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingViewModel.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingViewModel.kt
@@ -6,7 +6,9 @@ import com.arshadshah.nimaz.core.monitoring.Telemetry
 import com.arshadshah.nimaz.core.monitoring.launchSafely
 import com.arshadshah.nimaz.core.time.TodayProvider
 import com.arshadshah.nimaz.domain.repository.settings.HijriSettings
+import com.arshadshah.nimaz.domain.usecase.fasting.CountUnloggedRamadanDaysUseCase
 import com.arshadshah.nimaz.domain.usecase.fasting.GetDaysUntilAyyamAlBeedUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetRamadanCountdownUseCase
 import com.arshadshah.nimaz.core.monitoring.launchBestEffort
 import com.arshadshah.nimaz.domain.repository.settings.ZakatSettings
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
@@ -47,6 +49,8 @@ class FastingViewModel @Inject constructor(
     private val prayerUseCases: PrayerUseCases,
     private val todayProvider: TodayProvider,
     private val daysUntilAyyamAlBeed: GetDaysUntilAyyamAlBeedUseCase,
+    private val ramadanCountdown: GetRamadanCountdownUseCase,
+    private val countUnloggedRamadanDays: CountUnloggedRamadanDaysUseCase,
     // The offset the user set to match their local moon sighting. The seam, not the whole
     // SettingsRepository — the same argument ZakatSettings settled for the currency (#436).
     private val hijriSettings: HijriSettings,
@@ -313,8 +317,16 @@ class FastingViewModel @Inject constructor(
         ramadanJob = launchSafely(telemetry, DOMAIN, "load_ramadan") {
             // The offset the user set to match their local moon sighting. Read once per load
             // rather than collected: this whole block re-runs when the day does.
-            val ayyamDays = daysUntilAyyamAlBeed(hijriSettings.hijriDayOffset.first())
-            _ramadanState.update { it.copy(daysUntilAyyamAlBeed = ayyamDays) }
+            val offset = hijriSettings.hijriDayOffset.first()
+            val ayyamDays = daysUntilAyyamAlBeed(offset)
+            val countdown = ramadanCountdown(offset)
+            _ramadanState.update {
+                it.copy(
+                    daysUntilAyyamAlBeed = ayyamDays,
+                    daysUntilRamadan = countdown.daysAway,
+                    ramadanStartsOn = countdown.startsOn,
+                )
+            }
 
             val today = todayProvider.today()
             val hijriToday = HijriDateCalculator.toHijri(today)
@@ -341,6 +353,7 @@ class FastingViewModel @Inject constructor(
                             missedDays = missed,
                             remainingDays = daysInRamadan - currentDay,
                             currentDay = currentDay,
+                            unloggedDays = countUnloggedRamadanDays(currentDay, records),
                             isRamadan = true,
                             isLoading = false
                         )

--- a/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetScaffold.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/core/WidgetScaffold.kt
@@ -1,0 +1,96 @@
+package com.arshadshah.nimaz.widget.core
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.sp
+import androidx.glance.LocalContext
+import androidx.glance.action.actionStartActivity
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.arshadshah.nimaz.MainActivity
+import com.arshadshah.nimaz.R
+
+/**
+ * The frame every widget shares, minus the part that differs.
+ *
+ * All six widgets open with the same four colour reads and the same two non-success branches
+ * — a loading box and a "tap to refresh" message, both opening `MainActivity` — before
+ * anything specific to that widget happens (#488). The success branch is the whole of what
+ * makes a widget itself, so it stays where it is.
+ *
+ * [WidgetPalette] was already here for the colour half and **no widget used it**: the type had
+ * been extracted and never adopted, so the four lines stayed copied six times anyway. That is
+ * the other half of this change, and the reason an unused helper is worse than none — it reads
+ * as done.
+ */
+
+/** The "still loading" frame. Tapping it opens the app, like every other widget state. */
+@Composable
+fun WidgetLoading(palette: WidgetPalette) {
+    WidgetLoadingBox(
+        background = palette.background,
+        textSecondary = palette.textSecondary,
+        onClick = actionStartActivity<MainActivity>(),
+    )
+}
+
+/**
+ * The "something went wrong" frame.
+ *
+ * Deliberately not an error message: a widget cannot explain itself in the space it has, and
+ * the useful thing a reader can do is open the app, which is what the tap does.
+ */
+@Composable
+fun WidgetError(palette: WidgetPalette) {
+    // Reads the context itself, the way `WidgetLoadingBox` does — a caller that only wants
+    // the standard error frame should not have to thread one through.
+    val context = LocalContext.current
+    WidgetMessageBox(
+        background = palette.background,
+        onClick = actionStartActivity<MainActivity>(),
+    ) {
+        Text(
+            text = context.getString(R.string.widget_tap_to_refresh),
+            style = TextStyle(color = palette.textSecondary, fontSize = 12.sp)
+        )
+    }
+}
+
+/**
+ * A receiver whose whole job is starting and stopping its widget's refresh work.
+ *
+ * All six did exactly this, and the two countdown widgets additionally drove
+ * `WidgetUpdateScheduler`. Subclasses say which widget and which work; [onWidgetEnabled] and
+ * [onWidgetDisabled] are the hook for anything else, which is the alarm for those two.
+ *
+ * `onEnabled`/`onDisabled` are `final` on purpose: forgetting the `super` call in a Glance
+ * receiver is a silent break, and there is nothing a subclass needs from overriding them that
+ * the two hooks do not give it.
+ */
+abstract class WidgetWorkReceiver : GlanceAppWidgetReceiver() {
+
+    abstract override val glanceAppWidget: GlanceAppWidget
+
+    /** Start this widget's periodic refresh. */
+    protected abstract fun enqueueWork(context: Context)
+
+    /** Stop it. */
+    protected abstract fun cancelWork(context: Context)
+
+    protected open fun onWidgetEnabled(context: Context) = Unit
+    protected open fun onWidgetDisabled(context: Context) = Unit
+
+    final override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        enqueueWork(context)
+        onWidgetEnabled(context)
+    }
+
+    final override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        cancelWork(context)
+        onWidgetDisabled(context)
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijricalendar/HijriCalendarWidget.kt
@@ -13,7 +13,6 @@ import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
@@ -40,6 +39,10 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.widget.core.WidgetIcon
 import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
@@ -82,15 +85,12 @@ private fun HijriCalendarContent(
     openCalendarIntent: Intent,
 ) {
     val context = LocalContext.current
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
 
     when (state) {
         is HijriCalendarWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
+            background = palette.background,
+            textSecondary = palette.textSecondary,
             onClick = actionStartActivity(openCalendarIntent),
             cornerRadius = 20.dp,
         )
@@ -98,22 +98,22 @@ private fun HijriCalendarContent(
         is HijriCalendarWidgetState.Success -> {
             HijriCalendarSuccessContent(
                 data = state.data,
-                backgroundColor = backgroundColor,
-                textColor = textColor,
-                textSecondary = textSecondary,
-                primaryColor = primaryColor,
+                backgroundColor = palette.background,
+                textColor = palette.text,
+                textSecondary = palette.textSecondary,
+                primaryColor = palette.primary,
                 openCalendarIntent = openCalendarIntent,
             )
         }
 
         is HijriCalendarWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
+            background = palette.background,
             onClick = actionStartActivity(openCalendarIntent),
             cornerRadius = 20.dp,
         ) {
             Text(
                 text = context.getString(R.string.widget_tap_to_refresh),
-                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+                style = TextStyle(color = palette.textSecondary, fontSize = 12.sp)
             )
         }
     }
@@ -430,16 +430,11 @@ private fun EventRow(
     }
 }
 
-class HijriCalendarWidgetReceiver : GlanceAppWidgetReceiver() {
+class HijriCalendarWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = HijriCalendarWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         HijriCalendarWorker.enqueuePeriodicWork(context, force = true)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        HijriCalendarWorker.cancel(context)
-    }
+    override fun cancelWork(context: Context) = HijriCalendarWorker.cancel(context)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/hijridate/HijriDateWidget.kt
@@ -7,10 +7,8 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
-import androidx.glance.LocalContext
 import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.provideContent
 import androidx.glance.currentState
 import androidx.glance.layout.Alignment
@@ -27,11 +25,13 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.widget.core.WidgetCard
 import com.arshadshah.nimaz.widget.core.WidgetIcon
 import com.arshadshah.nimaz.widget.core.WidgetLabel
-import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
-import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class HijriDateWidget : GlanceAppWidget() {
 
@@ -50,38 +50,22 @@ class HijriDateWidget : GlanceAppWidget() {
 
 @Composable
 private fun HijriDateContent(state: HijriDateWidgetState) {
-    val context = LocalContext.current
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
 
     when (state) {
-        is HijriDateWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
-            onClick = actionStartActivity<MainActivity>(),
-        )
+        is HijriDateWidgetState.Loading -> WidgetLoading(palette)
 
         is HijriDateWidgetState.Success -> {
             HijriDateSuccessContent(
                 data = state.data,
-                backgroundColor = backgroundColor,
-                textColor = textColor,
-                textSecondary = textSecondary,
-                primaryColor = primaryColor
+                backgroundColor = palette.background,
+                textColor = palette.text,
+                textSecondary = palette.textSecondary,
+                primaryColor = palette.primary
             )
         }
 
-        is HijriDateWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
-            onClick = actionStartActivity<MainActivity>(),
-        ) {
-            Text(
-                text = context.getString(R.string.widget_tap_to_refresh),
-                style = TextStyle(color = textSecondary, fontSize = 12.sp)
-            )
-        }
+        is HijriDateWidgetState.Error -> WidgetError(palette)
     }
 }
 
@@ -135,16 +119,11 @@ private fun HijriDateSuccessContent(
     }
 }
 
-class HijriDateWidgetReceiver : GlanceAppWidgetReceiver() {
+class HijriDateWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = HijriDateWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         HijriDateWorker.enqueuePeriodicWork(context, force = true)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        HijriDateWorker.cancel(context)
-    }
+    override fun cancelWork(context: Context) = HijriDateWorker.cancel(context)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/khatam/KhatamWidget.kt
@@ -9,7 +9,6 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.LinearProgressIndicator
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
@@ -32,8 +31,11 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.widget.core.WidgetCard
-import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 
 class KhatamWidget : GlanceAppWidget() {
@@ -53,30 +55,23 @@ class KhatamWidget : GlanceAppWidget() {
 
 @Composable
 private fun KhatamContent(context: Context, state: KhatamWidgetState) {
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
     val gold = ColorProvider(R.color.widget_gold)
     val goldContainer = ColorProvider(R.color.widget_gold_container)
     val onGoldContainer = ColorProvider(R.color.widget_on_gold_container)
 
     when (state) {
-        is KhatamWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
-            onClick = actionStartActivity<MainActivity>(),
-        )
+        is KhatamWidgetState.Loading -> WidgetLoading(palette)
 
         is KhatamWidgetState.Success -> {
             if (state.data.hasActiveKhatam) {
                 KhatamProgressContent(
                     context = context,
                     data = state.data,
-                    backgroundColor = backgroundColor,
-                    textColor = textColor,
-                    textSecondary = textSecondary,
-                    primaryColor = primaryColor,
+                    backgroundColor = palette.background,
+                    textColor = palette.text,
+                    textSecondary = palette.textSecondary,
+                    primaryColor = palette.primary,
                     gold = gold,
                     goldContainer = goldContainer,
                     onGoldContainer = onGoldContainer,
@@ -84,15 +79,15 @@ private fun KhatamContent(context: Context, state: KhatamWidgetState) {
             } else {
                 KhatamEmptyContent(
                     context = context,
-                    backgroundColor = backgroundColor,
-                    textSecondary = textSecondary,
-                    primaryColor = primaryColor
+                    backgroundColor = palette.background,
+                    textSecondary = palette.textSecondary,
+                    primaryColor = palette.primary
                 )
             }
         }
 
         is KhatamWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
+            background = palette.background,
             onClick = actionStartActivity<MainActivity>(),
         ) {
             Column(
@@ -101,7 +96,7 @@ private fun KhatamContent(context: Context, state: KhatamWidgetState) {
                 Text(
                     text = context.getString(R.string.widget_error_loading),
                     style = TextStyle(
-                        color = textSecondary,
+                        color = palette.textSecondary,
                         fontSize = 12.sp
                     )
                 )
@@ -109,7 +104,7 @@ private fun KhatamContent(context: Context, state: KhatamWidgetState) {
                 Text(
                     text = context.getString(R.string.widget_tap_to_retry),
                     style = TextStyle(
-                        color = primaryColor,
+                        color = palette.primary,
                         fontSize = 10.sp
                     )
                 )
@@ -298,16 +293,11 @@ private fun KhatamEmptyContent(
     }
 }
 
-class KhatamWidgetReceiver : GlanceAppWidgetReceiver() {
+class KhatamWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = KhatamWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         KhatamWorker.enqueuePeriodicWork(context, force = true)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        KhatamWorker.cancel(context)
-    }
+    override fun cancelWork(context: Context) = KhatamWorker.cancel(context)
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/nextprayer/NextPrayerWidget.kt
@@ -10,7 +10,6 @@ import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.provideContent
 import androidx.glance.currentState
 import androidx.glance.layout.Alignment
@@ -27,11 +26,14 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
 import com.arshadshah.nimaz.widget.core.WidgetCard
 import com.arshadshah.nimaz.widget.core.WidgetIcon
 import com.arshadshah.nimaz.widget.core.WidgetLabel
-import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 import com.arshadshah.nimaz.widget.core.WidgetPill
 import com.arshadshah.nimaz.widget.core.prayerIconRes
@@ -55,35 +57,28 @@ class NextPrayerWidget : GlanceAppWidget() {
 @Composable
 private fun NextPrayerContent(state: NextPrayerWidgetState) {
     val context = LocalContext.current
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
 
     when (state) {
-        is NextPrayerWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
-            onClick = actionStartActivity<MainActivity>(),
-        )
+        is NextPrayerWidgetState.Loading -> WidgetLoading(palette)
 
         is NextPrayerWidgetState.Success -> {
             NextPrayerSuccessContent(
                 data = state.data,
-                backgroundColor = backgroundColor,
-                textColor = textColor,
-                textSecondary = textSecondary,
-                primaryColor = primaryColor
+                backgroundColor = palette.background,
+                textColor = palette.text,
+                textSecondary = palette.textSecondary,
+                primaryColor = palette.primary
             )
         }
 
         is NextPrayerWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
+            background = palette.background,
             onClick = actionStartActivity<MainActivity>(),
         ) {
             Text(
                 text = context.getString(R.string.widget_tap_to_setup),
-                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+                style = TextStyle(color = palette.textSecondary, fontSize = 12.sp)
             )
         }
     }
@@ -168,20 +163,17 @@ private fun NextPrayerSuccessContent(
     }
 }
 
-class NextPrayerWidgetReceiver : GlanceAppWidgetReceiver() {
+class NextPrayerWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = NextPrayerWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         NextPrayerWorker.enqueuePeriodicWork(context, force = true)
-        WidgetUpdateScheduler.schedule(context)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        NextPrayerWorker.cancel(context)
-        // Only cancel alarm if no other countdown widgets are active
-        // For simplicity, always re-schedule — PrayerTimesWidget will also schedule
+    override fun cancelWork(context: Context) = NextPrayerWorker.cancel(context)
+
+    override fun onWidgetEnabled(context: Context) =
+        WidgetUpdateScheduler.schedule(context)
+
+    override fun onWidgetDisabled(context: Context) =
         WidgetUpdateScheduler.cancel(context)
-    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertimes/PrayerTimesWidget.kt
@@ -10,7 +10,6 @@ import androidx.glance.GlanceTheme
 import androidx.glance.LocalContext
 import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
@@ -31,10 +30,13 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.widget.WidgetUpdateScheduler
 import com.arshadshah.nimaz.widget.core.WidgetCard
-import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 import com.arshadshah.nimaz.widget.core.nextPrayerIndex
 import com.arshadshah.nimaz.widget.core.prayerShortName
@@ -57,35 +59,28 @@ class PrayerTimesWidget : GlanceAppWidget() {
 @Composable
 private fun PrayerTimesContent(state: PrayerTimesWidgetState) {
     val context = LocalContext.current
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
 
     when (state) {
-        is PrayerTimesWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
-            onClick = actionStartActivity<MainActivity>(),
-        )
+        is PrayerTimesWidgetState.Loading -> WidgetLoading(palette)
 
         is PrayerTimesWidgetState.Success -> {
             PrayerTimesSuccessContent(
                 data = state.data,
-                backgroundColor = backgroundColor,
-                textColor = textColor,
-                textSecondary = textSecondary,
-                primaryColor = primaryColor
+                backgroundColor = palette.background,
+                textColor = palette.text,
+                textSecondary = palette.textSecondary,
+                primaryColor = palette.primary
             )
         }
 
         is PrayerTimesWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
+            background = palette.background,
             onClick = actionStartActivity<MainActivity>(),
         ) {
             Text(
                 text = context.getString(R.string.widget_tap_to_setup),
-                style = TextStyle(color = textSecondary, fontSize = 12.sp)
+                style = TextStyle(color = palette.textSecondary, fontSize = 12.sp)
             )
         }
     }
@@ -241,18 +236,17 @@ private fun PrayerPill(
     }
 }
 
-class PrayerTimesWidgetReceiver : GlanceAppWidgetReceiver() {
+class PrayerTimesWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = PrayerTimesWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         PrayerTimesWorker.enqueuePeriodicWork(context, force = true)
-        WidgetUpdateScheduler.schedule(context)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        PrayerTimesWorker.cancel(context)
+    override fun cancelWork(context: Context) = PrayerTimesWorker.cancel(context)
+
+    override fun onWidgetEnabled(context: Context) =
+        WidgetUpdateScheduler.schedule(context)
+
+    override fun onWidgetDisabled(context: Context) =
         WidgetUpdateScheduler.cancel(context)
-    }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/widget/prayertracker/PrayerTrackerWidget.kt
@@ -10,7 +10,6 @@ import androidx.glance.GlanceTheme
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
@@ -31,13 +30,16 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.arshadshah.nimaz.MainActivity
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.widget.core.WidgetError
+import com.arshadshah.nimaz.widget.core.WidgetLoading
+import com.arshadshah.nimaz.widget.core.WidgetPalette
+import com.arshadshah.nimaz.widget.core.WidgetWorkReceiver
 import com.arshadshah.nimaz.core.monitoring.CrashReporter
 import com.arshadshah.nimaz.core.util.toUtcMidnightMillis
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.widget.WidgetEntryPoint
 import com.arshadshah.nimaz.widget.core.WidgetCard
 import com.arshadshah.nimaz.widget.core.WidgetIcon
-import com.arshadshah.nimaz.widget.core.WidgetLoadingBox
 import com.arshadshah.nimaz.widget.core.WidgetMessageBox
 import dagger.hilt.android.EntryPointAccessors
 import java.time.LocalDate
@@ -62,31 +64,24 @@ class PrayerTrackerWidget : GlanceAppWidget() {
 
 @Composable
 private fun PrayerTrackerContent(context: Context, state: PrayerTrackerWidgetState) {
-    val backgroundColor = ColorProvider(R.color.widget_background)
-    val textColor = ColorProvider(R.color.widget_text)
-    val textSecondary = ColorProvider(R.color.widget_text_secondary)
-    val primaryColor = ColorProvider(R.color.widget_primary)
+    val palette = WidgetPalette()
 
     when (state) {
-        is PrayerTrackerWidgetState.Loading -> WidgetLoadingBox(
-            background = backgroundColor,
-            textSecondary = textSecondary,
-            onClick = actionStartActivity<MainActivity>(),
-        )
+        is PrayerTrackerWidgetState.Loading -> WidgetLoading(palette)
 
         is PrayerTrackerWidgetState.Success -> {
             PrayerTrackerSuccessContent(
                 context = context,
                 data = state.data,
-                backgroundColor = backgroundColor,
-                textColor = textColor,
-                textSecondary = textSecondary,
-                primaryColor = primaryColor
+                backgroundColor = palette.background,
+                textColor = palette.text,
+                textSecondary = palette.textSecondary,
+                primaryColor = palette.primary
             )
         }
 
         is PrayerTrackerWidgetState.Error -> WidgetMessageBox(
-            background = backgroundColor,
+            background = palette.background,
             onClick = actionStartActivity<MainActivity>(),
         ) {
             Column(
@@ -95,7 +90,7 @@ private fun PrayerTrackerContent(context: Context, state: PrayerTrackerWidgetSta
                 Text(
                     text = context.getString(R.string.widget_error_loading),
                     style = TextStyle(
-                        color = textSecondary,
+                        color = palette.textSecondary,
                         fontSize = 12.sp
                     )
                 )
@@ -103,7 +98,7 @@ private fun PrayerTrackerContent(context: Context, state: PrayerTrackerWidgetSta
                 Text(
                     text = context.getString(R.string.widget_tap_to_retry),
                     style = TextStyle(
-                        color = primaryColor,
+                        color = palette.primary,
                         fontSize = 10.sp
                     )
                 )
@@ -276,16 +271,11 @@ private fun togglePrayerStatus(context: Context, prayerName: String) {
     }
 }
 
-class PrayerTrackerWidgetReceiver : GlanceAppWidgetReceiver() {
+class PrayerTrackerWidgetReceiver : WidgetWorkReceiver() {
     override val glanceAppWidget: GlanceAppWidget = PrayerTrackerWidget()
 
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
+    override fun enqueueWork(context: Context) =
         PrayerTrackerWorker.enqueuePeriodicWork(context, force = true)
-    }
 
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        PrayerTrackerWorker.cancel(context)
-    }
+    override fun cancelWork(context: Context) = PrayerTrackerWorker.cancel(context)
 }

--- a/app/src/test/java/com/arshadshah/nimaz/domain/usecase/fasting/RamadanCalculationsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/domain/usecase/fasting/RamadanCalculationsTest.kt
@@ -1,0 +1,150 @@
+package com.arshadshah.nimaz.domain.usecase.fasting
+
+import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.core.util.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The two Ramadan calculations that had no test because they had nowhere to live.
+ *
+ * Both were inside private composables in `FastTrackerScreen.kt` — the countdown read
+ * `HijriDateCalculator.daysUntilNextRamadan()` at composition, the unlogged-days count read
+ * `LocalDate.now()` — so nothing could reach either, and both went stale on a screen left open
+ * across midnight. Issue #492 moves those cards to the shared component layer, which is what
+ * made the impurity worth fixing rather than carrying: a composable that reads the clock is a
+ * defect every future caller inherits.
+ */
+class RamadanCalculationsTest {
+
+    // ── the countdown ─────────────────────────────────────────────────────────
+
+    private fun countdownOn(date: LocalDate, offset: Int = 0) =
+        GetRamadanCountdownUseCase(FakeTodayProvider(date))(offset)
+
+    /** A Gregorian date whose Hijri month is [hijriMonth], found by walking forward. */
+    private fun gregorianInHijriMonth(hijriMonth: Int, day: Int = 1): LocalDate {
+        var date = LocalDate.of(2026, 1, 1)
+        repeat(800) {
+            val hijri = HijriDateCalculator.toHijri(date)
+            if (hijri.month == hijriMonth && hijri.day == day) return date
+            date = date.plusDays(1)
+        }
+        error("no date in Hijri month $hijriMonth day $day in range")
+    }
+
+    @Test
+    fun `the countdown lands on the first day of Ramadan`() {
+        val inShaban = gregorianInHijriMonth(hijriMonth = 8, day = 1)
+
+        val countdown = countdownOn(inShaban)
+
+        assertThat(HijriDateCalculator.toHijri(countdown.startsOn).month).isEqualTo(9)
+        assertThat(HijriDateCalculator.toHijri(countdown.startsOn).day).isEqualTo(1)
+        assertThat(inShaban.plusDays(countdown.daysAway.toLong()))
+            .isEqualTo(countdown.startsOn)
+    }
+
+    @Test
+    fun `during Ramadan the countdown is zero rather than eleven months`() {
+        // Month 9 counts as "this year": treating it as past would make the card claim the
+        // next Ramadan is 350 days away while the user is fasting it.
+        val inRamadan = gregorianInHijriMonth(hijriMonth = 9, day = 10)
+
+        assertThat(countdownOn(inRamadan).daysAway).isEqualTo(0)
+    }
+
+    @Test
+    fun `after Ramadan the countdown rolls to next year`() {
+        val inShawwal = gregorianInHijriMonth(hijriMonth = 10, day = 5)
+
+        val countdown = countdownOn(inShawwal)
+
+        assertThat(countdown.startsOn).isGreaterThan(inShawwal)
+        assertThat(HijriDateCalculator.toHijri(countdown.startsOn).month).isEqualTo(9)
+        // Roughly a lunar year out, and certainly not a small number.
+        assertThat(countdown.daysAway).isGreaterThan(300)
+    }
+
+    @Test
+    fun `the count is never negative, on any day of the year`() {
+        var date = LocalDate.of(2026, 1, 1)
+        repeat(400) {
+            assertThat(countdownOn(date).daysAway).isAtLeast(0)
+            date = date.plusDays(1)
+        }
+    }
+
+    @Test
+    fun `the hijri day offset shifts the answer, which is registry Open #10`() {
+        // A user who shifted their Hijri date to match a local moon sighting saw every other
+        // date honour it and this countdown ignore it.
+        val inShaban = gregorianInHijriMonth(hijriMonth = 8, day = 20)
+
+        val plain = countdownOn(inShaban).daysAway
+        assertThat(countdownOn(inShaban, offset = 1).daysAway).isEqualTo(plain - 1)
+    }
+
+    @Test
+    fun `the clock is a seam, so a card open across midnight is not stuck on yesterday`() {
+        val eve = gregorianInHijriMonth(hijriMonth = 8, day = 20)
+
+        assertThat(countdownOn(eve.plusDays(1)).daysAway)
+            .isEqualTo(countdownOn(eve).daysAway - 1)
+    }
+
+    // ── unlogged days ─────────────────────────────────────────────────────────
+
+    private val today = LocalDate.of(2026, 3, 15)
+
+    private fun unloggedOn(currentDay: Int, records: List<FastRecord>) =
+        CountUnloggedRamadanDaysUseCase(FakeTodayProvider(today))(currentDay, records)
+
+    private fun recordOn(date: LocalDate) = FastRecord(
+        id = 0,
+        date = date.toEpochDay() * 24 * 60 * 60 * 1000,
+        hijriDate = "",
+        hijriMonth = 9,
+        hijriYear = 1447,
+        fastType = FastType.RAMADAN,
+        status = FastStatus.FASTED,
+        exemptionReason = null,
+        suhoorTime = null,
+        iftarTime = null,
+        note = null,
+        createdAt = 0,
+        updatedAt = 0,
+    )
+
+    @Test
+    fun `the first day of Ramadan owes nothing, because today is still in progress`() {
+        assertThat(unloggedOn(currentDay = 1, records = emptyList())).isEqualTo(0)
+    }
+
+    @Test
+    fun `days gone by with no record at all are what the card counts`() {
+        // Day 5, so four days have elapsed; two of them were logged.
+        val logged = listOf(recordOn(today.minusDays(1)), recordOn(today.minusDays(2)))
+
+        assertThat(unloggedOn(currentDay = 5, records = logged)).isEqualTo(2)
+    }
+
+    @Test
+    fun `today's own record does not count towards days gone by`() {
+        // Logging today must not make the card claim a day is unaccounted for elsewhere.
+        val logged = listOf(recordOn(today))
+
+        assertThat(unloggedOn(currentDay = 3, records = logged)).isEqualTo(2)
+    }
+
+    @Test
+    fun `more records than elapsed days never reads as negative`() {
+        val logged = (1..6).map { recordOn(today.minusDays(it.toLong())) }
+
+        assertThat(unloggedOn(currentDay = 3, records = logged)).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingPrayerSettingsTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingPrayerSettingsTest.kt
@@ -2,7 +2,9 @@ package com.arshadshah.nimaz.presentation.viewmodel.tracker
 
 import java.time.LocalDate
 import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.fasting.CountUnloggedRamadanDaysUseCase
 import com.arshadshah.nimaz.domain.usecase.fasting.GetDaysUntilAyyamAlBeedUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetRamadanCountdownUseCase
 import com.arshadshah.nimaz.presentation.viewmodel.FakeHijriSettings
 import com.arshadshah.nimaz.presentation.viewmodel.FakeZakatSettings
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
@@ -69,6 +71,8 @@ class FastingPrayerSettingsTest {
         buildPrayerUseCases(prayers),
         FakeTodayProvider(LocalDate.now()),
         GetDaysUntilAyyamAlBeedUseCase(FakeTodayProvider(LocalDate.now())),
+        GetRamadanCountdownUseCase(FakeTodayProvider(LocalDate.now())),
+        CountUnloggedRamadanDaysUseCase(FakeTodayProvider(LocalDate.now())),
         FakeHijriSettings(),
         FakeZakatSettings(),
         RecordingTelemetry(),

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingViewModelTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.arshadshah.nimaz.presentation.viewmodel.tracker
 
 import com.arshadshah.nimaz.core.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.fasting.CountUnloggedRamadanDaysUseCase
 import com.arshadshah.nimaz.domain.usecase.fasting.GetDaysUntilAyyamAlBeedUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetRamadanCountdownUseCase
 import com.arshadshah.nimaz.presentation.viewmodel.FakeHijriSettings
 import com.arshadshah.nimaz.presentation.viewmodel.FakeZakatSettings
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
@@ -87,6 +89,8 @@ class FastingViewModelTest {
             buildPrayerUseCases(prayers),
             FakeTodayProvider(LocalDate.now()),
             GetDaysUntilAyyamAlBeedUseCase(FakeTodayProvider(LocalDate.now())),
+            GetRamadanCountdownUseCase(FakeTodayProvider(LocalDate.now())),
+            CountUnloggedRamadanDaysUseCase(FakeTodayProvider(LocalDate.now())),
             FakeHijriSettings(),
             FakeZakatSettings(),
             RecordingTelemetry(),


### PR DESCRIPTION
Closes #492. Closes #488.

## #492 — the Ramadan cards were in the wrong file, and not pure

`RamadanBanner`, `RamadanCountdownCard` and `RamadanMissedFastsTracker` were private composables inside `FastTrackerScreen.kt`. A Ramadan countdown is not fasting-tab-specific — the home screen and the calendar have as much claim on one. They now live in `presentation/components/molecules/RamadanCards.kt`.

**Moving them is what made their impurity worth fixing rather than carrying.** The countdown called `HijriDateCalculator.daysUntilNextRamadan()` and `today()` at composition, and the screen called `daysUntilNextRamadan()` a *third* time just to decide whether to show the card. The tracker read `LocalDate.now()` and did its own arithmetic inline.

A composable that reads the clock is a screen open across midnight showing yesterday's answer. Shared, it is that defect in every future caller — so the values arrive as parameters now, from two use cases that take the `TodayProvider` seam and honour `hijriDayOffset` like everything else does (registry Open #10):

- `GetRamadanCountdownUseCase` — days away + start date
- `CountUnloggedRamadanDaysUseCase` — days of Ramadan gone by with no record at all, which is **not** the same as `missedDays` (a day explicitly recorded as not fasted is logged)

Ten tests, none of which could have existed before the move.

## #488 — three clone pairs, and a helper nobody adopted

**`WidgetPalette` was already in `widget/core/WidgetUi.kt`** — extracted for exactly this purpose and used by **no widget**. The four colour reads stayed copied six times anyway. An unused helper is worse than none: it reads as done. All six widgets use it now.

Two more shapes join it in a new `WidgetScaffold.kt`:

| | |
|---|---|
| `WidgetLoading` / `WidgetError` | the loading box and "tap to refresh" message, byte-identical across all six |
| `WidgetWorkReceiver` | the receiver whose whole job is starting/stopping refresh work, with hooks for the two countdown widgets that also drive `WidgetUpdateScheduler` |

`WidgetWorkReceiver.onEnabled`/`onDisabled` are **`final`** on purpose: forgetting the `super` call in a Glance receiver is a silent break, and the two hooks cover everything a subclass legitimately needs.

`readerTypographySettings` is the Arabic-size / Arabic-font / translation-size block that `DuaSettingsScreen` and `HadithSettingsScreen` each carried in full. Both keep what makes them different — the live preview and their own display toggles, including hadith's grade badge and chain of narration.

## What I did not do, and why

**The widgets' private success composables still take four colour parameters rather than a palette.** I tried this and backed it out. `HijriCalendarWidget` alone has seven such composables taking varying subsets and forwarding to each other, and **nothing in the test suite renders a widget** — the widget tests cover data sources. A mistake there would be invisible until it reached someone's home screen. That's a bad trade for a cosmetic gain on six widgets you've just confirmed work on device.

**`QuranSettingsScreen` is not a caller of `readerTypographySettings`.** It has the same three controls but interleaved with its own script and translator pickers; making it fit would mean reordering that screen to suit the function.

## Net

**-309 lines.**

## Gates

- `:app:compileDebugKotlin` ✅
- `:app:testDebugUnitTest` ✅ 1858 tests, 0 failures
- `:app:lintDebug` ✅
- `scripts/check_docs.py` ✅ 23/23
- `:app:assembleDebugAndroidTest` ✅ — run because widget receivers changed

No doc owns component placement or widget internals beyond the `SUBSYSTEMS.md` §0 inventory, and no Worker or widget was renamed, so the inventory is unchanged. `check_docs.py` confirms it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012bm5qGfSXUoqP2uUSFPUYw)_