### PR TITLE
fix(quran): home screen crashes with two or more bookmarks

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -455,7 +455,7 @@ private fun HomeTabContent(
                 ) {
                     items(
                         items = bookmarks,
-                        key = { it.id }
+                        key = { quranBookmarkKey(it) }
                     ) { bookmark ->
                         BookmarkCard(
                             bookmark = bookmark,
@@ -888,7 +888,7 @@ private fun BookmarksTabContent(
         } else {
             items(
                 items = bookmarks,
-                key = { "bm_${it.id}" }
+                key = { "bm_${quranBookmarkKey(it)}" }
             ) { bookmark ->
                 BookmarkListItem(
                     bookmark = bookmark,
@@ -972,3 +972,17 @@ private fun JuzScrollbarPreview() {
         )
     }
 }
+
+/**
+ * The stable identity of a bookmark in a lazy list.
+ *
+ * **Not** [QuranBookmark.id]. `BookmarkEntity` has no id column — its primary key is
+ * the composite `(kind, target_id)` — so `QuranRepositoryImpl.toQuranBookmark()` has
+ * nothing to map and passes a literal `0` for every bookmark. Keying by it gave every
+ * row the same key, and Compose threw `Key "0" was already used` as soon as a reader
+ * had two bookmarks, taking the whole Qur'an home screen down.
+ *
+ * [QuranBookmark.ayahId] is the global ayah id, which is precisely what
+ * `(kind = AYAH, target_id)` makes unique.
+ */
+internal fun quranBookmarkKey(bookmark: QuranBookmark): Int = bookmark.ayahId

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/screens/quran/QuranBookmarkKeyTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/screens/quran/QuranBookmarkKeyTest.kt
@@ -1,0 +1,86 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.arshadshah.nimaz.domain.model.QuranBookmark
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression cover for a crash that took the Qur'an home screen down for any
+ * reader with two or more bookmarks.
+ *
+ * `BookmarkEntity` has no id column — its primary key is the composite
+ * `(kind, target_id)` — so `QuranRepositoryImpl.toQuranBookmark()` has nothing
+ * to map into `QuranBookmark.id` and passes a literal `0`. Both bookmark lists
+ * on the home screen keyed by that field, so the second bookmark reused the
+ * first one's key and Compose threw:
+ *
+ *     IllegalArgumentException: Key "0" was already used.
+ *
+ * The identity is [QuranBookmark.ayahId]: the global ayah id, which is exactly
+ * what `(kind = AYAH, target_id)` makes unique.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QuranBookmarkKeyTest {
+
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun bookmark(ayahId: Int, surah: Int, ayah: Int) = QuranBookmark(
+        id = 0,
+        ayahId = ayahId,
+        surahNumber = surah,
+        ayahNumber = ayah,
+        note = null,
+        color = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    /** Two real bookmarks, exactly as the live mapper produces them: both `id = 0`. */
+    private val bookmarks = listOf(
+        bookmark(ayahId = 1, surah = 1, ayah = 1),
+        bookmark(ayahId = 3, surah = 1, ayah = 3),
+    )
+
+    @Test
+    fun `distinct bookmarks produce distinct keys even though their ids collide`() {
+        assertThat(bookmarks.map { it.id }.distinct()).hasSize(1)
+
+        val keys = bookmarks.map { quranBookmarkKey(it) }
+        assertThat(keys.distinct()).hasSize(bookmarks.size)
+    }
+
+    @Test
+    fun `a lazy list keyed this way composes two bookmarks without throwing`() {
+        composeRule.setContent {
+            LazyRow {
+                items(items = bookmarks, key = { quranBookmarkKey(it) }) { bookmark ->
+                    Text("${bookmark.surahNumber}:${bookmark.ayahNumber}")
+                }
+            }
+        }
+        composeRule.onNodeWithText("1:1").assertExists()
+        composeRule.onNodeWithText("1:3").assertExists()
+    }
+
+    @Test
+    fun `the prefixed key used by the bookmarks list is also unique`() {
+        val keys = bookmarks.map { "bm_${quranBookmarkKey(it)}" }
+        assertThat(keys.distinct()).hasSize(bookmarks.size)
+    }
+
+    @Test
+    fun `keying by id would still collide - the bug this pins`() {
+        val brokenKeys = bookmarks.map { it.id }
+        assertThat(brokenKeys.distinct()).hasSize(1)
+    }
+}


### PR DESCRIPTION
## The crash

The Qur'an home screen crashes for **any reader with two or more Qur'an bookmarks**, as soon as the bookmarks row composes:

```
java.lang.IllegalArgumentException: Key "0" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

Reproducible every time on a Pixel 10 Pro: bookmark two ayahs, return to the Qur'an tab, scroll to Bookmarks.

## Why

Both bookmark lists on the home screen keyed by `QuranBookmark.id`:

- `QuranHomeScreen.kt:458` — `key = { it.id }` (the home strip)
- `QuranHomeScreen.kt:891` — `key = { "bm_${it.id}" }` (the bookmarks list) — which produced `"bm_0"` twice

That field is **always `0`**. `BookmarkEntity` has no id column — its primary key is the composite `(kind, target_id)` — so `QuranRepositoryImpl.toQuranBookmark()` has nothing to map and passes a literal `0` for every bookmark:

```kotlin
private fun BookmarkEntity.toQuranBookmark() = QuranBookmark(
    id = 0,                    // <- every bookmark
    ayahId = targetId,
    ...
```

The second bookmark therefore reused the first one's key and Compose threw before the screen could draw.

## The fix

Key by `ayahId` — the global ayah id, which is exactly what `(kind = AYAH, target_id)` makes unique.

Extracted as a single `quranBookmarkKey()` so the two call sites cannot drift apart again, with a KDoc explaining why `id` must not be used.

## Verification

- New `QuranBookmarkKeyTest` (4 tests) — including one that composes a `LazyRow` over two bookmarks, which is the exact case that crashed, and one that pins the old behaviour so the bug can't quietly return.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:lintDebug` — green.
- `python3 scripts/check_docs.py` — 23/23.
- On device: two bookmarks, both the home strip and the bookmarks list render, zero fatal exceptions.

## Scope

Deliberately minimal. `QuranBookmark.id` is left in place — a legacy mapper (`QuranBookmarkEntity.toDomain()`) still populates it with a real autogenerated id — but nothing keys by it any more.

Found while doing a screen-by-screen review of the Qur'an section for a redesign; raised on its own branch so the fix isn't gated on that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
