### PR TITLE
Fix unauthenticated bypass of the AI Worker's Play Integrity guard

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/data/ai/IntegrityTokenProvider.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/data/ai/IntegrityTokenProvider.kt
@@ -23,8 +23,8 @@ import kotlin.coroutines.resumeWithException
  * Standard, not classic: classic requests ([com.google.android.play.core.integrity.IntegrityTokenRequest])
  * are throttled per app-instance by Play services after a handful of calls in a
  * short window (TOO_MANY_REQUESTS). Making one per question meant a few asks
- * worked, then every token fetch failed → empty token → the Worker's
- * "unverified" 5/day cap for perfectly legitimate installs. The standard API is
+ * worked, then every token fetch failed → empty token → the Worker rejecting
+ * perfectly legitimate installs. The standard API is
  * built for frequent, per-action checks: one heavier [prepareProvider] warm-up,
  * then cheap [StandardIntegrityTokenProvider.request] calls that Play services
  * serves from its own cache. The Worker decodes both token kinds through the
@@ -34,8 +34,12 @@ import kotlin.coroutines.resumeWithException
  * services unavailable, offline) the behaviour depends on the build type:
  *  - debug builds fall back to the literal `"debug-skip"` token, which the
  *    Worker honours ONLY when it runs with `SKIP_ATTESTATION=true`;
- *  - release builds return an empty token, which the Worker runs at the
- *    unverified tier (smaller daily cap, never an error).
+ *  - release builds return an empty token, which the Worker rejects with
+ *    `ATTESTATION_FAILED` → [com.arshadshah.nimaz.domain.model.AiError.Unverified].
+ *    A missing token is not "verification could not run" server-side: anyone
+ *    could omit it, so the Worker fails closed on it (see
+ *    `worker/src/middleware/integrity.ts`). Hence the retry above — an empty
+ *    token now costs the user the answer.
  */
 @Singleton
 class IntegrityTokenProvider @Inject constructor(

--- a/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/domain/model/AiModels.kt
@@ -96,9 +96,9 @@ sealed interface Proof {
 /**
  * Errors surfaced by the AI feature, mapped from the Worker's error envelope
  * (and local/transport failures). The presentation layer renders friendly
- * messages from these. Play Integrity is the Worker's only guard: an explicit
- * failed verdict surfaces as [Unverified]; rate limits come from the AI
- * Gateway and surface as [RateLimited].
+ * messages from these. Play Integrity is the Worker's only guard: a failed
+ * verdict — or no usable integrity token at all — surfaces as [Unverified];
+ * rate limits come from the AI Gateway and surface as [RateLimited].
  */
 sealed interface AiError {
     data class RateLimited(val retryAfterSeconds: Long?) : AiError

--- a/docs/ai-ask-with-proof.md
+++ b/docs/ai-ask-with-proof.md
@@ -88,7 +88,7 @@ sequenceDiagram
 
     U->>App: Ask a question
     App->>W: POST /v1/invoke (search-assist) {question}
-    W->>W: Play Integrity — only guard, fail-open, blocks failed verdicts
+    W->>W: Play Integrity — only guard, blocks unusable tokens, bounded fail-open
     W->>GW: anthropic/v1/messages (cf-aig-authorization, forced submit_result tool)
     GW->>C: Unified Billing — Cloudflare-managed Anthropic credentials
     C-->>GW: tool_use JSON
@@ -107,32 +107,50 @@ injects its managed Anthropic credentials and bills the account's AI credits.
 The Worker's only credential is `CLOUDFLARE_AI_TOKEN` — the gateway's
 authentication token (`cf-aig-authorization`) — never an Anthropic key.
 
-### Play Integrity is the only Worker guard — and it fails open
+### Play Integrity is the only Worker guard — and it fails open only for our own faults
 
 The Worker keeps no rate-limit counters (no KV): request throttling is the AI
 Gateway's **Rate Limiting rule** and the monthly cost cap is its **Spend
 Limit**. The one check the Worker performs is Play Integrity:
 
-| Outcome       | When                                                            | Effect                        |
-| ------------- | ---------------------------------------------------------------- | ----------------------------- |
-| `verified`    | Token decodes with `PLAY_RECOGNIZED` + device/basic integrity    | proceeds                      |
-| `unavailable` | Missing token, Integrity API unreachable/unconfigured            | proceeds (fail-open)          |
-| `failed`      | Google decoded the token and the verdict failed                  | `ATTESTATION_FAILED` (403)    |
+| Outcome       | When                                                                                                                                  | Effect                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `verified`    | Token decodes with `PLAY_RECOGNIZED` + device/basic integrity + `requestPackageName` = `com.arshadshah.nimaz`                          | proceeds                      |
+| `failed`      | Missing/short token, token Google won't decode (400), no `requestDetails`, or a verdict that fails app / device / package              | `ATTESTATION_FAILED` (403)    |
+| `unavailable` | Service account unconfigured, or a Google-side error (mint failure, 401/403/429/5xx, network throw)                                    | proceeds (bounded fail-open)  |
 
-Fail-open matters: hard-failing the unavailable paths bricked the feature for
-legitimate users whenever Play services hiccuped or Google's API was
-unreachable. Only an explicit failed verdict (unrecognized app, tampered
-device, package mismatch) is rejected; the gateway's rate/spend limits bound
-whatever slips through.
+The line between the last two is *who is at fault*. Anything the caller
+controls is `failed`: a caller can always withhold a token, so treating a
+missing one as "verification could not run" left `POST /v1/invoke` open to
+anyone who omitted it — the request shape is public — on the account's AI
+credits. Only faults on our side (no credentials, Google unreachable) fail
+open, because hard-failing those bricked the feature for legitimate users
+whenever Play services hiccuped.
+
+That fail-open path is **bounded**: consecutive Google-side failures are
+counted per isolate (10, inside a rolling 5-minute window) and past the bound
+the Worker fails closed until Google answers a decode again, so a sustained
+outage can't be ridden as a standing bypass. Whatever still slips through is
+bounded in cost by the gateway's rate/spend limits.
+
+Two known gaps, deliberate: a Worker deployed **without**
+`GOOGLE_SERVICE_ACCOUNT_JSON` passes everything unbounded (there is nothing to
+verify against — set the secret in production), and tokens are **not**
+replay-bound to a per-request nonce, so a captured token can be reused until it
+expires.
 
 The app fetches tokens with the **standard** Play Integrity API (warm up a
 `StandardIntegrityTokenProvider` once, then a cheap `request()` per question),
 not the classic one. Classic requests are throttled per app-instance by Play
 services after a few calls in a short window, so fetching one per question
 meant legitimate installs "worked for a while" and then every token fetch
-failed → empty token → verification skipped for every request. The standard API is
-designed for frequent per-action checks; if the warmed-up provider goes stale,
-`IntegrityTokenProvider` re-prepares it once before falling back. The Worker is
+failed → empty token. That now means `ATTESTATION_FAILED`/403 (the app shows
+the `AiError.Unverified` state), which is exactly why the standard API is not
+optional: it is designed for frequent per-action checks. If the warmed-up
+provider goes stale, `IntegrityTokenProvider` re-prepares it once before
+falling back to an empty token (debug builds fall back to the literal
+`"debug-skip"`, honoured only when the Worker runs `SKIP_ATTESTATION=true`).
+The Worker is
 unaffected: `decodeIntegrityToken` decodes classic and standard tokens alike,
 and the verdict fields it checks are identical.
 
@@ -166,7 +184,7 @@ JSON object so one envelope serves every capability.
 ### `search-assist` (the single call)
 
 ```json
-{ "capability": "search-assist", "integrityToken": "<token or empty>", "deviceId": "…",
+{ "capability": "search-assist", "integrityToken": "<token; empty/short → 403>", "deviceId": "…",
   "input": { "question": "3..500 chars" } }
 ```
 
@@ -199,7 +217,7 @@ Error envelope (HTTP 400/403/429/502/503):
 ```
 
 (`RATE_LIMITED` is a pass-through of the gateway's Rate Limiting rule;
-`ATTESTATION_FAILED` is an explicit failed Play Integrity verdict — see the
+`ATTESTATION_FAILED` is an unusable token or a failed Play Integrity verdict — see the
 table above.)
 
 ### Citation ID grammar (`domain/model/CitationId.kt`)
@@ -374,8 +392,9 @@ visible for the rest of the session after the toggle went off.
   `retry-after` header when present). The monthly USD ceiling is the
   gateway's **Spend Limit** — when it trips (or credits run out) the Worker
   maps the gateway error to `BUDGET_EXCEEDED` (503). The Worker's own guard is
-  Play Integrity only (fail-open; explicit failed verdicts get
-  `ATTESTATION_FAILED`/403).
+  Play Integrity only (unusable tokens and failed verdicts get
+  `ATTESTATION_FAILED`/403; only our-side faults fail open, and only within a
+  bounded window).
 - Observability: every call attaches a `cf-aig-metadata: {"capability": …}`
   header (spend per feature in the dashboard; never the question text), logs
   an `ai_usage` line (token counts only), and echoes usage in the
@@ -411,7 +430,9 @@ committed to the repo.
    Claude credential.
    `npx wrangler secret put GOOGLE_SERVICE_ACCOUNT_JSON`
    (If the Google one is absent the Worker still works — verification is
-   "unavailable" and every request passes, fail-open.) There is **no
+   "unavailable" and every request passes, unbounded. Treat that as a
+   pre-setup state, not a deployment posture: it is an open endpoint on the
+   account's AI credits.) There is **no
    `ANTHROPIC_API_KEY`**: Unified Billing injects the Anthropic credentials.
 3. **Unified Billing (dashboard, cannot be scripted):** AI → AI Gateway →
    confirm the `nimaz` gateway exists → *Credits Available* → **Manage** →
@@ -458,8 +479,11 @@ committed to the repo.
    `playIntegrityCloudProjectNumber` (or pass `-PplayIntegrityCloudProjectNumber=…`).
 
 Note: even with none of this configured, AI answers work — verification is
-"unavailable" and requests pass unverified (fail-open); the gateway's rate and
-spend limits are the backstop.
+"unavailable" and requests pass unverified; the gateway's rate and spend limits
+are then the only backstop, so this is a bring-up state, not a shipping one.
+Once `GOOGLE_SERVICE_ACCOUNT_JSON` is set, a client without a usable token gets
+`ATTESTATION_FAILED`/403 — including release installs whose Play Integrity
+fetch fails, which is the intended trade.
 
 ### 3. GitHub secrets (for `worker_deploy.yml`)
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -9,7 +9,8 @@ plus related search terms, which the app resolves against its **local**
 database (real records become the proof cards and the results list).
 
 The Worker never stores questions or answers. Its only guard is **Play
-Integrity** (fail-open — see below); it then calls Claude with a fixed cached
+Integrity** (a caller with no usable token is rejected; a Google-side outage
+fails open within a bounded window — see below); it then calls Claude with a fixed cached
 prompt and a forced structured-output tool and returns strict JSON. Request
 throttling and the monthly cost cap are **not Worker code** — they are the
 `nimaz` AI Gateway's Rate Limiting rule and Spend Limit (dashboard).
@@ -28,7 +29,8 @@ code.
 ```
 POST /v1/invoke
   → integrity   (Play Integrity token → verified | unavailable | failed;
-                 only "failed" rejects — ATTESTATION_FAILED/403)
+                 "failed" rejects — ATTESTATION_FAILED/403. Missing, short or
+                 undecodable tokens are "failed", not "unavailable")
   → dispatch    (registry lookup → Zod-validate input → build request
                  → POST gateway.ai.cloudflare.com/v1/{acct}/nimaz/anthropic
                    /v1/messages  (Anthropic-native schema, Unified Billing)
@@ -51,23 +53,45 @@ is the path that works.)
 
 `GET /v1/health` returns `{ ok: true, capabilities: [...] }` (no auth).
 
-### Integrity is the only guard — and it fails open
+### Integrity is the only guard — and it fails open only for our own faults
 
 `checkIntegrity` returns one of three outcomes:
 
-- `verified` — token decodes with `PLAY_RECOGNIZED` and the device meets
-  device or basic integrity (or `SKIP_ATTESTATION=true`). Proceeds.
-- `unavailable` — verification could not run: missing/short token, no service
-  account configured, or a Google API failure. **Proceeds** (fail-open):
-  hard-failing these paths bricked the feature for legitimate users whenever
-  Play services hiccuped or Google's API was unreachable.
-- `failed` — Google decoded the token and the verdict failed (app not
-  Play-recognized, device integrity not met, package mismatch). Rejected with
+- `verified` — token decodes with `PLAY_RECOGNIZED`, the device meets device
+  or basic integrity, and `requestDetails.requestPackageName` is
+  `com.arshadshah.nimaz` (or `SKIP_ATTESTATION=true`). Proceeds.
+- `failed` — **anything the caller controls**: no token, a token shorter than
+  10 chars, a token Google refuses to decode (`400 INVALID_ARGUMENT`), a
+  decoded payload with no `requestDetails`, or a verdict that misses app
+  recognition / device integrity / the package name. Rejected with
   `ATTESTATION_FAILED` (403).
+- `unavailable` — verification could not run for a reason **outside** the
+  caller's control: no service account configured, or a Google-side error
+  (token mint failure, 401/403/429/5xx from `decodeIntegrityToken`, network
+  throw). **Proceeds** (fail-open): hard-failing every outage bricked the
+  feature for legitimate users whenever Play services hiccuped.
 
-Abuse cost is bounded by the AI Gateway: its **Rate Limiting rule** throttles
-request volume (surfaced to the app as `RATE_LIMITED`) and its **Spend Limit**
-is the hard monthly cost backstop. The Worker keeps no counters and has no KV.
+The split matters. Treating a missing token as "verification could not run"
+made the endpoint open to anyone who simply omitted it — the request shape is
+public — and billed the account's AI credits. A caller can always withhold a
+token, so that path can never be a reason to fail open.
+
+**The fail-open path is bounded.** Consecutive Google-side failures are counted
+per isolate (`MAX_CONSECUTIVE_FAIL_OPEN`, currently 10, inside a rolling
+5-minute window); past the bound the Worker fails closed until Google answers a
+decode again, so a sustained "verification is broken" condition can't be ridden
+as a standing bypass. Failures older than the window start a fresh run, so
+occasional blips never accumulate into a closed gate. The counter is
+per-isolate best-effort — the Worker has no KV — and is defence in depth, not a
+precise budget.
+
+Abuse cost is further bounded by the AI Gateway: its **Rate Limiting rule**
+throttles request volume (surfaced to the app as `RATE_LIMITED`) and its
+**Spend Limit** is the hard monthly cost backstop. The Worker keeps no
+per-device counters and has no KV.
+
+Replay protection (binding a token to a per-request nonce/`requestHash`) is
+**not** implemented — a captured token can be reused until it expires.
 
 ## API contract
 
@@ -76,7 +100,7 @@ is the hard monthly cost backstop. The Worker keeps no counters and has no KV.
 ```json
 {
   "capability": "search-assist",
-  "integrityToken": "<play-integrity-token, may be empty>",
+  "integrityToken": "<play-integrity-token; empty/short is rejected 403>",
   "deviceId": "<random UUID generated once per install>",
   "input": {
     "question": "What does the Quran say about patience?"
@@ -115,7 +139,7 @@ Errors use a typed envelope with the matching HTTP status:
 | code                 | status | when                                                     |
 | -------------------- | ------ | -------------------------------------------------------- |
 | `INVALID_INPUT`      | 400    | bad envelope / schema / unknown capability               |
-| `ATTESTATION_FAILED` | 403    | Play Integrity verdict explicitly failed                 |
+| `ATTESTATION_FAILED` | 403    | no usable Play Integrity token, or the verdict failed    |
 | `RATE_LIMITED`       | 429    | the gateway's Rate Limiting rule tripped (pass-through)  |
 | `UPSTREAM_ERROR`     | 502    | Claude call failed / returned bad shape                  |
 | `BUDGET_EXCEEDED`    | 503    | gateway spend limit tripped / AI credits exhausted       |
@@ -140,8 +164,11 @@ Secrets — set with `wrangler secret put`, never committed:
   There is **no Anthropic key** anywhere. In CI it lives as the GitHub secret
   of the same name and is pushed to the Worker on every deploy.
 - `GOOGLE_SERVICE_ACCOUNT_JSON` — the full service-account JSON (one string)
-  used to mint an OAuth token for the Play Integrity API. Optional — without
-  it verification is "unavailable" and every request passes (fail-open).
+  used to mint an OAuth token for the Play Integrity API. Technically optional
+  — without it verification is "unavailable" and **every request passes,
+  unbounded**, since there is nothing to verify against. That is a pre-setup /
+  dev state only: a deployed Worker without this secret is an open endpoint on
+  the account's AI credits. Set it in production.
 
 ## Setup
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -54,11 +54,13 @@ app.post("/v1/invoke", async (c) => {
   }
 
   try {
-    // 1. Play Integrity — the Worker's only guard. Blocks only an explicit
-    //    failed verdict; "unavailable" (missing token, unconfigured, Google
-    //    outage) fails open. Request throttling and the monthly USD cost cap
-    //    both live in the AI Gateway (Rate Limiting rule + Spend Limit);
-    //    callClaude maps them to RATE_LIMITED / BUDGET_EXCEEDED.
+    // 1. Play Integrity — the Worker's only guard. A missing, short or
+    //    undecodable token is "failed" and is rejected here; "unavailable"
+    //    (no service account configured, or a Google-side error inside the
+    //    bounded fail-open window) proceeds. Request throttling and the
+    //    monthly USD cost cap both live in the AI Gateway (Rate Limiting rule
+    //    + Spend Limit); callClaude maps them to RATE_LIMITED /
+    //    BUDGET_EXCEEDED.
     const integrity = await checkIntegrity(c.env, integrityToken, now.getTime());
     if (integrity === "failed") {
       throw new ApiError(

--- a/worker/src/middleware/integrity.ts
+++ b/worker/src/middleware/integrity.ts
@@ -13,16 +13,82 @@ const PLAY_INTEGRITY_SCOPE = "https://www.googleapis.com/auth/playintegrity";
  *
  *  - "verified":    Play Integrity confirmed the official app on a sane
  *                   device (or SKIP_ATTESTATION is on) → proceed.
- *  - "unavailable": verification could not run — missing token, service
- *                   account not configured, Google outage → fail OPEN and
- *                   proceed. Hard-failing these paths bricked the feature for
- *                   legitimate users whenever Play services hiccuped; the
- *                   gateway's rate limit + spend limit bound the abuse cost.
- *  - "failed":      Google decoded the token and the verdict failed (app not
- *                   Play-recognized, device integrity not met, package
- *                   mismatch) → the request is rejected (ATTESTATION_FAILED).
+ *  - "unavailable": verification could not run for a reason the *caller does
+ *                   not control* — the service account is not configured, or
+ *                   Google's API is unreachable/erroring → fail OPEN and
+ *                   proceed, but only within a bounded run of consecutive
+ *                   Google failures (see MAX_CONSECUTIVE_FAIL_OPEN).
+ *                   Hard-failing every outage bricked the feature for
+ *                   legitimate users whenever Play services hiccuped.
+ *  - "failed":      the caller did not present a usable token, or Google
+ *                   decoded it and the verdict failed (app not
+ *                   Play-recognized, device integrity not met, missing or
+ *                   mismatched package) → rejected with ATTESTATION_FAILED.
+ *
+ * A missing, short or undecodable token is "failed", NOT "unavailable": it is
+ * entirely caller-controlled, so treating it as an outage let anyone spend the
+ * account's AI credits by simply omitting the token.
  */
 export type IntegrityResult = "verified" | "unavailable" | "failed";
+
+/**
+ * Shortest plausible Play Integrity token. Real tokens (classic and standard
+ * alike) are long JWS strings — anything under this is not a truncated token,
+ * it is no token at all.
+ */
+const MIN_TOKEN_LENGTH = 10;
+
+/**
+ * Bounded fail-open. Google-side failures (token mint failure, 5xx from
+ * `decodeIntegrityToken`, network throw) still pass requests through — but
+ * only for this many consecutive failures inside OUTAGE_WINDOW_MS. Past the
+ * bound the Worker fails closed, so a sustained "verification is broken"
+ * condition cannot be ridden as a standing bypass.
+ *
+ * The counter lives in the isolate (the Worker has no KV), so the bound is
+ * per-isolate and best-effort — defence in depth on top of the AI Gateway's
+ * rate limit and spend limit, not a precise budget. Any decode that Google
+ * actually answers resets it, so recovery is automatic.
+ */
+export const MAX_CONSECUTIVE_FAIL_OPEN = 10;
+const OUTAGE_WINDOW_MS = 5 * 60_000;
+
+let consecutiveOutages = 0;
+let lastOutageAtMs = 0;
+
+/** Test seam: clear the per-isolate fail-open counter between cases. */
+export function resetIntegrityOutageState(): void {
+  consecutiveOutages = 0;
+  lastOutageAtMs = 0;
+}
+
+/**
+ * Record a Google-side failure and decide whether we may still fail open.
+ * Failures older than OUTAGE_WINDOW_MS start a fresh run, so occasional blips
+ * spread over hours never accumulate into a closed gate.
+ */
+function outage(nowMs: number, reason: string): IntegrityResult {
+  if (nowMs - lastOutageAtMs > OUTAGE_WINDOW_MS) consecutiveOutages = 0;
+  lastOutageAtMs = nowMs;
+  consecutiveOutages += 1;
+
+  if (consecutiveOutages > MAX_CONSECUTIVE_FAIL_OPEN) {
+    console.warn(
+      JSON.stringify({
+        event: "integrity_fail_closed",
+        reason,
+        consecutiveOutages,
+      }),
+    );
+    return "failed";
+  }
+  return "unavailable";
+}
+
+/** Google answered a decode — verification works again, end the outage run. */
+function outageCleared(): void {
+  consecutiveOutages = 0;
+}
 
 interface ServiceAccount {
   client_email: string;
@@ -138,10 +204,15 @@ interface IntegrityVerdict {
 }
 
 /**
- * Verify a request's Play Integrity token. NEVER throws. Only an explicit
- * failed verdict returns "failed" (and blocks the request); every path where
- * verification cannot run — missing token, unconfigured service account,
- * Google API outage — returns "unavailable" and the request proceeds.
+ * Verify a request's Play Integrity token. NEVER throws.
+ *
+ * Returns "failed" (→ ATTESTATION_FAILED/403) whenever the *caller* is at
+ * fault: no token, a token too short to be real, a token Google refuses to
+ * decode, or a decoded verdict that does not clear app + device + package.
+ * Returns "unavailable" (→ fail open) only when verification could not run for
+ * a reason outside the caller's control — no service account configured, or a
+ * Google-side error — and then only inside the bounded window enforced by
+ * `outage()`.
  */
 export async function checkIntegrity(
   env: Env,
@@ -152,11 +223,18 @@ export async function checkIntegrity(
     return "verified"; // Explicit bypass for local dev/testing.
   }
 
-  // Not configured yet, or the app couldn't obtain a token (Play services
-  // unavailable, offline fetch) → verification can't run; fail open.
+  // Deployment state, not a caller-controlled one: without credentials there
+  // is nothing to verify against. Unbounded fail-open — a Worker deployed
+  // without the secret is documented as running unverified (setup runbook).
   if (!env.GOOGLE_SERVICE_ACCOUNT_JSON) return "unavailable";
-  if (!integrityToken || integrityToken.length < 10) return "unavailable";
 
+  // Caller-controlled, so never a reason to fail open. Anyone can omit a
+  // token; letting that through billed our AI credits to the whole internet.
+  if (!integrityToken || integrityToken.length < MIN_TOKEN_LENGTH) {
+    return "failed";
+  }
+
+  let res: Response;
   try {
     const accessToken = await getGoogleAccessToken(
       env.GOOGLE_SERVICE_ACCOUNT_JSON,
@@ -164,7 +242,7 @@ export async function checkIntegrity(
     );
 
     const url = `https://playintegrity.googleapis.com/v1/${PACKAGE_NAME}:decodeIntegrityToken`;
-    const res = await fetch(url, {
+    res = await fetch(url, {
       method: "POST",
       headers: {
         authorization: `Bearer ${accessToken}`,
@@ -172,29 +250,54 @@ export async function checkIntegrity(
       },
       body: JSON.stringify({ integrity_token: integrityToken }),
     });
-    if (!res.ok) return "unavailable";
+  } catch {
+    // Token mint failed, network threw, or the service-account JSON is
+    // unparseable — Google-side/config fault, bounded fail-open.
+    return outage(nowMs, "request_failed");
+  }
 
+  if (!res.ok) {
+    // 400 INVALID_ARGUMENT means Google looked at the token and could not
+    // decrypt it — that is the caller's garbage, not an outage, and treating
+    // it as one would leave "send 10 junk characters" as a bypass. Every
+    // other non-2xx (401/403 bad credentials, 429, 5xx) is our side's problem.
+    if (res.status === 400) {
+      outageCleared(); // Google answered — the API is up, this token is junk.
+      return "failed";
+    }
+    return outage(nowMs, `http_${res.status}`);
+  }
+
+  let payload: IntegrityVerdict | undefined;
+  try {
     const decoded = (await res.json()) as {
       tokenPayloadExternal?: IntegrityVerdict;
     };
-    const payload = decoded.tokenPayloadExternal;
-
-    const appVerdict = payload?.appIntegrity?.appRecognitionVerdict;
-    const deviceVerdicts =
-      payload?.deviceIntegrity?.deviceRecognitionVerdict ?? [];
-    const pkg = payload?.requestDetails?.requestPackageName;
-
-    const appOk = appVerdict === "PLAY_RECOGNIZED";
-    // Accept the basic tier too — MEETS_DEVICE_INTEGRITY alone rejects many
-    // real, unrooted devices (custom ROMs, older Widevine states).
-    const deviceOk =
-      deviceVerdicts.includes("MEETS_DEVICE_INTEGRITY") ||
-      deviceVerdicts.includes("MEETS_BASIC_INTEGRITY");
-    const pkgOk = pkg === undefined || pkg === PACKAGE_NAME;
-
-    return appOk && deviceOk && pkgOk ? "verified" : "failed";
+    payload = decoded.tokenPayloadExternal;
   } catch {
-    // Google outage / transient failure — never punish the user for it.
-    return "unavailable";
+    return outage(nowMs, "malformed_response");
   }
+
+  // Google answered a decode, so verification is working again regardless of
+  // what this particular verdict says.
+  outageCleared();
+
+  // No requestDetails at all → not a verdict we can bind to this app. Real
+  // payloads always carry it; accepting its absence made the package check
+  // vacuous for anything that could shape a 200 response.
+  if (!payload?.requestDetails) return "failed";
+
+  const appVerdict = payload.appIntegrity?.appRecognitionVerdict;
+  const deviceVerdicts =
+    payload.deviceIntegrity?.deviceRecognitionVerdict ?? [];
+
+  const appOk = appVerdict === "PLAY_RECOGNIZED";
+  // Accept the basic tier too — MEETS_DEVICE_INTEGRITY alone rejects many
+  // real, unrooted devices (custom ROMs, older Widevine states).
+  const deviceOk =
+    deviceVerdicts.includes("MEETS_DEVICE_INTEGRITY") ||
+    deviceVerdicts.includes("MEETS_BASIC_INTEGRITY");
+  const pkgOk = payload.requestDetails.requestPackageName === PACKAGE_NAME;
+
+  return appOk && deviceOk && pkgOk ? "verified" : "failed";
 }

--- a/worker/test/integrity.test.ts
+++ b/worker/test/integrity.test.ts
@@ -1,23 +1,72 @@
 import { env, fetchMock } from "cloudflare:test";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import app from "../src/index";
-import { checkIntegrity } from "../src/middleware/integrity";
+import {
+  checkIntegrity,
+  MAX_CONSECUTIVE_FAIL_OPEN,
+  resetIntegrityOutageState,
+} from "../src/middleware/integrity";
 import {
   generateServiceAccountJson,
   makeAssistInput,
   makeEnvelope,
 } from "./helpers";
 
-// checkIntegrity never throws. It is the Worker's only guard: an explicit
-// failed verdict returns "failed" (the dispatcher rejects with
-// ATTESTATION_FAILED/403); every path where verification cannot run returns
-// "unavailable" and the request proceeds (fail-open). Throttling/cost caps
-// live in the AI Gateway, not here.
+const DECODE_HOST = "https://playintegrity.googleapis.com";
+const DECODE_PATH = "/v1/com.arshadshah.nimaz:decodeIntegrityToken";
+const REAL_TOKEN = "a-real-looking-integrity-token";
+
+/** Mint interceptor — one per service account (the access token is cached). */
+function mockTokenMint(status = 200, body: object = {
+  access_token: "ya29.test",
+  expires_in: 3600,
+}) {
+  fetchMock
+    .get("https://oauth2.googleapis.com")
+    .intercept({ path: "/token", method: "POST" })
+    .reply(status, body);
+}
+
+function mockDecode(status: number, body: object, times = 1) {
+  fetchMock
+    .get(DECODE_HOST)
+    .intercept({ path: DECODE_PATH, method: "POST" })
+    .reply(status, body)
+    .times(times);
+}
+
+/** A decoded payload that passes every check, with the given overrides. */
+function verdict(overrides: Record<string, unknown> = {}) {
+  return {
+    tokenPayloadExternal: {
+      appIntegrity: { appRecognitionVerdict: "PLAY_RECOGNIZED" },
+      deviceIntegrity: { deviceRecognitionVerdict: ["MEETS_DEVICE_INTEGRITY"] },
+      requestDetails: { requestPackageName: "com.arshadshah.nimaz" },
+      ...overrides,
+    },
+  };
+}
+
+async function liveEnv() {
+  return {
+    ...env,
+    SKIP_ATTESTATION: "false",
+    GOOGLE_SERVICE_ACCOUNT_JSON: await generateServiceAccountJson(),
+  };
+}
+
+// checkIntegrity never throws. It is the Worker's only guard. Anything the
+// caller controls — no token, a short token, a token Google won't decode, a
+// verdict that doesn't clear app/device/package — is "failed" and the
+// dispatcher rejects it (ATTESTATION_FAILED/403). Only reasons outside the
+// caller's control (no service account, Google-side error) fail open, and only
+// within the bounded window. Throttling/cost caps live in the AI Gateway.
 describe("integrity verification", () => {
   beforeAll(() => {
     fetchMock.activate();
     fetchMock.disableNetConnect();
   });
+  beforeEach(() => resetIntegrityOutageState());
   afterEach(() => fetchMock.assertNoPendingInterceptors());
 
   it("returns verified when SKIP_ATTESTATION is true (no network)", async () => {
@@ -31,151 +80,188 @@ describe("integrity verification", () => {
     await expect(
       checkIntegrity(
         { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: undefined },
-        "a-real-looking-integrity-token",
+        REAL_TOKEN,
         Date.now(),
       ),
     ).resolves.toBe("unavailable");
   });
 
-  it("returns unavailable when the token is missing or too short", async () => {
-    const envNoSkip = {
-      ...env,
-      SKIP_ATTESTATION: "false",
-      GOOGLE_SERVICE_ACCOUNT_JSON: await generateServiceAccountJson(),
-    };
-    await expect(checkIntegrity(envNoSkip, "", Date.now())).resolves.toBe(
-      "unavailable",
+  it("fails an empty token without calling Google", async () => {
+    // No interceptors: reaching the network here would throw, so this also
+    // proves the empty token short-circuits before any Google call.
+    await expect(checkIntegrity(await liveEnv(), "", Date.now())).resolves.toBe(
+      "failed",
     );
-    await expect(checkIntegrity(envNoSkip, "short", Date.now())).resolves.toBe(
-      "unavailable",
+  });
+
+  it("fails a token too short to be real, without calling Google", async () => {
+    const live = await liveEnv();
+    await expect(checkIntegrity(live, "short", Date.now())).resolves.toBe(
+      "failed",
+    );
+    await expect(checkIntegrity(live, "123456789", Date.now())).resolves.toBe(
+      "failed",
     );
   });
 
   it("verifies a token with PLAY_RECOGNIZED + MEETS_DEVICE_INTEGRITY", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(200, { access_token: "ya29.test", expires_in: 3600 });
-    fetchMock
-      .get("https://playintegrity.googleapis.com")
-      .intercept({
-        path: "/v1/com.arshadshah.nimaz:decodeIntegrityToken",
-        method: "POST",
-      })
-      .reply(200, {
-        tokenPayloadExternal: {
-          appIntegrity: { appRecognitionVerdict: "PLAY_RECOGNIZED" },
-          deviceIntegrity: {
-            deviceRecognitionVerdict: ["MEETS_DEVICE_INTEGRITY"],
-          },
-          requestDetails: { requestPackageName: "com.arshadshah.nimaz" },
-        },
-      });
+    mockTokenMint();
+    mockDecode(200, verdict());
 
     await expect(
-      checkIntegrity(
-        { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
-        "a-real-looking-integrity-token",
-        Date.now(),
-      ),
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
     ).resolves.toBe("verified");
   });
 
   it("accepts MEETS_BASIC_INTEGRITY as sufficient device integrity", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(200, { access_token: "ya29.test", expires_in: 3600 });
-    fetchMock
-      .get("https://playintegrity.googleapis.com")
-      .intercept({
-        path: "/v1/com.arshadshah.nimaz:decodeIntegrityToken",
-        method: "POST",
-      })
-      .reply(200, {
-        tokenPayloadExternal: {
-          appIntegrity: { appRecognitionVerdict: "PLAY_RECOGNIZED" },
-          deviceIntegrity: {
-            deviceRecognitionVerdict: ["MEETS_BASIC_INTEGRITY"],
-          },
-        },
-      });
+    mockTokenMint();
+    mockDecode(
+      200,
+      verdict({
+        deviceIntegrity: { deviceRecognitionVerdict: ["MEETS_BASIC_INTEGRITY"] },
+      }),
+    );
 
     await expect(
-      checkIntegrity(
-        { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
-        "a-real-looking-integrity-token",
-        Date.now(),
-      ),
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
     ).resolves.toBe("verified");
   });
 
   it("fails an unrecognized app verdict (never throws)", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(200, { access_token: "ya29.test", expires_in: 3600 });
-    fetchMock
-      .get("https://playintegrity.googleapis.com")
-      .intercept({
-        path: "/v1/com.arshadshah.nimaz:decodeIntegrityToken",
-        method: "POST",
-      })
-      .reply(200, {
-        tokenPayloadExternal: {
-          appIntegrity: { appRecognitionVerdict: "UNRECOGNIZED_VERSION" },
-          deviceIntegrity: { deviceRecognitionVerdict: [] },
+    mockTokenMint();
+    mockDecode(
+      200,
+      verdict({
+        appIntegrity: { appRecognitionVerdict: "UNRECOGNIZED_VERSION" },
+        deviceIntegrity: { deviceRecognitionVerdict: [] },
+      }),
+    );
+
+    await expect(
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
+    ).resolves.toBe("failed");
+  });
+
+  it("fails a verdict with no requestDetails at all", async () => {
+    mockTokenMint();
+    mockDecode(200, {
+      tokenPayloadExternal: {
+        appIntegrity: { appRecognitionVerdict: "PLAY_RECOGNIZED" },
+        deviceIntegrity: {
+          deviceRecognitionVerdict: ["MEETS_DEVICE_INTEGRITY"],
         },
-      });
+      },
+    });
+
+    await expect(
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
+    ).resolves.toBe("failed");
+  });
+
+  it("fails a verdict whose requestDetails names another package", async () => {
+    mockTokenMint();
+    mockDecode(
+      200,
+      verdict({ requestDetails: { requestPackageName: "com.someone.else" } }),
+    );
+
+    await expect(
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
+    ).resolves.toBe("failed");
+  });
+
+  it("fails a 200 response with no decoded payload", async () => {
+    mockTokenMint();
+    mockDecode(200, {});
+
+    await expect(
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
+    ).resolves.toBe("failed");
+  });
+
+  it("fails a token Google refuses to decode (400)", async () => {
+    mockTokenMint();
+    mockDecode(400, { error: { status: "INVALID_ARGUMENT" } });
 
     await expect(
       checkIntegrity(
-        { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
-        "a-real-looking-integrity-token",
+        await liveEnv(),
+        "not-a-real-token-just-long-enough",
         Date.now(),
       ),
     ).resolves.toBe("failed");
   });
 
   it("returns unavailable when the Play Integrity API is down", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(200, { access_token: "ya29.test", expires_in: 3600 });
-    fetchMock
-      .get("https://playintegrity.googleapis.com")
-      .intercept({
-        path: "/v1/com.arshadshah.nimaz:decodeIntegrityToken",
-        method: "POST",
-      })
-      .reply(503, { error: "unavailable" });
+    mockTokenMint();
+    mockDecode(503, { error: "unavailable" });
 
     await expect(
-      checkIntegrity(
-        { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
-        "a-real-looking-integrity-token",
-        Date.now(),
-      ),
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
     ).resolves.toBe("unavailable");
   });
 
   it("returns unavailable when Google token minting fails", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(500, { error: "boom" });
+    mockTokenMint(500, { error: "boom" });
 
     await expect(
-      checkIntegrity(
-        { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
-        "a-real-looking-integrity-token",
-        Date.now(),
-      ),
+      checkIntegrity(await liveEnv(), REAL_TOKEN, Date.now()),
+    ).resolves.toBe("unavailable");
+  });
+
+  it("stops failing open past the bounded outage window", async () => {
+    const live = await liveEnv();
+    const attempts = MAX_CONSECUTIVE_FAIL_OPEN + 1;
+    mockTokenMint();
+    mockDecode(503, { error: "unavailable" }, attempts);
+
+    const results: string[] = [];
+    for (let i = 0; i < attempts; i++) {
+      results.push(await checkIntegrity(live, REAL_TOKEN, Date.now()));
+    }
+
+    expect(results.slice(0, MAX_CONSECUTIVE_FAIL_OPEN)).toEqual(
+      Array(MAX_CONSECUTIVE_FAIL_OPEN).fill("unavailable"),
+    );
+    // Past the bound an induced outage is no longer a way through.
+    expect(results[MAX_CONSECUTIVE_FAIL_OPEN]).toBe("failed");
+  });
+
+  it("resets the fail-open budget once Google answers a decode again", async () => {
+    const live = await liveEnv();
+    const now = Date.now();
+    mockTokenMint();
+    mockDecode(503, { error: "unavailable" }, MAX_CONSECUTIVE_FAIL_OPEN);
+    for (let i = 0; i < MAX_CONSECUTIVE_FAIL_OPEN; i++) {
+      await checkIntegrity(live, REAL_TOKEN, now);
+    }
+
+    // Google recovers…
+    mockDecode(200, verdict());
+    await expect(checkIntegrity(live, REAL_TOKEN, now)).resolves.toBe(
+      "verified",
+    );
+
+    // …so the next blip is fail-open again rather than instantly closed.
+    mockDecode(503, { error: "unavailable" });
+    await expect(checkIntegrity(live, REAL_TOKEN, now)).resolves.toBe(
+      "unavailable",
+    );
+  });
+
+  it("starts a fresh fail-open run after the outage window lapses", async () => {
+    const live = await liveEnv();
+    const start = Date.now();
+    mockTokenMint();
+    mockDecode(503, { error: "unavailable" }, MAX_CONSECUTIVE_FAIL_OPEN + 1);
+    for (let i = 0; i < MAX_CONSECUTIVE_FAIL_OPEN; i++) {
+      await checkIntegrity(live, REAL_TOKEN, start);
+    }
+
+    // Ten minutes later the earlier run is stale (the window is five) — a lone
+    // blip must not be punished for failures that happened long ago.
+    await expect(
+      checkIntegrity(live, REAL_TOKEN, start + 10 * 60_000),
     ).resolves.toBe("unavailable");
   });
 });
@@ -185,26 +271,18 @@ describe("integrity gating (integration)", () => {
     fetchMock.activate();
     fetchMock.disableNetConnect();
   });
+  beforeEach(() => resetIntegrityOutageState());
   afterEach(() => fetchMock.assertNoPendingInterceptors());
 
   it("rejects a failed verdict with ATTESTATION_FAILED/403", async () => {
-    const sa = await generateServiceAccountJson();
-    fetchMock
-      .get("https://oauth2.googleapis.com")
-      .intercept({ path: "/token", method: "POST" })
-      .reply(200, { access_token: "ya29.test", expires_in: 3600 });
-    fetchMock
-      .get("https://playintegrity.googleapis.com")
-      .intercept({
-        path: "/v1/com.arshadshah.nimaz:decodeIntegrityToken",
-        method: "POST",
-      })
-      .reply(200, {
-        tokenPayloadExternal: {
-          appIntegrity: { appRecognitionVerdict: "UNRECOGNIZED_VERSION" },
-          deviceIntegrity: { deviceRecognitionVerdict: [] },
-        },
-      });
+    mockTokenMint();
+    mockDecode(
+      200,
+      verdict({
+        appIntegrity: { appRecognitionVerdict: "UNRECOGNIZED_VERSION" },
+        deviceIntegrity: { deviceRecognitionVerdict: [] },
+      }),
+    );
 
     const res = await app.request(
       "/v1/invoke",
@@ -213,7 +291,41 @@ describe("integrity gating (integration)", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(makeEnvelope(makeAssistInput())),
       },
-      { ...env, SKIP_ATTESTATION: "false", GOOGLE_SERVICE_ACCOUNT_JSON: sa },
+      await liveEnv(),
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error.code).toBe("ATTESTATION_FAILED");
+  });
+
+  it("rejects an empty integrityToken with ATTESTATION_FAILED/403", async () => {
+    // The reported bypass: no token, no Google call, a real Claude answer.
+    // No interceptors are registered, so a Claude call would throw too.
+    const res = await app.request(
+      "/v1/invoke",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          makeEnvelope(makeAssistInput(), { integrityToken: "" }),
+        ),
+      },
+      await liveEnv(),
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error.code).toBe("ATTESTATION_FAILED");
+  });
+
+  it("rejects a short integrityToken with ATTESTATION_FAILED/403", async () => {
+    const res = await app.request(
+      "/v1/invoke",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          makeEnvelope(makeAssistInput(), { integrityToken: "abc" }),
+        ),
+      },
+      await liveEnv(),
     );
     expect(res.status).toBe(403);
     expect(((await res.json()) as any).error.code).toBe("ATTESTATION_FAILED");


### PR DESCRIPTION
`POST /v1/invoke` accepted any request that simply omitted the integrity
token: `checkIntegrity()` returned "unavailable" for a missing or short
token, and the dispatcher only rejects "failed", so the call reached
Claude and billed the account's AI credits. The request shape is public.

Split the verdict by who is at fault:

- Anything the caller controls is now "failed" (ATTESTATION_FAILED/403):
  no token, a token under 10 chars, a token Google refuses to decode
  (400 INVALID_ARGUMENT), a decoded payload with no `requestDetails`, or
  a verdict missing app recognition / device integrity / the package
  name. `requestPackageName` must equal the app id — `pkgOk` previously
  passed on `undefined`, making the package check vacuous.
- Only our-side faults still fail open: no service account configured,
  or a Google-side error (mint failure, 401/403/429/5xx, network throw).

The fail-open path is now bounded. Consecutive Google-side failures are
counted per isolate (10, inside a rolling 5-minute window); past the
bound the Worker fails closed until Google answers a decode again, so a
sustained outage can't be ridden as a standing bypass. Older failures
start a fresh run, so blips never accumulate into a closed gate.
`SKIP_ATTESTATION=true` is untouched.

Tests cover empty token, short token, decode failure (400 and 5xx),
missing `requestDetails`, package mismatch, a valid token, the bounded
window and its reset, plus 403s end to end through `/v1/invoke`.

Docs: worker/README.md and docs/ai-ask-with-proof.md restate the outcome
table, the bounded fail-open, and that a Worker deployed without
GOOGLE_SERVICE_ACCOUNT_JSON is an open endpoint. Android KDoc that
described the retired "unverified tier" now says an empty token means
ATTESTATION_FAILED. Replay protection remains out of scope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JsE2gcWV7en6EjgZCMABxu