### PR TITLE
fix(ci): translate qibla redesign strings + restore worship card test hook

### DIFF
--- a/app/src/androidTest/java/com/arshadshah/nimaz/behavior/WorshipCardNavigationTest.kt
+++ b/app/src/androidTest/java/com/arshadshah/nimaz/behavior/WorshipCardNavigationTest.kt
@@ -1,10 +1,10 @@
 package com.arshadshah.nimaz.behavior
 
-import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.domain.model.WorshipReminderType
@@ -16,11 +16,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * The Home "Next Worship" card must lead somewhere.
+ * The Home "Next Worship" entry must lead somewhere.
  *
  * It shipped inert: it counted down at you and then did nothing, because `WorshipEventCard` took an
  * `onAction` that Home never passed. Nothing failed — an unwired callback is not a test failure,
- * which is precisely why this needs a test that drives the real navigation graph.
+ * which is precisely why this needs a test that drives the real navigation graph. Compact Home now
+ * surfaces the reminder as an "Also today" row rather than a carousel card; both shapes carry
+ * [WorshipCardTestTag], so this test asserts the destination, not the presentation.
  *
  * ## Keeping it deterministic
  *
@@ -49,10 +51,9 @@ class WorshipCardNavigationTest : BaseAppTest() {
     @Test
     fun tappingTheWorshipCardOpensItsDuaCategory() {
         launchApp()
-        waitForWorshipCard()
+        scrollToWorshipCard()
 
-        compose.onNodeWithTag(WorshipCardTestTag, useUnmergedTree = true).performClick()
-        compose.waitForIdle()
+        tapWorshipCard()
 
         // Both adhkar reminders resolve to a dua category, so that is the destination either way.
         assertScreen(ScreenTags.DuaCategory)
@@ -62,28 +63,50 @@ class WorshipCardNavigationTest : BaseAppTest() {
     @Test
     fun backFromTheWorshipDestinationReturnsHome() {
         launchApp()
-        waitForWorshipCard()
+        scrollToWorshipCard()
 
-        compose.onNodeWithTag(WorshipCardTestTag, useUnmergedTree = true).performClick()
-        compose.waitForIdle()
+        tapWorshipCard()
         assertScreen(ScreenTags.DuaCategory)
 
         pressBack()
         assertScreen(ScreenTags.Home)
     }
 
-    @OptIn(ExperimentalTestApi::class)
-    private fun waitForWorshipCard() {
-        // The card is resolved off ~30 sequential DataStore reads plus an astronomical pass, so it
-        // arrives a beat after Home itself.
-        compose.waitUntilAtLeastOneExists(hasTestTag(WorshipCardTestTag), 15_000)
-        val found = compose.onAllNodes(hasTestTag(WorshipCardTestTag), useUnmergedTree = true)
-            .fetchSemanticsNodes().size
-        assertTrue("No worship card surfaced with both adhkar reminders enabled", found > 0)
+    /**
+     * Bring the worship entry on screen.
+     *
+     * Two things keep a plain `waitUntilAtLeastOneExists` from ever seeing it: the card is resolved
+     * off ~30 sequential DataStore reads plus an astronomical pass, so it arrives a beat after Home
+     * itself; and "Also today" sits below the fold in a `LazyColumn`, so the row is not composed at
+     * all until it is scrolled to. Hence scroll on each attempt until the node exists.
+     */
+    private fun scrollToWorshipCard() {
+        waitForTag(ScreenTags.HomeList)
+        val deadline = System.currentTimeMillis() + WORSHIP_CARD_TIMEOUT_MS
+        var found = false
+        while (!found && System.currentTimeMillis() < deadline) {
+            found = runCatching {
+                compose.onNodeWithTag(ScreenTags.HomeList)
+                    .performScrollToNode(hasTestTag(WorshipCardTestTag))
+            }.isSuccess
+            compose.waitForIdle()
+        }
+        assertTrue("No worship card surfaced with both adhkar reminders enabled", found)
+    }
+
+    /**
+     * Tap coordinate-free via the row's `OnClick` semantics: a list row scrolled just into view can
+     * sit at the viewport edge or under the gesture-nav inset, where a synthetic tap is rejected.
+     */
+    private fun tapWorshipCard() {
+        compose.onNodeWithTag(WorshipCardTestTag)
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.waitForIdle()
     }
 
     private companion object {
         const val LONDON_LAT = 51.5074
         const val LONDON_LON = -0.1278
+        const val WORSHIP_CARD_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/ScreenTags.kt
@@ -114,6 +114,7 @@ object ScreenTags {
         "screen_settings_notifications_diagnostics"
 
     /** Scrollable lists on hub screens — let UI tests scroll to off-screen entries. */
+    const val HomeList = "home_list"
     const val MoreList = "more_menu_list"
     const val SettingsList = "settings_list"
     const val AppearanceList = "settings_appearance_list"

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeAlsoTodaySection.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeAlsoTodaySection.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
@@ -70,6 +71,10 @@ fun HomeAlsoTodaySection(
                     icon = Icons.Default.Bedtime,
                     iconTint = Color(0xFF7C4DFF),
                     onClick = { onOpenWorship(worshipCard.type) },
+                    // Same tag the tablet layout's WorshipEventCard carries: compact Home
+                    // surfaces the next worship reminder as this row, and the behaviour test
+                    // asserts that whichever shape it takes, it navigates.
+                    modifier = Modifier.testTag(WorshipCardTestTag),
                 )
             }
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/home/HomeScreen.kt
@@ -44,12 +44,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.LocalInAppUpdateManager
 import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.core.navigation.ScreenTags
 import com.arshadshah.nimaz.core.util.UpdateState
 import com.arshadshah.nimaz.core.util.formatFullDate
 import com.arshadshah.nimaz.domain.model.AnnouncementType
@@ -352,7 +354,11 @@ private fun HomeCompactContent(
 
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize(),
+        // Tagged so behavior tests can scroll to entries below the fold ("Also today"
+        // sits under the hero, the banner slot and the prayer card).
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(ScreenTags.HomeList),
     ) {
         item(key = "hero") {
             HomeHero(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2139,4 +2139,17 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Heutiges Pensum</string>
     <string name="khatam_read_todays_portion">Heutiges Pensum lesen</string>
+
+    <!-- Qibla screen redesign -->
+    <string name="finding_direction">Richtung wird gesucht…</string>
+    <string name="hold_this_direction">Diese Richtung halten</string>
+    <string name="you_are_facing_format">Du blickst nach %1$d° %2$s</string>
+    <string name="qibla_bearing_label">Qibla-Peilung</string>
+    <string name="you_are_facing_label">Du blickst nach</string>
+    <string name="compass_is_unsure_title">Der Kompass ist unsicher</string>
+    <string name="compass_is_unsure_body">Magnete und Metall in der Nähe stören ihn. Eine kurze Kalibrierung behebt das.</string>
+    <string name="calibration_sheet_subtitle">Lass dies offen, während du dich bewegst – die Anzeige aktualisiert sich live</string>
+    <string name="accuracy_now_label">Genauigkeit jetzt</string>
+    <string name="back_to_compass">Zurück zum Kompass</string>
+    <string name="point_with_camera">Mit der Kamera zielen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2182,4 +2182,17 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Portion du jour</string>
     <string name="khatam_read_todays_portion">Lire la portion du jour</string>
+
+    <!-- Qibla screen redesign -->
+    <string name="finding_direction">Recherche de la direction…</string>
+    <string name="hold_this_direction">Gardez cette direction</string>
+    <string name="you_are_facing_format">Vous êtes orienté vers %1$d° %2$s</string>
+    <string name="qibla_bearing_label">Relèvement de la qibla</string>
+    <string name="you_are_facing_label">Vous êtes orienté vers</string>
+    <string name="compass_is_unsure_title">La boussole hésite</string>
+    <string name="compass_is_unsure_body">Les aimants et le métal à proximité la perturbent. Un bref étalonnage y remédie.</string>
+    <string name="calibration_sheet_subtitle">Gardez ceci ouvert pendant que vous bougez — la mesure se met à jour en direct</string>
+    <string name="accuracy_now_label">Précision actuelle</string>
+    <string name="back_to_compass">Retour à la boussole</string>
+    <string name="point_with_camera">Viser avec la caméra</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2098,4 +2098,17 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Bagian hari ini</string>
     <string name="khatam_read_todays_portion">Baca bagian hari ini</string>
+
+    <!-- Qibla screen redesign -->
+    <string name="finding_direction">Mencari arah…</string>
+    <string name="hold_this_direction">Pertahankan arah ini</string>
+    <string name="you_are_facing_format">Anda menghadap %1$d° %2$s</string>
+    <string name="qibla_bearing_label">Sudut kiblat</string>
+    <string name="you_are_facing_label">Anda menghadap</string>
+    <string name="compass_is_unsure_title">Kompas tidak yakin</string>
+    <string name="compass_is_unsure_body">Magnet dan logam di sekitar mengganggunya. Kalibrasi singkat akan memperbaikinya.</string>
+    <string name="calibration_sheet_subtitle">Biarkan ini terbuka saat Anda bergerak — pembacaan diperbarui secara langsung</string>
+    <string name="accuracy_now_label">Akurasi saat ini</string>
+    <string name="back_to_compass">Kembali ke kompas</string>
+    <string name="point_with_camera">Arahkan dengan kamera</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2099,4 +2099,17 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Bahagian hari ini</string>
     <string name="khatam_read_todays_portion">Baca bahagian hari ini</string>
+
+    <!-- Qibla screen redesign -->
+    <string name="finding_direction">Mencari arah…</string>
+    <string name="hold_this_direction">Kekalkan arah ini</string>
+    <string name="you_are_facing_format">Anda menghadap %1$d° %2$s</string>
+    <string name="qibla_bearing_label">Sudut kiblat</string>
+    <string name="you_are_facing_label">Anda menghadap</string>
+    <string name="compass_is_unsure_title">Kompas tidak pasti</string>
+    <string name="compass_is_unsure_body">Magnet dan logam berdekatan mengganggunya. Penentukuran ringkas akan membetulkannya.</string>
+    <string name="calibration_sheet_subtitle">Biarkan ini terbuka semasa anda bergerak — bacaan dikemas kini secara langsung</string>
+    <string name="accuracy_now_label">Ketepatan sekarang</string>
+    <string name="back_to_compass">Kembali ke kompas</string>
+    <string name="point_with_camera">Halakan dengan kamera</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2145,4 +2145,17 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Bugünün bölümü</string>
     <string name="khatam_read_todays_portion">Bugünün bölümünü oku</string>
+
+    <!-- Qibla screen redesign -->
+    <string name="finding_direction">Yön bulunuyor…</string>
+    <string name="hold_this_direction">Bu yönü koruyun</string>
+    <string name="you_are_facing_format">%1$d° %2$s yönüne bakıyorsunuz</string>
+    <string name="qibla_bearing_label">Kıble açısı</string>
+    <string name="you_are_facing_label">Baktığınız yön</string>
+    <string name="compass_is_unsure_title">Pusula emin değil</string>
+    <string name="compass_is_unsure_body">Yakındaki mıknatıslar ve metaller pusulayı şaşırtır. Kısa bir kalibrasyon bunu düzeltir.</string>
+    <string name="calibration_sheet_subtitle">Hareket ederken bunu açık tutun — ölçüm canlı olarak güncellenir</string>
+    <string name="accuracy_now_label">Şu anki doğruluk</string>
+    <string name="back_to_compass">Pusulaya dön</string>
+    <string name="point_with_camera">Kamerayla nişan al</string>
 </resources>


### PR DESCRIPTION
Fixes the two real CI failures on #528. Targets that PR's branch, so merging this turns #528's checks over.

## `check` — lint: 11 `MissingTranslation` errors

The qibla redesign (35e2249) added 11 strings to `values/strings.xml` and never translated them, so `lintDebug` aborted the build:

```
strings.xml:276: Error: "finding_direction" is not translated in "de", "ms", "id", "fr", "tr" [MissingTranslation]
```

Adds de/ms/id/fr/tr for all 11 (`finding_direction`, `hold_this_direction`, `you_are_facing_format`, `qibla_bearing_label`, `you_are_facing_label`, `compass_is_unsure_title`, `compass_is_unsure_body`, `calibration_sheet_subtitle`, `accuracy_now_label`, `back_to_compass`, `point_with_camera`). Verified across the whole resource set, not just these keys: every translatable string in `values/` now exists in all five locales, with matching format specifiers on both sides.

## `emulator.wtf` — `WorshipCardNavigationTest` (2 tests, 6 failures)

```
ComposeTimeoutException: Condition (at least one node matches (TestTag = 'worship_card'))
still not satisfied after 15000 ms
```

The tag was genuinely gone from compact Home. After the home rewrite, the next worship reminder is an "Also today" row (`HomeAlsoTodaySection`) instead of the `WorshipEventCard` in the events carousel — the carousel path now only exists in the tablet layout, which the test does not drive.

- The row carries the same `WorshipCardTestTag`, so the test keeps asserting the behaviour (tap → `DuaCategory`, back → Home) rather than the presentation.
- "Also today" sits below the fold inside a `LazyColumn`, where an uncomposed row can never satisfy `waitUntilAtLeastOneExists` no matter the timeout. The list is tagged `ScreenTags.HomeList` and the test scrolls to the row before tapping — polling the scroll, because the card resolves asynchronously off ~30 DataStore reads.
- The tap goes through `SemanticsActions.OnClick` rather than a synthetic touch, matching `BaseAppTest.scrollListToAndTap`: a row scrolled just into view can sit under the gesture-nav inset, where injected touches are rejected.

## Not addressed

`claude-review` also failed, with an empty `ANTHROPIC_API_KEY` in the job env — a secret/config issue in the workflow, not something this diff can fix.

## Verification

`compileDebugKotlin`, `compileDebugAndroidTestKotlin` and `scripts/check_docs.py` (23/23) pass locally. `lintDebug` and `testDebugUnitTest` could not run here — both depend on `:app:fetchNimazData`, which needs `NIMAZ_DATA_TOKEN`; CI will run them. The lint fix was verified by diffing every translatable key and its format specifiers across all five locale files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuu3ZDm4itBB6NF565Yva5)_