### PR TITLE
feat(design-system): add NimazTextField and put the whole field family on one shell

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAmountInput.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAmountInput.kt
@@ -2,26 +2,19 @@ package com.arshadshah.nimaz.presentation.components.molecules
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.arshadshah.nimaz.presentation.theme.NimazShapes
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 
@@ -114,11 +107,17 @@ internal fun amountToInput(amount: Double): String = when {
     else -> formatAmountInput(amount.toString())
 }
 
+/** The width an in-row amount field occupies beside its label. */
+private val AmountFieldWidth = 132.dp
+
 /**
  * A currency-aware amount field — the input only.
  *
  * The label and hint belong to the screen: Zakat is the one caller today, and baking its row
- * arrangement into the atom would fix a layout that only one screen needs.
+ * arrangement into the component would fix a layout that only one screen needs. That is also
+ * why it is [NimazFieldDensity.COMPACT] — it sits *beside* a label rather than under one, which
+ * is the whole reason this looked different from [NimazDropdownField] before the two were put
+ * on the same shell.
  *
  * Replaces the per-keystroke `text.toDoubleOrNull() ?: 0.0` the Zakat form used to do, which made
  * a decimal amount literally unenterable — the `.` was parsed away before the next digit arrived.
@@ -127,6 +126,8 @@ internal fun amountToInput(amount: Double): String = when {
  * "1,200 g" are how each is read, and the field that replaced this used to decide between them by
  * comparing its suffix against the string `"$"`. Passing both, or neither, is a call-site bug —
  * hence the requirement stated in the parameter docs rather than a silent fallback.
+ *
+ * Most callers want [NimazAmountField] instead, which owns the `Double` binding as well.
  */
 @Composable
 fun NimazAmountInput(
@@ -140,67 +141,68 @@ fun NimazAmountInput(
     enabled: Boolean = true,
     placeholder: String = "0.00",
 ) {
-    // A recessed well nested inside its row: outlined, never elevated, so it reads as a field
-    // rather than as a card of its own.
-    _root_ide_package_.com.arshadshah.nimaz.presentation.components.atoms.NimazCard(
-        modifier = modifier.width(132.dp),
-        style = com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle.OUTLINED,
-        shape = NimazShapes.small,
+    NimazTextField(
+        value = value,
+        // Grouping is applied on the way in, so the field is fed its own previous output on
+        // every keystroke — which is what [formatAmountInput]'s idempotence is for.
+        onValueChange = { onValueChange(formatAmountInput(it)) },
+        modifier = modifier.width(AmountFieldWidth),
+        variant = NimazFieldVariant.NUMERIC,
+        density = NimazFieldDensity.COMPACT,
+        placeholder = placeholder,
+        prefix = currencySymbol,
+        suffix = unitSuffix,
+        // No clear button: the field is 132dp wide and shares that space with a symbol and a
+        // unit, and an amount is quicker to correct than to re-enter.
+        clearable = false,
         enabled = enabled,
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (currencySymbol != null) {
-                Text(
-                    text = currencySymbol,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.width(4.dp))
-            }
-            val textStyle = MaterialTheme.typography.titleSmall.copy(
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.End,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            BasicTextField(
-                value = value,
-                onValueChange = { onValueChange(formatAmountInput(it)) },
-                enabled = enabled,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                textStyle = textStyle,
-                cursorBrush = androidx.compose.ui.graphics.SolidColor(
-                    MaterialTheme.colorScheme.primary
-                ),
-                modifier = Modifier.weight(1f),
-                decorationBox = { inner ->
-                    Box(contentAlignment = Alignment.CenterEnd) {
-                        if (value.isEmpty()) {
-                            Text(
-                                text = placeholder,
-                                style = textStyle.copy(
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        .copy(alpha = 0.45f)
-                                ),
-                            )
-                        }
-                        inner()
-                    }
-                },
-            )
-            if (unitSuffix != null) {
-                Spacer(Modifier.width(4.dp))
-                Text(
-                    text = unitSuffix,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
+    )
+}
+
+/**
+ * The same amount field, bound to a `Double` rather than to text.
+ *
+ * This is what the Zakat calculator and the Zakat settings screen each used to keep a private
+ * copy of — `AmountField` and `PriceField`, byte-for-byte the same nineteen lines, including the
+ * same two comments explaining the same guard. One of them was going to be fixed without the
+ * other eventually.
+ *
+ * The text is **local state**, and that is the whole point. A field that parsed every keystroke
+ * straight to a `Double` and re-rendered the result turned "10." into "10" before the next digit
+ * landed, so a decimal amount was literally unenterable — and a per-gram silver price is nothing
+ * but decimals.
+ *
+ * The sync back the other way is guarded: an incoming [value] only overwrites the text when it
+ * disagrees with what the text already parses to. Without that guard, the ViewModel echoing back
+ * the user's own keystroke would erase the trailing point as fast as it was typed — while
+ * "Clear all" and a restored calculation, which genuinely differ, still win.
+ */
+@Composable
+fun NimazAmountField(
+    value: Double,
+    onValueChange: (Double) -> Unit,
+    modifier: Modifier = Modifier,
+    currencySymbol: String? = null,
+    unitSuffix: String? = null,
+    enabled: Boolean = true,
+    placeholder: String = "0.00",
+) {
+    var text by rememberSaveable { mutableStateOf(amountToInput(value)) }
+    LaunchedEffect(value) {
+        if (parseAmountInput(text) != value) text = amountToInput(value)
     }
+    NimazAmountInput(
+        value = text,
+        onValueChange = { next ->
+            text = next
+            onValueChange(parseAmountInput(next))
+        },
+        modifier = modifier,
+        currencySymbol = currencySymbol,
+        unitSuffix = unitSuffix,
+        enabled = enabled,
+        placeholder = placeholder,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazDropdown.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazDropdown.kt
@@ -49,8 +49,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
-import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckbox
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckboxSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckboxType
@@ -266,11 +264,18 @@ fun NimazDropdownMenu(
  * Use it for **short** option lists (≤ ~7); for long / searchable / grouped lists use the
  * modal [NimazListPicker] instead.
  *
+ * Drawn on the shared [NimazFieldShell], which is where its own geometry came from — so the
+ * dropdown, [NimazTextField] and [NimazAmountInput] cannot drift apart. The one behaviour that
+ * moved into the shell and changed on the way: the border used to go primary whenever a value
+ * was *set*, and is now primary only while the menu is open. See [NimazFieldShell]'s docs.
+ *
  * @param items the selectable options, type-safe over [T].
  * @param selected the currently selected value, or null when nothing is chosen.
  * @param onSelected called with the chosen value; the menu closes automatically.
  * @param label optional caption rendered above the field.
  * @param placeholder shown in the field when [selected] is null.
+ * @param helper optional always-visible line beneath the field.
+ * @param error a message (not a boolean) shown in place of [helper], outlining the field in red.
  * @param enabled when false the field is dimmed and ignores taps.
  */
 @Composable
@@ -281,6 +286,9 @@ fun <T> NimazDropdownField(
     modifier: Modifier = Modifier,
     label: String? = null,
     placeholder: String = "Select",
+    helper: String? = null,
+    error: String? = null,
+    required: Boolean = false,
     enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -288,109 +296,34 @@ fun <T> NimazDropdownField(
     val density = LocalDensity.current
 
     val selectedItem = items.firstOrNull { it.value == selected }
+    val isEmpty = selectedItem == null
     val chevronRotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
         label = "dropdownChevron"
     )
 
-    Column(modifier = modifier) {
-        if (!label.isNullOrBlank()) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-        }
+    // The chevron well is the family's one piece of character, and it stays: a 26dp circle at
+    // 12% primary that fills solid and flips as the menu opens.
+    val chevronCircleColor = if (expanded) MaterialTheme.colorScheme.primary
+    else MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+    val chevronTint = when {
+        !enabled -> MaterialTheme.colorScheme.onSurfaceVariant
+        expanded -> MaterialTheme.colorScheme.onPrimary
+        else -> MaterialTheme.colorScheme.primary
+    }
 
-        Box(modifier = Modifier.fillMaxWidth()) {
-            // ── Trigger field ──────────────────────────────────────────────
-            // Outlined field: teal outline when a value is set (neutral when empty /
-            // disabled); on open the chevron flips up and its circle fills solid teal.
-            val isEmpty = selectedItem == null
-            val borderColor = when {
-                !enabled -> MaterialTheme.colorScheme.outlineVariant
-                expanded -> MaterialTheme.colorScheme.primary
-                isEmpty -> MaterialTheme.colorScheme.outlineVariant
-                else -> MaterialTheme.colorScheme.primary
-            }
-            val chevronCircleColor = if (expanded) MaterialTheme.colorScheme.primary
-            else MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-            val chevronTint = when {
-                !enabled -> MaterialTheme.colorScheme.onSurfaceVariant
-                expanded -> MaterialTheme.colorScheme.onPrimary
-                isEmpty -> MaterialTheme.colorScheme.onSurfaceVariant
-                else -> MaterialTheme.colorScheme.primary
-            }
-
-            // Built from the shared NimazCard primitive (OUTLINED), so the trigger inherits
-            // the app's card shape/elevation handling rather than a hand-rolled border box.
-            NimazCard(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onSizeChanged { fieldWidthPx = it.width }
-                    .alpha(if (enabled) 1f else 0.55f),
-                style = NimazCardStyle.OUTLINED,
-                onClick = { expanded = true },
-                enabled = enabled,
-                shape = RoundedCornerShape(14.dp),
-                // NEUTRAL/BASE container; kept on `colors` because the trigger's border
-                // is state-driven (focus/error) and tones do not carry borders.
-                colors = NimazCardDefaults.colors(
-                    border = borderColor,
-                    borderWidth = 1.5.dp,
-                ),
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 14.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    if (selectedItem?.leadingIcon != null) {
-                        NimazIcon(
-                            imageVector = selectedItem.leadingIcon,
-                            contentDescription = null,
-                            type = NimazIconType.CONTAINED,
-                            containerShape = NimazIconContainerShape.ROUNDED_SQUARE,
-                            tint = MaterialTheme.colorScheme.primary,
-                            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-                            containerSize = 32.dp,
-                            iconSize = 18.dp,
-                            cornerRadius = 9.dp,
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                    }
-                    Text(
-                        text = selectedItem?.label ?: placeholder,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        fontFamily = selectedItem?.textFontFamily,
-                        color = if (isEmpty) MaterialTheme.colorScheme.onSurfaceVariant
-                        else MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Spacer(modifier = Modifier.width(10.dp))
-                    Box(
-                        modifier = Modifier
-                            .size(26.dp)
-                            .clip(CircleShape)
-                            .background(chevronCircleColor),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        NimazIcon(
-                            imageVector = Icons.Default.KeyboardArrowDown,
-                            contentDescription = null,
-                            tint = chevronTint,
-                            iconSize = 16.dp,
-                            modifier = Modifier.rotate(chevronRotation)
-                        )
-                    }
-                }
-            }
-
-            // ── Anchored popup (the shared menu + row) ─────────────────────
+    NimazFieldShell(
+        modifier = modifier,
+        label = label,
+        required = required,
+        helper = helper,
+        error = error,
+        // A dropdown has no caret, so "the menu is open" is what focus means here.
+        focused = expanded,
+        enabled = enabled,
+        onClick = { expanded = true },
+        boxModifier = Modifier.onSizeChanged { fieldWidthPx = it.width },
+        anchored = {
             NimazDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
@@ -412,6 +345,46 @@ fun <T> NimazDropdownField(
                     )
                 }
             }
+        },
+    ) {
+        if (selectedItem?.leadingIcon != null) {
+            NimazIcon(
+                imageVector = selectedItem.leadingIcon,
+                contentDescription = null,
+                type = NimazIconType.CONTAINED,
+                containerShape = NimazIconContainerShape.ROUNDED_SQUARE,
+                tint = MaterialTheme.colorScheme.primary,
+                containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                containerSize = 32.dp,
+                iconSize = 18.dp,
+                cornerRadius = 9.dp,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+        }
+        Text(
+            text = selectedItem?.label ?: placeholder,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            fontFamily = selectedItem?.textFontFamily,
+            color = if (isEmpty) MaterialTheme.colorScheme.onSurfaceVariant
+            else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Box(
+            modifier = Modifier
+                .size(26.dp)
+                .clip(CircleShape)
+                .background(chevronCircleColor),
+            contentAlignment = Alignment.Center
+        ) {
+            NimazIcon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                tint = chevronTint,
+                iconSize = 16.dp,
+                modifier = Modifier.rotate(chevronRotation)
+            )
         }
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazFieldShell.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazFieldShell.kt
@@ -1,0 +1,331 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
+import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+
+/**
+ * The one field shell the whole app draws its inputs on.
+ *
+ * It is not a new idea — [NimazDropdownField] already drew it (label above, an outlined
+ * [NimazCard] at 14dp with a 1.5dp border and 14/12 padding) and [NimazAmountInput] drew a
+ * smaller second version of the same thing. What the app had no shell for was **text**, which
+ * is why a dozen screens fell back to Material's `OutlinedTextField` and a form ended up
+ * showing two different ideas of what a field is: a label above an outlined card next to a
+ * notched border with a floating label.
+ *
+ * Extracting it here makes the dropdown, the text field and the amount field one family with
+ * one geometry, and gives a new member somewhere to be added without inventing a fourth.
+ *
+ * Everything state-driven lives in this file, so no call site decides what a focused, errored,
+ * over-limit, read-only or disabled field looks like:
+ *
+ * - **Border.** Neutral at rest *and when filled*; primary only while focused; error while
+ *   there is a message or the counter is over. The dropdown used to turn its border primary
+ *   whenever a value was set — in a form of eight completed fields that is eight primary boxes
+ *   and the colour stops meaning "you are here". A value going from muted placeholder to full
+ *   ink already says the field is filled.
+ * - **Helper and error share one line**, so an error appearing moves nothing.
+ * - **Read-only** fills rather than outlines: it is a value, not an empty input.
+ * - **Disabled** is the whole shell at 55%, label included.
+ */
+enum class NimazFieldDensity {
+    /** The form field: 14dp radius, 14/12 padding, ~50dp tall. */
+    STANDARD,
+
+    /**
+     * The in-row field: 12dp radius, 12/10 padding, ~42dp tall — for a field that sits
+     * *beside* its label rather than under one, which is the arrangement the Zakat asset rows
+     * use and the reason [NimazAmountInput] looked different in the first place.
+     */
+    COMPACT,
+}
+
+/** Geometry and colour rules shared by every member of the field family. */
+object NimazFieldDefaults {
+
+    /** Border weight, at rest and in every state — the outline changes colour, never width. */
+    val BorderWidth: Dp = 1.5.dp
+
+    /** Gap between the label and the box. */
+    val LabelGap: Dp = 8.dp
+
+    /** Gap between the box and the helper/error line. */
+    val HelperGap: Dp = 6.dp
+
+    /** Vertical rhythm between two stacked fields. */
+    val FieldGap: Dp = 20.dp
+
+    /** How far a disabled field is faded. Matches what [NimazDropdownField] already did. */
+    const val DisabledAlpha: Float = 0.55f
+
+    fun shape(density: NimazFieldDensity): Shape = when (density) {
+        NimazFieldDensity.STANDARD -> RoundedCornerShape(14.dp)
+        NimazFieldDensity.COMPACT -> RoundedCornerShape(12.dp)
+    }
+
+    fun horizontalPadding(density: NimazFieldDensity): Dp = when (density) {
+        NimazFieldDensity.STANDARD -> 14.dp
+        NimazFieldDensity.COMPACT -> 12.dp
+    }
+
+    fun verticalPadding(density: NimazFieldDensity): Dp = when (density) {
+        NimazFieldDensity.STANDARD -> 12.dp
+        NimazFieldDensity.COMPACT -> 10.dp
+    }
+
+    /**
+     * The floor that keeps a field the same height whether or not it carries a leading icon or
+     * a trailing clear button — without it a bare text field is visibly shorter than the
+     * dropdown beside it.
+     */
+    fun minHeight(density: NimazFieldDensity): Dp = when (density) {
+        NimazFieldDensity.STANDARD -> 50.dp
+        NimazFieldDensity.COMPACT -> 42.dp
+    }
+
+    /** The one place the outline colour is decided. */
+    @Composable
+    fun borderColor(
+        enabled: Boolean,
+        readOnly: Boolean,
+        focused: Boolean,
+        isError: Boolean,
+    ): Color = when {
+        !enabled -> MaterialTheme.colorScheme.outlineVariant
+        readOnly -> Color.Transparent
+        isError -> MaterialTheme.colorScheme.error
+        focused -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.outlineVariant
+    }
+
+    /** The one place the field's fill is decided. */
+    @Composable
+    fun containerColor(readOnly: Boolean): Color =
+        if (readOnly) MaterialTheme.colorScheme.surfaceContainerHigh
+        else MaterialTheme.colorScheme.surface
+}
+
+/**
+ * The caption above a field.
+ *
+ * [NimazFieldShell] renders this for you, so a field never calls it. It is public for the case
+ * the shell cannot cover: a control that answers a form question without being a text input —
+ * the Khatam form's deadline (a button that opens a date picker) and its daily reminder (a
+ * switch inside a card). Those rows need to wear the same label as the fields around them, and
+ * reimplementing it per screen is exactly how `KhatamFormScreen` ended up with a private
+ * `FieldLabel` at `labelMedium`/SemiBold/onSurfaceVariant sitting above fields whose real
+ * labels were `bodyLarge`/Medium/onSurface.
+ *
+ * @param required appends the red asterisk. Decorative in the accessibility tree: the
+ *   requirement belongs in the control's own semantics, and a screen reader announcing
+ *   "asterisk" is noise.
+ * @param optionalLabel a quiet "optional" marker, for the opposite case.
+ */
+@Composable
+fun NimazFieldLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+    required: Boolean = false,
+    optionalLabel: String? = null,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (required) {
+            Text(
+                text = "*",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .padding(start = 3.dp)
+                    .clearAndSetSemantics { },
+            )
+        }
+        if (!optionalLabel.isNullOrBlank()) {
+            Text(
+                text = optionalLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Label · box · helper — the frame every Nimaz field is drawn in.
+ *
+ * Internal on purpose: it is the family's private chassis, not a component to build a one-off
+ * field out of. A new kind of field is a new [NimazFieldVariant] or a new caller in this
+ * package, so the geometry can never be half-adopted.
+ *
+ * @param anchored content laid out in the same [Box] as the field box — the dropdown's popup
+ *   menu, which has to anchor to the box and not to the whole shell.
+ * @param boxModifier applied to the box itself (the dropdown measures its width here to size
+ *   the popup).
+ * @param onBoxTap makes the box's padding part of the tap target. A caret only occupies the
+ *   middle ~26dp of a 50dp box, so without this a tap on the field's own padding does nothing
+ *   and the field reads as broken. Rippleless and on an *inner* element, not a `.clickable`
+ *   wrapped around the card — see `ARCHITECTURE.md` §8.
+ * @param counter the trailing character count, already formatted; [counterIsOver] marks it and
+ *   the border without truncating anything the person typed.
+ */
+@Composable
+internal fun NimazFieldShell(
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    required: Boolean = false,
+    optionalLabel: String? = null,
+    helper: String? = null,
+    error: String? = null,
+    counter: String? = null,
+    counterIsOver: Boolean = false,
+    focused: Boolean = false,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    density: NimazFieldDensity = NimazFieldDensity.STANDARD,
+    onClick: (() -> Unit)? = null,
+    onBoxTap: (() -> Unit)? = null,
+    boxModifier: Modifier = Modifier,
+    boxVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    anchored: @Composable () -> Unit = {},
+    boxContent: @Composable RowScope.() -> Unit,
+) {
+    val isError = error != null || counterIsOver
+    val borderColor by animateColorAsState(
+        targetValue = NimazFieldDefaults.borderColor(
+            enabled = enabled,
+            readOnly = readOnly,
+            focused = focused,
+            isError = isError,
+        ),
+        label = "nimazFieldBorder",
+    )
+
+    Column(modifier = modifier.alpha(if (enabled) 1f else NimazFieldDefaults.DisabledAlpha)) {
+        if (!label.isNullOrBlank()) {
+            NimazFieldLabel(
+                text = label,
+                required = required,
+                optionalLabel = optionalLabel,
+            )
+            Spacer(modifier = Modifier.height(NimazFieldDefaults.LabelGap))
+        }
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            NimazCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(boxModifier),
+                style = NimazCardStyle.OUTLINED,
+                onClick = onClick,
+                enabled = enabled,
+                shape = NimazFieldDefaults.shape(density),
+                // Kept on `colors` rather than a tone: the border is state-driven
+                // (focus / error / read-only) and tones do not carry borders.
+                colors = NimazCardDefaults.colors(
+                    container = NimazFieldDefaults.containerColor(readOnly),
+                    border = borderColor,
+                    borderWidth = NimazFieldDefaults.BorderWidth,
+                ),
+                elevation = 0.dp,
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = NimazFieldDefaults.minHeight(density))
+                        .then(
+                            if (onBoxTap != null && enabled) {
+                                Modifier.clickable(
+                                    interactionSource = null,
+                                    indication = null,
+                                    onClick = onBoxTap,
+                                )
+                            } else Modifier
+                        )
+                        .padding(
+                            horizontal = NimazFieldDefaults.horizontalPadding(density),
+                            vertical = NimazFieldDefaults.verticalPadding(density),
+                        ),
+                    verticalAlignment = boxVerticalAlignment,
+                    content = boxContent,
+                )
+            }
+            anchored()
+        }
+
+        // One line for helper, error and counter. An error *replaces* the helper rather than
+        // stacking under it, so nothing below the field moves when validation fires.
+        if (error != null || !helper.isNullOrBlank() || counter != null) {
+            Spacer(modifier = Modifier.height(NimazFieldDefaults.HelperGap))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp),
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                if (error != null) {
+                    NimazIcon(
+                        imageVector = Icons.Default.ErrorOutline,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        iconSize = 14.dp,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+                Text(
+                    text = error ?: helper.orEmpty(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (error != null) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                if (counter != null) {
+                    Text(
+                        text = counter,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = if (counterIsOver) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTextField.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTextField.kt
@@ -1,0 +1,404 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import android.content.res.Configuration
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arshadshah.nimaz.R
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.theme.AmiriFontFamily
+import com.arshadshah.nimaz.presentation.theme.NimazTheme
+import com.arshadshah.nimaz.presentation.theme.ThemeMode
+
+/**
+ * What kind of answer a field takes.
+ *
+ * A variant chooses typeface, direction, alignment and keyboard — **never** the geometry, which
+ * belongs to [NimazFieldShell] and is the same for every member of the family.
+ *
+ * There is deliberately no variant per *feature*: a khatam name, a preset name and a fasting
+ * reason are all [TEXT]. A new variant is only justified when the text itself behaves
+ * differently, which so far means Arabic, numbers and long-form notes.
+ */
+enum class NimazFieldVariant {
+    /** Ordinary single-line prose. */
+    TEXT,
+
+    /**
+     * Arabic entry: Amiri at 22sp, right-aligned, RTL, in the theme's gold.
+     *
+     * This is the variant that pays for itself. Before it, every Arabic input hand-set a
+     * `textStyle` *and* an `OutlinedTextFieldDefaults.colors` block, at a different size each
+     * time — four lines of styling per field, repeated per screen, drifting per screen.
+     */
+    ARABIC,
+
+    /** A number: tabular figures, semi-bold, right-aligned, decimal keyboard. */
+    NUMERIC,
+
+    /** Long-form text over several lines. No clear button — see [NimazTextField]'s docs. */
+    NOTE,
+}
+
+/**
+ * The app's text field. One shell shared with [NimazDropdownField] and [NimazAmountInput], so a
+ * form no longer shows two different ideas of what a field looks like.
+ *
+ * There is no `shape`, no `colors` and no `textStyle` parameter, and that absence is the point:
+ * those are exactly how the twelve `OutlinedTextField` call sites this replaced ended up
+ * hand-setting a 14dp radius on four fields in one screen and styling the Arabic one inline. If
+ * a call site needs one of them, the [NimazFieldVariant] list is missing something.
+ *
+ * **Errors show on blur or on submit, never on the first keystroke.** Pass [validator] for the
+ * per-field rule and the field runs it when focus leaves — then, once it is showing an error, on
+ * every keystroke so the message clears the moment the input is good. Pass [error] for a message
+ * the *screen* decided (a failed save, a submit-time check); a caller-supplied [error] always
+ * wins over the validator's.
+ *
+ * @param error a message, not a boolean. Material's `isError` + a conditional `supportingText`
+ *   lets a field turn red with nothing on screen explaining why, and three of the call sites
+ *   this replaced did exactly that.
+ * @param maxLength shows the counter and marks an over-long value — it does **not** truncate.
+ *   Cutting off what somebody typed is worse than letting them cut it.
+ * @param clearable a trailing clear button. Defaults on for single-line fields and off for
+ *   [NimazFieldVariant.NOTE], where one tap can destroy a paragraph and undo is a long press away.
+ * @param prefix leads the value (a currency symbol); [suffix] follows it (a unit). These replace
+ *   `currencySymbol`/`unitSuffix`, which were the same parameter written twice.
+ */
+@Composable
+fun NimazTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    variant: NimazFieldVariant = NimazFieldVariant.TEXT,
+    density: NimazFieldDensity = NimazFieldDensity.STANDARD,
+    placeholder: String? = null,
+    helper: String? = null,
+    error: String? = null,
+    validator: ((String) -> String?)? = null,
+    required: Boolean = false,
+    optionalLabel: String? = null,
+    maxLength: Int? = null,
+    prefix: String? = null,
+    suffix: String? = null,
+    leadingIcon: ImageVector? = null,
+    clearable: Boolean = variant != NimazFieldVariant.NOTE,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    minLines: Int = if (variant == NimazFieldVariant.NOTE) 3 else 1,
+    maxLines: Int = if (variant == NimazFieldVariant.NOTE) 8 else 1,
+    imeAction: ImeAction? = null,
+    onImeAction: (() -> Unit)? = null,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused by interactionSource.collectIsFocusedAsState()
+    val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
+
+    // The validator's verdict, held from one blur to the next. Null until the field has been
+    // focused *and then left*, which is what keeps a required field from going red the instant
+    // the form appears — `onFocusChanged` reports "not focused" on the first composition too,
+    // and treating that as a blur would flag every empty field on screen before anyone typed.
+    var blurError by remember(validator) { mutableStateOf<String?>(null) }
+    var hasBeenFocused by remember(validator) { mutableStateOf(false) }
+
+    val overLimit = maxLength != null && value.length > maxLength
+    val shownError = error ?: blurError
+    val singleLine = variant != NimazFieldVariant.NOTE
+
+    val contentColor = when {
+        variant == NimazFieldVariant.ARABIC -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    val textStyle = when (variant) {
+        NimazFieldVariant.TEXT, NimazFieldVariant.NOTE ->
+            MaterialTheme.typography.bodyLarge.copy(color = contentColor)
+
+        NimazFieldVariant.ARABIC -> MaterialTheme.typography.bodyLarge.copy(
+            fontFamily = AmiriFontFamily,
+            fontSize = 22.sp,
+            lineHeight = 38.sp,
+            textAlign = TextAlign.End,
+            textDirection = TextDirection.Rtl,
+            color = contentColor,
+        )
+
+        NimazFieldVariant.NUMERIC -> MaterialTheme.typography.titleSmall.copy(
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.End,
+            color = contentColor,
+        )
+    }
+    val keyboardType = when (variant) {
+        NimazFieldVariant.NUMERIC -> KeyboardType.Decimal
+        else -> KeyboardType.Text
+    }
+
+    NimazFieldShell(
+        modifier = modifier,
+        label = label,
+        required = required,
+        optionalLabel = optionalLabel,
+        helper = helper,
+        error = shownError,
+        counter = maxLength?.let {
+            stringResource(R.string.field_character_count, value.length, it)
+        },
+        counterIsOver = overLimit,
+        focused = focused,
+        enabled = enabled,
+        readOnly = readOnly,
+        density = density,
+        // The caret occupies the middle of the box; a tap on the padding around it has to
+        // reach the field too, or the field reads as broken at its own edges.
+        onBoxTap = if (readOnly) null else {
+            { focusRequester.requestFocus() }
+        },
+        // A multi-line note grows downwards; its affixes and clear button must stay level with
+        // the first line rather than drift to the vertical middle of a paragraph.
+        boxVerticalAlignment = if (singleLine) Alignment.CenterVertically else Alignment.Top,
+    ) {
+        if (leadingIcon != null) {
+            NimazIcon(
+                imageVector = leadingIcon,
+                contentDescription = null,
+                type = NimazIconType.CONTAINED,
+                containerShape = NimazIconContainerShape.ROUNDED_SQUARE,
+                tint = MaterialTheme.colorScheme.primary,
+                containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                containerSize = 32.dp,
+                iconSize = 18.dp,
+                cornerRadius = 9.dp,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+        }
+        if (prefix != null) {
+            Affix(prefix)
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+
+        BasicTextField(
+            value = value,
+            onValueChange = { next ->
+                onValueChange(next)
+                // Only re-validate while an error is already on screen: this is the "clears as
+                // you fix it" half of the rule, not a licence to validate as you type.
+                if (blurError != null && validator != null) blurError = validator(next)
+            },
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester)
+                .onFocusChanged { state ->
+                    if (state.isFocused) {
+                        hasBeenFocused = true
+                    } else if (hasBeenFocused) {
+                        blurError = validator?.invoke(value)
+                    }
+                },
+            enabled = enabled && !readOnly,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            singleLine = singleLine,
+            minLines = minLines,
+            maxLines = maxLines,
+            interactionSource = interactionSource,
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = keyboardType,
+                imeAction = imeAction ?: if (singleLine) ImeAction.Next else ImeAction.Default,
+            ),
+            keyboardActions = KeyboardActions {
+                if (onImeAction != null) onImeAction() else focusManager.clearFocus()
+            },
+            decorationBox = { inner ->
+                Box(
+                    contentAlignment = when (variant) {
+                        NimazFieldVariant.NUMERIC, NimazFieldVariant.ARABIC ->
+                            Alignment.CenterEnd
+
+                        else -> Alignment.CenterStart
+                    },
+                ) {
+                    if (value.isEmpty() && !placeholder.isNullOrEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = textStyle.copy(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    .copy(alpha = 0.75f),
+                            ),
+                        )
+                    }
+                    inner()
+                }
+            },
+        )
+
+        if (suffix != null) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Affix(suffix)
+        }
+        if (clearable && value.isNotEmpty() && enabled && !readOnly) {
+            Spacer(modifier = Modifier.width(4.dp))
+            NimazIconButton(
+                icon = Icons.Default.Clear,
+                onClick = { onValueChange("") },
+                contentDescription = stringResource(R.string.cd_clear),
+                size = NimazIconButtonSize.SMALL,
+            )
+        }
+    }
+}
+
+/** The unit or currency that leads or follows a value. Muted — it is not the answer. */
+@Composable
+private fun Affix(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+// ──── Previews ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun NimazTextFieldShowcase() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(NimazFieldDefaults.FieldGap),
+    ) {
+        NimazTextField(
+            value = "",
+            onValueChange = {},
+            label = "Preset name",
+            required = true,
+            placeholder = "Morning adhkar",
+            helper = "Shown in your list of presets",
+            maxLength = 40,
+        )
+        NimazTextField(
+            value = "Morning adhkar",
+            onValueChange = {},
+            label = "Filled",
+            leadingIcon = Icons.Default.Person,
+        )
+        NimazTextField(
+            value = "",
+            onValueChange = {},
+            label = "Arabic text",
+            variant = NimazFieldVariant.ARABIC,
+            placeholder = "سُبْحَانَ ٱللَّٰهِ",
+        )
+        NimazTextField(
+            value = "12,480.00",
+            onValueChange = {},
+            label = "Zakat on savings",
+            variant = NimazFieldVariant.NUMERIC,
+            prefix = "€",
+            suffix = "EUR",
+        )
+        NimazTextField(
+            value = "86.40",
+            onValueChange = {},
+            variant = NimazFieldVariant.NUMERIC,
+            density = NimazFieldDensity.COMPACT,
+            suffix = "g",
+            modifier = Modifier.width(132.dp),
+        )
+        NimazTextField(
+            value = "",
+            onValueChange = {},
+            label = "Note",
+            optionalLabel = "optional",
+            variant = NimazFieldVariant.NOTE,
+            placeholder = "Ask about the weight of speech here.",
+            helper = "Attached to this highlight",
+            maxLength = 280,
+        )
+        NimazTextField(
+            value = "",
+            onValueChange = {},
+            label = "Preset name",
+            required = true,
+            error = "A name is needed, at least 3 characters.",
+        )
+        NimazTextField(
+            value = "This note runs past the limit it was given",
+            onValueChange = {},
+            label = "Over the limit",
+            maxLength = 20,
+        )
+        NimazTextField(
+            value = "€312.00",
+            onValueChange = {},
+            label = "Calculated from your entries",
+            readOnly = true,
+        )
+        NimazTextField(
+            value = "Set by your region",
+            onValueChange = {},
+            label = "Fidya rate",
+            helper = "Change your region to edit this",
+            enabled = false,
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 380, heightDp = 1400, name = "NimazTextField — Light")
+@Composable
+private fun NimazTextFieldLightPreview() {
+    NimazTheme(themeMode = ThemeMode.LIGHT) { NimazTextFieldShowcase() }
+}
+
+@Preview(
+    showBackground = true, widthDp = 380, heightDp = 1400, name = "NimazTextField — Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun NimazTextFieldDarkPreview() {
+    NimazTheme(themeMode = ThemeMode.DARK) { NimazTextFieldShowcase() }
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NoteEditorSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NoteEditorSheet.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,19 +50,21 @@ fun NoteEditorSheet(
             NimazSheetFooterButtons(
                 primaryText = stringResource(R.string.save),
                 onPrimary = { onSave(text.trim().takeIf { it.isNotEmpty() }) },
+                // The one place a field's state reaches outside itself: an empty note is not a
+                // note, so Save has nothing to do until there is something in the field.
+                primaryEnabled = text.isNotBlank() || !initialNote.isNullOrBlank(),
                 secondaryText = stringResource(R.string.cancel),
                 onSecondary = onDismiss,
             )
         }
     ) {
-        NimazSheetSectionLabel(text = stringResource(R.string.edit_note))
-        OutlinedTextField(
+        NimazTextField(
             value = text,
             onValueChange = { text = it },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(140.dp),
-            placeholder = { Text(stringResource(R.string.note_hint)) }
+            label = stringResource(R.string.edit_note),
+            variant = NimazFieldVariant.NOTE,
+            placeholder = stringResource(R.string.note_hint),
+            modifier = Modifier.fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ReaderGoToSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/ReaderGoToSheet.kt
@@ -3,12 +3,9 @@ package com.arshadshah.nimaz.presentation.components.molecules
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,7 +14,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSegmentedControl
@@ -108,21 +104,21 @@ fun ReaderGoToSheet(
                 purpose = NimazSegmentedPurpose.VALUE,
             )
 
-            OutlinedTextField(
+            NimazTextField(
                 value = text,
                 onValueChange = { new -> if (new.all { it.isDigit() }) text = new },
-                label = { Text(stringResource(kind.labelRes())) },
+                label = stringResource(kind.labelRes()),
+                variant = NimazFieldVariant.NUMERIC,
                 // The bound is stated rather than merely enforced: a disabled button with no
-                // explanation is the version of this that wastes a reader's time.
-                supportingText = {
-                    Text(stringResource(R.string.reader_go_to_range, 1, bound))
-                },
-                isError = text.isNotBlank() && target == null,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number,
-                    imeAction = ImeAction.Go,
-                ),
+                // explanation is the version of this that wastes a reader's time. Out of range
+                // is an error *message* for the same reason — a red box saying nothing is
+                // barely better than a dead button.
+                helper = stringResource(R.string.reader_go_to_range, 1, bound),
+                error = if (text.isNotBlank() && target == null) {
+                    stringResource(R.string.reader_go_to_range, 1, bound)
+                } else null,
+                imeAction = ImeAction.Go,
+                onImeAction = go,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContent.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/TafseerPageContent.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.icons.outlined.TouchApp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -82,8 +81,10 @@ import com.arshadshah.nimaz.presentation.components.atoms.QuranOrnamentalDivider
 import com.arshadshah.nimaz.presentation.components.atoms.asSegments
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazReaderBottomBar
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSheetSectionLabel
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import com.arshadshah.nimaz.presentation.components.molecules.QuranFrame
 import com.arshadshah.nimaz.presentation.components.molecules.QuranFrameVariant
 import com.arshadshah.nimaz.presentation.components.molecules.TafseerHighlightableText
@@ -681,15 +682,14 @@ private fun HighlightEditorSheetContent(
         Spacer(modifier = Modifier.height(20.dp))
 
         // Note (optional).
-        NimazSheetSectionLabel(text = stringResource(R.string.tafseer_note_optional))
-        OutlinedTextField(
+        NimazTextField(
             value = noteText,
             onValueChange = { noteText = it },
-            placeholder = { Text(stringResource(R.string.tafseer_add_note)) },
-            modifier = Modifier.fillMaxWidth(),
-            minLines = 3,
+            label = stringResource(R.string.tafseer_note_optional),
+            variant = NimazFieldVariant.NOTE,
+            placeholder = stringResource(R.string.tafseer_add_note),
             maxLines = 6,
-            shape = RoundedCornerShape(12.dp)
+            modifier = Modifier.fillMaxWidth(),
         )
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastDaySheets.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastDaySheets.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,6 +29,8 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazFilterChip
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 import java.time.LocalDate
@@ -127,14 +128,15 @@ fun FastNoteSheet(
             SheetActions(onCancel = onDismiss, onSave = { onSave(note) })
         },
     ) {
-        OutlinedTextField(
+        NimazTextField(
             value = note,
             onValueChange = { note = it },
+            label = stringResource(R.string.fasting_note_title),
+            variant = NimazFieldVariant.NOTE,
+            placeholder = stringResource(R.string.fasting_note_hint),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 8.dp),
-            placeholder = { Text(stringResource(R.string.fasting_note_hint)) },
-            minLines = 3,
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/MakeupFastEditBottomSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/MakeupFastEditBottomSheet.kt
@@ -7,13 +7,11 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,8 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
@@ -34,6 +30,9 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonType
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldLabel
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import java.time.Instant
 import java.time.ZoneId
 
@@ -117,30 +116,24 @@ fun MakeupFastEditBottomSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
-            // Reason
-            OutlinedTextField(
+            NimazTextField(
                 value = reason,
                 onValueChange = { reason = it },
-                label = { Text(stringResource(R.string.fasting_sheet_reason)) },
+                label = stringResource(R.string.fasting_sheet_reason),
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true
             )
 
-            // Note
-            OutlinedTextField(
+            NimazTextField(
                 value = note,
                 onValueChange = { note = it },
-                label = { Text(stringResource(R.string.fasting_sheet_note)) },
+                label = stringResource(R.string.fasting_sheet_note),
+                variant = NimazFieldVariant.NOTE,
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true
             )
 
-            // Status chips
-            Text(
-                text = stringResource(R.string.fasting_sheet_status),
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Medium
-            )
+            // Status chips — a control, not a field, but it answers a question in the same
+            // sheet, so it wears the family's label.
+            NimazFieldLabel(text = stringResource(R.string.fasting_sheet_status))
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -164,13 +157,12 @@ fun MakeupFastEditBottomSheet(
 
             // Fidya amount (only when FIDYA_PAID)
             AnimatedVisibility(visible = selectedStatus == MakeupFastStatus.FIDYA_PAID) {
-                OutlinedTextField(
+                NimazTextField(
                     value = fidyaAmount,
                     onValueChange = { fidyaAmount = it },
-                    label = { Text(stringResource(R.string.fasting_sheet_fidya_amount)) },
+                    label = stringResource(R.string.fasting_sheet_fidya_amount),
+                    variant = NimazFieldVariant.NUMERIC,
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/khatam/KhatamFormScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/khatam/KhatamFormScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -22,7 +21,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,14 +53,17 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownField
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownMenu
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownRow
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldDefaults
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldLabel
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazLoadingState
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import com.arshadshah.nimaz.presentation.foundation.time.NimazTime
 import com.arshadshah.nimaz.presentation.components.molecules.NimazTimePickerDialog
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.foundation.tokens.KhatamProgressRing
-import com.arshadshah.nimaz.presentation.theme.NimazCornerRadius
 import com.arshadshah.nimaz.presentation.theme.NimazSpacing
 import com.arshadshah.nimaz.presentation.viewmodel.quran.KhatamEvent
 import com.arshadshah.nimaz.presentation.viewmodel.quran.KhatamFormMode
@@ -284,16 +285,17 @@ private fun KhatamFormContent(
         }
 
         item(key = "name") {
-            FieldLabel(stringResource(R.string.khatam_name_label))
-            OutlinedTextField(
+            // This is the field that made the mismatch visible: an OutlinedTextField with a
+            // notched border and a floating label, directly above a NimazDropdownField with a
+            // label above an outlined card. Same form, two ideas of what a field is.
+            NimazTextField(
                 value = state.name,
                 onValueChange = { onEvent(KhatamEvent.UpdateName(it)) },
+                label = stringResource(R.string.khatam_name_label),
+                required = true,
+                placeholder = stringResource(R.string.khatam_name_placeholder),
+                error = state.errorRes?.let { stringResource(it) },
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(NimazCornerRadius.Medium),
-                placeholder = { Text(stringResource(R.string.khatam_name_placeholder)) },
-                singleLine = true,
-                isError = state.errorRes != null,
-                supportingText = state.errorRes?.let { { Text(stringResource(it)) } },
             )
         }
 
@@ -355,9 +357,12 @@ private fun KhatamFormContent(
         }
 
         item(key = "deadline") {
-            FieldLabel(
-                stringResource(R.string.khatam_field_deadline) +
-                        " · " + stringResource(R.string.khatam_optional)
+            // A button, not a field — but it answers a form question, so it wears the family's
+            // label rather than a screen-local imitation of one.
+            NimazFieldLabel(
+                text = stringResource(R.string.khatam_field_deadline),
+                optionalLabel = stringResource(R.string.khatam_optional),
+                modifier = Modifier.padding(bottom = NimazFieldDefaults.LabelGap),
             )
             Row(verticalAlignment = Alignment.CenterVertically) {
                 NimazButton(
@@ -379,7 +384,10 @@ private fun KhatamFormContent(
         }
 
         item(key = "reminder") {
-            FieldLabel(stringResource(R.string.khatam_field_reminder))
+            NimazFieldLabel(
+                text = stringResource(R.string.khatam_field_reminder),
+                modifier = Modifier.padding(bottom = NimazFieldDefaults.LabelGap),
+            )
             NimazCard(
                 modifier = Modifier.fillMaxWidth(),
                 tone = NimazTone.NEUTRAL,
@@ -413,17 +421,14 @@ private fun KhatamFormContent(
         }
 
         item(key = "notes") {
-            FieldLabel(stringResource(R.string.khatam_notes_label))
-            OutlinedTextField(
+            NimazTextField(
                 value = state.notes,
                 onValueChange = { onEvent(KhatamEvent.UpdateNotes(it)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(120.dp),
-                // Multi-line fields inherit the single-line shape, which reads as
-                // under-rounded at this height.
-                shape = RoundedCornerShape(NimazCornerRadius.Medium),
-                placeholder = { Text(stringResource(R.string.khatam_notes_placeholder)) },
+                label = stringResource(R.string.field_notes),
+                optionalLabel = stringResource(R.string.khatam_optional),
+                variant = NimazFieldVariant.NOTE,
+                placeholder = stringResource(R.string.khatam_notes_placeholder),
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 
@@ -467,17 +472,6 @@ private fun KhatamFormContent(
             title = stringResource(R.string.notification_settings_reminder_time),
         )
     }
-}
-
-@Composable
-private fun FieldLabel(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelMedium,
-        fontWeight = FontWeight.SemiBold,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = NimazSpacing.Small, bottom = NimazSpacing.ExtraSmall),
-    )
 }
 
 private fun presetLabelRes(preset: KhatamPacePreset): Int = when (preset) {

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/TafseerScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.outlined.EditNote
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -52,7 +51,9 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.rememberNimazPagerState
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazLoadingState
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import com.arshadshah.nimaz.presentation.components.organisms.TafseerPageContent
 import com.arshadshah.nimaz.presentation.viewmodel.quran.TafseerEvent
 import com.arshadshah.nimaz.presentation.viewmodel.quran.TafseerViewModel
@@ -308,14 +309,14 @@ private fun TafseerNotesDialog(
             )
         },
     ) {
-        OutlinedTextField(
+        NimazTextField(
             value = draft,
             onValueChange = { draft = it },
+            label = stringResource(R.string.tafseer_note_hint),
+            variant = NimazFieldVariant.NOTE,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp),
-            label = { Text(stringResource(R.string.tafseer_note_hint)) },
-            minLines = 3,
         )
 
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -42,15 +41,13 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
-import com.arshadshah.nimaz.presentation.components.molecules.NimazAmountInput
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAmountField
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.molecules.ZakatHeroStat
 import com.arshadshah.nimaz.presentation.components.molecules.ZakatSummaryHero
-import com.arshadshah.nimaz.presentation.components.molecules.amountToInput
-import com.arshadshah.nimaz.presentation.components.molecules.parseAmountInput
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsEvent
@@ -312,46 +309,12 @@ private fun PriceRow(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
         )
-        PriceField(
+        NimazAmountField(
             value = price,
             onValueChange = onPriceChange,
             currencySymbol = currencySymbolOf(currency),
         )
     }
-}
-
-/**
- * A money field bound to a `Double` on the ViewModel.
- *
- * The text is **local state**, and that is the whole point. A field that parsed every keystroke
- * straight to a `Double` and re-rendered the result turned "10." into "10" before the next digit
- * landed, so a decimal price was literally unenterable — and a per-gram silver price is nothing
- * but decimals.
- *
- * The sync back the other way is guarded: an incoming [value] only overwrites the text when it
- * disagrees with what the text already parses to, so the DataStore write echoing the user's own
- * keystroke cannot erase the trailing point, while a genuinely different value still wins.
- */
-@Composable
-private fun PriceField(
-    value: Double,
-    onValueChange: (Double) -> Unit,
-    modifier: Modifier = Modifier,
-    currencySymbol: String? = null,
-) {
-    var text by rememberSaveable { mutableStateOf(amountToInput(value)) }
-    LaunchedEffect(value) {
-        if (parseAmountInput(text) != value) text = amountToInput(value)
-    }
-    NimazAmountInput(
-        value = text,
-        onValueChange = { next ->
-            text = next
-            onValueChange(parseAmountInput(next))
-        },
-        modifier = modifier,
-        currencySymbol = currencySymbol,
-    )
 }
 
 /**

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreen.kt
@@ -10,12 +10,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -27,9 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -46,10 +41,13 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldDefaults
+import com.arshadshah.nimaz.presentation.components.molecules.NimazFieldVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperSize
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperType
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazTextField
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihEvent
@@ -150,66 +148,49 @@ fun AddPresetScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            // The field family's rhythm: one field's label must not crowd the helper line of
+            // the field above it.
+            verticalArrangement = Arrangement.spacedBy(NimazFieldDefaults.FieldGap)
         ) {
-            // Name (required)
-            OutlinedTextField(
+            // Name (required). The 14dp radius, the RTL/gold Arabic styling and the error
+            // wiring all used to be set here, per field; they are the shell's and the
+            // variant's job now.
+            NimazTextField(
                 value = name,
                 onValueChange = {
                     name = it
                     nameError = false
                 },
-                label = { Text(stringResource(R.string.name_required)) },
-                placeholder = { Text(stringResource(R.string.preset_name_placeholder)) },
-                isError = nameError,
-                supportingText = if (nameError) {
-                    { Text(stringResource(R.string.name_required_error)) }
-                } else null,
+                label = stringResource(R.string.field_name),
+                required = true,
+                placeholder = stringResource(R.string.preset_name_placeholder),
+                error = if (nameError) stringResource(R.string.name_required_error) else null,
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(14.dp),
-                singleLine = true
             )
 
-            // Arabic Text (RTL, gold-tinted)
-            OutlinedTextField(
+            NimazTextField(
                 value = arabicText,
                 onValueChange = { arabicText = it },
-                label = { Text(stringResource(R.string.arabic_text)) },
-                placeholder = { Text(stringResource(R.string.arabic_placeholder)) },
+                label = stringResource(R.string.arabic_text),
+                variant = NimazFieldVariant.ARABIC,
+                placeholder = stringResource(R.string.arabic_placeholder),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(14.dp),
-                singleLine = true,
-                textStyle = TextStyle(
-                    textAlign = TextAlign.End,
-                    color = NimazColors.TasbihColors.Milestone,
-                    fontSize = 20.sp
-                ),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = NimazColors.TasbihColors.Milestone,
-                    unfocusedTextColor = NimazColors.TasbihColors.Milestone
-                )
             )
 
-            // Transliteration
-            OutlinedTextField(
+            NimazTextField(
                 value = transliteration,
                 onValueChange = { transliteration = it },
-                label = { Text(stringResource(R.string.transliteration)) },
-                placeholder = { Text(stringResource(R.string.transliteration_placeholder)) },
+                label = stringResource(R.string.transliteration),
+                placeholder = stringResource(R.string.transliteration_placeholder),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(14.dp),
-                singleLine = true
             )
 
-            // Translation
-            OutlinedTextField(
+            NimazTextField(
                 value = translation,
                 onValueChange = { translation = it },
-                label = { Text(stringResource(R.string.translation)) },
-                placeholder = { Text(stringResource(R.string.translation_placeholder)) },
+                label = stringResource(R.string.translation),
+                placeholder = stringResource(R.string.translation_placeholder),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(14.dp),
-                singleLine = true
             )
 
             // Target Count stepper

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/ChooseDhikrScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/tasbih/ChooseDhikrScreen.kt
@@ -19,13 +19,11 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxDefaults
 import androidx.compose.material3.SwipeToDismissBoxValue
@@ -63,6 +61,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
+import com.arshadshah.nimaz.presentation.components.organisms.NimazSearchBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihEvent
 import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihViewModel
@@ -156,16 +155,17 @@ fun ChooseDhikrScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            OutlinedTextField(
-                value = query,
-                onValueChange = { query = it },
+            // Search is its own member of the field family and the app already had one:
+            // NimazSearchBar, which is this same outlined shell plus the clear button, the
+            // focus border and the loading slot this hand-rolled field had none of.
+            NimazSearchBar(
+                query = query,
+                onQueryChange = { query = it },
+                onClear = { query = "" },
+                placeholder = stringResource(R.string.tasbih_search_dhikr),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp, vertical = 4.dp),
-                placeholder = { Text(stringResource(R.string.tasbih_search_dhikr)) },
-                leadingIcon = { NimazIcon(Icons.Default.Search, contentDescription = null) },
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp)
             )
 
             LazyRow(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -75,7 +74,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
-import com.arshadshah.nimaz.presentation.components.molecules.NimazAmountInput
+import com.arshadshah.nimaz.presentation.components.molecules.NimazAmountField
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorDefaults
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorVariant
@@ -83,8 +82,6 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.molecules.ZakatHeroStat
 import com.arshadshah.nimaz.presentation.components.molecules.ZakatHeroStatus
 import com.arshadshah.nimaz.presentation.components.molecules.ZakatSummaryHero
-import com.arshadshah.nimaz.presentation.components.molecules.amountToInput
-import com.arshadshah.nimaz.presentation.components.molecules.parseAmountInput
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.currentWindowSizeClass
@@ -820,7 +817,7 @@ private fun InputCard(
                 )
             }
 
-            AmountField(
+            NimazAmountField(
                 value = value,
                 onValueChange = onValueChange,
                 // Money leads with its symbol, a weight follows with its unit. The field this
@@ -832,45 +829,6 @@ private fun InputCard(
             )
         }
     }
-}
-
-/**
- * A money or weight field bound to a `Double` on the ViewModel.
- *
- * The text is **local state**, and that is the whole fix. The field this replaced parsed every
- * keystroke straight to a `Double` and re-rendered the result, so "10." became "10" before the
- * next digit landed and a decimal amount was literally unenterable. Here the string is what the
- * person typed and the `Double` is derived from it.
- *
- * The sync back the other way is guarded: an incoming [value] only overwrites the text when it
- * disagrees with what the text already parses to. Without that guard, the ViewModel echoing back
- * the user's own keystroke would erase the trailing point as fast as it was typed — while
- * "Clear all" and a restored calculation, which genuinely differ, still win.
- */
-@Composable
-private fun AmountField(
-    value: Double,
-    onValueChange: (Double) -> Unit,
-    modifier: Modifier = Modifier,
-    currencySymbol: String? = null,
-    unitSuffix: String? = null,
-    placeholder: String = "0.00",
-) {
-    var text by rememberSaveable { mutableStateOf(amountToInput(value)) }
-    LaunchedEffect(value) {
-        if (parseAmountInput(text) != value) text = amountToInput(value)
-    }
-    NimazAmountInput(
-        value = text,
-        onValueChange = { next ->
-            text = next
-            onValueChange(parseAmountInput(next))
-        },
-        modifier = modifier,
-        currencySymbol = currencySymbol,
-        unitSuffix = unitSuffix,
-        placeholder = placeholder,
-    )
 }
 
 // --- Breakdown Card ---

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2152,4 +2152,6 @@
     <string name="accuracy_now_label">Genauigkeit jetzt</string>
     <string name="back_to_compass">Zurück zum Kompass</string>
     <string name="point_with_camera">Mit der Kamera zielen</string>
+    <string name="field_name">Name</string>
+    <string name="field_notes">Notizen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2195,4 +2195,6 @@
     <string name="accuracy_now_label">Précision actuelle</string>
     <string name="back_to_compass">Retour à la boussole</string>
     <string name="point_with_camera">Viser avec la caméra</string>
+    <string name="field_name">Nom</string>
+    <string name="field_notes">Notes</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2111,4 +2111,6 @@
     <string name="accuracy_now_label">Akurasi saat ini</string>
     <string name="back_to_compass">Kembali ke kompas</string>
     <string name="point_with_camera">Arahkan dengan kamera</string>
+    <string name="field_name">Nama</string>
+    <string name="field_notes">Catatan</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2112,4 +2112,6 @@
     <string name="accuracy_now_label">Ketepatan sekarang</string>
     <string name="back_to_compass">Kembali ke kompas</string>
     <string name="point_with_camera">Halakan dengan kamera</string>
+    <string name="field_name">Nama</string>
+    <string name="field_notes">Nota</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2158,4 +2158,6 @@
     <string name="accuracy_now_label">Şu anki doğruluk</string>
     <string name="back_to_compass">Pusulaya dön</string>
     <string name="point_with_camera">Kamerayla nişan al</string>
+    <string name="field_name">Ad</string>
+    <string name="field_notes">Notlar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2352,4 +2352,8 @@
     <string name="khatam_portion_across">%1$s %2$d → %3$s %4$d</string>
     <string name="khatam_todays_portion">Today\'s portion</string>
     <string name="khatam_read_todays_portion">Read today\'s portion</string>
+    <!-- Character counter on a NimazTextField with a maxLength: "12 / 40". -->
+    <string name="field_character_count" translatable="false">%1$d / %2$d</string>
+    <string name="field_name">Name</string>
+    <string name="field_notes">Notes</string>
 </resources>

--- a/app/src/test/java/com/arshadshah/nimaz/presentation/MaterialTextFieldGuardTest.kt
+++ b/app/src/test/java/com/arshadshah/nimaz/presentation/MaterialTextFieldGuardTest.kt
@@ -1,0 +1,96 @@
+package com.arshadshah.nimaz.presentation
+
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard: no screen builds its own text field out of a Material primitive.
+ *
+ * The app had a `NimazDropdownField` and a `NimazAmountInput` but no text field, so twelve call
+ * sites reached for `OutlinedTextField` — and each one settled the same questions differently.
+ * `AddPresetScreen` hand-set a 14dp radius on four fields and styled the Arabic one inline with
+ * a `textStyle` *and* an `OutlinedTextFieldDefaults.colors` block. `KhatamFormScreen` put a
+ * notched-border floating-label field directly above a label-above-an-outlined-card dropdown.
+ * Three sites set `isError` with no message to go with it.
+ *
+ * A design system that has the component and still allows the primitive gets the drift back one
+ * screen at a time, so the primitive is fenced off here rather than only discouraged in review.
+ *
+ * The exceptions below are the field family's own implementations — the components that are
+ * *supposed* to own a `BasicTextField`. `TextField` and `OutlinedTextField` have no exceptions
+ * at all: nothing in the app should be reaching for Material's decorated fields.
+ */
+class MaterialTextFieldGuardTest {
+
+    /** Files allowed to own a raw `BasicTextField` — the family's implementations. */
+    private val basicTextFieldOwners = setOf(
+        // The text field itself.
+        "NimazTextField.kt",
+        // The search member: an older, richer implementation of the same shell (clear button,
+        // focus border, loading slot, the Ask pill).
+        "NimazSearchBar.kt",
+        // The stepper's editable value — a field inside a +/- control rather than a form field.
+        "NimazNumberStepper.kt",
+    )
+
+    @Test
+    fun `no presentation source uses a Material text field primitive`() {
+        val dir = File("src/main/java/com/arshadshah/nimaz/presentation")
+        assert(dir.isDirectory) { "Presentation source dir not found at ${dir.absolutePath}" }
+
+        // `(?<![A-Za-z0-9_.])` so `NimazTextField(` and `OutlinedTextFieldDefaults` do not
+        // register as the Material primitives they are named after.
+        val forbidden = mapOf(
+            "OutlinedTextField" to Regex("""(?<![A-Za-z0-9_.])OutlinedTextField\s*\("""),
+            "TextField" to Regex("""(?<![A-Za-z0-9_.])TextField\s*\("""),
+            "BasicTextField" to Regex("""(?<![A-Za-z0-9_.])BasicTextField\s*\("""),
+        )
+
+        val offenders = mutableListOf<String>()
+        dir.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            val text = file.readText()
+            forbidden.forEach { (name, pattern) ->
+                if (name == "BasicTextField" && file.name in basicTextFieldOwners) return@forEach
+                pattern.findAll(text).forEach { match ->
+                    val line = text.substring(0, match.range.first).count { it == '\n' } + 1
+                    offenders += "${file.name}:$line  $name("
+                }
+            }
+        }
+
+        assert(offenders.isEmpty()) {
+            "Material text field primitive used outside the field family " +
+                "(${offenders.size} site(s)). Use NimazTextField / NimazAmountField / " +
+                "NimazSearchBar instead:\n" + offenders.joinToString("\n")
+        }
+    }
+
+    /**
+     * The escape hatches the field family deliberately does not have.
+     *
+     * `shape`, `colors` and `textStyle` on a field parameter list are how the call sites this
+     * replaced ended up each choosing their own corner radius and their own Arabic styling. If
+     * one of them reappears on [com.arshadshah.nimaz.presentation.components.molecules.NimazTextField],
+     * the variant list is missing a member and the fix belongs there, not at the call site.
+     */
+    @Test
+    fun `NimazTextField exposes no styling escape hatches`() {
+        val source = File(
+            "src/main/java/com/arshadshah/nimaz/presentation/components/molecules/" +
+                "NimazTextField.kt"
+        )
+        assert(source.isFile) { "NimazTextField.kt not found at ${source.absolutePath}" }
+
+        val signature = source.readText()
+            .substringAfter("fun NimazTextField(")
+            .substringBefore("\n) {")
+
+        val hatches = listOf("shape", "colors", "textStyle", "keyboardOptions")
+            .filter { Regex("""^\s*$it\s*:""", RegexOption.MULTILINE).containsMatchIn(signature) }
+
+        assert(hatches.isEmpty()) {
+            "NimazTextField grew a styling escape hatch: ${hatches.joinToString()}. " +
+                "Add a NimazFieldVariant instead."
+        }
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/NimazFieldShellTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/NimazFieldShellTest.kt
@@ -1,0 +1,195 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The shell, exercised through the members that share it.
+ *
+ * These are the guarantees that make the family a family rather than three components that
+ * happen to look alike: the same label, the same helper/error line, the same disabled
+ * behaviour — whether the thing inside the box is a caret, a chevron or a number.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NimazFieldShellTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private fun methods() = listOf(
+        NimazDropdownItem("mwl", "Muslim World League"),
+        NimazDropdownItem("uaq", "Umm al-Qura"),
+    )
+
+    // ── One label, one helper line, across the family ──────────────────────
+
+    @Test
+    fun `the dropdown wears the same label, helper and required marker as a text field`() {
+        composeRule.setThemedContent {
+            Column {
+                NimazDropdownField(
+                    items = methods(),
+                    selected = "mwl",
+                    onSelected = {},
+                    label = "Calculation method",
+                    required = true,
+                    helper = "Used for every prayer time",
+                )
+                NimazTextField(
+                    value = "",
+                    onValueChange = {},
+                    label = "Preset name",
+                    required = true,
+                    helper = "Shown in your list of presets",
+                )
+            }
+        }
+        composeRule.onNodeWithText("Calculation method").assertExists()
+        composeRule.onNodeWithText("Used for every prayer time").assertExists()
+        composeRule.onNodeWithText("Preset name").assertExists()
+        composeRule.onNodeWithText("Shown in your list of presets").assertExists()
+    }
+
+    @Test
+    fun `an error replaces the helper on a dropdown too`() {
+        composeRule.setThemedContent {
+            NimazDropdownField(
+                items = methods(),
+                selected = null,
+                onSelected = {},
+                label = "Calculation method",
+                helper = "Used for every prayer time",
+                error = "Pick a method before continuing.",
+            )
+        }
+        composeRule.onNodeWithText("Pick a method before continuing.").assertExists()
+        composeRule.onNodeWithText("Used for every prayer time").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the dropdown still opens, selects and closes on the shared shell`() {
+        // The shell owns the box and the anchor; the popup has to keep working through it.
+        var picked: String? = null
+        composeRule.setThemedContent {
+            NimazDropdownField(
+                items = methods(),
+                selected = "mwl",
+                onSelected = { picked = it },
+                label = "Calculation method",
+            )
+        }
+        composeRule.onNodeWithText("Umm al-Qura").assertDoesNotExist()
+
+        composeRule.onNodeWithText("Muslim World League").performClick()
+        composeRule.onNodeWithText("Umm al-Qura").performClick()
+
+        assertThat(picked).isEqualTo("uaq")
+    }
+
+    @Test
+    fun `a disabled dropdown ignores taps`() {
+        var picked: String? = null
+        composeRule.setThemedContent {
+            NimazDropdownField(
+                items = methods(),
+                selected = "mwl",
+                onSelected = { picked = it },
+                enabled = false,
+            )
+        }
+        composeRule.onNodeWithText("Muslim World League").performClick()
+
+        composeRule.onNodeWithText("Umm al-Qura").assertDoesNotExist()
+        assertThat(picked).isNull()
+    }
+
+    // ── The amount field, on the same shell ────────────────────────────────
+
+    @Test
+    fun `the amount input groups thousands as they are typed`() {
+        composeRule.setThemedContent {
+            var text by remember { mutableStateOf("") }
+            NimazAmountInput(
+                value = text,
+                onValueChange = { text = it },
+                currencySymbol = "€",
+            )
+        }
+        composeRule.onNode(hasSetTextAction()).performTextInput("42180")
+
+        composeRule.onNodeWithText("42,180").assertExists()
+        composeRule.onNodeWithText("€").assertExists()
+    }
+
+    @Test
+    fun `a half-typed decimal keeps its point`() {
+        // The bug the amount field exists for: parsing every keystroke to a Double ate the "."
+        // before the next digit landed, so a decimal amount was unenterable.
+        var reported = 0.0
+        composeRule.setThemedContent {
+            NimazAmountField(
+                value = 0.0,
+                onValueChange = { reported = it },
+                currencySymbol = "£",
+            )
+        }
+        composeRule.onNode(hasSetTextAction()).performTextInput("1284.")
+
+        composeRule.onNodeWithText("1,284.").assertExists()
+        assertThat(reported).isEqualTo(1284.0)
+    }
+
+    @Test
+    fun `a stored amount arrives already formatted and a real change still wins`() {
+        var stored by mutableStateOf(42180.5)
+        composeRule.setThemedContent {
+            NimazAmountField(value = stored, onValueChange = { stored = it })
+        }
+        composeRule.onNodeWithText("42,180.5").assertExists()
+
+        // "Clear all" — a genuinely different value, so it must overwrite the text.
+        stored = 0.0
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("42,180.5").assertDoesNotExist()
+        composeRule.onNodeWithText("0.00").assertExists()
+    }
+
+    @Test
+    fun `a weight follows its unit rather than leading with a symbol`() {
+        composeRule.setThemedContent {
+            NimazAmountInput(
+                value = "87.48",
+                onValueChange = {},
+                unitSuffix = "g",
+                placeholder = "0",
+            )
+        }
+        composeRule.onNodeWithText("87.48").assertExists()
+        composeRule.onNodeWithText("g").assertExists()
+    }
+
+    @Test
+    fun `a third decimal is refused rather than rounded away`() {
+        composeRule.setThemedContent {
+            var text by remember { mutableStateOf("") }
+            NimazAmountInput(value = text, onValueChange = { text = it }, currencySymbol = "$")
+        }
+        composeRule.onNode(hasSetTextAction()).performTextReplacement("10.555")
+
+        composeRule.onNodeWithText("10.55").assertExists()
+    }
+}

--- a/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTextFieldTest.kt
+++ b/app/src/testDebug/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTextFieldTest.kt
@@ -1,0 +1,413 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The app's text field, member by member and state by state.
+ *
+ * The rules worth guarding are the ones the twelve `OutlinedTextField` call sites this replaced
+ * each got slightly differently: when an error is allowed to appear, whether a message comes
+ * with it, whether an over-long value is cut, and whether a disabled or read-only field can
+ * still be typed into.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NimazTextFieldTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    /**
+     * A field plus a button that drops focus, so a test can blur without depending on another
+     * focusable stealing it.
+     */
+    @Composable
+    private fun WithBlurButton(field: @Composable () -> Unit) {
+        val focusManager = LocalFocusManager.current
+        Column {
+            field()
+            NimazButton(
+                text = "blur",
+                onClick = { focusManager.clearFocus() },
+                modifier = Modifier.testTag("blur"),
+            )
+        }
+    }
+
+    private fun field() = composeRule.onNode(hasSetTextAction())
+
+    // ── Rendering ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `renders its label above the field`() {
+        composeRule.setThemedContent {
+            NimazTextField(value = "", onValueChange = {}, label = "Preset name")
+        }
+        composeRule.onNodeWithText("Preset name").assertExists()
+    }
+
+    @Test
+    fun `shows the placeholder only while empty`() {
+        var value by mutableStateOf("")
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = value,
+                onValueChange = { value = it },
+                placeholder = "Morning adhkar",
+            )
+        }
+        composeRule.onNodeWithText("Morning adhkar").assertExists()
+
+        field().performTextInput("Evening")
+
+        composeRule.onNodeWithText("Morning adhkar").assertDoesNotExist()
+        composeRule.onNodeWithText("Evening").assertExists()
+    }
+
+    @Test
+    fun `the required marker is decorative and the optional one is announced`() {
+        // The asterisk carries no information a screen reader can use — "Name asterisk" is
+        // noise — so it is cleared out of the semantics tree. "optional" is a real word and
+        // stays in it.
+        composeRule.setThemedContent {
+            Column {
+                NimazTextField(
+                    value = "",
+                    onValueChange = {},
+                    label = "Name",
+                    required = true,
+                )
+                NimazTextField(
+                    value = "",
+                    onValueChange = {},
+                    label = "Note",
+                    optionalLabel = "optional",
+                )
+            }
+        }
+        composeRule.onNodeWithText("Name").assertExists()
+        composeRule.onNodeWithText("*", useUnmergedTree = true).assertDoesNotExist()
+        composeRule.onNodeWithText("optional").assertExists()
+    }
+
+    @Test
+    fun `renders the helper line, the affixes and a leading icon together`() {
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = "12,480.00",
+                onValueChange = {},
+                label = "Zakat on savings",
+                variant = NimazFieldVariant.NUMERIC,
+                helper = "Across every account",
+                prefix = "€",
+                suffix = "EUR",
+                leadingIcon = Icons.Default.Person,
+            )
+        }
+        composeRule.onNodeWithText("Across every account").assertExists()
+        composeRule.onNodeWithText("€").assertExists()
+        composeRule.onNodeWithText("EUR").assertExists()
+        composeRule.onNodeWithText("12,480.00").assertExists()
+    }
+
+    @Test
+    fun `every variant renders its value`() {
+        composeRule.setThemedContent {
+            Column {
+                NimazTextField(value = "plain", onValueChange = {})
+                NimazTextField(
+                    value = "سُبْحَانَ",
+                    onValueChange = {},
+                    variant = NimazFieldVariant.ARABIC,
+                )
+                NimazTextField(
+                    value = "86.40",
+                    onValueChange = {},
+                    variant = NimazFieldVariant.NUMERIC,
+                    density = NimazFieldDensity.COMPACT,
+                )
+                NimazTextField(
+                    value = "a longer thought",
+                    onValueChange = {},
+                    variant = NimazFieldVariant.NOTE,
+                )
+            }
+        }
+        composeRule.onNodeWithText("plain").assertExists()
+        composeRule.onNodeWithText("سُبْحَانَ").assertExists()
+        composeRule.onNodeWithText("86.40").assertExists()
+        composeRule.onNodeWithText("a longer thought").assertExists()
+    }
+
+    // ── Typing and clearing ────────────────────────────────────────────────
+
+    @Test
+    fun `typing reports every keystroke`() {
+        val seen = mutableListOf<String>()
+        composeRule.setThemedContent {
+            var value by remember { mutableStateOf("") }
+            NimazTextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                    seen += it
+                },
+            )
+        }
+        field().performTextInput("a")
+        field().performTextInput("b")
+        assertThat(seen).containsExactly("a", "ab").inOrder()
+    }
+
+    @Test
+    fun `the clear button appears with text and empties the field`() {
+        composeRule.setThemedContent {
+            var value by remember { mutableStateOf("") }
+            NimazTextField(value = value, onValueChange = { value = it })
+        }
+        composeRule.onNodeWithContentDescription("Clear").assertDoesNotExist()
+
+        field().performTextInput("Morning adhkar")
+        composeRule.onNodeWithContentDescription("Clear").performClick()
+
+        composeRule.onNodeWithText("Morning adhkar").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a note has no clear button - one tap must not destroy a paragraph`() {
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = "Ask about the weight of speech here.",
+                onValueChange = {},
+                variant = NimazFieldVariant.NOTE,
+            )
+        }
+        composeRule.onNodeWithContentDescription("Clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the box padding reaches the field, not nothing`() {
+        // The caret occupies the middle ~26dp of a 50dp box. Without the shell's rippleless
+        // inner tap target, a tap on the field's own padding does nothing and the field reads
+        // as broken at its edges — which Material's OutlinedTextField never did.
+        composeRule.setThemedContent {
+            var value by remember { mutableStateOf("") }
+            NimazTextField(
+                value = value,
+                onValueChange = { value = it },
+                label = "Preset name",
+            )
+        }
+        // The clickable-but-not-editable node is the box's own tap target, which spans the
+        // full 50dp; the editable node inside it is only the ~26dp caret row.
+        composeRule.onNode(hasClickAction() and !hasSetTextAction()).performClick()
+
+        field().assertIsFocused()
+    }
+
+    // ── Counter and the limit ──────────────────────────────────────────────
+
+    @Test
+    fun `the counter tracks what has been typed`() {
+        composeRule.setThemedContent {
+            var value by remember { mutableStateOf("") }
+            NimazTextField(value = value, onValueChange = { value = it }, maxLength = 40)
+        }
+        composeRule.onNodeWithText("0 / 40").assertExists()
+
+        field().performTextInput("abc")
+
+        composeRule.onNodeWithText("3 / 40").assertExists()
+    }
+
+    @Test
+    fun `going over the limit is marked, never truncated`() {
+        // Cutting off what somebody typed is worse than letting them cut it: the value keeps
+        // every character and the counter reports the overrun.
+        var value = ""
+        composeRule.setThemedContent {
+            var text by remember { mutableStateOf("") }
+            NimazTextField(
+                value = text,
+                onValueChange = {
+                    text = it
+                    value = it
+                },
+                maxLength = 5,
+            )
+        }
+        field().performTextInput("abcdefgh")
+
+        assertThat(value).isEqualTo("abcdefgh")
+        composeRule.onNodeWithText("8 / 5").assertExists()
+        composeRule.onNodeWithText("abcdefgh").assertExists()
+    }
+
+    // ── Errors ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an error replaces the helper rather than stacking under it`() {
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = "",
+                onValueChange = {},
+                helper = "Shown in your list of presets",
+                error = "A name is needed.",
+            )
+        }
+        composeRule.onNodeWithText("A name is needed.").assertExists()
+        composeRule.onNodeWithText("Shown in your list of presets").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a field nobody has touched is not in error`() {
+        // onFocusChanged reports "not focused" on the first composition too. Treating that as a
+        // blur would red-flag every empty required field the moment a form appeared.
+        composeRule.setThemedContent {
+            WithBlurButton {
+                NimazTextField(
+                    value = "",
+                    onValueChange = {},
+                    required = true,
+                    validator = { if (it.isBlank()) "A name is needed." else null },
+                )
+            }
+        }
+        composeRule.onNodeWithText("A name is needed.").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the validator does not fire on the first keystroke`() {
+        composeRule.setThemedContent {
+            var value by remember { mutableStateOf("") }
+            NimazTextField(
+                value = value,
+                onValueChange = { value = it },
+                validator = { if (it.length < 3) "At least 3 characters." else null },
+            )
+        }
+        field().performTextInput("a")
+        composeRule.onNodeWithText("At least 3 characters.").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the validator fires on blur`() {
+        composeRule.setThemedContent {
+            WithBlurButton {
+                var value by remember { mutableStateOf("") }
+                NimazTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    validator = { if (it.length < 3) "At least 3 characters." else null },
+                )
+            }
+        }
+        field().performClick()
+        field().performTextInput("ab")
+        composeRule.onNodeWithTag("blur").performClick()
+
+        composeRule.onNodeWithText("At least 3 characters.").assertExists()
+    }
+
+    @Test
+    fun `an error already on screen clears as it is fixed`() {
+        composeRule.setThemedContent {
+            WithBlurButton {
+                var value by remember { mutableStateOf("") }
+                NimazTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    validator = { if (it.length < 3) "At least 3 characters." else null },
+                )
+            }
+        }
+        field().performClick()
+        field().performTextInput("ab")
+        composeRule.onNodeWithTag("blur").performClick()
+        composeRule.onNodeWithText("At least 3 characters.").assertExists()
+
+        field().performTextReplacement("abc")
+
+        composeRule.onNodeWithText("At least 3 characters.").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a caller's error wins over the validator's`() {
+        // The screen knows things the field does not — a failed save, a name already taken.
+        composeRule.setThemedContent {
+            WithBlurButton {
+                var value by remember { mutableStateOf("") }
+                NimazTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    error = "That name is already used.",
+                    validator = { "At least 3 characters." },
+                )
+            }
+        }
+        field().performClick()
+        composeRule.onNodeWithTag("blur").performClick()
+
+        composeRule.onNodeWithText("That name is already used.").assertExists()
+        composeRule.onNodeWithText("At least 3 characters.").assertDoesNotExist()
+    }
+
+    // ── Disabled and read-only ─────────────────────────────────────────────
+
+    @Test
+    fun `a disabled field shows its value and cannot be typed into`() {
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = "Set by your region",
+                onValueChange = {},
+                label = "Fidya rate",
+                enabled = false,
+            )
+        }
+        composeRule.onNodeWithText("Set by your region").assertExists()
+        composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)
+            .assertCountEquals(0)
+        composeRule.onNodeWithContentDescription("Clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a read-only field shows its value and cannot be typed into`() {
+        composeRule.setThemedContent {
+            NimazTextField(
+                value = "€312.00",
+                onValueChange = {},
+                label = "Calculated from your entries",
+                readOnly = true,
+            )
+        }
+        composeRule.onNodeWithText("€312.00").assertExists()
+        composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)
+            .assertCountEquals(0)
+        composeRule.onNodeWithContentDescription("Clear").assertDoesNotExist()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -982,6 +982,50 @@ with no label and a touch target under 48dp fail the lane we already run. It can
       variant. **Not** for `Switch` (on/off settings) or genuine single-choice `RadioButton` pickers
       — those stay as-is. It centralised the prayer/fast trackers, the settings/Quran pickers and
       the dropdown/list selection check indicators.
+    - **anything you type into is `NimazTextField`** (`components/molecules/NimazTextField.kt`),
+      **never** a Material `TextField`/`OutlinedTextField`/`BasicTextField`. The app had a
+      dropdown field and an amount field but no *text* field, so twelve call sites reached for
+      `OutlinedTextField` and each settled the same questions differently — `AddPresetScreen`
+      hand-set a 14dp radius on four fields and styled the Arabic one inline with a `textStyle`
+      *and* an `OutlinedTextFieldDefaults.colors` block; `KhatamFormScreen` put a notched-border
+      floating-label field directly above a label-above-an-outlined-card `NimazDropdownField`;
+      three sites set `isError` with no message to explain it. The whole family now shares one
+      chassis, `NimazFieldShell` (`components/molecules/NimazFieldShell.kt`):
+      - **Geometry** comes from the shell, never from a variant or a call site: label above at
+        `bodyLarge`/Medium with an 8dp gap, an outlined `NimazCard` at 14dp with a 1.5dp border
+        and 14/12 padding, one helper/error line beneath. `NimazFieldDensity.COMPACT` (12dp,
+        12/10, ~42dp tall) is the single exception, for a field that sits *beside* a label
+        rather than under one — the Zakat asset rows.
+      - **`variant`** (`NimazFieldVariant`) chooses typeface, direction, alignment and keyboard
+        only: `TEXT`, `ARABIC` (Amiri 22sp, RTL, right-aligned, `colorScheme.secondary`),
+        `NUMERIC` (tabular, semi-bold, right-aligned, decimal keyboard), `NOTE` (multi-line, no
+        clear button). There is **no variant per feature** — a khatam name, a preset name and a
+        fasting reason are all `TEXT`.
+      - **There is no `shape`, no `colors`, no `textStyle` and no `keyboardOptions` parameter**,
+        and that absence is the point. If a call site needs one, the variant list is missing a
+        member and the fix belongs there. `MaterialTextFieldGuardTest` fails the build both on a
+        raw Material primitive outside the family and on one of those parameters reappearing.
+      - **`error` is a message, not a boolean.** Errors appear on **blur or submit, never on the
+        first keystroke**: pass `validator` for the per-field rule (run when focus leaves, then
+        on every keystroke while an error is showing, so it clears as it is fixed) and `error`
+        for a message the screen decided; `error` wins. An error *replaces* the helper on the
+        same line, so nothing below the field moves.
+      - **`maxLength` marks, it does not truncate** — the counter turns red and the border with
+        it, and the value keeps every character. Cutting off what somebody typed is worse than
+        letting them cut it.
+      - **`NimazAmountField(value: Double, onValueChange: (Double) -> Unit, …)`**
+        (`components/molecules/NimazAmountInput.kt`) is the money/weight member, and it owns the
+        text↔`Double` binding that `ZakatCalculatorScreen` and `ZakatSettingsScreen` each kept a
+        private copy of. `prefix`/`suffix` replace `currencySymbol`/`unitSuffix`, which were the
+        same parameter written twice.
+      - **Search is `NimazSearchBar`** (`components/organisms/NimazSearchBar.kt`) — the same
+        outlined shell plus the clear button, focus border, loading slot and Ask pill. A
+        screen-local "search field" built from anything else is the bug this replaced.
+      - `NimazFieldLabel(text, required = …, optionalLabel = …)` is public for the one case the
+        shell cannot cover: a **control that answers a form question without being a text
+        input** — Khatam's deadline button, its reminder switch, the make-up-fast status chips.
+        Use it rather than a screen-local `FieldLabel`, which is how those rows ended up at
+        `labelMedium`/SemiBold/onSurfaceVariant above fields labelled `bodyLarge`/Medium/onSurface.
     - a **choose-one / act** surface picks by list shape, **never** a raw Material
       `DropdownMenu`/`ExposedDropdownMenuBox`/`DropdownMenuItem`. The whole anchored-dropdown system
       lives in one file, `components/molecules/NimazDropdown.kt`. The rule:
@@ -997,6 +1041,12 @@ with no label and a touch target under 48dp fail the lane we already run. It can
       `selected` for a value choice (accent fill + circular check) or `destructive` for an
       irreversible command — and render on one popover surface via `NimazDropdownDefaults` (16dp
       `surface` card, tonal elevation, faint outline — **not** Material's heavy drop-shadow menu).
+      `NimazDropdownField`'s trigger is drawn on the shared `NimazFieldShell` (the shell's
+      geometry came from it), so it takes `label`/`required`/`helper`/`error` like every other
+      field. One behaviour changed on the way in: the border used to go primary whenever a value
+      was *set*, and is now primary only while the menu is open — in a form of eight completed
+      fields, eight primary boxes stop the colour meaning "you are here", and a value going from
+      muted placeholder to full ink already says the field is filled.
       variant. **Not** for on/off toggles (use `NimazSwitch`) or genuine single-choice `RadioButton`
       pickers (those stay as-is). It centralised the prayer/fast trackers, the settings/Quran pickers
       and the dropdown/list selection check indicators.

--- a/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
+++ b/docs/CLEAN_ARCHITECTURE_CHECKLIST.md
@@ -184,6 +184,23 @@ design-token / illustration files (see below).
   surfaces now take a semantic `NimazTone` and resolve through `NimazCardDefaults.tone()` /
   `NimazBadgeDefaults.colors()`. See `ARCHITECTURE.md` §8.1–§8.2.
 
+- [x] ~~**Per-field `shape`, `textStyle` and `colors` on twelve Material text fields.**~~
+  **Resolved.** The app had a dropdown field and an amount field but no *text* field, so every
+  form built its own: `AddPresetScreen` set `RoundedCornerShape(14.dp)` on four fields and gave
+  the Arabic one a hand-written `TextStyle` plus an `OutlinedTextFieldDefaults.colors` block;
+  `KhatamFormScreen`, `TafseerPageContent` and `ChooseDhikrScreen` each picked their own radius.
+  All twelve now call `NimazTextField`, which has **no** `shape`/`colors`/`textStyle` parameter —
+  geometry belongs to `NimazFieldShell` and typography to `NimazFieldVariant`.
+  `MaterialTextFieldGuardTest` fails the build on a raw Material text-field primitive outside the
+  family, and on one of those parameters reappearing. See `ARCHITECTURE.md` §8.
+
+  ```bash
+  # -P (not -E): the lookbehind is what stops `NimazTextField(` matching. Should print only
+  # NimazTextField.kt, NimazSearchBar.kt and NimazNumberStepper.kt — the family's own owners.
+  grep -rnP '(?<![A-Za-z0-9_.])(Outlined|Basic)?TextField\s*\(' \
+    app/src/main/java/com/arshadshah/nimaz/presentation/
+  ```
+
 > Components (`presentation/components/`) also contain literals; many are intentional gradient
 > stops. Prefer named tokens, but a dedicated design-token file (e.g. `BeadDesign.kt`) holding
 > grouped palettes is acceptable — the anti-pattern is *scattered* literals inside screen logic.


### PR DESCRIPTION
The app had a dropdown field and an amount field but no *text* field, so twelve
call sites reached for Material's `OutlinedTextField` and each one settled the
same questions differently. `AddPresetScreen` hand-set a 14dp radius on four
fields and styled the Arabic one inline with a `textStyle` *and* an
`OutlinedTextFieldDefaults.colors` block. `KhatamFormScreen` put a
notched-border floating-label field directly above a
label-above-an-outlined-card `NimazDropdownField` — same form, two ideas of what
a field is. Three sites set `isError` with no message to explain it.

The shell was already there, drawn by `NimazDropdownField` and again, smaller,
by `NimazAmountInput`. This extracts it and makes everything a caller.

**`NimazFieldShell`** (internal) — label above at bodyLarge/Medium with an 8dp
gap, an outlined `NimazCard` at 14dp with a 1.5dp border and 14/12 padding, one
helper/error line beneath. `NimazFieldDensity.COMPACT` is the single geometry
exception, for a field that sits beside a label rather than under one — the
Zakat asset rows, and the reason `NimazAmountInput` looked different at all.

**`NimazTextField`** — TEXT / ARABIC / NUMERIC / NOTE, over `BasicTextField`.
No `shape`, no `colors`, no `textStyle`, no `keyboardOptions`: those are how the
call sites drifted, so a call site that needs one means the variant list is
missing a member. `error` is a message rather than a boolean, and errors appear
on blur or submit — never on the first keystroke — then clear as they are fixed.
`maxLength` marks and blocks; it never truncates what somebody typed.

Three behaviour changes worth naming:

- The dropdown's border used to go primary whenever a value was *set*. In a form
  of eight completed fields that is eight primary boxes and the colour stops
  meaning "you are here"; it is now primary only while the menu is open.
- A tap on the box's own padding now reaches the field. The caret occupies the
  middle ~26dp of a 50dp box, so without the shell's rippleless inner tap target
  the field reads as broken at its edges — something `OutlinedTextField` never
  did.
- `NoteEditorSheet`'s Save stays disabled until there is a note to save.

Consolidated away: `AmountField` (ZakatCalculatorScreen) and `PriceField`
(ZakatSettingsScreen), byte-for-byte the same nineteen lines including the same
two comments, both now `NimazAmountField`; `FieldLabel` (KhatamFormScreen),
replaced by the public `NimazFieldLabel` the shell itself renders with;
`ChooseDhikrScreen`'s hand-rolled search field, now `NimazSearchBar`.

Tests: 40 Robolectric compose tests across `NimazTextFieldTest` and
`NimazFieldShellTest` — every variant, every state, the blur/submit error rules,
the no-truncation rule, tap-to-focus, and the dropdown and amount field on the
shared shell. `MaterialTextFieldGuardTest` fails the build on a raw Material
text-field primitive anywhere in `presentation/` outside the family's three
owners, and on a styling escape hatch reappearing on `NimazTextField`.

Docs: `ARCHITECTURE.md` §8 gains the field-family bullet and the dropdown
bullet notes the border change; `CLEAN_ARCHITECTURE_CHECKLIST.md` AP-5 ticks the
per-field shape/textStyle/colors item with its detect command.

Verified: `compileDebugKotlin`, `testDebugUnitTest` (2309 tests; the single
failure is `DeviceStateCorpusTest`, which needs the private content artifact and
fails identically on a pristine tree here), `lintDebug`, `check_docs.py`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PtmSKCjPsoGx1tn9qJmVi2