### PR TITLE
Give the Qur'an surfaces one divider and one arrow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,12 @@ The obligations, in short:
    whole-card tap target is `NimazCard(onClick = …)` (or `NimazMenuItem` for list rows), **not** a
    `Modifier.clickable` wrapped around the card — a wrapping `.clickable` paints a **sharp-cornered
    ripple** that ignores the card radius. `.clickable` on *inner* elements (a `Text`, an icon, a
-   sub-row) is fine. For `EventCard`/`WorshipEventCard`, pass `onClick`/`onClickLabel`. See
-   `docs/ARCHITECTURE.md` §8 (the `NimazButton`/`NimazCard` bullets).
+   sub-row) is fine. For `EventCard`/`WorshipEventCard`, pass `onClick`/`onClickLabel`. Rows in a
+   `NimazMenuGroup` are separated with **`NimazMenuDivider()`** (`inset = false` where there is no
+   icon column), never a hand-measured `NimazDivider`; every arrow/chevron comes from
+   **`NimazIcons`** (`Forward` for "this row opens something"), never a per-call-site
+   `ArrowForward`/`ChevronRight`/`KeyboardArrowRight`. See `docs/ARCHITECTURE.md` §8 (the
+   `NimazButton`/`NimazCard`/`NimazMenuDivider`/`NimazIcons` bullets).
 
 ## Verify before finishing
 

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIcons.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazIcons.kt
@@ -1,0 +1,53 @@
+package com.arshadshah.nimaz.presentation.components.atoms
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * The app's directional glyphs, named by what they *mean* rather than by which Material icon
+ * happens to draw them.
+ *
+ * Before this existed, "this row opens something" was drawn four different ways —
+ * `ArrowForward` on the Qur'an home rows and the browse jump card, `KeyboardArrowRight` on every
+ * settings row, `ChevronRight` on the prayer card, `ArrowForwardIos` in Help — so two rows doing
+ * the same thing on two screens did not look like the same thing. There is one chevron now, and
+ * a screen that wants a different one has to change it here, for everybody.
+ *
+ * All of these are auto-mirrored where direction is about *reading order* (forward, back,
+ * previous, next), so an RTL locale flips them without a call site knowing. [Expand] and
+ * [Collapse] are not: down is down in every locale.
+ */
+object NimazIcons {
+
+    /**
+     * Disclosure: "this opens something." The trailing chevron on a [NimazMenuItem]-style row,
+     * on a banner that navigates, on a card whose whole body is a link, and — rotated 90° — the
+     * expander on a collapsible row.
+     *
+     * @see com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
+     */
+    val Forward: ImageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight
+
+    /** Up one level. The top-app-bar back button. */
+    val Back: ImageVector = Icons.AutoMirrored.Filled.ArrowBack
+
+    /**
+     * Step back through a sequence — a page, a month, a lesson. Paired with [Next]; prefer
+     * [NimazNavArrowButton] over drawing this directly.
+     */
+    val Previous: ImageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft
+
+    /** Step forward through a sequence. The same glyph as [Forward] — see [Previous]. */
+    val Next: ImageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight
+
+    /** Reveal a collapsed section. */
+    val Expand: ImageVector = Icons.Default.KeyboardArrowDown
+
+    /** Fold a revealed section away. */
+    val Collapse: ImageVector = Icons.Default.KeyboardArrowUp
+}

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazNavArrowButton.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/atoms/NimazNavArrowButton.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -18,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 
@@ -49,8 +47,8 @@ fun NimazNavArrowButton(
     size: Dp = 48.dp
 ) {
     val icon = when (direction) {
-        NavArrowDirection.PREVIOUS -> Icons.AutoMirrored.Filled.KeyboardArrowLeft
-        NavArrowDirection.NEXT -> Icons.AutoMirrored.Filled.KeyboardArrowRight
+        NavArrowDirection.PREVIOUS -> NimazIcons.Previous
+        NavArrowDirection.NEXT -> NimazIcons.Next
     }
     val tint = if (enabled) {
         MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/HadithOfTheDayCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -32,6 +31,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazPalette
@@ -104,7 +104,7 @@ fun HadithOfTheDayCard(
                         color = HadithAccent
                     )
                     NimazIcon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        imageVector = NimazIcons.Forward,
                         contentDescription = null,
                         tint = HadithAccent,
                         iconSize = 14.dp,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazAccordion.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.HelpOutline
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,6 +35,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
@@ -159,7 +159,7 @@ fun NimazAccordion(
                     Spacer(modifier = Modifier.width(4.dp))
                 }
                 NimazIcon(
-                    imageVector = Icons.Default.ExpandMore,
+                    imageVector = NimazIcons.Expand,
                     contentDescription = null,
                     variant = NimazIconVariant.MUTED,
                     modifier = Modifier.rotate(chevronRotation)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazBanner.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazBanner.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.filled.BatteryAlert
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Warning
@@ -49,6 +48,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
@@ -252,7 +252,7 @@ fun NimazBanner(
             when {
                 onClick != null -> {
                     NimazIcon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        imageVector = NimazIcons.Forward,
                         contentDescription = null,
                         tint = palette.accent,
                         iconSize = 18.dp,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazBreadcrumbBar.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazBreadcrumbBar.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -23,6 +21,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazChipVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 
@@ -96,7 +95,7 @@ const val HOME_INDEX = -1
 @Composable
 private fun CrumbSeparator() {
     NimazIcon(
-        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+        imageVector = NimazIcons.Forward,
         contentDescription = null,
         variant = NimazIconVariant.MUTED,
         size = NimazIconSize.SMALL,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazDropdown.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazDropdown.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.WbSunny
@@ -57,6 +56,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
 
@@ -379,7 +379,7 @@ fun <T> NimazDropdownField(
             contentAlignment = Alignment.Center
         ) {
             NimazIcon(
-                imageVector = Icons.Default.KeyboardArrowDown,
+                imageVector = NimazIcons.Expand,
                 contentDescription = null,
                 tint = chevronTint,
                 iconSize = 16.dp,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazMenuItem.kt
@@ -10,8 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Fastfood
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -27,15 +28,18 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.TranslationLanguage
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.asLanguageLabel
 
@@ -63,7 +67,7 @@ fun NimazMenuItem(
     subtitle: String? = null,
     icon: ImageVector? = null,
     iconTint: Color = MaterialTheme.colorScheme.onPrimaryContainer,
-    trailingIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowForward,
+    trailingIcon: ImageVector? = NimazIcons.Forward,
     trailing: (@Composable RowScope.() -> Unit)? = null,
     enabled: Boolean = true,
     selected: Boolean = false,
@@ -167,6 +171,52 @@ fun NimazMenuGroup(
     }
 }
 
+/** The measurements every [NimazMenuGroup] and its rows share. */
+object NimazMenuDefaults {
+    /**
+     * How far a [NimazMenuDivider] is pushed in on a row that carries a leading icon: the row's
+     * own 16dp of padding plus the 40dp icon well, so the line begins where the icon ends.
+     */
+    val RowDividerInset: Dp = 56.dp
+
+    /**
+     * The symmetric inset for a divider between blocks that are *not* icon rows — a slider, a
+     * dropdown, a free-form section. Matches the block's own content padding.
+     */
+    val SectionDividerInset: Dp = 16.dp
+}
+
+/**
+ * The hairline between two rows of a [NimazMenuGroup].
+ *
+ * This exists because the same line was being written out by hand at every call site, and it
+ * drifted: `padding(start = 56.dp), alpha = 0.5f` in More and Settings, `padding(horizontal =
+ * 16.dp)` at full strength in the Qur'an settings, nothing at all on the Qur'an home — four rows
+ * that behave identically, separated four different ways. There is one line now, at one weight,
+ * and a group that wants no separation simply omits it.
+ *
+ * @param inset `true` (the default) starts the line past the leading icon well, which is what a
+ *   group of [NimazMenuItem]/`NimazSettingsItem` rows wants. Pass `false` between blocks that
+ *   have no icon column — a slider, a dropdown, a section of prose — where a start-inset line
+ *   would hang off the content it is meant to divide.
+ */
+@Composable
+fun NimazMenuDivider(
+    modifier: Modifier = Modifier,
+    inset: Boolean = true,
+) {
+    NimazDivider(
+        modifier = modifier.padding(
+            start = if (inset) {
+                NimazMenuDefaults.RowDividerInset
+            } else {
+                NimazMenuDefaults.SectionDividerInset
+            },
+            end = if (inset) 0.dp else NimazMenuDefaults.SectionDividerInset,
+        )
+    )
+}
+
 @Preview(showBackground = true, widthDp = 400, name = "NimazMenuItem")
 @Composable
 private fun NimazMenuItemPreview() {
@@ -191,6 +241,20 @@ private fun NimazMenuGroupPreview() {
                 icon = Icons.Default.Schedule,
                 onClick = {}
             )
+            NimazMenuDivider()
+            NimazMenuItem(
+                title = "Fasting",
+                subtitle = "2 make-up fasts",
+                icon = Icons.Default.Fastfood,
+                onClick = {}
+            )
+            NimazMenuDivider()
+            NimazMenuItem(
+                title = "Khatam",
+                subtitle = "Juz 14 of 30",
+                icon = Icons.AutoMirrored.Filled.MenuBook,
+                onClick = {}
+            )
         }
     }
 }
@@ -207,6 +271,7 @@ private fun NimazMenuItemSelectedPreview() {
                 trailingIcon = null,
                 onClick = {}
             )
+            NimazMenuDivider(inset = false)
             NimazMenuItem(
                 title = "Abul A'ala Maududi",
                 subtitle = "اردو",
@@ -218,6 +283,7 @@ private fun NimazMenuItemSelectedPreview() {
                 selected = true,
                 onClick = {}
             )
+            NimazMenuDivider(inset = false)
             NimazMenuItem(
                 title = "Marmaduke Pickthall",
                 subtitle = "English",

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazSettingsItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -24,8 +23,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
-import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
@@ -130,11 +130,15 @@ fun NimazSettingsItem(
             }
 
             showArrow || (onClick != null && checked == null) -> {
+                // Same glyph, same tint, same 18dp as NimazMenuItem's trailing chevron. It used
+                // to be a 20dp chevron at half opacity here and an 18dp one at full
+                // `onSurfaceVariant` there, so the identical affordance on the Settings list and
+                // the More list did not read as identical.
                 NimazIcon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    imageVector = NimazIcons.Forward,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                    size = NimazIconSize.MEDIUM
+                    variant = NimazIconVariant.MUTED,
+                    iconSize = 18.dp
                 )
             }
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTreeRow.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/NimazTreeRow.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,6 +35,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.foundation.debug.NimazMarginRule
 import com.arshadshah.nimaz.presentation.foundation.debug.nimazMarginRules
@@ -107,7 +106,7 @@ fun NimazTreeRow(
             ) {
                 if (expandable) {
                     NimazIconButton(
-                        icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        icon = NimazIcons.Forward,
                         onClick = onToggleExpanded,
                         size = NimazIconButtonSize.MEDIUM,
                         contentDescription = stringResource(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranVerseOfTheDayCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/QuranVerseOfTheDayCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -30,6 +29,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 
@@ -120,7 +120,7 @@ internal fun VerseOfTheDayCard(
                     )
                     Spacer(modifier = Modifier.size(4.dp))
                     NimazIcon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        imageVector = NimazIcons.Forward,
                         contentDescription = null,
                         variant = NimazIconVariant.PRIMARY,
                         size = NimazIconSize.SMALL

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/SurahInfoSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/molecules/SurahInfoSheet.kt
@@ -196,6 +196,9 @@ fun SurahInfoSheet(
                         )
                     }
                     if (passageCount > 0) {
+                        // Guarded by what precedes it rather than drawn unconditionally: a row
+                        // that is the first one present has nothing above it to divide from.
+                        if (sectionCount > 0) NimazMenuDivider()
                         NimazMenuItem(
                             title = stringResource(R.string.surah_info_passages),
                             subtitle = pluralStringResource(
@@ -209,6 +212,7 @@ fun SurahInfoSheet(
                         )
                     }
                     if (subjectCount > 0) {
+                        if (sectionCount > 0 || passageCount > 0) NimazMenuDivider()
                         NimazMenuItem(
                             title = stringResource(R.string.surah_info_subjects),
                             subtitle = stringResource(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeBannerSlot.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomeBannerSlot.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +32,7 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
@@ -80,7 +80,7 @@ fun HomeBannerSlot(
                 onClick = { sheetOpen = true },
                 variant = NimazButtonVariant.TEXT,
                 size = NimazButtonSize.SMALL,
-                leadingIcon = Icons.Default.KeyboardArrowDown,
+                leadingIcon = NimazIcons.Expand,
                 fullWidth = true,
                 modifier = Modifier.padding(top = 4.dp),
             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomePrayerCard.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/HomePrayerCard.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -49,6 +48,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.PrayerStatusBadge
 import com.arshadshah.nimaz.presentation.components.atoms.clockTimeText
 import com.arshadshah.nimaz.presentation.foundation.tokens.getPrayerColor
@@ -200,7 +200,7 @@ private fun PrayerRow(
         if (canExpand) {
             Spacer(Modifier.width(8.dp))
             Icon(
-                imageVector = Icons.Default.ChevronRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 modifier = Modifier
                     .size(16.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranAyahItem.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.EditNote
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.RadioButtonUnchecked
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -59,6 +58,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
+import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
@@ -97,6 +97,11 @@ internal fun AyahItem(
     /** Opens the ayah sheet, which now carries every per-verse action. */
     onOpenActions: () -> Unit = {},
     onKhatamToggle: () -> Unit = {},
+    /**
+     * Draws the rule that closes this verse. The reader turns it off for the last verse in the
+     * list, where there is no next verse to divide from and the line would hang over whitespace.
+     */
+    showDivider: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val isDarkTheme = isSystemInDarkTheme()
@@ -118,207 +123,228 @@ internal fun AyahItem(
             // list row inside a reader, not a card, and wrapping it in a NimazCard would put a
             // border around every verse of the Qur'an.
             .clickable(onClick = onOpenActions)
-            .padding(horizontal = 15.dp, vertical = 6.dp)
     ) {
-        // Number badge, and — only with a khatam running — the read mark. The permanent
-        // five-icon action pill that used to sit opposite is gone: it drew five icons per
-        // verse, thirty on a screenful, for actions a reader wants on one verse at a time.
-        // Tapping the row opens the sheet that holds all of them, and four more besides.
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            // 14dp top and bottom, against 6dp before. Two verses used to sit 12dp apart with a
+            // 0.5dp line at 30% opacity between them — a rule you have to go looking for, on a
+            // screen whose whole job is telling one verse from the next. The gap and the rule do
+            // the work together; neither is enough alone.
+            modifier = Modifier.padding(horizontal = 15.dp, vertical = 14.dp)
         ) {
+            // Number badge, and — only with a khatam running — the read mark. The permanent
+            // five-icon action pill that used to sit opposite is gone: it drew five icons per
+            // verse, thirty on a screenful, for actions a reader wants on one verse at a time.
+            // Tapping the row opens the sheet that holds all of them, and four more besides.
             Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.primaryContainer),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = ayah.numberInSurah.toString(),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-                // Tiny marks for what has been done to this verse. The sheet is where you
-                // bookmark, favourite and annotate, and once it closes there was nothing left
-                // on the row to say you had — so a reader scrolling back could not find their
-                // own marks without opening every verse. Not buttons: 14dp glyphs, tapped
-                // through to the same sheet as the rest of the row.
-                SavedMarks(
-                    isBookmarked = ayah.isBookmarked,
-                    isFavourite = isFavorite,
-                    hasNote = hasNote,
-                )
-                if (isKhatamMode) {
-                    IconButton(
-                        onClick = onKhatamToggle,
-                        modifier = Modifier.size(36.dp)
-                    ) {
-                        NimazIcon(
-                            imageVector = if (isKhatamRead) Icons.Filled.CheckCircle else Icons.Outlined.RadioButtonUnchecked,
-                            contentDescription = if (isKhatamRead) stringResource(R.string.cd_mark_as_unread) else stringResource(
-                                R.string.cd_mark_as_read
-                            ),
-                            tint = if (isKhatamRead) NimazColors.Success else MaterialTheme.colorScheme.onSurfaceVariant,
-                            size = NimazIconSize.MEDIUM
-                        )
-                    }
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Arabic text with ayah end marker (with optional tajweed colors)
-        val displayText = ayah.getDisplayArabicText()
-        val textColor = MaterialTheme.colorScheme.onBackground
-        // Ayah end-marker: gold brackets + teal number, matching the ornament language.
-        val markerBracketColor = NimazColors.Gold500
-        val markerNumberColor = MaterialTheme.colorScheme.primary
-
-        if (showTajweed && ayah.textTajweed != null) {
-            // Render with tajweed colors using BasicText
-            val tajweedAnnotated = remember(
-                ayah.textTajweed, isDarkTheme, ayah.numberInSurah,
-                textColor, markerBracketColor, markerNumberColor, tajweedUnderline
-            ) {
-                val parsed = TajweedParser.parse(
-                    tajweedText = ayah.textTajweed,
-                    isDarkTheme = isDarkTheme,
-                    defaultColor = textColor,
-                    stripPrefix = if (ayah.hasLeadingBismillah) BISMILLAH_TEXT else null,
-                    annotateRules = true,  // enable tap-to-explain (#294)
-                    underlineRules = tajweedUnderline
-                )
-                // Append the coloured end marker to the tajweed text
-                buildAnnotatedString {
-                    append(parsed)
-                    append(" ")
-                    appendAyahEndMarker(ayah.numberInSurah, markerBracketColor, markerNumberColor)
-                }
-            }
-            // Tap a coloured tajweed word to explain its rule (#294) — mirrors the
-            // continuous mushaf page, so the verse-list reader is no longer dead.
-            var tappedRuleCode by remember { mutableStateOf<String?>(null) }
-            var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-            BasicText(
-                text = tajweedAnnotated,
-                onTextLayout = { result -> textLayoutResult = result },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .pointerInput(tajweedAnnotated) {
-                        detectTapGestures { position ->
-                            val layout = textLayoutResult ?: return@detectTapGestures
-                            val offset = layout.getOffsetForPosition(position)
-                            tajweedAnnotated.getStringAnnotations(
-                                tag = TajweedParser.RULE_TAG, start = offset, end = offset
-                            ).firstOrNull()?.let { tappedRuleCode = it.item }
-                        }
-                    },
-                style = TextStyle(
-                    fontFamily = arabicFontFamily,
-                    fontSize = arabicFontSize.sp,
-                    lineHeight = (arabicFontSize * 2).sp,
-                    textDirection = TextDirection.Rtl,
-                    color = textColor
-                )
-            )
-            tappedRuleCode?.let { code ->
-                TajweedRuleSheet(ruleCode = code, onDismiss = { tappedRuleCode = null })
-            }
-        } else {
-            QuranVerseText(
-                arabicText = displayText,
-                verseNumber = ayah.numberInSurah,
-                customFontSize = arabicFontSize.sp.value,
-                fontFamily = arabicFontFamily
-            )
-        }
-
-        // Translation
-        if (showTranslation && ayah.translation != null) {
-            Spacer(modifier = Modifier.height(12.dp))
-            // Plain text, not an outlined box. A box per verse drew 114 borders down a surah
-            // to separate two things that are already separated by script and direction.
-            Text(
-                text = ayah.translation,
-                // The catalogue ships right-to-left translations (Urdu), so the paragraph
-                // direction has to come from the text itself rather than from the app's
-                // locale — otherwise Urdu renders left-aligned with its punctuation on the
-                // wrong side. TextAlign.Start then follows the resolved direction.
-                style = MaterialTheme.typography.bodyMedium
-                    .asTranslationText(translationLanguage, fontSize.sp),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
-        // Transliteration
-        if (showTransliteration && ayah.transliteration != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            NimazCard(style = NimazCardStyle.OUTLINED, tone = NimazTone.SUCCESS, elevation = 0.dp) {
-                Text(
-                    text = ayah.transliteration,
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        fontSize = fontSize.sp,
-                        lineHeight = (fontSize * 1.5f).sp
-                    ),
-                    modifier = Modifier.padding(12.dp)
-                )
-            }
-        }
-
-        // Indicators row
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (ayah.sajdaType != null) {
-                    NimazBadge(
-                        text = if (ayah.sajdaType == SajdaType.OBLIGATORY) stringResource(R.string.sajdah_wajib) else stringResource(
-                            R.string.sajdah
-                        ),
-                        shape = NimazBadgeShape.ROUNDED,
-                        size = NimazBadgeSize.SMALL,
-                        colors = NimazBadgeDefaults.feature(
-                            color = NimazPalette.Red600,
-                            emphasis = NimazBadgeEmphasis.SOFT
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primaryContainer),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = ayah.numberInSurah.toString(),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
+                    }
+                    // Tiny marks for what has been done to this verse. The sheet is where you
+                    // bookmark, favourite and annotate, and once it closes there was nothing left
+                    // on the row to say you had — so a reader scrolling back could not find their
+                    // own marks without opening every verse. Not buttons: 14dp glyphs, tapped
+                    // through to the same sheet as the rest of the row.
+                    SavedMarks(
+                        isBookmarked = ayah.isBookmarked,
+                        isFavourite = isFavorite,
+                        hasNote = hasNote,
+                    )
+                    if (isKhatamMode) {
+                        IconButton(
+                            onClick = onKhatamToggle,
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            NimazIcon(
+                                imageVector = if (isKhatamRead) Icons.Filled.CheckCircle else Icons.Outlined.RadioButtonUnchecked,
+                                contentDescription = if (isKhatamRead) stringResource(R.string.cd_mark_as_unread) else stringResource(
+                                    R.string.cd_mark_as_read
+                                ),
+                                tint = if (isKhatamRead) NimazColors.Success else MaterialTheme.colorScheme.onSurfaceVariant,
+                                size = NimazIconSize.MEDIUM
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Arabic text with ayah end marker (with optional tajweed colors)
+            val displayText = ayah.getDisplayArabicText()
+            val textColor = MaterialTheme.colorScheme.onBackground
+            // Ayah end-marker: gold brackets + teal number, matching the ornament language.
+            val markerBracketColor = NimazColors.Gold500
+            val markerNumberColor = MaterialTheme.colorScheme.primary
+
+            if (showTajweed && ayah.textTajweed != null) {
+                // Render with tajweed colors using BasicText
+                val tajweedAnnotated = remember(
+                    ayah.textTajweed, isDarkTheme, ayah.numberInSurah,
+                    textColor, markerBracketColor, markerNumberColor, tajweedUnderline
+                ) {
+                    val parsed = TajweedParser.parse(
+                        tajweedText = ayah.textTajweed,
+                        isDarkTheme = isDarkTheme,
+                        defaultColor = textColor,
+                        stripPrefix = if (ayah.hasLeadingBismillah) BISMILLAH_TEXT else null,
+                        annotateRules = true,  // enable tap-to-explain (#294)
+                        underlineRules = tajweedUnderline
+                    )
+                    // Append the coloured end marker to the tajweed text
+                    buildAnnotatedString {
+                        append(parsed)
+                        append(" ")
+                        appendAyahEndMarker(ayah.numberInSurah, markerBracketColor, markerNumberColor)
+                    }
+                }
+                // Tap a coloured tajweed word to explain its rule (#294) — mirrors the
+                // continuous mushaf page, so the verse-list reader is no longer dead.
+                var tappedRuleCode by remember { mutableStateOf<String?>(null) }
+                var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+                BasicText(
+                    text = tajweedAnnotated,
+                    onTextLayout = { result -> textLayoutResult = result },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .pointerInput(tajweedAnnotated) {
+                            detectTapGestures { position ->
+                                val layout = textLayoutResult ?: return@detectTapGestures
+                                val offset = layout.getOffsetForPosition(position)
+                                tajweedAnnotated.getStringAnnotations(
+                                    tag = TajweedParser.RULE_TAG, start = offset, end = offset
+                                ).firstOrNull()?.let { tappedRuleCode = it.item }
+                            }
+                        },
+                    style = TextStyle(
+                        fontFamily = arabicFontFamily,
+                        fontSize = arabicFontSize.sp,
+                        lineHeight = (arabicFontSize * 2).sp,
+                        textDirection = TextDirection.Rtl,
+                        color = textColor
+                    )
+                )
+                tappedRuleCode?.let { code ->
+                    TajweedRuleSheet(ruleCode = code, onDismiss = { tappedRuleCode = null })
+                }
+            } else {
+                QuranVerseText(
+                    arabicText = displayText,
+                    verseNumber = ayah.numberInSurah,
+                    customFontSize = arabicFontSize.sp.value,
+                    fontFamily = arabicFontFamily
+                )
+            }
+
+            // Translation
+            if (showTranslation && ayah.translation != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                // Plain text, not an outlined box. A box per verse drew 114 borders down a surah
+                // to separate two things that are already separated by script and direction.
+                Text(
+                    text = ayah.translation,
+                    // The catalogue ships right-to-left translations (Urdu), so the paragraph
+                    // direction has to come from the text itself rather than from the app's
+                    // locale — otherwise Urdu renders left-aligned with its punctuation on the
+                    // wrong side. TextAlign.Start then follows the resolved direction.
+                    style = MaterialTheme.typography.bodyMedium
+                        .asTranslationText(translationLanguage, fontSize.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // Transliteration
+            if (showTransliteration && ayah.transliteration != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                NimazCard(style = NimazCardStyle.OUTLINED, tone = NimazTone.SUCCESS, elevation = 0.dp) {
+                    Text(
+                        text = ayah.transliteration,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontSize = fontSize.sp,
+                            lineHeight = (fontSize * 1.5f).sp
+                        ),
+                        modifier = Modifier.padding(12.dp)
                     )
                 }
+            }
 
-                // Hizb quarter — marked on the verse that *opens* the quarter, the way a
-                // printed Mushaf marks it. This used to render on every verse that merely fell
-                // inside a quarter, and read `rubNumber` (a counter over all 240 quarters in
-                // the book) as though it were the 1..4 position within a hizb — so the four
-                // quarters at the very start of the Quran got a label and the other 236 got
-                // an empty string, i.e. no marker at all.
-                if (ayah.isRubStart) {
-                    val quarterLabel = when (ayah.quarterInHizb) {
-                        1 -> stringResource(R.string.hizb_format, ayah.hizbOfQuarter)
-                        2 -> stringResource(R.string.hizb_quarter_format, ayah.hizbOfQuarter)
-                        3 -> stringResource(R.string.hizb_half_format, ayah.hizbOfQuarter)
-                        4 -> stringResource(R.string.hizb_three_quarter_format, ayah.hizbOfQuarter)
-                        else -> ""
-                    }
-                    if (quarterLabel.isNotEmpty()) {
+            // Indicators row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (ayah.sajdaType != null) {
                         NimazBadge(
-                            text = quarterLabel,
-                            tone = NimazTone.SUCCESS,
+                            text = if (ayah.sajdaType == SajdaType.OBLIGATORY) stringResource(R.string.sajdah_wajib) else stringResource(
+                                R.string.sajdah
+                            ),
+                            shape = NimazBadgeShape.ROUNDED,
+                            size = NimazBadgeSize.SMALL,
+                            colors = NimazBadgeDefaults.feature(
+                                color = NimazPalette.Red600,
+                                emphasis = NimazBadgeEmphasis.SOFT
+                            )
+                        )
+                    }
+
+                    // Hizb quarter — marked on the verse that *opens* the quarter, the way a
+                    // printed Mushaf marks it. This used to render on every verse that merely fell
+                    // inside a quarter, and read `rubNumber` (a counter over all 240 quarters in
+                    // the book) as though it were the 1..4 position within a hizb — so the four
+                    // quarters at the very start of the Quran got a label and the other 236 got
+                    // an empty string, i.e. no marker at all.
+                    if (ayah.isRubStart) {
+                        val quarterLabel = when (ayah.quarterInHizb) {
+                            1 -> stringResource(R.string.hizb_format, ayah.hizbOfQuarter)
+                            2 -> stringResource(R.string.hizb_quarter_format, ayah.hizbOfQuarter)
+                            3 -> stringResource(R.string.hizb_half_format, ayah.hizbOfQuarter)
+                            4 -> stringResource(R.string.hizb_three_quarter_format, ayah.hizbOfQuarter)
+                            else -> ""
+                        }
+                        if (quarterLabel.isNotEmpty()) {
+                            NimazBadge(
+                                text = quarterLabel,
+                                tone = NimazTone.SUCCESS,
+                                emphasis = NimazBadgeEmphasis.SOFT,
+                                shape = NimazBadgeShape.ROUNDED,
+                                size = NimazBadgeSize.SMALL
+                            )
+                        }
+                    }
+
+                    // Rukūʿ — the surah's own sections, from the `rukus` table. Same badge
+                    // language as the hizb quarter beside it, but on the verse that *closes*
+                    // the section: the ʿayn (ع) ends a rukūʿ in a printed Mushaf rather than
+                    // announcing it. Al-Fātiḥah is one rukūʿ, so this shows on 1:7, not 1:1.
+                    if (ayah.isRukuEnd && ayah.rukuNumber != null) {
+                        NimazBadge(
+                            text = stringResource(R.string.ruku_format, ayah.rukuNumber),
+                            tone = NimazTone.ACCENT,
                             emphasis = NimazBadgeEmphasis.SOFT,
                             shape = NimazBadgeShape.ROUNDED,
                             size = NimazBadgeSize.SMALL
@@ -326,31 +352,18 @@ internal fun AyahItem(
                     }
                 }
 
-                // Rukūʿ — the surah's own sections, from the `rukus` table. Same badge
-                // language as the hizb quarter beside it, but on the verse that *closes*
-                // the section: the ʿayn (ع) ends a rukūʿ in a printed Mushaf rather than
-                // announcing it. Al-Fātiḥah is one rukūʿ, so this shows on 1:7, not 1:1.
-                if (ayah.isRukuEnd && ayah.rukuNumber != null) {
-                    NimazBadge(
-                        text = stringResource(R.string.ruku_format, ayah.rukuNumber),
-                        tone = NimazTone.ACCENT,
-                        emphasis = NimazBadgeEmphasis.SOFT,
-                        shape = NimazBadgeShape.ROUNDED,
-                        size = NimazBadgeSize.SMALL
-                    )
-                }
+                // The juz/page badge that used to close this row is gone: it repeated the same
+                // coordinate on every verse for a fact that changes about once a page. It is said
+                // once now, in the reader's anchor bar (`ReaderAnchorBar`).
             }
-
-            // The juz/page badge that used to close this row is gone: it repeated the same
-            // coordinate on every verse for a fact that changes about once a page. It is said
-            // once now, in the reader's anchor bar (`ReaderAnchorBar`).
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
-        HorizontalDivider(
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-            thickness = 0.5.dp
-        )
+        // Full-bleed, and outside the verse's own padding: a rule that stops 15dp short of
+        // either edge reads as an underline belonging to the verse above it. Running edge to
+        // edge, it reads as the boundary between two rows, which is what it is.
+        if (showDivider) {
+            NimazDivider()
+        }
     }
 }
 
@@ -448,7 +461,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 2. Active states: bookmarked + favourited
         AyahItem(
             ayah = ayah(2, bookmarked = true),
@@ -457,7 +469,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 3. Audio playing + highlighted row
         AyahItem(
             ayah = ayah(3),
@@ -467,7 +478,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 4. Transliteration shown
         AyahItem(
             ayah = ayah(
@@ -479,7 +489,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 5. Sajdah verse marker
         AyahItem(
             ayah = ayah(5, sajda = SajdaType.OBLIGATORY),
@@ -487,7 +496,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 6. Hizb / quarter marker
         AyahItem(
             ayah = ayah(6, hizb = 2, rub = 6),
@@ -495,7 +503,6 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
         // 6b. Rukūʿ marker, alongside a quarter marker on the same verse
         AyahItem(
             ayah = ayah(8, hizb = 2, rub = 5, ruku = 3),
@@ -503,8 +510,7 @@ private fun AyahItemShowcase() {
             arabicFontSize = 28f,
             fontSize = 16f,
         )
-        HorizontalDivider()
-        // 7. Khatam mode (read-tracking), marked read
+        // 7. Khatam mode (read-tracking), marked read — and, being last, with no closing rule
         AyahItem(
             ayah = ayah(7),
             showTranslation = true,
@@ -512,6 +518,7 @@ private fun AyahItemShowcase() {
             isKhatamRead = true,
             arabicFontSize = 28f,
             fontSize = 16f,
+            showDivider = false,
         )
     }
 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranJuzGrid.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranJuzGrid.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -33,6 +31,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.atoms.ShamsaMedallion
 import com.arshadshah.nimaz.presentation.theme.NimazColors
@@ -166,7 +165,7 @@ private fun JuzRangeBadges(startPage: Int, endPage: Int) {
             contentAlignment = Alignment.Center
         ) {
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 variant = NimazIconVariant.PRIMARY,
                 iconSize = 13.dp

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranPageGrid.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/components/organisms/QuranPageGrid.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,6 +37,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.theme.NimazTheme
 import com.arshadshah.nimaz.presentation.theme.ThemeMode
@@ -168,7 +167,7 @@ internal fun LazyListScope.pageGridItems(
                             contentAlignment = Alignment.Center
                         ) {
                             NimazIcon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                                imageVector = NimazIcons.Forward,
                                 contentDescription = null,
                                 variant = NimazIconVariant.PRIMARY,
                                 iconSize = 14.dp

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/foundation/reader/ReaderTypographySettings.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/foundation/reader/ReaderTypographySettings.kt
@@ -7,8 +7,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.arshadshah.nimaz.R
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.theme.QuranArabicFont
 
 /**
@@ -52,7 +52,7 @@ fun LazyListScope.readerTypographySettings(
                 contentDescription = stringResource(R.string.arabic_font_size)
             )
 
-            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            NimazMenuDivider(inset = false)
 
             Column(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 14.dp)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/LicenseDetailScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/LicenseDetailScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -64,6 +62,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
@@ -435,7 +434,7 @@ private fun LicenseTextCard(license: LibraryLicense) {
             onClick = { expanded = !expanded },
             variant = NimazButtonVariant.TEXT,
             size = NimazButtonSize.MEDIUM,
-            leadingIcon = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+            leadingIcon = if (expanded) NimazIcons.Collapse else NimazIcons.Expand,
             fullWidth = true,
         )
     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/LicensesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/about/LicensesScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +43,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazFilterChip
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionTitle
@@ -404,7 +404,7 @@ private fun LibraryRow(
                 )
             }
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 variant = NimazIconVariant.MUTED,
                 size = NimazIconSize.SMALL,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreen.kt
@@ -29,10 +29,10 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.DuaArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -113,7 +113,7 @@ fun DuaSettingsScreen(
                         checked = duaState.showArabic,
                         onCheckedChange = { viewModel.onEvent(SettingsEvent.SetDuaShowArabic(!duaState.showArabic)) }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.show_transliteration),
                         subtitle = stringResource(R.string.show_transliteration_subtitle),
@@ -126,7 +126,7 @@ fun DuaSettingsScreen(
                             )
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.show_translation),
                         subtitle = stringResource(R.string.show_translation_subtitle),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -46,6 +45,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconContainerShape
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconType
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazStatusDotStyle
@@ -346,7 +346,7 @@ private fun MakeupFastsRow(
                 Spacer(modifier = Modifier.width(8.dp))
             }
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 size = NimazIconSize.SMALL,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -46,6 +44,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorDefaults
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorState
@@ -259,7 +258,7 @@ private fun ChapterItem(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 size = NimazIconSize.MEDIUM

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -77,6 +76,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazBadge
 import com.arshadshah.nimaz.presentation.components.atoms.NimazBadgeSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPager
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPillActionButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
@@ -385,7 +385,7 @@ private fun ChainOfNarrationSection(
                 color = MaterialTheme.colorScheme.onSurface
             )
             NimazIcon(
-                imageVector = Icons.Default.KeyboardArrowDown,
+                imageVector = NimazIcons.Expand,
                 contentDescription = null,
                 variant = NimazIconVariant.PRIMARY,
                 modifier = Modifier.rotate(rotation)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreen.kt
@@ -30,10 +30,10 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.presentation.components.atoms.HadithArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -112,7 +112,7 @@ fun HadithSettingsScreen(
                         checked = hadithState.showArabic,
                         onCheckedChange = { viewModel.onEvent(SettingsEvent.SetHadithShowArabic(!hadithState.showArabic)) }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.show_translation),
                         subtitle = stringResource(R.string.show_translation_subtitle),
@@ -125,14 +125,14 @@ fun HadithSettingsScreen(
                             )
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.hadith_show_grade),
                         subtitle = stringResource(R.string.hadith_show_grade_subtitle),
                         checked = hadithState.showGrade,
                         onCheckedChange = { viewModel.onEvent(SettingsEvent.SetHadithShowGrade(!hadithState.showGrade)) }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.hadith_show_chain),
                         subtitle = stringResource(R.string.hadith_show_chain_subtitle),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpContentUi.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpContentUi.kt
@@ -23,9 +23,7 @@ import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Calculate
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DarkMode
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Language
@@ -61,6 +59,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.theme.NimazColors
 
 fun helpIcon(key: String?): ImageVector = when (key) {
@@ -156,7 +155,7 @@ fun HelpQuestionRow(question: HelpItem.HelpQuestion, modifier: Modifier = Modifi
                 modifier = Modifier.weight(1f)
             )
             NimazIcon(
-                imageVector = Icons.Filled.ExpandMore,
+                imageVector = NimazIcons.Expand,
                 contentDescription = null,
                 tint = if (expanded) MaterialTheme.colorScheme.primary
                 else MaterialTheme.colorScheme.onSurfaceVariant,
@@ -206,7 +205,7 @@ fun HelpGuideRow(
                 )
             }
             NimazIcon(
-                imageVector = Icons.Filled.ChevronRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 variant = NimazIconVariant.MUTED
             )
@@ -314,7 +313,7 @@ private fun HelpPathChip(
             )
             if (i != labels.lastIndex) {
                 NimazIcon(
-                    imageVector = Icons.Filled.ChevronRight,
+                    imageVector = NimazIcons.Forward,
                     contentDescription = null,
                     variant = NimazIconVariant.MUTED,
                     iconSize = 14.dp

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/help/HelpScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +35,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionTitle
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorDefaults
@@ -156,7 +156,7 @@ private fun HelpResultRow(result: HelpSearchResult, onClick: () -> Unit) {
                 modifier = Modifier.weight(1f)
             )
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 variant = NimazIconVariant.MUTED,
                 modifier = Modifier.padding(start = 8.dp)
@@ -207,7 +207,7 @@ private fun HelpContactCard(onClick: () -> Unit) {
                 )
             }
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 tint = tint
             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreen.kt
@@ -57,12 +57,12 @@ import com.arshadshah.nimaz.core.util.WorshipReminderContent
 import com.arshadshah.nimaz.core.util.formatCurrency
 import com.arshadshah.nimaz.domain.model.PinnedShortcut
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazTopAppBar
@@ -203,14 +203,14 @@ fun MoreMenuScreen(
                         icon = Icons.Default.Schedule,
                         onClick = onNavigateToPrayerTracker
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.fasting),
                         subtitle = MoreSubtitles.fasting(state.pendingMakeupFasts).resolve(),
                         icon = Icons.Default.Fastfood,
                         onClick = onNavigateToFasting
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.night_worship_title),
                         subtitle = MoreSubtitles.nightWorship(
@@ -220,7 +220,7 @@ fun MoreMenuScreen(
                         icon = Icons.Default.Bedtime,
                         onClick = onNavigateToNightWorship
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.khatam_quran),
                         subtitle = MoreSubtitles.khatam(
@@ -248,7 +248,7 @@ fun MoreMenuScreen(
                         icon = Icons.Default.Abc,
                         onClick = onNavigateToQaida
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     // No subtitle from here down: these are reference collections with nothing
                     // true to report about them. Restating the title is what was removed.
                     // One row for what used to be three — "Allah's 99 Names", "Prophet's 99
@@ -260,19 +260,19 @@ fun MoreMenuScreen(
                         icon = Icons.Default.AutoAwesome,
                         onClick = onNavigateToNames
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.hadith),
                         icon = Icons.Default.FormatQuote,
                         onClick = onNavigateToHadith
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.duas),
                         icon = ImageVector.vectorResource(R.drawable.ic_dua),
                         onClick = onNavigateToDuas
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.tafseer),
                         icon = Icons.AutoMirrored.Filled.Article,
@@ -293,19 +293,19 @@ fun MoreMenuScreen(
                         icon = Icons.Default.CalendarMonth,
                         onClick = onNavigateToCalendar
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.prayer_times),
                         icon = Icons.Default.Mosque,
                         onClick = onNavigateToPrayerTimes
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.monthly_prayer_times),
                         icon = Icons.Default.CalendarViewMonth,
                         onClick = onNavigateToMonthlyPrayerTimes
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.zakat),
                         subtitle = state.zakatSubtitle(),
@@ -326,19 +326,19 @@ fun MoreMenuScreen(
                         icon = Icons.Default.Info,
                         onClick = onNavigateToAbout
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.help_support),
                         icon = Icons.AutoMirrored.Filled.Help,
                         onClick = onNavigateToHelp
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.share_app),
                         icon = Icons.Default.Share,
                         onClick = onShareApp
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.rate_us),
                         icon = Icons.Default.Star,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/PinnedShortcutsSheet.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/more/PinnedShortcutsSheet.kt
@@ -15,6 +15,7 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.PinnedShortcut
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCheckbox
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBottomSheet
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 
@@ -53,7 +54,8 @@ fun PinnedShortcutsSheet(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             NimazMenuGroup {
-                PinnedShortcut.entries.forEach { shortcut ->
+                PinnedShortcut.entries.forEachIndexed { index, shortcut ->
+                    if (index > 0) NimazMenuDivider(inset = false)
                     val isPinned = shortcut in pinned
                     val toggle = {
                         onPinnedChange(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.LocationOn
@@ -69,6 +68,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPageIndicator
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPager
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
@@ -340,7 +340,7 @@ fun OnboardingScreen(
                             variant = NimazButtonVariant.TONAL,
                             leadingIcon = if (pagerState.currentPage == totalPages - 1)
                                 Icons.Default.Check
-                            else Icons.AutoMirrored.Filled.ArrowForward
+                            else NimazIcons.Next
                         )
                     }
                 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.DarkMode
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -78,6 +77,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazNavArrowButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.clockTimeText
@@ -516,7 +516,7 @@ private fun DayMetaRow(
         }
 
         NimazIcon(
-            imageVector = Icons.Default.ExpandMore,
+            imageVector = NimazIcons.Expand,
             contentDescription = stringResource(if (isExpanded) R.string.cd_collapse else R.string.cd_expand),
             tint = onColor.copy(alpha = 0.6f),
             modifier = Modifier.rotate(rotation)

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreen.kt
@@ -27,8 +27,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
@@ -64,6 +62,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.atoms.TickResolution
 import com.arshadshah.nimaz.presentation.components.atoms.clockTimeText
@@ -340,7 +339,7 @@ private fun DayNavBar(
     ) {
         FilledTonalIconButton(onClick = onPrev) {
             NimazIcon(
-                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                NimazIcons.Previous,
                 contentDescription = stringResource(R.string.cd_previous_day)
             )
         }
@@ -383,7 +382,7 @@ private fun DayNavBar(
         }
         FilledTonalIconButton(onClick = onNext) {
             NimazIcon(
-                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                NimazIcons.Next,
                 contentDescription = stringResource(R.string.cd_next_day)
             )
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranBrowseScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranBrowseScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.SearchOff
@@ -38,6 +37,7 @@ import com.arshadshah.nimaz.domain.model.QuranSearchQuery
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicText
 import com.arshadshah.nimaz.presentation.components.atoms.ArabicTextSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorState
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
@@ -322,7 +322,7 @@ private fun JumpToCard(
                 modifier = Modifier.weight(1f)
             )
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
                 variant = NimazIconVariant.MUTED,
             )

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranHomeScreen.kt
@@ -52,6 +52,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.BookmarkCard
 import com.arshadshah.nimaz.presentation.components.molecules.ContinueReadingCard
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.molecules.QuranRecommendedSurahs
@@ -289,6 +290,7 @@ private fun Destinations(
             icon = Icons.AutoMirrored.Filled.MenuBook,
             onClick = onNavigateToBrowse,
         )
+        NimazMenuDivider()
         NimazMenuItem(
             title = stringResource(R.string.saved),
             subtitle = stringResource(R.string.quran_home_destination_saved_subtitle),
@@ -301,6 +303,7 @@ private fun Destinations(
             },
         )
         if (state.hasThematicContent) {
+            NimazMenuDivider()
             NimazMenuItem(
                 title = stringResource(R.string.quran_home_browse_subjects),
                 subtitle = stringResource(R.string.quran_home_browse_subjects_subtitle),
@@ -311,6 +314,7 @@ private fun Destinations(
         val khatamPercent = state.activeKhatam?.let {
             (it.progressPercent * 100).toInt().coerceIn(0, 100)
         }
+        NimazMenuDivider()
         NimazMenuItem(
             title = stringResource(R.string.khatam),
             subtitle = stringResource(R.string.quran_home_destination_khatam_subtitle),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/QuranReaderScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.automirrored.filled.ViewList
@@ -73,6 +72,7 @@ import com.arshadshah.nimaz.domain.model.RecitationRepeat
 import com.arshadshah.nimaz.domain.model.RecitationSpeed
 import com.arshadshah.nimaz.domain.model.Surah
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPager
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.PageSurahSeparator
@@ -754,7 +754,7 @@ fun QuranReaderScreen(
                         onClick = { onNavigateToNextSurah(khatamSurah.surah.number + 1) },
                     ) {
                         NimazIcon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                            imageVector = NimazIcons.Next,
                             contentDescription = stringResource(R.string.quran_continue_next_surah),
                         )
                     }
@@ -1031,7 +1031,10 @@ fun QuranReaderScreen(
                                 onOpenActions = { sheetAyah = ayah },
                                 onKhatamToggle = {
                                     viewModel.onEvent(QuranEvent.ToggleKhatamAyah(ayah.id))
-                                }
+                                },
+                                // No rule under the final verse — there is nothing below it to
+                                // divide from, and the line would hang over the list's padding.
+                                showDivider = ayah.id != displayAyahs.lastOrNull()?.id,
                             )
                         }
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectTranslationScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SelectTranslationScreen.kt
@@ -43,6 +43,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -207,7 +208,7 @@ fun SelectTranslationScreen(
                                 }
                             )
                             if (index < translations.lastIndex) {
-                                NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                                NimazMenuDivider(inset = false)
                             }
                         }
                     }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahSubjectsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/quran/SurahSubjectsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.SearchOff
@@ -28,6 +27,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconSize
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconVariant
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazEmptyState
@@ -198,7 +198,7 @@ private fun SubjectList(
                 // badge reads as a fact about the row, not as an invitation to open it.
                 trailingContent = {
                     NimazIcon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        imageVector = NimazIcons.Forward,
                         contentDescription = null,
                         variant = NimazIconVariant.MUTED,
                         size = NimazIconSize.SMALL,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreen.kt
@@ -50,10 +50,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.navigation.ScreenTags
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazPatternBackground
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
@@ -212,7 +212,7 @@ private fun ThemeSelectionCard(
                     onClick = { onThemeSelected(AppTheme.DARK) },
                 )
             }
-            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            NimazMenuDivider(inset = false)
             NimazSettingsItem(
                 title = stringResource(R.string.theme_follow_device),
                 subtitle = stringResource(R.string.theme_follow_device_subtitle),
@@ -391,14 +391,14 @@ private fun DisplaySettingsCard(
             checked = animationsEnabled,
             onCheckedChange = { onAnimationsToggle() }
         )
-        NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        NimazMenuDivider(inset = false)
         NimazSettingsItem(
             title = stringResource(R.string.appearance_haptic),
             subtitle = stringResource(R.string.appearance_haptic_subtitle),
             checked = hapticFeedback,
             onCheckedChange = { onHapticFeedbackToggle() }
         )
-        NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        NimazMenuDivider(inset = false)
         NimazSettingsItem(
             title = stringResource(R.string.appearance_24hour),
             subtitle = stringResource(R.string.appearance_24hour_subtitle),
@@ -542,7 +542,7 @@ private fun HomeScreenSettingsCard(
             checked = useHijriPrimary,
             onCheckedChange = { onHijriPrimaryToggle() }
         )
-        NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+        NimazMenuDivider(inset = false)
         NimazNumberStepper(
             label = stringResource(R.string.hijri_day_offset_label),
             value = hijriDayOffset,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreen.kt
@@ -44,6 +44,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -108,6 +109,7 @@ fun NotificationDiagnosticsScreen(
                             )
                         }
                     )
+                    NimazMenuDivider()
                     DiagnosticRow(
                         title = stringResource(R.string.notif_diag_exact_alarms),
                         ok = diagnostics.exactAlarmsAllowed,
@@ -120,6 +122,7 @@ fun NotificationDiagnosticsScreen(
                             )
                         }
                     )
+                    NimazMenuDivider()
                     DiagnosticRow(
                         title = stringResource(R.string.notif_diag_battery),
                         ok = diagnostics.batteryUnrestricted,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -35,6 +35,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBannerVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -140,6 +141,7 @@ fun NotificationSettingsScreen(
                             onClick = onNavigateToPrayers,
                             showArrow = true
                         )
+                        NimazMenuDivider(inset = false)
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_sound_title),
                             subtitle = soundSubtitle(notificationState),
@@ -161,6 +163,7 @@ fun NotificationSettingsScreen(
                             onClick = onNavigateToWorshipReminders,
                             showArrow = true
                         )
+                        NimazMenuDivider(inset = false)
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_weekly_title),
                             subtitle = weeklySubtitle(notificationState),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreen.kt
@@ -43,6 +43,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
@@ -156,6 +157,7 @@ fun NotificationSoundScreen(
                             viewModel.onEvent(SettingsEvent.SetVibrationEnabled(!notificationState.vibrationEnabled))
                         }
                     )
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.notification_settings_dnd),
                         subtitle = stringResource(R.string.notification_settings_dnd_subtitle),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreen.kt
@@ -41,6 +41,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
@@ -131,6 +132,7 @@ fun PrayerNotificationsScreen(
                             )
                         }
                     )
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.notif_all_prayers_lead_title),
                         value = reminderLabel(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreen.kt
@@ -28,12 +28,12 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
 import com.arshadshah.nimaz.domain.model.HighLatitudeRule
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBannerVariant
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPickerItem
@@ -94,7 +94,7 @@ fun PrayerSettingsScreen(
                         value = prayerState.calculationMethod.displayName(),
                         onClick = { showCalculationMethodDialog = true }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         icon = Icons.Default.WbSunny,
                         title = stringResource(R.string.asr_calculation),
@@ -104,7 +104,7 @@ fun PrayerSettingsScreen(
                         },
                         onClick = { showAsrMethodDialog = true }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         icon = Icons.Default.WbSunny,
                         title = stringResource(R.string.high_latitude_method),
@@ -143,7 +143,7 @@ fun PrayerSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetPrayerAdjustment("fajr", it))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazNumberStepper(
                         label = stringResource(R.string.prayer_sunrise),
                         value = prayerState.sunriseAdjustment,
@@ -151,7 +151,7 @@ fun PrayerSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetPrayerAdjustment("sunrise", it))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazNumberStepper(
                         label = stringResource(R.string.prayer_dhuhr),
                         value = prayerState.dhuhrAdjustment,
@@ -159,7 +159,7 @@ fun PrayerSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetPrayerAdjustment("dhuhr", it))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazNumberStepper(
                         label = stringResource(R.string.prayer_asr),
                         value = prayerState.asrAdjustment,
@@ -167,7 +167,7 @@ fun PrayerSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetPrayerAdjustment("asr", it))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazNumberStepper(
                         label = stringResource(R.string.prayer_maghrib),
                         value = prayerState.maghribAdjustment,
@@ -175,7 +175,7 @@ fun PrayerSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetPrayerAdjustment("maghrib", it))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazNumberStepper(
                         label = stringResource(R.string.prayer_isha),
                         value = prayerState.ishaAdjustment,
@@ -213,7 +213,7 @@ fun PrayerSettingsScreen(
                         },
                         onClick = onNavigateToNotifications
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         icon = Icons.Default.Schedule,
                         // Reminders are per prayer now; this row reports Fajr's, the same

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreen.kt
@@ -46,12 +46,12 @@ import com.arshadshah.nimaz.domain.model.QuranTranslation
 import com.arshadshah.nimaz.domain.model.TranslationLanguage
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownField
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDropdownItem
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsSlider
@@ -214,7 +214,7 @@ fun QuranSettingsScreen(
                         )
                     }
 
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
 
                     NimazSettingsSlider(
                         title = stringResource(R.string.arabic_font_size),
@@ -253,7 +253,7 @@ fun QuranSettingsScreen(
                         onClick = onNavigateToSelectTranslation,
                         showArrow = true
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.show_translation),
                         subtitle = stringResource(R.string.show_translation_subtitle),
@@ -264,7 +264,7 @@ fun QuranSettingsScreen(
                             )
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     // The Quran reader has always read this preference (QuranViewModel ->
                     // AyahItem.fontSize) but no screen ever offered a control for it, unlike
                     // the Dua and Hadith settings screens — so Quran translation size was
@@ -283,7 +283,7 @@ fun QuranSettingsScreen(
                         enabled = quranState.showTranslation,
                         contentDescription = stringResource(R.string.translation_font_size)
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.show_transliteration),
                         subtitle = stringResource(R.string.show_transliteration_subtitle),
@@ -314,7 +314,7 @@ fun QuranSettingsScreen(
                             viewModel.onEvent(SettingsEvent.SetShowTajweed(!quranState.showTajweed))
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     // Colour-blind-friendly mode: underline rule spans so they are marked by
                     // a non-hue channel too (#294).
                     NimazSettingsItem(
@@ -328,7 +328,7 @@ fun QuranSettingsScreen(
                             )
                         }
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     // Reachable regardless of script so users can learn what the colours
                     // mean even on a layout that cannot show them (#294).
                     NimazSettingsItem(
@@ -355,7 +355,7 @@ fun QuranSettingsScreen(
                         onClick = onNavigateToSelectReciter,
                         showArrow = true
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     // Under Audio, where it belongs. Called "Continuous Reading" and filed
                     // under Reading behaviour, it read as a twin of the player's "Follow
                     // along" — which is the *scroll*. This one is the playlist: whether the

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreen.kt
@@ -35,7 +35,6 @@ import com.arshadshah.nimaz.domain.model.MatchStrictness
 import com.arshadshah.nimaz.domain.model.SearchPreferences
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazButtonVariant
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
@@ -43,6 +42,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazDialog
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogCancelButton
 import com.arshadshah.nimaz.presentation.components.molecules.NimazDialogDestructiveButton
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
@@ -111,7 +111,7 @@ fun SearchSettingsScreen(
                             .padding(horizontal = 16.dp)
                             .padding(bottom = 12.dp),
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.search_strictness),
                         subtitle = stringResource(strictnessDescription(state.search.strictness)),
@@ -119,7 +119,7 @@ fun SearchSettingsScreen(
                         onClick = { showStrictnessPicker = true },
                         showArrow = true,
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     NimazSettingsItem(
                         title = stringResource(R.string.search_default_scope),
                         subtitle = stringResource(R.string.search_default_scope_subtitle),
@@ -138,7 +138,7 @@ fun SearchSettingsScreen(
                 NimazMenuGroup {
                     LibrarySource.entries.forEachIndexed { index, source ->
                         if (index > 0) {
-                            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                            NimazMenuDivider(inset = false)
                         }
                         val isOn = source in state.search.sources
                         // The last source left on cannot be switched off: an empty set is a
@@ -199,7 +199,7 @@ fun SearchSettingsScreen(
                             viewModel.onEvent(SearchSettingsEvent.SetHistoryEnabled(it))
                         },
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     // An in-place destructive action, not navigation — no
                     // trailing arrow; disabled while there is nothing to clear.
                     NimazMenuItem(

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreen.kt
@@ -41,10 +41,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.navigation.ScreenTags
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazConfirmDialog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
@@ -107,14 +107,14 @@ fun SettingsScreen(
                         icon = Icons.Default.Calculate,
                         onClick = onNavigateToPrayerSettings
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.location),
                         subtitle = stringResource(R.string.location_subtitle),
                         icon = Icons.Default.LocationOn,
                         onClick = onNavigateToLocation
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.notifications),
                         subtitle = stringResource(R.string.notifications_subtitle),
@@ -175,14 +175,14 @@ fun SettingsScreen(
                         icon = Icons.Default.DarkMode,
                         onClick = onNavigateToAppearance
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.language),
                         subtitle = stringResource(R.string.language_subtitle),
                         icon = Icons.Default.Language,
                         onClick = onNavigateToLanguage
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.widgets),
                         subtitle = stringResource(R.string.widgets_subtitle),
@@ -202,7 +202,7 @@ fun SettingsScreen(
                         icon = Icons.Default.Sync,
                         onClick = onNavigateToSync
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.reset_settings),
                         subtitle = stringResource(R.string.reset_settings_subtitle),
@@ -210,7 +210,7 @@ fun SettingsScreen(
                         iconTint = MaterialTheme.colorScheme.error,
                         onClick = { showResetDialog = true }
                     )
-                    NimazDivider(modifier = Modifier.padding(start = 56.dp), alpha = 0.5f)
+                    NimazMenuDivider()
                     NimazMenuItem(
                         title = stringResource(R.string.delete_all_data),
                         subtitle = stringResource(R.string.delete_all_data_subtitle),

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreen.kt
@@ -25,13 +25,13 @@ import com.arshadshah.nimaz.R
 import com.arshadshah.nimaz.core.util.HijriDateCalculator
 import com.arshadshah.nimaz.domain.model.WorshipReminderCategory
 import com.arshadshah.nimaz.domain.model.WorshipReminderType
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSwitch
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAccordion
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBanner
 import com.arshadshah.nimaz.presentation.components.molecules.NimazBannerVariant
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepper
 import com.arshadshah.nimaz.presentation.components.molecules.NimazNumberStepperVariant
@@ -171,7 +171,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.worshipSection(
                             onCheckedChange = { onToggle(type.key, it) }
                         )
                         if (index < plain.lastIndex) {
-                            NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                            NimazMenuDivider(inset = false)
                         }
                     }
                 }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreen.kt
@@ -38,11 +38,11 @@ import com.arshadshah.nimaz.domain.model.ZakatDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCard
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardDefaults
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
-import com.arshadshah.nimaz.presentation.components.atoms.NimazDivider
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.molecules.NimazAmountField
 import com.arshadshah.nimaz.presentation.components.organisms.NimazListPicker
+import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.organisms.NimazPickerItem
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
@@ -178,7 +178,7 @@ fun ZakatSettingsScreen(
                             viewModel.onEvent(ZakatSettingsEvent.SetGoldPrice(it))
                         },
                     )
-                    NimazDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    NimazMenuDivider(inset = false)
                     PriceRow(
                         label = stringResource(R.string.zakat_silver_price_label),
                         price = state.silverPricePerGram,

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.NightsStay
@@ -41,6 +40,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazCardStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazClockText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazCountdownText
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIcon
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.TickResolution
 import com.arshadshah.nimaz.presentation.components.atoms.rememberNow
@@ -420,7 +420,7 @@ private fun NightWorshipRow(
                 )
             }
             NimazIcon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = NimazIcons.Forward,
                 contentDescription = null,
             )
         }

--- a/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.Business
 import androidx.compose.material.icons.filled.CreditCard
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.IosShare
@@ -70,6 +68,7 @@ import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButton
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconButtonStyle
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWell
 import com.arshadshah.nimaz.presentation.components.atoms.NimazIconWellSize
+import com.arshadshah.nimaz.presentation.components.atoms.NimazIcons
 import com.arshadshah.nimaz.presentation.components.atoms.NimazScreenScaffold
 import com.arshadshah.nimaz.presentation.components.atoms.NimazSectionHeader
 import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
@@ -879,8 +878,8 @@ private fun BreakdownCard(
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 NimazIcon(
-                    imageVector = if (expanded) Icons.Filled.ExpandLess
-                    else Icons.Filled.ExpandMore,
+                    imageVector = if (expanded) NimazIcons.Collapse
+                    else NimazIcons.Expand,
                     contentDescription = stringResource(
                         if (expanded) R.string.cd_collapse else R.string.cd_expand
                     ),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,10 @@ These are the rules most often broken. Keep this checklist in mind for every cha
    - **A whole card is made tappable with `NimazCard(onClick = …)`, never `Modifier.clickable`
      wrapped around the card** — the latter paints a sharp-cornered ripple that ignores the card's
      radius (see §8, the `NimazCard` bullet). `NimazMenuItem` is the ready-made clickable list row.
+   - **Rows in a `NimazMenuGroup` are separated with `NimazMenuDivider()`, never a hand-measured
+     `NimazDivider`** (`inset = false` between blocks that carry no icon column), and **every
+     arrow/chevron comes from `NimazIcons`** — `Forward` for "this row opens something", never a
+     per-call-site pick between `ArrowForward`, `ChevronRight` and `KeyboardArrowRight`. Both in §8.
    > **Exception (Location screen only):** country flags on the Location screen
    > (`LocationScreen`, curated cities in `LocationCatalog.kt`) are rendered as emoji.
    > This is the single sanctioned emoji use in the app; no other emoji are permitted.
@@ -1066,6 +1070,29 @@ with no label and a touch target under 48dp fail the lane we already run. It can
       the twelve you are not (this is what the translation picker shipped as). `subtitleStyle`
       exists for the same rows, whose subtitle is often a **non-Latin endonym** — see the
       typography bullet below.
+    - the line between two rows of a `NimazMenuGroup` is **`NimazMenuDivider()`**
+      (`components/molecules/NimazMenuItem.kt`), **never** a hand-written `NimazDivider` with its
+      own padding and alpha. The same hairline had been spelled out at ~55 call sites in three
+      different ways — `NimazDivider(Modifier.padding(start = 56.dp), alpha = 0.5f)` in More and
+      Settings, `NimazDivider(Modifier.padding(horizontal = 16.dp))` at full strength in the
+      Qur'an/prayer settings, and nothing at all on the Qur'an home — so four rows that behave
+      identically were separated three different ways or not separated at all. Two shapes, both
+      measured from `NimazMenuDefaults`: the default `inset = true` starts the line past the 40dp
+      icon well (`RowDividerInset`, 56dp) for a group of icon rows, and `inset = false` insets it
+      symmetrically (`SectionDividerInset`, 16dp) between blocks that have no icon column — a
+      slider, a dropdown, a section of prose. A group of one row takes none; a group of two or
+      more takes one between each pair, including where a row is drawn conditionally (guard the
+      divider on what precedes it, as `SurahInfoSheet` does).
+    - **every directional glyph comes from `NimazIcons`** (`components/atoms/NimazIcons.kt`) —
+      `Forward` (row disclosure, and the rotated expander chevron), `Back`, `Previous`/`Next`
+      (stepping a sequence), `Expand`/`Collapse` — **never** a `Icons.*.ArrowForward` /
+      `ChevronRight` / `ArrowForwardIos` / `KeyboardArrowRight` picked per call site. "This row
+      opens something" used to be drawn four ways: `ArrowForward` on the Qur'an home rows and the
+      browse jump card, `KeyboardArrowRight` on every settings row, `ChevronRight` on the prayer
+      card, `ArrowForwardIos` in Help — so the same affordance on two screens did not look like
+      the same affordance. All the reading-order glyphs are auto-mirrored, so an RTL locale flips
+      them without a call site knowing. Prefer `NimazNavArrowButton` over drawing `Previous`/`Next`
+      directly.
     - an on/off toggle is `NimazSwitch(checked, onCheckedChange, variant = …)`
       (`components/atoms/NimazSwitch.kt`), **not** a raw Material 3 `Switch`. It wraps Material's
       `Switch` (keeping the drag gesture, `Role.Switch` semantics and thumb animation) and bakes in


### PR DESCRIPTION
Three related inconsistencies, each of which the design system had no single
answer for.

**The ayah list had no visible separation.** Each verse closed with a raw
`HorizontalDivider` at 0.5dp and 30% opacity, drawn inside the verse's own 15dp
padding, with 6dp of air either side — a rule you have to go looking for, in the
one list whose whole job is telling one verse from the next. It is a full-bleed
`NimazDivider` now, outside the verse padding so it reads as a row boundary
rather than an underline, with 14dp of breathing room above and below.
`showDivider = false` drops it under the final verse, where it would otherwise
hang over the list's bottom padding.

**The Qur'an home's four destinations had no dividers at all**, while the More
menu's identical rows did. Both now come from one component: `NimazMenuDivider`
(`components/molecules/NimazMenuItem.kt`), measured from `NimazMenuDefaults`.
The same hairline had been written out by hand at ~55 call sites in three
flavours — `padding(start = 56.dp), alpha = 0.5f` in More and Settings,
`padding(horizontal = 16.dp)` at full strength in the Qur'an/prayer settings,
nothing on the Qur'an home. All of them go through the component, which takes
`inset = true` (past the 40dp icon well) for a group of icon rows and
`inset = false` (symmetric) between blocks with no icon column — a slider, a
dropdown, a section of prose. Multi-row groups that had been missing dividers
entirely gained them: the surah-info sheet, the notification hub, sound and
prayer-notification groups, the diagnostics list and the pinned-shortcut picker.

**"This row opens something" was drawn four ways** — `ArrowForward` on the
Qur'an home rows and the browse jump card, `KeyboardArrowRight` on every
settings row, `ChevronRight` on the prayer card, `ArrowForwardIos` in Help — so
the same affordance on two screens did not look like the same affordance. Every
directional glyph now comes from `NimazIcons` (`components/atoms/NimazIcons.kt`),
named for what it means: `Forward` (row disclosure and the rotated expander),
`Back`, `Previous`/`Next`, `Expand`/`Collapse`. The reading-order glyphs are
auto-mirrored, so RTL flips them without a call site knowing.
`NimazSettingsItem`'s trailing chevron was also a 20dp glyph at half opacity
against `NimazMenuItem`'s 18dp at full `onSurfaceVariant`; both are 18dp/MUTED
now, so a Settings row and a More row read as the same control.

Docs: `docs/ARCHITECTURE.md` §0 golden rules and §8 component inventory, plus
the matching rule 8 in `CLAUDE.md`.

Verified: `compileDebugKotlin`, `lintDebug` and `scripts/check_docs.py` all
clean; `testDebugUnitTest` 2332/2333, the one failure being `DeviceStateCorpusTest`,
which needs the private content artifact this environment has no credential for.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R8YVVwa6EqRzGQW5U2mr6R