### PR TITLE
ci: only run Android checks for Android changes, and cache the PR lane

### DIFF
--- a/.github/workflows/android_instrumented_tests.yml
+++ b/.github/workflows/android_instrumented_tests.yml
@@ -11,13 +11,40 @@ name: Android Instrumentation Tests (emulator.wtf)
 #
 # The debug build needs no secrets: google-services.json is only required for the
 # release/deploy lane, and the app's Firebase calls are guarded to no-op without it.
-# The emulator.wtf step requires the EW_API_TOKEN repo secret; if it is missing the
-# workflow still builds + uploads the APKs and simply skips the cloud test run (with a
-# warning) instead of failing.
+# The emulator.wtf step requires the EW_API_TOKEN repo secret. When the run *could* have
+# had it and does not, the lane fails: a missing token used to downgrade "instrumented
+# tests run on every PR" into "the APKs compiled" behind a green check, which is worse than
+# not having the lane at all. Forks and dependabot cannot be given the secret, so those
+# still skip with a warning — see the token step below.
+#
+# Paths are an allowlist and fail closed: a worker-only or docs-only change no longer
+# builds two APKs and books cloud device time for code it did not touch. The two lists are
+# duplicated rather than shared via a YAML anchor — GitHub Actions does not support
+# anchors/aliases in workflow files. Keep them in sync.
 on:
   push:
     branches: [ dev ]
+    paths:
+      - 'app/**'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'data.lock.json'
+      - '.github/workflows/android_instrumented_tests.yml'
   pull_request:
+    paths:
+      - 'app/**'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'data.lock.json'
+      - '.github/workflows/android_instrumented_tests.yml'
 
 concurrency:
   group: ew-instrumentation-${{ github.ref }}
@@ -32,6 +59,8 @@ jobs:
   instrumentation-tests:
     name: emulator.wtf instrumentation tests
     runs-on: ubuntu-latest
+    # The emulator.wtf step has its own 20m cap, but the Gradle build before it had none.
+    timeout-minutes: 45
     steps:
       # The content artifact lives in a private repository. Mint a short-lived
       # installation token for it rather than carrying a long-lived PAT: the token
@@ -94,20 +123,37 @@ jobs:
             app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
           if-no-files-found: error
 
-      # ── Gate on the API token so the lane never hard-fails when it's unset ───
-      # (the `secrets` context can't be used directly in an `if:`, so resolve it
-      # into a step output here; the value is masked in logs).
+      # ── The token is required, except where GitHub cannot supply it ──────────
+      # (the `secrets` context can't be used directly in an `if:`, so resolve it into a step
+      # output here; the value is masked in logs).
+      #
+      # A missing token used to skip the cloud run with a warning and leave the job green.
+      # That is the failure mode where the lane looks like it is guarding every PR while
+      # actually asserting nothing but "the APKs compiled" — and a warning annotation is not
+      # something anyone reads on a passing run. So: fail.
+      #
+      # The exception is a run that could never have had the secret. GitHub withholds repo
+      # secrets from fork PRs and gives Dependabot a separate store, so those runs are not
+      # misconfigured and there is nothing their author can do. They skip, loudly, and the
+      # build+upload above still proves the androidTest source set compiles.
       - name: Check emulator.wtf token
         id: ew
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' }}
         run: |
           if [ -n "$EW_API_TOKEN" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=emulator.wtf skipped::EW_API_TOKEN secret is not set. Add it in repo Settings → Secrets to run the cloud instrumentation tests."
+            exit 0
           fi
+          if [ "$IS_FORK" = "true" ] || [ "$IS_DEPENDABOT" = "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=emulator.wtf skipped::EW_API_TOKEN is not available to fork or Dependabot pull requests. The APKs were built and uploaded, but the instrumentation suite did not run."
+            exit 0
+          fi
+          echo "::error title=emulator.wtf token missing::EW_API_TOKEN is not set, so the instrumentation suite cannot run. This lane is the only thing running the androidTest suite, so it fails rather than passing without it. Add the secret in Settings → Secrets and variables → Actions."
+          exit 1
 
       # ── Route the built APKs to emulator.wtf and run the suite ───────────────
       - name: Run instrumentation tests on emulator.wtf

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -15,6 +15,7 @@ jobs:
   apk:
     name: Generate APK
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # The content artifact lives in a private repository. Mint a short-lived
       # installation token for it rather than carrying a long-lived PAT: the token
@@ -65,6 +66,7 @@ jobs:
     name: Release APK
     needs: apk
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,31 @@ on:
   # happen for unreviewed PR code (and re-using a version code makes the upload
   # fail with "Version code N has already been used"). PRs are validated by the
   # Android PR Checks workflow instead.
+  #
+  # Paths are an allowlist and fail closed. Without one, a merge to dev that touched only
+  # worker/ or docs/ ran a full signed release build, uploaded to the Play Store internal
+  # track, burned a versionCode, pushed a bump commit and cut a git tag and a GitHub Release
+  # — for a change with no effect on the Android app. A new top-level directory ships nothing
+  # until it is added here deliberately, which is the right direction for a lane that
+  # publishes to Play.
   push:
     branches: [ dev ]
+    paths:
+      - 'app/**'
+      - 'baselineprofile/**'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      # The release is driven by fastlane, so its own tooling ships a release.
+      - 'fastlane/**'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      # A new content artifact is a user-visible change and does warrant a release.
+      - 'data.lock.json'
+      - '.github/workflows/deploy.yml'
 
 # Never run two deploys at once. Each one bumps the version, uploads, and only
 # then pushes the bump back to dev, so overlapping runs read the same baseline
@@ -21,6 +44,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Skip the automated version-bump commit so it never re-triggers a
     # build/deploy. That commit carries a [skip ci] marker in its message.
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -34,6 +34,7 @@ jobs:
   docs:
     name: Docs match the code
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/internal_testing.yml
+++ b/.github/workflows/internal_testing.yml
@@ -52,6 +52,7 @@ concurrency:
 jobs:
   internal:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # workflow_dispatch always runs. A push only runs when it explicitly opts in with [deploy],
     # so ordinary commits on a feature branch never burn a Play version code. [skip ci] (used by
     # the bump commit below) is always excluded, so this cannot re-trigger itself.

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,12 +1,45 @@
 name: Android PR Checks
 
+# An allowlist, not a `paths-ignore`: it fails closed. A new top-level directory gets no
+# Gradle build until someone adds it here, which is the safe direction. Before this filter
+# existed, a dependabot bump touching only worker/package.json ran the full test + lint +
+# coverage lane (PR #520 is exactly that); worker/ has its own workflow, docs/ has
+# docs_check.yml, and the theme files have tajweed_contrast_check.yml.
 on:
   pull_request:
     branches: [ master, dev ]
+    paths:
+      - 'app/**'
+      - 'baselineprofile/**'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      # The lane runs through fastlane and checks the version bump, so its own tooling counts.
+      - 'fastlane/**'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      # Invoked by the coverage step below.
+      - 'scripts/coverage_summary.py'
+      # A new content artifact changes what the app builds against.
+      - 'data.lock.json'
+      - '.github/workflows/pr_checks.yml'
+
+# A new push to the PR supersedes the old run. Without this every push to an open PR ran the
+# full ~13-minute lane to completion: one branch pushed nine times in four and a half hours and
+# paid for all nine. The sampled history contains zero cancelled runs, which is what a missing
+# guard looks like from the outside.
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    # The lane's median is ~13 minutes. Without a cap a hang bills toward the 6-hour default.
+    timeout-minutes: 45
     # pull-requests: write is for the sticky coverage comment below. Without it the
     # comment step fails on a repository whose default token is read-only.
     permissions:
@@ -44,6 +77,14 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+
+      # This lane had no Gradle caching at all, which made `org.gradle.caching=true` in
+      # gradle.properties a no-op here: the local build cache lives on the runner's disk and
+      # the disk is destroyed when the job ends. Every PR therefore resolved the full
+      # dependency graph and rebuilt from zero. android_instrumented_tests.yml has always done
+      # this correctly; this is the same step.
+      - name: Setup Gradle (with cache)
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Set up ruby env
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tajweed_contrast_check.yml
+++ b/.github/workflows/tajweed_contrast_check.yml
@@ -20,6 +20,7 @@ jobs:
   contrast:
     name: Tajweed colour contrast
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/worker_deploy.yml
+++ b/.github/workflows/worker_deploy.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Typecheck & test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -44,6 +45,7 @@ jobs:
     # must never publish unreviewed code to production.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -81,6 +83,7 @@ jobs:
     needs: deploy
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # No checkout here, so the workflow-level `working-directory: worker`
     # default would point at a nonexistent dir — run from the workspace root.
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,9 @@ all four gates stay green — a branch that goes out clean locally and red on th
 touched navigation, build `androidTest` too.
 
 **`lintDebug` is a real gate, not an optional extra.** `fastlane/Fastfile`'s `test` lane runs
-`gradle test` *and* `gradle lint`, so every PR check fails on a lint **error** — and lint catches a
-class of defect the other three cannot: `LocalContextGetResourceValueCall` (a `context.getString`
+`:app:testDebugUnitTest` *and* `:app:lintDebug` — the same two tasks listed above — so every PR
+check fails on a lint **error**, and lint catches a class of defect the other three cannot:
+`LocalContextGetResourceValueCall` (a `context.getString`
 inside a composable, which does not re-resolve across a configuration change) and
 `MissingTranslation` (a new string absent from a shipped locale). Neither breaks a build or a test.
 It is slow, and running it is still cheaper than a red `dev`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,14 +2,21 @@ default_platform(:android)
 
 platform :android do
   desc "Runs all the tests"
+    # Debug-scoped, not the bare `test`/`lint` lifecycle tasks. `gradle test` aggregates
+    # test<Variant>UnitTest across every build type, and the baseline-profile plugin adds
+    # nonMinifiedRelease and benchmarkRelease on top of debug and release — so the same 212-file
+    # suite ran several times over for one suite's worth of signal. Nothing downstream ever
+    # looked at the extra variants: jacocoTestReport depends on testDebugUnitTest, and
+    # pr_checks.yml uploads lint-results-debug.html. These are the same two tasks CLAUDE.md
+    # tells contributors to run locally.
     lane :test do
-      gradle(task: "test")
-      gradle(task: "lint")
+      gradle(task: ":app:testDebugUnitTest")
+      gradle(task: ":app:lintDebug")
     end
 
     desc "Run lint check"
     lane :lint do
-      gradle(task: "lint")
+      gradle(task: ":app:lintDebug")
     end
 
 


### PR DESCRIPTION
Acts on a CI efficiency audit of this repo and foolscap. This repo is **public**, so its Actions minutes are free — the cost here is PR feedback latency, not money. `pr_checks.yml` is the repo's biggest lane at 543 lifetime runs and a ~13.4-minute median, with a 30% failure rate.

## Only build Android for Android changes

`pr_checks.yml`, `android_instrumented_tests.yml` and `deploy.yml` had no `paths:` filter at all. **PR #520 is the live example** — a dependabot bump touching only `worker/package.json` and its lockfile, on which all three of these ran:

| Check on #520 | Result |
|---|---|
| Typecheck & test (worker) | correct — it's a worker change |
| check (Android PR Checks) | full test + lint + coverage, for two changed JSON lines |
| emulator.wtf instrumentation | built two APKs and booked cloud device time |

`worker_deploy.yml`, `docs_check.yml` and `tajweed_contrast_check.yml` were already scoped correctly; these three now match them. The filters are **allowlists** rather than `paths-ignore`, so they fail closed — a new top-level directory gets no build until it is added deliberately.

That matters most on `deploy.yml`, where the old behaviour was that a worker-only or docs-only merge to `dev` ran a full signed release build, uploaded to the Play Store internal track, burned a versionCode, pushed a bump commit, and cut a git tag and a GitHub Release.

## Cache Gradle on the PR lane

`pr_checks.yml` called `setup-java` with no `cache:` key and had no `setup-gradle` step, which made `org.gradle.caching=true` in `gradle.properties` a **no-op there** — the local build cache lives on the runner's disk and the disk dies with the job. Every PR resolved the full dependency graph from zero. `android_instrumented_tests.yml` has always had the right step; this adds the same one.

## Cancel superseded PR runs

`pr_checks.yml` had no `concurrency` group. Branch `refactor/presentation-layer-atomic-design-cleanup` pushed nine times in four and a half hours on 2026-08-14 and every one of those runs went to full ~13-minute completion, including three starts inside fourteen minutes. The sampled history contains **zero cancelled runs** — which is what a missing guard looks like from the outside.

## Stop running the unit suite once per build type

The fastlane `test` lane called the bare `test` and `lint` lifecycle tasks. `gradle test` aggregates `test<Variant>UnitTest` across every build type, and the baseline-profile plugin adds `nonMinifiedRelease` and `benchmarkRelease` on top of debug and release — so the 212-file suite ran several times over for one suite's worth of signal.

Nothing downstream ever looked at the extra variants: `jacocoTestReport` depends on `testDebugUnitTest` (`app/build.gradle.kts:479`) and the workflow uploads `lint-results-debug.html`. Now scoped to `:app:testDebugUnitTest` and `:app:lintDebug` — the same two tasks CLAUDE.md already tells contributors to run locally. CLAUDE.md's description of the lane is updated in the same commit, per the docs contract.

## Fail when the instrumentation suite cannot run

A missing `EW_API_TOKEN` used to skip the emulator.wtf run with a warning annotation and leave the job **green**, quietly turning "instrumented tests run on every PR" into "the APKs compiled". Nobody reads a warning on a passing run. It now fails — except on fork and Dependabot pull requests, which GitHub structurally cannot give the secret to; those still skip loudly, and the APK build above still proves the `androidTest` source set compiles.

## Also

Added the `timeout-minutes` that were missing from every job outside the two Claude workflows (which already had 30). A hang previously billed toward the 6-hour default.

## Verification

`python3 scripts/check_docs.py` — **all 23 checks pass**. `ruby -c fastlane/Fastfile` — syntax OK. All ten workflow files parse.

**No Gradle ran.** This environment has no Android SDK, so `compileDebugKotlin`, `testDebugUnitTest` and `lintDebug` were not executed here. The specific thing worth watching on the first run: that `:app:lintDebug` and `:app:testDebugUnitTest` behave as the bare aggregates did. They are the documented local commands and the only variants anything consumes, so this should strictly reduce work — but it is the change in this PR most worth a real run.

One number I could not settle: whether the bare `test` task was fanning out across two build types or four. Two audit passes disagreed, and `./gradlew :app:tasks --all` is what resolves it. The direction was never in doubt — more than one variant, only debug consumed — so the fix is the same either way; only the size of the saving is uncertain.

## Deliberately not done

- **The `internal_testing.yml` / `deploy.yml` concurrency race.** They use different groups (`internal-testing-${{ github.ref }}` vs `android-deploy`) and `internal_testing`'s `workflow_dispatch` has no branch restriction, so a manual run on `dev` can race an organic deploy. `fastlane/version_bump_spec.rb:1-8` documents this happening on 2026-07-30 at versionCode 380. It touches the release path and deserves its own change.
- `worker_deploy.yml` and `build_and_release.yml` still have no `concurrency` group.
- `worker_deploy.yml`'s 47% failure rate — highest of any workflow sampled. Cheap runs (~1 min each), but it is a lot of red X's to triage.
- The `fetchNimazData` → every-`lint*`-task coupling, which the repo already tracks as #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Utk1x6JCSV2e1FGTqYxTVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utk1x6JCSV2e1FGTqYxTVo)_