### PR TITLE
Plan the multi-module split: assessment, and a 22-PR stack to execute it

### DIFF
--- a/docs/specs/multi-module-migration/EPIC.md
+++ b/docs/specs/multi-module-migration/EPIC.md
@@ -1,0 +1,299 @@
+# Multi-module migration — epic, issue breakdown and PR stack
+
+**Repo:** `arshad-shah/nimaz` · **Integration branch:** `epic/multi-module`
+**Spec:** [`SPEC.md`](SPEC.md) — the assessment and the reasoning. This document is the
+execution plan: the issue tree, the branch topology, and the exit criteria for each PR.
+**Status:** proposal. No issues have been filed and no branches exist yet.
+
+---
+
+## 0. How this is meant to run
+
+One epic issue, seven milestones, **22 pull requests** stacked onto a single long-lived
+integration branch. Merging that branch into `dev` once gives a fully decoupled Nimaz with
+documentation that matches the code — not a half-migrated tree that someone has to finish
+later under pressure.
+
+The stack exists because these PRs are **not independent**. PR *n* is cut from the branch of
+PR *n−1*, not from `dev`. Reviewing them in isolation would mean reviewing a tree that does
+not compile.
+
+```
+dev
+ └── epic/multi-module                 ← integration branch, never merged into until the end
+      ├── mm/00-build-logic            PR  1
+      ├── mm/01-check-docs-roots       PR  2   ─┐ phase 0
+      ├── mm/02-baseline-metrics       PR  3   ─┘
+      ├── mm/03-domain-route-inversion PR  4   ─┐ phase 1
+      ├── mm/04-core-domain            PR  5   ─┘
+      ├── mm/05-core-common            PR  6   ─┐
+      ├── mm/06-core-database          PR  7    │ phase 2
+      ├── mm/07-core-datastore         PR  8    │
+      ├── mm/08-core-data              PR  9   ─┘
+      ├── mm/09-core-ui                PR 10   ── phase 3
+      ├── mm/10-core-navigation        PR 11   ─┐ phase 4
+      ├── mm/11-navgraph-decompose     PR 12   ─┘
+      ├── mm/12-feature-widget         PR 13   ─┐
+      ├── mm/13-feature-onboarding-about PR 14  │
+      ├── mm/14-feature-tools-calendar PR 15    │
+      ├── mm/15-feature-search         PR 16    │ phase 5
+      ├── mm/16-feature-content        PR 17    │
+      ├── mm/17-feature-tracker        PR 18    │
+      ├── mm/18-feature-quran          PR 19    │
+      ├── mm/19-feature-prayer         PR 20    │
+      ├── mm/20-feature-settings       PR 21   ─┘
+      └── mm/21-di-split-and-guardrails PR 22  ── phase 6
+```
+
+Each retargets to `epic/multi-module` on merge,
+so the integration branch always holds every merged step and nothing else.
+
+**Rebase discipline.** When `dev` moves, rebase `epic/multi-module` onto it once and
+force-push the stack, rather than merging `dev` into each open branch. With 22 branches the
+merge-commit approach produces an unreviewable history.
+
+---
+
+## 1. The epic issue
+
+> **Title:** Split Nimaz into feature and core Gradle modules
+>
+> **Body:**
+>
+> 190,505 lines across 1,121 files sit in one `:app` module. The layering `CLAUDE.md` claims —
+> `presentation → domain → data` — is real in the code but enforced by nothing, because a single
+> module cannot enforce it. This epic converts that convention into compile errors, and takes
+> the build-time improvement as a secondary benefit.
+>
+> Full assessment and reasoning: `docs/specs/multi-module-migration/SPEC.md`.
+> Execution plan and PR stack: `docs/specs/multi-module-migration/EPIC.md`.
+>
+> **Target:** 11 feature modules, 7 core modules, `:app` reduced to a shell.
+>
+> **Integration branch:** `epic/multi-module`. Merged into `dev` once, at the end.
+>
+> **Definition of done**
+> - [ ] `:app` contains only `MainActivity`, `NimazApp`, the NavHost shell, `screens/adaptive`,
+>       `screens/home`, the manifest, Firebase and signing config
+> - [ ] `:core:domain` builds with the `kotlin-jvm` plugin and no Android on its classpath
+> - [ ] No `:feature:*` module depends on another `:feature:*` module, enforced by a `check` task
+> - [ ] All 2,333 unit and 121 instrumented tests green
+> - [ ] `python3 scripts/check_docs.py` green **and** asserting non-zero scan counts
+> - [ ] Release AAB diffed against baseline: manifest, DEX, resources, R8 output
+> - [ ] `ARCHITECTURE.md`, `SUBSYSTEMS.md`, `NAVIGATION.md`, `TESTING.md`,
+>       `CLEAN_ARCHITECTURE_CHECKLIST.md` and `docs/README.md` describe the module structure
+> - [ ] Phase 5 build-time measurements recorded against the Phase 0 baseline
+>
+> **Explicit non-goals:** splitting `strings.xml`; moving `screens/adaptive` out of `:app`;
+> any behaviour, UI or schema change.
+
+---
+
+## 2. Milestones and sub-issues
+
+Each sub-issue below is one PR. "Exit" is what a reviewer checks before approving.
+
+### Milestone 0 — Foundations (PRs 1–3)
+
+Nothing moves. This milestone exists so that the checks which would otherwise silently stop
+working are fixed *before* anything can break them.
+
+**#1 — Add `build-logic` convention plugins** · `mm/00-build-logic`
+Included build with `nimaz.android.library`, `nimaz.android.feature`, `nimaz.jvm.library`,
+`nimaz.android.hilt`, `nimaz.android.compose`. Each carries compileSdk 37 / minSdk 29, Java 21,
+the `-Xannotation-default-target=param-property` arg, and the Hilt/KSP wiring. Add
+`android-library` and `kotlin-jvm` aliases to `libs.versions.toml`. Apply the plugins to `:app`
+itself so they are exercised immediately. Move the `fetchNimazData` lint/asset ordering
+workaround into the convention plugin rather than leaving it inline — every module that
+consumes those generated assets will need it.
+*Exit:* `:app` builds; no change to the produced APK; `./gradlew :app:assembleRelease` green.
+
+**#2 — Make `scripts/check_docs.py` module-aware** · `mm/01-check-docs-roots`
+**This is the highest-priority item in the whole epic and must land before any file moves.**
+The script roots every scan at `APP = ROOT / "app/src/main/java/com/arshadshah/nimaz"`.
+SUB-02 (Workers), SUB-03 (Services), SUB-05 (notification channels) and SUB-06 (DataStore
+files) scan `APP.rglob(...)`. Six of the seven Workers live in `widget/` and three of the four
+Services in `data/audio/` — both of which move in Phase 5. When they do, those globs return a
+smaller set and "every Worker is documented" passes because there are fewer Workers to find.
+Change the roots to scan all modules, and add a floor assertion per scan (`>= 7 Workers`,
+`>= 4 Services`, `>= 12 channels`, `>= 3 DataStore files`) so an empty or shrunken scan fails
+rather than passes.
+*Exit:* deliberately move one Worker to a scratch directory and confirm the check goes **red**.
+Revert. This negative test is the point of the PR.
+
+**#3 — Record the baseline and enable configuration cache** · `mm/02-baseline-metrics`
+Add `org.gradle.configuration-cache=true`. Commit a `BASELINE.md` in this spec folder holding
+the pre-migration measurements from SPEC §6.5: clean `assembleDebug`, the four incremental
+scenarios, `testDebugUnitTest` wall time, and configuration time. The known starting point is
+`:app:compileDebugKotlin` = **3m 44s** cold.
+*Exit:* numbers committed. Without them the epic cannot demonstrate it worked.
+
+### Milestone 1 — `:core:domain` (PRs 4–5)
+
+**#4 — Remove the domain → navigation inversion** · `mm/03-domain-route-inversion`
+Five domain files import `core.navigation.Route`: `UnifiedBookmark.kt`, `AiModels.kt`,
+`Announcement.kt`, `AskWithProofUseCase.kt`, `AnnouncementUseCases.kt`. Introduce a domain-level
+target type and map it to `Route` at the presentation edge. Also fix the three KDoc references
+from `domain/model` into `data`/`presentation` (`QuranReciter.kt`, `MushafLayout.kt`,
+`QuranTranslation.kt`).
+*Exit:* `grep -rl 'core\.navigation\.Route' domain/` returns nothing. Announcement deep links
+still resolve — NAV-06 through NAV-08 green.
+
+**#5 — Extract `:core:domain` as a pure JVM module** · `mm/04-core-domain`
+Move all 103 files under the `kotlin-jvm` plugin. No Android on the classpath.
+*Exit:* `:core:domain:test` runs without AGP or Robolectric and completes in seconds; adding
+`import android.content.Context` to a domain file fails the build. Demonstrate that in the PR
+description — it is the first compile-enforced rule the epic buys.
+
+### Milestone 2 — Data-side core modules (PRs 6–9)
+
+**#6 — `:core:common`** · `mm/05-core-common`
+`core/util` is 24 files and 5,336 LOC and currently reaches into domain (11 files),
+presentation, data and widget. Triage file by file: genuinely shared helpers go to
+`:core:common`, the rest are pushed down to their real owners. Also moves `core/time`,
+`core/monitoring`, `core/share`, `core/text`, `core/feedback`, `core/init`.
+*Exit:* `:core:common` depends on `:core:domain` and Android only — never on data or
+presentation.
+
+**#7 — `:core:database`** · `mm/06-core-database`
+Both `@Database` classes, 15 entities, 22 DAOs, all migrations, **and the `schemas/`
+directory**. The `room.schemaLocation` KSP arg and the `androidTest` `assets.srcDir(schemas)`
+wiring move with it.
+*Exit:* **the exported schema JSON for version 25 is byte-identical to the pre-move file.** If
+Room regenerates it differently the identity hash changed and every install would attempt a
+destructive migration. `MigrationTestHelper` tests green. SUB-01 green.
+
+**#8 — `:core:datastore`** · `mm/07-core-datastore`
+`PreferencesDataStore` (990 LOC) and the 11 `SettingsSeams` implementations.
+*Exit:* SUB-06 green with its new floor assertion; no preference key renamed.
+
+**#9 — `:core:data`** · `mm/08-core-data`
+19 repository implementations and their mappers.
+*Exit:* every repository still returns domain models; no entity type escapes the module.
+
+### Milestone 3 — `:core:ui` (PR 10)
+
+**#10 — Extract the design system** · `mm/09-core-ui`
+52 atoms, the generic `Nimaz*` molecules, `theme/` (18 files), `foundation/` (17 files), and
+**every resource including the full 1,910-entry `strings.xml` and all five translation
+directories**. Fix the three design-system → feature leaks. Feature-specific molecules and
+organisms stay put; they travel with their feature in Milestone 5.
+*Exit:* `:core:ui` has no import from `presentation.screens` or `presentation.viewmodel`.
+Resource resolution verified in a release build — see the R8 note in SPEC §6.4.
+
+### Milestone 4 — Navigation (PRs 11–12) — **the critical path**
+
+**#11 — `:core:navigation`** · `mm/10-core-navigation`
+The `Route` hierarchy, `ScreenTags`, the `taggedComposable` helper, `HelpDeepLink`,
+`AnnouncementRoutes`, `WorshipDestinations`. Nothing that imports a screen.
+*Exit:* NAV-01, NAV-02, NAV-05, NAV-09, NAV-10 green against the new location.
+
+**#12 — Decompose `NavGraph.kt`** · `mm/11-navgraph-decompose`
+1,442 LOC importing 70 screens and registering 94 destinations. Convert each destination into a
+per-feature `fun NavGraphBuilder.quranGraph(onNavigate: (Route) -> Unit)` extension placed
+beside the screens it registers — **still inside `:app`**. `:app` keeps the `NavHost` and
+`NavigationSuiteScaffold` shell and calls each feature's graph function.
+**This PR moves no files between modules.** It is reviewable on its own merits and is the
+change that makes Milestone 5 possible.
+*Exit:* all 94 destinations still registered with `taggedComposable`, never a bare
+`composable` — NAV-03 and NAV-04 green. Every route still reachable; deep links unchanged.
+
+### Milestone 5 — Feature modules (PRs 13–21)
+
+Ordered least-coupled first, so the pipeline is proven on something that cannot break a screen.
+Each PR moves: screens, ViewModels, that feature's molecules and organisms, its Hilt module
+slice, its nav-graph extension, and its tests.
+
+| PR | Issue | Branch | Contents |
+|---:|---|---|---|
+| 13 | **#13** `:feature:widget` | `mm/12-feature-widget` | 6 Glance widgets, 7 receivers, 6 workers. Zero presentation deps — proves the pipeline. **SUB-02/04/05 must stay green with floors.** |
+| 14 | **#14** `:feature:onboarding`, `:feature:about` | `mm/13-feature-onboarding-about` | about, help, licenses, more |
+| 15 | **#15** `:feature:tools`, `:feature:calendar` | `mm/14-feature-tools-calendar` | zakat; Islamic calendar + events |
+| 16 | **#16** `:feature:search` | `mm/15-feature-search` | search + AI ask-with-proof. Touches `worker/` contract — leave it alone. |
+| 17 | **#17** `:feature:content` | `mm/16-feature-content` | dua, hadith, qaida, asma, asmaunnabi, names, prophets, catalog — **moved together**, their ViewModels are one package |
+| 18 | **#18** `:feature:tracker` | `mm/17-feature-tracker` | prayer tracker, fasting, tasbih — likewise |
+| 19 | **#19** `:feature:quran` | `mm/18-feature-quran` | quran, khatam, bookmarks. `QuranDao` stays in `:core:database` (4 repos use it) |
+| 20 | **#20** `:feature:prayer` | `mm/19-feature-prayer` | prayer times, qibla, night worship, adhan audio. **SUB-03 must stay green** — 3 of 4 Services move here |
+| 21 | **#21** `:feature:settings` | `mm/20-feature-settings` | 18 screens, the 1,324-line `SettingsViewModel`. Largest and most cross-referenced — last |
+
+`screens/adaptive` and `screens/home` stay in `:app`. All 26 `screens/` directories are
+accounted for across this table plus those two.
+
+*Exit for every PR in this milestone:* the moved feature's tests compile **without being
+relaxed**. A test that will not compile after the move is a real coupling signal, not migration
+noise — fix the coupling, do not weaken the test.
+
+### Milestone 6 — Guardrails and docs (PR 22)
+
+**#22 — Split the DI god-modules and lock the graph** · `mm/21-di-split-and-guardrails`
+`RepositoryModule.kt` (863 LOC) dissolves; each module owns its `@Binds`/`@Provides`.
+`DatabaseModule`'s DAO providers move to `:core:database`. Add the dependency-graph `check`
+task: fail the build if any `:core:*` depends on a `:feature:*`, or any `:feature:*` depends on
+another `:feature:*`.
+*Exit:* deliberately add a forbidden dependency and confirm the build fails. Revert.
+
+---
+
+## 3. Documentation, and which PR owns each change
+
+`CLAUDE.md` requires docs to be updated **in the same commit** as the change they describe, and
+`scripts/check_docs.py` enforces 23 of those rules on every PR. This epic invalidates a lot of
+prose, so ownership is assigned explicitly rather than left to a cleanup PR at the end.
+
+| Doc | What goes stale | Owning PR |
+|---|---|---|
+| `ARCHITECTURE.md` §DI | "All modules live in `core/di`" becomes false | PR 22 |
+| `ARCHITECTURE.md` §layers | The layer diagram gains module boundaries | PR 5 (`:core:domain`), extended each milestone |
+| `ARCHITECTURE.md` §9 registry | Records **nine** settings seams; there are **11** (`HijriSettings`, `SearchSettings` were added without a doc update) | PR 1 — fix the pre-existing drift up front |
+| `ARCHITECTURE.md` new-feature recipe | "Add it to `NimazDatabase` … bind it in `RepositoryModule`" — both move | PR 7, PR 22 |
+| `NAVIGATION.md` | Route graph gains per-feature graph functions; destination count claim | PR 12 |
+| `SUBSYSTEMS.md` | Worker, Service, widget and DataStore tables gain module columns | PR 7, 13, 20 |
+| `TESTING.md` | Test invocation moves from `:app:testDebugUnitTest` to all-module | PR 3, PR 22 |
+| `CLEAN_ARCHITECTURE_CHECKLIST.md` | Detection commands grep paths that move; several anti-patterns become compile errors and can be ticked | every PR that moves the path a command greps |
+| `docs/README.md` | Index gains this spec folder if any doc here is promoted to top level | PR 22 |
+| `DOCUMENTATION.md` §1 | Ownership matrix gains the module-structure owner | PR 22 |
+
+Two rules for the stack:
+
+1. **A PR that moves a path referenced by a detection command in
+   `CLEAN_ARCHITECTURE_CHECKLIST.md` updates that command in the same PR.** Otherwise the
+   checklist rots into a list of commands that return nothing and therefore "pass".
+2. **A PR that resolves a checklist anti-pattern ticks the box** rather than leaving it for
+   PR 22. Several of them — the layering assertions in particular — stop being assertable
+   because the compiler now enforces them; say so in the checklist instead of deleting the row.
+
+---
+
+## 4. What runs on every PR in the stack
+
+Non-negotiable, in this order. A PR that cannot show all five does not merge into
+`epic/multi-module`.
+
+1. `./gradlew testDebugUnitTest` — all 2,333 unit tests, no test relaxed to compile
+2. `./gradlew lintDebug` across all modules
+3. `python3 scripts/check_docs.py` — 23 checks, **with the floor assertions from PR 2**
+4. `./gradlew :app:assembleRelease` — R8 and resource shrinking exercised, not just debug
+5. The docs listed in §3 for that PR, updated in the same commit
+
+Instrumented tests (121) run per milestone rather than per PR, on the existing
+`android_instrumented_tests.yml` lane.
+
+Artifact diffing (SPEC §6.4 — merged manifest, DEX class list, merged resources, R8 output)
+runs at each **milestone** boundary against the Phase 0 baseline, not per PR. Per PR it is too
+slow to be useful; per milestone it is the thing that catches a stripped font or a dropped
+`values-tr`.
+
+---
+
+## 5. Risks specific to running this as a stack
+
+- **The stack goes stale.** 22 PRs against a moving `dev` is the main practical risk. Rebase
+  `epic/multi-module` onto `dev` weekly and force-push; do not let it drift a month.
+- **Milestone 5 PRs conflict with feature work on `dev`.** A PR touching `screens/settings`
+  while PR 21 is open will conflict badly. Either freeze the feature area for the duration of
+  its PR, or land that PR first. This is worth agreeing before starting Milestone 5.
+- **The integration branch is never itself released.** It merges to `dev` once, at the end,
+  after a full release-build diff. Do not cut a release from `epic/multi-module`.
+- **Reviewer fatigue.** PRs 13–21 are nine mechanically similar moves. The interesting review
+  happens in PRs 2, 5, 7, 12 and 22; the rest should be reviewed for *what did not move* — a
+  file that quietly stayed behind in `:app` is the common failure.

--- a/docs/specs/multi-module-migration/SPEC.md
+++ b/docs/specs/multi-module-migration/SPEC.md
@@ -1,0 +1,442 @@
+# Multi-module migration — assessment and spec
+
+**Repo:** `arshad-shah/nimaz` · **Base:** `dev` · **Written against:** `77534cb`
+**Scope:** the Gradle module structure only. No behaviour changes, no UI changes, no schema
+changes. Every phase below is a refactor whose success criterion is that nothing observable
+changed.
+**Status:** proposal. Nothing here has been implemented.
+
+---
+
+## 0. How to work from this document
+
+§1–§3 are the assessment: what the code looks like today, what is already in good shape, and
+what actually stands in the way. §4 is the target module graph. §5 is the phase order. §6 is
+the validation strategy, which is the half of this document that decides whether the migration
+succeeds or quietly breaks the release lane.
+
+Phases are meant to ship as separate PRs. Phase 4 is the critical path; do not start Phase 5
+without it.
+
+---
+
+## 1. What the code looks like today
+
+Measured on `77534cb`.
+
+| Layer | Files | LOC | Share |
+|---|---:|---:|---:|
+| `presentation/` | 428 | 97,290 | 51% |
+| `data/` | 98 | 18,351 | 10% |
+| `core/` | 54 | 11,377 | 6% |
+| `domain/` | 103 | 9,693 | 5% |
+| `widget/` | 39 | 3,530 | 2% |
+| **total `app/src`** | **1,121** | **190,505** | |
+
+Modules: `:app` and `:baselineprofile`. Tests: 2,333 unit `@Test` methods across 360 files,
+121 instrumented across 37. No `buildSrc`, no `build-logic`, and no ArchUnit/Konsist-style
+architecture test anywhere in the repo.
+
+**Measured build baseline** (cold daemon, warm Gradle build cache, this machine):
+`./gradlew :app:compileDebugKotlin` = **3m 44s** for Kotlin compilation alone — no dexing, no
+resource merging, no lint. Gradle's own output notes that configuration cache is not enabled.
+
+Within `presentation/`, the design system is the larger half:
+
+| Package | Files | LOC |
+|---|---:|---:|
+| `components/molecules` | 88 | 21,093 |
+| `components/organisms` | 42 | 12,481 |
+| `components/atoms` | 52 | 9,293 |
+| `theme` + `foundation` + `model` | 37 | 3,779 |
+| `screens/` (26 directories) | 107 | ~35,000 |
+
+---
+
+## 2. What is already in good shape
+
+This matters, because each item below is work a typical modularization has to do *first* and
+that Nimaz has already done. The migration is unusually well-prepared.
+
+1. **The domain layer is genuinely pure.** Across 103 files there is not one `android`,
+   `androidx`, `dagger`, `room` or Firebase import. The only external annotation is
+   `javax.inject.Inject` (28 files) — a plain JVM annotation, fine in a `kotlin-jvm` module.
+   `:core:domain` can be a non-Android module on day one.
+2. **Screens are navigation-decoupled.** 84 of 107 screen files take `onNavigate`/`onBack`
+   lambdas; only 7 import `NavController` or `NavHostController`. This is the single biggest
+   determinant of feature-extraction difficulty and it is already handled.
+3. **Vertical slices are clean at the data layer.** 22 DAOs map to 20 repository
+   implementations nearly 1:1. `QuranDao` is the only DAO used by more than one repository
+   (four: Quran, Khatam, Tafseer, Library).
+4. **Interface segregation on settings is done.** `domain/repository/settings/SettingsSeams.kt`
+   already splits the 179-member `SettingsRepository` into nine feature-scoped interfaces
+   (`QuranPreferences`, `HadithDisplaySettings`, `TasbihSettings`, …). Each feature module
+   depends on its own seam rather than the whole store. Normally the fiddliest part of a split.
+5. **`android.nonTransitiveRClass=true` is already set**, which multi-module R-class
+   resolution requires.
+6. **Widgets are isolated** — zero imports from `presentation/`.
+7. **Tests mirror the main package tree**, so they move with the code they cover.
+8. **The design system barely leaks** — only 3 files across `components/`, `theme/` and
+   `foundation/` reference a feature package.
+
+---
+
+## 3. The real blockers
+
+### 3.1 `NavGraph.kt` — 1,442 LOC, the largest file in the repository
+
+It imports **70 screen composables** and registers **94 destinations** via `taggedComposable<Route.X>`.
+Every screen in the app is reachable from this one file, which means **no feature can move into
+its own module while it exists in this form.** This is the critical path.
+
+### 3.2 `RepositoryModule.kt` — 863 LOC
+
+One Hilt module carrying every `@Binds` interface→impl pair plus an `object UseCaseModule` of
+`@Provides` functions at the bottom. `DatabaseModule.kt` similarly provides both databases and
+all 22 DAOs one method at a time. Both must dissolve into per-module slices.
+
+### 3.3 Screens and ViewModels are grouped on different axes
+
+`screens/` has 26 directories organised by feature. `viewmodel/` has 17 organised by *domain
+area*. The mismatch is the source of essentially all cross-feature coupling:
+
+| Shared ViewModel package | Consumed by |
+|---|---|
+| `viewmodel/content` | dua, hadith, qaida, asma, asmaunnabi, names, prophets, catalog |
+| `viewmodel/tracker` | prayer, fasting, tasbih, dua |
+| `viewmodel/settings` | quran, dua, hadith (`SettingsViewModel` + `SettingsEvent`) |
+
+Plus `screens/adaptive`, which depends on twelve features by design — it is the list-detail shell.
+
+**The module boundary must follow the ViewModel grouping, not the screen grouping.** One module
+per `screens/` directory would produce 26 modules in a dense mesh: strictly worse than the
+monolith. Grouping by ViewModel package yields ~11 modules in a near-tree shape.
+
+### 3.4 Resources — 1,910 strings across 6 locales
+
+A single `strings.xml` with 1,910 entries, referenced from 206 presentation files, translated
+into `values-de`, `values-fr`, `values-id`, `values-ms`, `values-tr`. Splitting these per feature
+is the highest-toil, lowest-value work in the migration, and `bundle.language.enableSplit = false`
+means every locale ships in the base APK regardless. **Recommendation: do not split them.**
+
+### 3.5 Two Room databases
+
+`NimazDatabase` (15 entities, 22 DAOs) and `NimazUserDatabase`. A Room `@Database` class must
+see all its entities at compile time, so entities cannot be distributed across feature modules.
+One `:core:database` module owns both databases, all entities, all DAOs and all migrations.
+It is a shared rebuild hub and that is unavoidable.
+
+### 3.6 `core/` is a grab bag, not a foundation
+
+Nothing in it is "core" in the dependency-order sense:
+
+| Package | Files | LOC | Reaches into |
+|---|---:|---:|---|
+| `core/util` | 24 | 5,336 | domain (11 files), presentation, data, widget |
+| `core/navigation` | 6 | 2,279 | presentation (2), domain (4) |
+| `core/di` | 9 | 1,426 | data (6), domain (5) |
+| `core/share` | 5 | 1,019 | domain (1) |
+| `core/monitoring` | 6 | 960 | — |
+| `core/init`, `feedback`, `text`, `time` | 4 | 357 | data (1) |
+
+`core/util` has to be triaged file by file before anything can depend on it.
+
+### 3.7 A domain → navigation inversion
+
+Five domain files import `core.navigation.Route`: `UnifiedBookmark.kt`, `AiModels.kt`,
+`Announcement.kt`, `AskWithProofUseCase.kt`, `AnnouncementUseCases.kt`. Domain must not know
+about navigation. Hold a domain-level target type and map it to `Route` at the presentation edge.
+
+Three further references are KDoc-only (`QuranReciter.kt`, `MushafLayout.kt`,
+`QuranTranslation.kt` point at `data`/`presentation` symbols in comments). Harmless to the
+compiler, but they read as real dependencies to the next person.
+
+### 3.8 No convention-plugin infrastructure
+
+No `buildSrc`, no `build-logic`. `gradle/libs.versions.toml` has no `android-library` or
+`kotlin-jvm` plugin alias. Note the AGP 9 constraint already documented in `app/build.gradle.kts`:
+the standalone `kotlin-android` plugin must not be applied because AGP 9 compiles Kotlin itself.
+That applies to every library module too.
+
+---
+
+## 4. Target module graph
+
+```
+:app
+  MainActivity, NimazApp, the NavHost + NavigationSuiteScaffold shell,
+  screens/adaptive, screens/home, the merged manifest, Firebase, signing,
+  fetchNimazData, R8 config
+   │
+   ├─ :feature:quran      quran, khatam, bookmarks
+   ├─ :feature:prayer     prayer times, qibla, adhan audio
+   ├─ :feature:tracker    prayer tracker, fasting, tasbih
+   ├─ :feature:content    dua, hadith, qaida, asma, asmaunnabi, names, prophets, catalog
+   ├─ :feature:settings   18 screens, SettingsViewModel
+   ├─ :feature:search     search + AI ask-with-proof
+   ├─ :feature:tools      zakat
+   ├─ :feature:onboarding
+   ├─ :feature:about      about, help, licenses, more
+   └─ :feature:widget     6 Glance widgets, receivers, workers
+        │
+        ├─ :core:ui          atoms, generic Nimaz* molecules, theme, foundation,
+        │                    ALL strings and locale resources
+        ├─ :core:navigation  the Route hierarchy, ScreenTags, taggedComposable,
+        │                    the announcement and help deep-link grammars.
+        │                    No composables from features. No screen imports.
+        ├─ :core:data        20 repository impls + mappers
+        ├─ :core:database    both Room DBs, 15 entities, 22 DAOs, migrations, schemas/
+        ├─ :core:datastore   PreferencesDataStore + the nine SettingsSeams impls
+        ├─ :core:common      util, time, monitoring, share, text
+        └─ :core:domain      models, repository interfaces, 33 use cases   ← pure JVM
+```
+
+Eleven feature modules, seven core modules. Rules: `:core:*` never depends on `:feature:*`;
+no `:feature:*` depends on another `:feature:*`; only `:app` depends on features.
+
+Feature-specific molecules and organisms (`Home*`, `Mushaf*`, `Qaida*`, `Quran*`, `Prayer*`,
+`Khatam*`, `Fasting*`, `Hadith*`, `Name*`) travel to their feature module. Only genuinely
+generic `Nimaz*` components stay in `:core:ui`.
+
+---
+
+## 5. Migration phases
+
+### Phase 0 — Foundations, no code moves
+
+- Add a `build-logic` included build with convention plugins: `nimaz.android.library`,
+  `nimaz.android.feature`, `nimaz.jvm.library`, `nimaz.android.hilt`, `nimaz.android.compose`.
+  These carry compileSdk/minSdk, Java 21, the `-Xannotation-default-target=param-property`
+  compiler arg, and the Hilt/KSP wiring so no module repeats them.
+- Add `android-library` and `kotlin-jvm` aliases to `libs.versions.toml`.
+- Enable `org.gradle.configuration-cache=true`. Multi-module gains most of its speed from
+  configuration cache plus the build cache already enabled.
+- **Record the baseline measurements in §6.5.** Without a before number, none of this can be
+  shown to have worked.
+
+*Gate:* `:app` builds identically; all 2,333 unit and 121 instrumented tests green;
+`python3 scripts/check_docs.py` green.
+
+### Phase 1 — Extract `:core:domain` as a pure JVM module
+
+Fix §3.7 first (the five `Route` imports and the three KDoc references), then move `domain/`
+wholesale under the `kotlin-jvm` plugin.
+
+Highest-leverage single step: it compiles without AGP or Robolectric, its tests run in seconds,
+and from here a stray `import android.*` in domain is a build failure rather than a review
+comment. The sibling repo `arshad-shah/foolscap` ran exactly this step ("Make the pure layer its
+own module") and is the model to copy.
+
+### Phase 2 — The data-side core modules
+
+Triage `core/util` first (§3.6) — split genuinely shared helpers into `:core:common` and push
+the rest down to their real owners. Then:
+
+- `:core:database` — both `@Database` classes, entities, DAOs, migrations, **and the `schemas/`
+  directory**; the `room.schemaLocation` KSP arg and the `androidTest` `assets.srcDir(schemas)`
+  wiring move with it.
+- `:core:datastore` — `PreferencesDataStore` (990 LOC) plus the nine settings seams.
+- `:core:data` — 20 repository impls and mappers.
+
+### Phase 3 — `:core:ui`
+
+Atoms, the generic `Nimaz*` molecules, `theme/`, `foundation/`, and every resource including the
+full `strings.xml` and all five translation directories. Fix the three design-system → feature
+leaks. Feature-specific molecules and organisms stay put for now; they travel in Phase 5.
+
+### Phase 4 — Decompose `NavGraph.kt` (the unlock)
+
+- `:core:navigation` holds the `Route` hierarchy, `ScreenTags`, the `taggedComposable` helper,
+  `HelpDeepLink`, `AnnouncementRoutes` and `WorshipDestinations` — and nothing that imports a
+  screen.
+- Convert each of the 94 destination registrations into per-feature
+  `fun NavGraphBuilder.quranGraph(onNavigate: (Route) -> Unit)` extensions placed beside the
+  screens they register — still inside `:app` at this point.
+- `:app` keeps the `NavHost` and `NavigationSuiteScaffold` shell and calls each feature's graph
+  function.
+- **Every destination must still be registered with `taggedComposable`**, never a bare
+  `composable` — `scripts/check_docs.py` NAV-04 enforces this and NAV-03 checks the count.
+
+**This phase moves no files between modules and is independently shippable.** Ship it as its own
+PR. It is the change that makes Phase 5 possible and it can be reviewed on its own merits.
+
+### Phase 5 — Feature modules, one PR each, least-coupled first
+
+1. `:feature:widget` — zero presentation dependencies, self-contained. Proves the pipeline on
+   something that cannot break a screen.
+2. `:feature:onboarding`, `:feature:about`
+3. `:feature:tools`
+4. `:feature:search`
+5. `:feature:content` — dua, hadith, qaida, asma, asmaunnabi, names, prophets and catalog move
+   **together**, because their ViewModels are one package.
+6. `:feature:tracker` — prayer tracker, fasting, tasbih, likewise.
+7. `:feature:quran` — quran, khatam, bookmarks. `QuranDao` stays in `:core:database`.
+8. `:feature:prayer`
+9. `:feature:settings` — 18 screens and a 1,324-line ViewModel. Largest and most
+   cross-referenced; do it last.
+
+`screens/adaptive` and `screens/home` stay in `:app`. The adaptive shell depends on twelve
+features because it is the shell; moving it would invert the graph.
+
+Each PR moves: screens, ViewModels, that feature's molecules and organisms, its Hilt module
+slice, its nav-graph extension, and its tests.
+
+### Phase 6 — Dissolve the DI god-modules and add guardrails
+
+`RepositoryModule.kt` disappears; each module owns its `@Binds`/`@Provides`. `DatabaseModule`'s
+DAO providers move to `:core:database`. Add the dependency-graph guardrail (§6.6).
+
+---
+
+## 6. How we validate
+
+Six tiers, cheapest and most automatic first. Every phase gate runs tiers 1–3.
+
+### 6.1 Tier 1 — let the compiler carry the load
+
+This is the return on the whole exercise, so it is worth stating as the success metric rather
+than a side effect. Today `presentation → domain → data` is enforced by review alone — there is
+no architecture test in the repo. After Phase 1 it is enforced by the absence of the Android SDK
+on `:core:domain`'s classpath.
+
+**Metric:** count the architectural rules that became compile errors at each phase. If a phase
+adds no enforcement, ask why it is being done.
+
+### 6.2 Tier 2 — behavioural equivalence, every phase
+
+- **All 2,333 unit tests and 121 instrumented tests green.** Non-negotiable, every phase.
+- Because tests mirror the package tree and move with their code, **a test that stops compiling
+  after a move is a genuine coupling signal, not migration noise.** Do not relax a test to make
+  it compile — that is precisely the fault line where a regression hides.
+- **Room schema identity.** After `:core:database` moves, diff the exported schema JSON for the
+  current version byte-for-byte against the pre-move file. If Room regenerates it differently the
+  identity hash has changed, and every existing install will attempt a destructive migration.
+  Confirm `MigrationTestHelper` still finds the schemas via the `androidTest` assets wiring.
+- **Hilt graph resolution.** `./gradlew :app:kspDebugKotlin` failing is the signal. Add a smoke
+  instrumented test injecting the top ~20 singletons, so a missing binding fails loudly rather
+  than on first open of some rarely-visited screen.
+
+### 6.3 Tier 3 — the repo's own CI checks, which this migration will break
+
+**`scripts/check_docs.py` is the sharpest hazard in this migration and deserves its own gate.**
+It hardcodes
+
+```python
+APP = ROOT / "app/src/main/java/com/arshadshah/nimaz"
+```
+
+and derives every source path from it: `core/navigation`, `data/local/database/NimazDatabase.kt`,
+`widget/`, `data/announcement/AnnouncementPayloadMapper.kt`, `domain/model/Announcement.kt`.
+**All of those move.** The failure modes split in two, and only one of them is safe:
+
+- **Loud (fine).** Single-file reads (`read()` has no existence guard) and `widget_packages()`
+  (`.iterdir()`) raise on a missing path. CI goes red, someone fixes it.
+- **Silent (dangerous).** SUB-02 (Workers), SUB-03 (Services), SUB-05 (notification channel ids)
+  and SUB-06 (DataStore file names) scan `APP.rglob(...)`. Once `widget/` (6 workers) and
+  `data/audio/` (3 services, 1 worker) leave that tree, those globs return a *shrinking* set and
+  the "every X is documented" assertions pass **vacuously**. CI stays green while checking
+  progressively less.
+
+**Therefore:** in Phase 0, before any code moves, refactor `check_docs.py` to resolve its roots
+across all modules, and add a self-check asserting each scan found a non-zero, expected-minimum
+count. An empty scan must fail, not pass.
+
+Also on the CI lane:
+
+- **`scripts/coverage_summary.py`** reads a pinned XML path (`app/build/reports/jacoco/jacocoTestReport.xml`)
+  that Phase 0 changes.
+- **`fastlane/Fastfile`** runs `:app:testDebugUnitTest` and `:app:lintDebug`. After the split
+  those cover a shrinking fraction of the codebase — move to all-module `testDebugUnitTest` /
+  `lintDebug`.
+- **The five JaCoCo report tasks** in `app/build.gradle.kts` hardcode `src/main/java` and
+  `intermediates/classes/debug`. **These have already failed silently once** — producing 237-byte
+  reports that read as 0% rather than as an error. Re-point them per module or move to a merged
+  multi-module report, and **assert the report is non-empty**, because an empty JaCoCo report and
+  genuine zero coverage look identical at a glance.
+- **`scripts/check_tajweed_contrast.py`** and `check_mermaid.mjs` — re-check their path roots too.
+
+### 6.4 Tier 4 — artifact equivalence, which catches what tests cannot
+
+Build a release AAB before and after each phase and diff:
+
+- **Merged manifest** (`build/intermediates/merged_manifests/release/AndroidManifest.xml`) —
+  identical modulo element ordering. There are 14 components: six widget receivers,
+  `WidgetTickReceiver`, `BootReceiver`, three audio services, `NimazMessagingService`, a
+  `FileProvider` and `MainActivity`. Manifest merging across library modules is exactly where an
+  `exported` or `process` attribute changes silently.
+- **DEX class list and method count.**
+- **Merged resources.** With six locales and `enableSplit = false`, a dropped `values-tr` is
+  invisible until a Turkish user opens the app.
+- **R8 output.** `isMinifyEnabled = true` *and* `isShrinkResources = true`. **Resource shrinking
+  across module boundaries is the most likely source of a silent, release-only regression in this
+  whole migration** — an asset referenced by name rather than by `R.` reference can survive in the
+  monolith and be stripped once it lives in a library module. The eight Quran fonts in `res/font`
+  are exactly this shape of risk. Diff the resource-removal report, not just the mapping file.
+- **BuildConfig fields survive:** `CONTENT_ARTIFACT_SHA256` (computed from `data.lock.json`),
+  `PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER`, `AI_WORKER_BASE_URL`, and the `versionCode`/`versionName`
+  that CI bumps and pushes back to `dev`.
+
+Runtime-only hazards:
+
+- **Widgets.** Six Glance widgets, seven receivers, six workers, thin instrumented coverage. Pin
+  all six manually and confirm they update after any phase touching `:feature:widget` or
+  `:core:database`.
+- **Baseline profile.** Fully-qualified class names do not change under this migration (package
+  names are stable), so `app/src/main/baseline-prof.txt` should still match — but regenerate and
+  diff anyway. A profile that quietly stops matching costs startup time and reports no error.
+- **The `fetchNimazData` task-ordering workaround.** `app/build.gradle.kts` makes every
+  `merge*Assets` and every `lint*` task depend on `fetchNimazData`. This has already broken the
+  release lane once while both PR lanes stayed green, because lint-vital runs for release only.
+  **Once a library module consumes those generated assets the same race reappears there.** Move
+  the workaround into the convention plugin rather than copying it per module.
+- **Firebase.** `google-services.json` exists only on the CI release lane and the plugins are
+  applied conditionally on its presence. Confirm the Crashlytics mapping upload still resolves
+  once `:app`'s own class set has shrunk to a shell.
+
+### 6.5 Tier 5 — did it actually pay off?
+
+Baseline all of these in Phase 0 and re-measure at every phase gate. The known starting point is
+`:app:compileDebugKotlin` = 3m 44s cold.
+
+| Measurement | Expectation |
+|---|---|
+| Clean `:app:assembleDebug` | Roughly flat, possibly slightly worse |
+| Incremental: touch a leaf screen | **Should improve substantially — the number that matters** |
+| Incremental: touch `NimazButton.kt` | Will not improve; shared hub by design |
+| Incremental: touch a `domain` model | Will not improve much |
+| Incremental: touch `strings.xml` | Will not improve; deliberately unsplit |
+| `testDebugUnitTest` wall time | Should improve via parallel module execution |
+| `:core:domain:test` alone | Should drop to seconds |
+| Configuration time (`--profile`) | Watch it — more modules means more configuration |
+
+**Stopping rule:** if incremental rebuild after touching a leaf screen has not improved by at
+least 40% once Phase 5 is half done, the split is not paying for its complexity. Stop and
+reassess rather than finishing the remaining features out of momentum.
+
+### 6.6 Tier 6 — guardrails so it does not regress
+
+- **A dependency-graph check** wired into `check`: fail the build if any `:core:*` depends on a
+  `:feature:*`, or if any `:feature:*` depends on another `:feature:*`. Without this the graph
+  degrades back to a mesh within months.
+- **Update `docs/ARCHITECTURE.md`** — §9's tech-debt registry and the DI section, which currently
+  states "All modules live in `core/di`", become wrong at Phase 6.
+- **Update `docs/CLEAN_ARCHITECTURE_CHECKLIST.md`** — several of its detection commands grep
+  paths that move.
+
+---
+
+## 7. What I would push back on
+
+- **26 screen directories are not 26 modules.** Group by ViewModel package: eleven feature
+  modules, not twenty-six.
+- **Do not split `strings.xml`.** 1,910 strings across six locales for no build-time gain given
+  `enableSplit = false`.
+- **Leave `screens/adaptive` in `:app`.** It depends on twelve features because it is the shell.
+  That is not a violation to be fixed.
+- **Phase 4 before Phase 5, always.** Attempting a feature module while `NavGraph.kt` still
+  imports 70 screens produces a circular dependency and a bad week.
+- **Do not start Phase 5 without the Phase 0 baseline numbers.** The justification for this work
+  is build times. If we cannot show the before, we cannot show the after, and the whole thing
+  becomes a matter of taste.
+- **Fix `check_docs.py` in Phase 0, not reactively.** It is the one piece of CI that will go
+  green while silently checking less, and that is worse than it going red.

--- a/docs/specs/multi-module-migration/SPEC.md
+++ b/docs/specs/multi-module-migration/SPEC.md
@@ -4,6 +4,8 @@
 **Scope:** the Gradle module structure only. No behaviour changes, no UI changes, no schema
 changes. Every phase below is a refactor whose success criterion is that nothing observable
 changed.
+**Execution plan:** [`EPIC.md`](EPIC.md) — the issue tree, the 22-PR stack and the
+`epic/multi-module` integration branch that turns this assessment into merged work.
 **Status:** proposal. Nothing here has been implemented.
 
 ---
@@ -65,13 +67,20 @@ that Nimaz has already done. The migration is unusually well-prepared.
 2. **Screens are navigation-decoupled.** 84 of 107 screen files take `onNavigate`/`onBack`
    lambdas; only 7 import `NavController` or `NavHostController`. This is the single biggest
    determinant of feature-extraction difficulty and it is already handled.
-3. **Vertical slices are clean at the data layer.** 22 DAOs map to 20 repository
+3. **Vertical slices are clean at the data layer.** 22 DAOs map to 19 repository
    implementations nearly 1:1. `QuranDao` is the only DAO used by more than one repository
    (four: Quran, Khatam, Tafseer, Library).
 4. **Interface segregation on settings is done.** `domain/repository/settings/SettingsSeams.kt`
-   already splits the 179-member `SettingsRepository` into nine feature-scoped interfaces
-   (`QuranPreferences`, `HadithDisplaySettings`, `TasbihSettings`, …). Each feature module
-   depends on its own seam rather than the whole store. Normally the fiddliest part of a split.
+   already splits the flat preference store into **11** feature-scoped interfaces
+   (`QuranPreferences`, `HadithDisplaySettings`, `DuaDisplaySettings`, `TasbihSettings`,
+   `ZakatSettings`, `HijriSettings`, `SearchSettings`, `AiSettings`, `LocationSettings`,
+   `MoreSettings`, `AppSettings`), and `SettingsRepository` extends all 11 while declaring a
+   further 44 vals and 48 functions of its own. Each feature module depends on its own seam
+   rather than the whole store. Normally the fiddliest part of a split.
+
+   Note that `docs/ARCHITECTURE.md` §9 still records **nine** seams — `HijriSettings` and
+   `SearchSettings` were added without the doc being updated. Correct it in Phase 0; it is a
+   small instance of exactly the drift the module boundaries are meant to make impossible.
 5. **`android.nonTransitiveRClass=true` is already set**, which multi-module R-class
    resolution requires.
 6. **Widgets are isolated** — zero imports from `presentation/`.
@@ -97,7 +106,7 @@ all 22 DAOs one method at a time. Both must dissolve into per-module slices.
 
 ### 3.3 Screens and ViewModels are grouped on different axes
 
-`screens/` has 26 directories organised by feature. `viewmodel/` has 17 organised by *domain
+`screens/` has 26 directories organised by feature. `viewmodel/` has 16 organised by *domain
 area*. The mismatch is the source of essentially all cross-feature coupling:
 
 | Shared ViewModel package | Consumed by |
@@ -185,9 +194,9 @@ That applies to every library module too.
         ├─ :core:navigation  the Route hierarchy, ScreenTags, taggedComposable,
         │                    the announcement and help deep-link grammars.
         │                    No composables from features. No screen imports.
-        ├─ :core:data        20 repository impls + mappers
+        ├─ :core:data        19 repository impls + mappers
         ├─ :core:database    both Room DBs, 15 entities, 22 DAOs, migrations, schemas/
-        ├─ :core:datastore   PreferencesDataStore + the nine SettingsSeams impls
+        ├─ :core:datastore   PreferencesDataStore + the 11 SettingsSeams impls
         ├─ :core:common      util, time, monitoring, share, text
         └─ :core:domain      models, repository interfaces, 33 use cases   ← pure JVM
 ```
@@ -236,8 +245,8 @@ the rest down to their real owners. Then:
 - `:core:database` — both `@Database` classes, entities, DAOs, migrations, **and the `schemas/`
   directory**; the `room.schemaLocation` KSP arg and the `androidTest` `assets.srcDir(schemas)`
   wiring move with it.
-- `:core:datastore` — `PreferencesDataStore` (990 LOC) plus the nine settings seams.
-- `:core:data` — 20 repository impls and mappers.
+- `:core:datastore` — `PreferencesDataStore` (990 LOC) plus the 11 settings seams.
+- `:core:data` — 19 repository impls and mappers.
 
 ### Phase 3 — `:core:ui`
 

--- a/docs/specs/multi-module-migration/SPEC.md
+++ b/docs/specs/multi-module-migration/SPEC.md
@@ -169,12 +169,13 @@ That applies to every library module too.
   fetchNimazData, R8 config
    │
    ├─ :feature:quran      quran, khatam, bookmarks
-   ├─ :feature:prayer     prayer times, qibla, adhan audio
+   ├─ :feature:prayer     prayer times, qibla, night worship, adhan audio
    ├─ :feature:tracker    prayer tracker, fasting, tasbih
    ├─ :feature:content    dua, hadith, qaida, asma, asmaunnabi, names, prophets, catalog
    ├─ :feature:settings   18 screens, SettingsViewModel
    ├─ :feature:search     search + AI ask-with-proof
    ├─ :feature:tools      zakat
+   ├─ :feature:calendar   Islamic calendar, events
    ├─ :feature:onboarding
    ├─ :feature:about      about, help, licenses, more
    └─ :feature:widget     6 Glance widgets, receivers, workers
@@ -265,17 +266,17 @@ PR. It is the change that makes Phase 5 possible and it can be reviewed on its o
 1. `:feature:widget` — zero presentation dependencies, self-contained. Proves the pipeline on
    something that cannot break a screen.
 2. `:feature:onboarding`, `:feature:about`
-3. `:feature:tools`
+3. `:feature:tools`, `:feature:calendar`
 4. `:feature:search`
 5. `:feature:content` — dua, hadith, qaida, asma, asmaunnabi, names, prophets and catalog move
    **together**, because their ViewModels are one package.
 6. `:feature:tracker` — prayer tracker, fasting, tasbih, likewise.
 7. `:feature:quran` — quran, khatam, bookmarks. `QuranDao` stays in `:core:database`.
-8. `:feature:prayer`
+8. `:feature:prayer` — prayer times, qibla and night worship
 9. `:feature:settings` — 18 screens and a 1,324-line ViewModel. Largest and most
    cross-referenced; do it last.
 
-`screens/adaptive` and `screens/home` stay in `:app`. The adaptive shell depends on twelve
+All 26 `screens/` directories are accounted for: `screens/adaptive` and `screens/home` stay in `:app`. The adaptive shell depends on twelve
 features because it is the shell; moving it would invert the graph.
 
 Each PR moves: screens, ViewModels, that feature's molecules and organisms, its Hilt module


### PR DESCRIPTION
Adds `docs/specs/multi-module-migration/` — [`SPEC.md`](../blob/claude/nimaz-multi-module-migration-pkgqtc/docs/specs/multi-module-migration/SPEC.md) (the assessment) and [`EPIC.md`](../blob/claude/nimaz-multi-module-migration-pkgqtc/docs/specs/multi-module-migration/EPIC.md) (the execution plan). Docs only — no code changes, no behaviour changes, nothing implemented.

## What the assessment concludes

190,505 lines across 1,121 files in one `:app` module is worth splitting — but the argument isn't build times. **The layering `CLAUDE.md` claims is actually true in the code, and nothing enforces it**, because a single module can't:

- the domain layer has zero `android`/`androidx`/`dagger`/`room` imports across 103 files (only `javax.inject.Inject`), so `:core:domain` can be pure JVM on day one
- 84 of 107 screen files take `onNavigate`/`onBack` lambdas; only 7 touch `NavController`
- 22 DAOs map onto 19 repositories nearly 1:1 (`QuranDao` is the only shared one, by 4)
- `SettingsSeams.kt` has already done the interface segregation that normally blocks this

**Target: 11 feature modules, 7 core modules, `:app` reduced to a shell.**

## What blocks it

1. **`NavGraph.kt`** — 1,442 LOC, imports 70 screens, registers 94 destinations. Nothing moves until it's decomposed.
2. **`screens/` is grouped by feature, `viewmodel/` by domain area.** `viewmodel/content` is shared by eight screen packages. Hence eleven modules along the ViewModel axis, not twenty-six along the screen axis.
3. **`RepositoryModule.kt`** at 863 LOC, plus `core/util` reaching into domain, presentation, data and widget.

It argues *against* splitting the 1,910-string `strings.xml` (no gain — `enableSplit = false`) and against moving `screens/adaptive` out of `:app` (it depends on twelve features because it *is* the shell).

## The validation half

2,333 unit tests already cover behaviour, so the risk is elsewhere. The sharpest finding:

**`scripts/check_docs.py` will go green while checking less.** It roots every scan at `app/src/main/java/com/arshadshah/nimaz`, and SUB-02/03/05/06 use `rglob` from there. Move `widget/` and `data/audio/` out and those globs return a smaller set — "every Worker is documented" passes because there are fewer Workers to find. On `dev` today SUB-02 finds 7 Workers and SUB-03 finds 4 Services; **6 and 3 of those are in exactly those two directories.** Single-file reads crash loudly, which is fine. These four degrade silently, which isn't.

So it's fixed in **PR 2 of the stack, before any file moves**, and its exit criterion is a negative test: move a Worker to a scratch directory, confirm the check goes red, revert.

Also covered: resource shrinking across module boundaries as the likeliest release-only regression (the eight `res/font` Quran fonts are the exposure), Room schema-identity diffing so nobody gets a destructive migration, the `fetchNimazData` lint-ordering race reappearing per module, and the JaCoCo tasks that already once produced 237-byte reports reading as 0% rather than as an error.

**Measured baseline:** `:app:compileDebugKotlin` cold = **3m 44s**, Kotlin compilation alone. Plus a stopping rule — if incremental rebuild of a leaf screen hasn't improved 40% by the time Milestone 5 is half done, stop rather than finish out of momentum.

## The execution plan

`EPIC.md` lays it out as one epic issue, seven milestones and **22 PRs stacked on a single `epic/multi-module` integration branch**, merged into `dev` once at the end. The stack exists because these changes aren't independent — each branch is cut from the previous one, and reviewing them against `dev` would mean reviewing a tree that doesn't compile.

Two things drove the ordering: `check_docs.py` is fixed first (above), and **`NavGraph.kt` is decomposed in PR 12 without moving a single file between modules** — so the change that unblocks the nine feature PRs is reviewable on its own merits.

Documentation ownership is assigned per PR rather than deferred to a cleanup at the end, since a detection command that greps a moved path returns nothing and therefore "passes". Every PR in the stack runs unit tests, all-module lint, `check_docs.py` with new floor assertions, and `assembleRelease` — debug alone wouldn't exercise R8 or resource shrinking.

## On the numbers

Every figure was re-audited against the tree after the first draft. Four were wrong and are fixed: 19 repository impls not 20 (`data/repository` holds 20 files, one is a mapper); `SettingsSeams` declares 11 interfaces not nine; `viewmodel/` has 16 directories not 17. The "nine seams" figure came from `ARCHITECTURE.md` §9, which is itself stale — `HijriSettings` and `SearchSettings` were added without a doc update, so correcting that is now the first documentation item in the epic.

An earlier revision of this PR also listed ten feature modules while the prose said eleven; `worship` and `calendar` had been dropped. `calendar` is now its own module and `worship` folds into `:feature:prayer`. All 26 `screens/` directories are now explicitly accounted for.

## Verification

`python3 scripts/check_docs.py` → all 23 checks pass, DOC-03 resolving cross-links across 18 files. Both docs live under `docs/specs/`, matching the `notifications-rework` precedent, which sits outside the DOC-01/DOC-02 top-level house-style rules.