### PR TITLE
ci(docs): make check_docs.py module-aware and add scan floors

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -12,36 +12,34 @@ on:
     branches: [ dev ]
     paths:
       - 'docs/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/core/navigation/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/data/announcement/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/data/local/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/domain/model/Announcement.kt'
-      - 'app/src/main/java/com/arshadshah/nimaz/widget/**'
-      # Module-agnostic mirrors of the paths above. The globs are rooted at app/ today,
-      # but the multi-module split (#551) moves navigation, announcements, the DataStore
-      # code and the widgets into core/ and feature/ modules. Without these two entries
-      # this lane would silently stop firing on the very files it guards — a green check
-      # that ran nothing, which is the failure #553 exists to prevent.
-      - 'core/**'
-      - 'feature/**'
-      - 'scripts/check_docs.py'
+      # One module-agnostic glob rather than a list of packages. The narrow list it
+      # replaces was both stale and incomplete: it named navigation, announcements,
+      # data/local and widget/, but not data/audio/ (three of the four Services
+      # SUB-03 guards) nor core/util/PrayerNotificationScheduler.kt (which declares
+      # channels SUB-05 guards), so changes there never fired this lane. It would
+      # also have stopped matching entirely once the multi-module split (#551) moves
+      # those packages into core/ and feature/ modules — a green check that ran
+      # nothing, which is the failure #553 exists to prevent. The lane costs seconds;
+      # a gap in it costs a doc nobody can trust.
+      - '**/src/main/java/com/arshadshah/nimaz/**'
+      - '**/src/main/kotlin/com/arshadshah/nimaz/**'
+      - 'scripts/**'
       - '.github/workflows/docs_check.yml'
   pull_request:
     paths:
       - 'docs/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/core/navigation/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/data/announcement/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/data/local/**'
-      - 'app/src/main/java/com/arshadshah/nimaz/domain/model/Announcement.kt'
-      - 'app/src/main/java/com/arshadshah/nimaz/widget/**'
-      # Module-agnostic mirrors of the paths above. The globs are rooted at app/ today,
-      # but the multi-module split (#551) moves navigation, announcements, the DataStore
-      # code and the widgets into core/ and feature/ modules. Without these two entries
-      # this lane would silently stop firing on the very files it guards — a green check
-      # that ran nothing, which is the failure #553 exists to prevent.
-      - 'core/**'
-      - 'feature/**'
-      - 'scripts/check_docs.py'
+      # One module-agnostic glob rather than a list of packages. The narrow list it
+      # replaces was both stale and incomplete: it named navigation, announcements,
+      # data/local and widget/, but not data/audio/ (three of the four Services
+      # SUB-03 guards) nor core/util/PrayerNotificationScheduler.kt (which declares
+      # channels SUB-05 guards), so changes there never fired this lane. It would
+      # also have stopped matching entirely once the multi-module split (#551) moves
+      # those packages into core/ and feature/ modules — a green check that ran
+      # nothing, which is the failure #553 exists to prevent. The lane costs seconds;
+      # a gap in it costs a doc nobody can trust.
+      - '**/src/main/java/com/arshadshah/nimaz/**'
+      - '**/src/main/kotlin/com/arshadshah/nimaz/**'
+      - 'scripts/**'
       - '.github/workflows/docs_check.yml'
 
 jobs:
@@ -54,6 +52,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      # The checker's own tests. They pin the two properties that stop it failing
+      # silently: the scans span every Gradle module, and each has a floor below
+      # which it goes red instead of reporting that the little it found is all
+      # documented. Run before the checker itself, so a broken checker is named as
+      # a broken checker rather than as doc drift.
+      - name: Test the doc checker
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/ -q
+
       - name: Check the docs for drift
         run: python3 scripts/check_docs.py
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -158,7 +158,7 @@ on every PR via `.github/workflows/docs_check.yml`.
 |---|---|
 | `NAV-01` | every `Route` in `Routes.kt` appears in the `NAVIGATION.md` route reference |
 | `NAV-02` | every route named in `NAVIGATION.md` still exists in `Routes.kt` |
-| `NAV-03` | the destination count claimed in `NAVIGATION.md` matches `NavGraph.kt` |
+| `NAV-03` | the destination count claimed in `NAVIGATION.md` matches the wiring |
 | `NAV-04` | every destination is wired with `taggedComposable` (never a bare `composable`) |
 | `NAV-05` | every `Route` has a matching `ScreenTags` entry |
 | `NAV-06` | every static announcement route key is documented |
@@ -185,6 +185,10 @@ on every PR via `.github/workflows/docs_check.yml`.
 `NAV-09`/`NAV-10`) — that is deliberate. A doc that lists a route deleted three releases ago is
 as misleading as one missing a route added yesterday, and only the second kind gets noticed.
 
+**The checker has its own tests.** `scripts/test_check_docs.py` runs in the same CI lane
+(`python3 -m pytest scripts/ -q`, before the checker itself). A checker nobody tests is a green
+tick nobody has earned.
+
 ### 4.1 Adding a check
 
 Extend `scripts/check_docs.py` whenever a doc makes a **countable, list-shaped claim** about the
@@ -196,11 +200,64 @@ rot invisibly.
    `report.expect_covered(...)` for coverage-shaped checks so the failure message stays uniform.
 3. Register its id and one-line description in the `CHECKS` dict.
 4. Add the row to the table above.
-5. Make the failure message say **which file to edit and what to add** — a checker that only says
+5. If it scans the tree for an inventory, add a floor to `MINIMUMS` and call
+   `report.expect_floor(...)` before the coverage check — see [§4.2](#42-scan-floors--why-a-check-can-fail-without-a-doc-changing).
+6. Add a test to `scripts/test_check_docs.py`, including the negative case: make the scan come
+   back short and assert the check goes red.
+7. Make the failure message say **which file to edit and what to add** — a checker that only says
    "failed" gets suppressed rather than fixed.
 
 **Do not** add a check that greps a doc for prose. Check identifiers, not sentences: prose
 changes for good reasons, and a brittle check is one the next person will delete.
+
+### 4.2 Scan floors — why a check can fail without a doc changing
+
+Most `SUB-*` and half the `NAV-*` checks are **coverage-shaped**: they read an inventory out of
+the code and assert that every item in it is documented. That is only as good as the inventory.
+If a scan silently returns fewer items, the check passes *because there was less to find* — the
+one failure mode a green tick cannot show you. It is not hypothetical: before the module split
+every scan was rooted at `app/src/main/java/com/arshadshah/nimaz`, so moving the widgets into a
+`:feature:widget` module would have taken six of the seven `Worker`s out of reach and left
+`SUB-02` reporting `ok 0 Workers documented`.
+
+Two things stop that now.
+
+- **The scans span every module.** `source_roots()` finds every
+  `*/src/main/{java,kotlin}/com/arshadshah/nimaz` directory in the repo (build output pruned) and
+  raises if there are none. Single-file readers go through `find_one(...)`, which fails on **0
+  matches and on more than 1** rather than quietly picking one. `nav_graph_source()` concatenates
+  every file that wires a destination, so `NAV-03`/`NAV-04` keep working once `NavGraph.kt` is
+  split into per-feature graph extensions.
+- **Every scan has a floor.** The `MINIMUMS` table in `check_docs.py` records the count measured
+  when the floor was added; `report.expect_floor(...)` fails the check if the scan ever comes
+  back with fewer. An empty expected-set fails on its own too, independently of the floor.
+
+Floors are counted separately from checks — a green run prints
+`All 23 documentation checks passed (13 scan floors met)`. The floor *count* is asserted by
+`scripts/test_check_docs.py`, so deleting an `expect_floor(...)` call fails the test suite rather
+than quietly shrinking the guard.
+
+| Floor | Minimum | Counts |
+|---|---|---|
+| `NAV-01` | 94 | `Route` declarations in `Routes.kt` |
+| `NAV-03` | 94 | destinations wired across every nav-graph file |
+| `NAV-05` | 104 | `ScreenTags` entries — more than the 94 `Route`s: tabs inside a parent screen carry a tag without owning a route |
+| `NAV-06` | 57 | static announcement route keys |
+| `NAV-08` | 67 | `Route`s reachable from an announcement key |
+| `NAV-09` | 22 | help deep-link keys |
+| `SUB-02` | 7 | `Worker` classes |
+| `SUB-03` | 4 | `Service` classes |
+| `SUB-04` | 6 | widget packages |
+| `SUB-05` | 12 | notification channel ids |
+| `SUB-06` | 10 | DataStore files: 3 `preferencesDataStore`, the Glance state definition, and the 6 widget files it writes |
+| `SUB-06-PREFS` | 3 | of which, `preferencesDataStore(name = …)` files |
+| `SUB-06-GLANCE` | 6 | of which, per-widget Glance state files (`fileName = "…"` in each `*StateDefinition.kt`) |
+
+**Raising a floor is routine — lower it only with a reason, in the commit message.** A floor going
+down is a claim that the thing was genuinely deleted, not that a scan stopped seeing it; those two
+look identical in the check output and only the commit message can tell them apart. If you are
+lowering a floor to make a refactor go green, the refactor moved code out of the scan's reach and
+the scan is what needs fixing.
 
 ---
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -149,11 +149,23 @@ Every widget also refreshes when a setting it is computed from changes, via
 Each is a separate file on disk; a new one is a new migration surface, so prefer adding keys to
 `nimaz_preferences` unless the slice is genuinely self-contained.
 
+Three are Preferences DataStores created with `preferencesDataStore(name = …)`. The fourth entry
+is a **typed** DataStore built by hand with `DataStoreFactory.create`, which takes its file name
+as a parameter rather than a literal — so it is listed by its owner.
+
 | File name | Owner | Holds | Section |
 |---|---|---|---|
 | `nimaz_preferences` | `data/local/datastore/PreferencesDataStore.kt` | every user setting; the sync payload's `preferences` block | [§6](#6-preferences-datastore) |
 | `nimaz_announcements` | `data/local/datastore/AnnouncementLocalDataSource.kt` | the current announcement (JSON) + permanently dismissed ids | [§12](#12-engagement-announcements-fcm) |
 | `nimaz_ai_device` | `data/ai/DeviceIdProvider.kt` | the rotating pseudonymous device id sent with Ask-with-Proof calls | [`ai-ask-with-proof.md`](ai-ask-with-proof.md) |
+| `<widget>_widget` × 6 | `JsonGlanceStateDefinition` (`widget/core/`) | one JSON-serialized Glance state per widget: `next_prayer_widget`, `prayer_times_widget`, `prayer_tracker_widget`, `hijri_date_widget`, `hijri_calendar_widget`, `khatam_widget` | [§2](#2-glance-widgets) |
+
+The widget stores hold **rendered state, never user data**: each is a cache a worker refills, and
+a corrupt one is replaced with the default rather than migrated ([§2](#2-glance-widgets)). They
+are deliberately outside the sync payload for that reason.
+
+> Not a DataStore, and correctly outside this table: `SharedPreferencesContentArtifactStore`
+> (`data/local/content/ContentArtifactStore.kt`) is a `SharedPreferences` file.
 
 ### 0.6 Notification channels
 
@@ -1052,13 +1064,14 @@ place** whenever you add a migration — the two can no longer drift.
 
 ## 6. Preferences (DataStore)
 
-The app has **three** DataStore files, listed in [§0.5](#05-datastore-files). This section is
-about the main one; the other two are self-contained slices documented where they are used.
+The app has **three** Preferences DataStore files plus the per-widget Glance state stores, all
+listed in [§0.5](#05-datastore-files). This section is about the main one; the others are
+self-contained slices documented where they are used.
 
 `data/local/datastore/PreferencesDataStore.kt` — the app's **single central settings store**,
 backed by a Jetpack Preferences DataStore (`preferencesDataStore(name = "nimaz_preferences")`).
 
-> **Adding a fourth DataStore file is a decision, not a detail.** Each one is an independent
+> **Adding another DataStore file is a decision, not a detail.** Each one is an independent
 > migration and export surface: the sync payload (§10) carries `nimaz_preferences` only, so a
 > setting that lives anywhere else silently does not sync. Add keys to `nimaz_preferences`
 > unless the slice is genuinely not user settings (as announcements and the AI device id are).

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -23,14 +23,24 @@ couple of seconds. Same spirit as `scripts/check_tajweed_contrast.py`.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-APP = ROOT / "app/src/main/java/com/arshadshah/nimaz"
-NAV_DIR = APP / "core/navigation"
 DOCS = ROOT / "docs"
+
+# Directories that are never source: build output, VCS, tooling caches. Pruned
+# rather than filtered, so the walk below stays fast on a repo with 20 modules
+# each carrying a build/ tree.
+PRUNED_DIRS = {"build", ".git", ".gradle", ".idea", "node_modules", ".kotlin", "generated"}
+
+# Where Kotlin/Java source lives inside a Gradle module.
+SOURCE_SET_SUFFIXES = (
+    Path("src/main/java/com/arshadshah/nimaz"),
+    Path("src/main/kotlin/com/arshadshah/nimaz"),
+)
 
 ARCHITECTURE = DOCS / "ARCHITECTURE.md"
 NAVIGATION = DOCS / "NAVIGATION.md"
@@ -54,6 +64,10 @@ class Report:
     def __init__(self) -> None:
         self.failures: list[tuple[str, str]] = []
         self.passes: list[str] = []
+        # Floors are not checks in their own right — they are a precondition of the
+        # check they belong to — so they are counted separately and never inflate
+        # the "All N documentation checks passed" total.
+        self.floors_met: list[str] = []
 
     def ok(self, check: str, detail: str) -> None:
         self.passes.append(f"{check}  {detail}")
@@ -72,6 +86,18 @@ class Report:
         fix: str,
     ) -> None:
         """Every item in `expected` must appear, backticked, in `haystack`."""
+        # An empty expected-set is never a pass. "ok 0 Workers documented" is the
+        # exact shape of the silent failure this script exists to prevent: the scan
+        # found nothing, so every item it found was trivially documented.
+        if not expected:
+            self.fail(
+                check,
+                f"the {noun} scan matched nothing — 0 found across "
+                f"{len(source_roots())} module source root(s)."
+                "\n         → this is a broken scan, not a clean result: the code it looks "
+                "for moved, was renamed, or lives outside every source root",
+            )
+            return
         missing = [item for item in expected if f"`{item}`" not in haystack]
         if missing:
             self.fail(
@@ -83,9 +109,85 @@ class Report:
         else:
             self.ok(check, f"{len(expected)} {noun} documented in {doc.relative_to(ROOT)}")
 
+    def expect_floor(self, check: str, actual: int, floor: int, *, noun: str) -> None:
+        """`actual` must be at least `floor`, or the scan has shrunk and lies.
+
+        See MINIMUMS for why these numbers exist and what it takes to lower one.
+        """
+        if actual < floor:
+            self.fail(
+                check,
+                f"only {actual} {noun} found, floor is {floor} — the scan shrank."
+                "\n         → code moved out of every source root, or a pattern stopped "
+                "matching. Fix the scan. Lowering the floor in MINIMUMS is only correct "
+                "when the thing was genuinely deleted, and needs saying so in the commit "
+                "message (see docs/DOCUMENTATION.md §4).",
+            )
+        else:
+            self.floors_met.append(f"{check} {actual} >= {floor} {noun}")
+
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def source_roots() -> list[Path]:
+    """Every `…/src/main/{java,kotlin}/com/arshadshah/nimaz` directory in the repo.
+
+    Nimaz is being split into Gradle modules (#551). Before that split every scan
+    in this file was rooted at the single `app/…` path, so the moment a Worker or
+    a widget moved into `feature/…` the scan simply found fewer of them and the
+    "everything is documented" checks passed *because there was less to find*.
+    Rooting at every module makes a move invisible to the checks, which is the
+    point: the inventory is a property of the app, not of one module.
+
+    Walks the tree once with build/VCS directories pruned. Raises if the result is
+    empty — a scan with no roots is a broken checkout, never a clean bill of health.
+    """
+    roots: list[Path] = []
+    for dirpath, dirnames, _ in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in PRUNED_DIRS]
+        here = Path(dirpath)
+        for suffix in SOURCE_SET_SUFFIXES:
+            candidate = here / suffix
+            if candidate.is_dir():
+                roots.append(candidate)
+        # Do not descend into a source set we just matched: the package tree below
+        # it cannot contain another module.
+        if any((here / suffix).is_dir() for suffix in SOURCE_SET_SUFFIXES):
+            dirnames[:] = [d for d in dirnames if d != "src"]
+    if not roots:
+        raise SystemExit(
+            "no Kotlin source roots found under "
+            f"{ROOT} — expected at least one */src/main/{{java,kotlin}}/com/arshadshah/nimaz"
+        )
+    return sorted(set(roots))
+
+
+def source_files(pattern: str = "*.kt") -> list[Path]:
+    """Every source file matching `pattern` across every module."""
+    return sorted({path for root in source_roots() for path in root.rglob(pattern)})
+
+
+def find_one(relative: str) -> Path:
+    """The single file at `relative` (a package path or glob) across all modules.
+
+    Fails loudly on 0 matches (the file moved out of the package tree, or was
+    renamed) and on more than 1 (two modules both declare it — an ambiguity the
+    caller must resolve, not something to silently pick a winner for).
+    """
+    matches = sorted({p for root in source_roots() for p in root.glob(relative) if p.is_file()})
+    if not matches:
+        raise SystemExit(
+            f"could not find {relative} in any module source root "
+            f"({', '.join(str(r.relative_to(ROOT)) for r in source_roots())})"
+        )
+    if len(matches) > 1:
+        raise SystemExit(
+            f"{relative} matches {len(matches)} files, expected exactly one: "
+            + ", ".join(str(m.relative_to(ROOT)) for m in matches)
+        )
+    return matches[0]
 
 
 def section(text: str, heading_contains: str, level: str = "## ") -> str:
@@ -137,20 +239,50 @@ def slugify(heading: str) -> str:
 # ──────────────────────────────────────────────────────────────────────────────
 
 def routes() -> list[str]:
-    src = read(NAV_DIR / "Routes.kt")
+    src = read(find_one("core/navigation/Routes.kt"))
     return sorted(set(re.findall(r"^\s+data (?:object|class) (\w+)", src, re.M)))
 
 
 def nav_graph_source() -> str:
-    return read(NAV_DIR / "NavGraph.kt")
+    """Every file that wires a destination, concatenated.
+
+    This used to read the single file `core/navigation/NavGraph.kt`. The migration
+    dissolves that file into per-feature `NavGraphBuilder` extensions living beside
+    their screens, at which point NAV-03 (the destination count) would go red — loud,
+    and tempting to "fix" by editing the documented number — while NAV-04, the
+    bare-`composable` detector, would go **silently vacuous**: nothing to scan means
+    nothing untagged to find. Scanning every file that mentions a destination keeps
+    both checks meaningful wherever the wiring lives.
+
+    Joined with newlines because NAV-04 anchors on the start of a line.
+    """
+    sources = [
+        text
+        for text in (read(path) for path in source_files("*.kt"))
+        if "taggedComposable<Route." in text or "composable<Route." in text
+    ]
+    return "\n".join(sources)
+
+
+def wired_destination_count(graph: str) -> int:
+    """How many destinations the nav graph wires, tagged or not."""
+    return len(re.findall(r"\b(?:tagged)?[Cc]omposable<Route\.", graph))
+
+
+def bare_composable_destinations(graph: str) -> list[str]:
+    """Destinations wired with a bare `composable<Route.X>` — no ScreenTag, untestable."""
+    return sorted(set(re.findall(r"^\s*composable<Route\.(\w+)>", graph, re.M)))
 
 
 def screen_tags() -> set[str]:
-    return set(re.findall(r"const val (\w+)", read(NAV_DIR / "ScreenTags.kt")))
+    return set(re.findall(r"const val (\w+)", read(find_one("core/navigation/ScreenTags.kt"))))
 
 
 def announcement_static_keys() -> list[str]:
-    body = kotlin_block(read(NAV_DIR / "AnnouncementRoutes.kt"), "private fun staticAnnouncementRoute")
+    body = kotlin_block(
+        read(find_one("core/navigation/AnnouncementRoutes.kt")),
+        "private fun staticAnnouncementRoute",
+    )
     keys: list[str] = []
     for line in body.splitlines():
         if "->" not in line:
@@ -160,17 +292,17 @@ def announcement_static_keys() -> list[str]:
 
 
 def announcement_routes_used() -> list[str]:
-    src = read(NAV_DIR / "AnnouncementRoutes.kt")
+    src = read(find_one("core/navigation/AnnouncementRoutes.kt"))
     return sorted(set(re.findall(r"Route\.(\w+)", src)))
 
 
 def help_deeplink_keys() -> list[str]:
-    src = read(NAV_DIR / "HelpDeepLink.kt")
+    src = read(find_one("core/navigation/HelpDeepLink.kt"))
     return sorted(set(re.findall(r'"([^"]+)"\s*->', src)))
 
 
 def database_version() -> int:
-    src = read(APP / "data/local/database/NimazDatabase.kt")
+    src = read(find_one("data/local/database/NimazDatabase.kt"))
     match = re.search(r"const val NIMAZ_DATABASE_VERSION = (\d+)", src)
     if not match:
         raise SystemExit("could not read NIMAZ_DATABASE_VERSION from NimazDatabase.kt")
@@ -179,45 +311,90 @@ def database_version() -> int:
 
 def worker_classes() -> list[str]:
     names: set[str] = set()
-    for path in APP.rglob("*Worker.kt"):
+    for path in source_files("*Worker.kt"):
         names |= set(re.findall(r"class (\w+Worker)", read(path)))
     return sorted(names)
 
 
 def service_classes() -> list[str]:
     names: set[str] = set()
-    for path in APP.rglob("*Service.kt"):
+    for path in source_files("*Service.kt"):
         names |= set(re.findall(r"^class (\w+Service)", read(path), re.M))
     return sorted(names)
 
 
 def widget_packages() -> list[str]:
     return sorted(
-        p.name for p in (APP / "widget").iterdir() if p.is_dir() and p.name != "core"
+        {
+            child.name
+            for root in source_roots()
+            if (root / "widget").is_dir()
+            for child in (root / "widget").iterdir()
+            if child.is_dir() and child.name != "core"
+        }
     )
 
 
 def notification_channel_ids() -> list[str]:
     ids: set[str] = set()
-    for path in APP.rglob("*.kt"):
+    for path in source_files("*.kt"):
         ids |= set(re.findall(r'const val CHANNEL_ID[A-Z_]* = "([^"]+)"', read(path)))
     return sorted(ids)
 
 
-def datastore_names() -> list[str]:
+def preferences_datastore_names() -> list[str]:
+    """The `preferencesDataStore(name = "…")` files — one named file each."""
     names: set[str] = set()
-    for path in APP.rglob("*.kt"):
+    for path in source_files("*.kt"):
         names |= set(re.findall(r'preferencesDataStore\(\s*\n?\s*name = "([^"]+)"', read(path)))
     return sorted(names)
 
 
+def typed_datastore_owners() -> list[str]:
+    """Files that build a DataStore by hand with `DataStoreFactory.create`.
+
+    These have no literal file name to capture — `JsonGlanceStateDefinition` takes
+    its file name as a constructor parameter and creates one store per widget — so
+    the *owner* is what gets documented. Without this the SUB-06 claim that "every
+    DataStore file is documented" was checking three files out of four.
+    """
+    return sorted(
+        {path.stem for path in source_files("*.kt") if "DataStoreFactory.create" in read(path)}
+    )
+
+
+def glance_state_file_names() -> list[str]:
+    """The DataStore file name each widget's Glance state definition writes to.
+
+    `JsonGlanceStateDefinition` takes its file name as a constructor argument, so
+    naming the owner alone leaves the six files on disk as prose no check reads.
+    Scoped to files that subclass it: `fileName = "…"` on its own also matches the
+    bundled adhan audio, which is not a DataStore.
+    """
+    names: set[str] = set()
+    for path in source_files("*.kt"):
+        src = read(path)
+        if "JsonGlanceStateDefinition<" not in src:
+            continue
+        names |= set(re.findall(r'fileName = "([^"]+)"', src))
+    return sorted(names)
+
+
+def datastore_names() -> list[str]:
+    return sorted(
+        set(preferences_datastore_names())
+        | set(typed_datastore_owners())
+        | set(glance_state_file_names())
+    )
+
+
 def announcement_payload_keys() -> list[str]:
-    src = read(APP / "data/announcement/AnnouncementPayloadMapper.kt")
+    src = read(find_one("data/announcement/AnnouncementPayloadMapper.kt"))
     return sorted(set(re.findall(r'const val KEY_\w+ = "([^"]+)"', src)))
 
 
 def announcement_enum_keys(enum_name: str) -> list[str]:
-    src = read(APP / "domain/model/Announcement.kt")
+    src = read(find_one("domain/model/Announcement.kt"))
     body = kotlin_block(src, f"enum class {enum_name}")
     return sorted(set(re.findall(r'\w+\("([^"]+)"\)', body)))
 
@@ -259,6 +436,34 @@ CHECKS: dict[str, str] = {
 # Below this, a reader can scroll. Above it, they need an index. See DOCUMENTATION.md §2.
 CONTENTS_REQUIRED_LINES = 150
 
+# ── Scan floors ───────────────────────────────────────────────────────────────
+# A "documented everything I found" check is only as good as what it found. If a
+# scan silently returns fewer items — because the code moved into a module the
+# scan does not reach, or a pattern stopped matching — the check passes because
+# there is less to find. Each number below is the count measured in the tree at
+# the time it was added; the scan may only ever grow past it.
+#
+# Lowering one is a claim that the thing was genuinely deleted. Say so in the
+# commit message. See docs/DOCUMENTATION.md §4.
+MINIMUMS: dict[str, int] = {
+    "NAV-01": 94,   # Routes in Routes.kt
+    "NAV-03": 94,   # destinations wired across every nav-graph file
+    "NAV-05": 104,  # ScreenTags entries — more than the 94 Routes on purpose: some
+                    #                       screens are tabs inside a parent, so they
+                    #                       carry a tag without owning a Route
+    "NAV-06": 57,   # static announcement route keys
+    "NAV-08": 67,   # Routes reachable from an announcement key
+    "NAV-09": 22,   # help deep-link keys
+    "SUB-02": 7,    # Worker classes
+    "SUB-03": 4,    # Service classes
+    "SUB-04": 6,    # widget packages
+    "SUB-05": 12,   # notification channel ids
+    "SUB-06": 10,   # DataStore files: 3 preferencesDataStore + the Glance state
+                    #                  definition and the 6 widget files it writes
+    "SUB-06-PREFS": 3,   # of which, `preferencesDataStore(name = …)` files
+    "SUB-06-GLANCE": 6,  # of which, per-widget Glance state files
+}
+
 
 def check_nav(report: Report) -> None:
     nav_doc = read(NAVIGATION)
@@ -266,6 +471,8 @@ def check_nav(report: Report) -> None:
     grammar = section(nav_doc, "Announcement route grammar")
     deeplinks = section(nav_doc, "Help deep-link grammar")
     all_routes = routes()
+
+    report.expect_floor("NAV-01", len(all_routes), MINIMUMS["NAV-01"], noun="routes")
 
     # NAV-01 — no undocumented route.
     report.expect_covered(
@@ -296,7 +503,8 @@ def check_nav(report: Report) -> None:
 
     # NAV-03 — the destination count in prose.
     graph = nav_graph_source()
-    wired = len(re.findall(r"\b(?:tagged)?[Cc]omposable<Route\.", graph))
+    wired = wired_destination_count(graph)
+    report.expect_floor("NAV-03", wired, MINIMUMS["NAV-03"], noun="wired destinations")
     claimed = re.search(r"\((\d+) `composable<Route\.X>` destinations\)", nav_doc)
     if not claimed:
         report.fail("NAV-03", "NAVIGATION.md no longer states the destination count "
@@ -311,18 +519,19 @@ def check_nav(report: Report) -> None:
         report.ok("NAV-03", f"{wired} destinations, count matches")
 
     # NAV-04 — every destination carries a test tag.
-    untagged = re.findall(r"^\s*composable<Route\.(\w+)>", graph, re.M)
+    untagged = bare_composable_destinations(graph)
     if untagged:
         report.fail(
             "NAV-04",
-            "wired with bare composable<> (no ScreenTag): " + ", ".join(sorted(set(untagged)))
-            + "\n         → use taggedComposable<Route.X>(ScreenTags.X) in NavGraph.kt",
+            "wired with bare composable<> (no ScreenTag): " + ", ".join(untagged)
+            + "\n         → use taggedComposable<Route.X>(ScreenTags.X) where it is wired",
         )
     else:
         report.ok("NAV-04", "every destination uses taggedComposable")
 
     # NAV-05 — a tag exists for every route.
     tags = screen_tags()
+    report.expect_floor("NAV-05", len(tags), MINIMUMS["NAV-05"], noun="ScreenTags entries")
     tagless = [r for r in all_routes if r not in tags]
     if tagless:
         report.fail(
@@ -335,6 +544,7 @@ def check_nav(report: Report) -> None:
 
     # NAV-06 / NAV-07 — the announcement static allowlist, both directions.
     code_keys = announcement_static_keys()
+    report.expect_floor("NAV-06", len(code_keys), MINIMUMS["NAV-06"], noun="announcement keys")
     report.expect_covered(
         "NAV-06",
         expected=code_keys,
@@ -365,9 +575,13 @@ def check_nav(report: Report) -> None:
         report.ok("NAV-07", f"{len(doc_keys)} documented announcement keys all exist")
 
     # NAV-08 — every route an announcement can reach is named in the grammar section.
+    reachable = announcement_routes_used()
+    report.expect_floor(
+        "NAV-08", len(reachable), MINIMUMS["NAV-08"], noun="announcement-reachable routes"
+    )
     report.expect_covered(
         "NAV-08",
-        expected=announcement_routes_used(),
+        expected=reachable,
         haystack=grammar,
         doc=NAVIGATION,
         noun="announcement-reachable routes",
@@ -376,6 +590,7 @@ def check_nav(report: Report) -> None:
 
     # NAV-09 / NAV-10 — help deep links, both directions.
     code_help = help_deeplink_keys()
+    report.expect_floor("NAV-09", len(code_help), MINIMUMS["NAV-09"], noun="help deep-link keys")
     report.expect_covered(
         "NAV-09",
         expected=code_help,
@@ -422,25 +637,43 @@ def check_sub(report: Report) -> None:
     else:
         report.ok("SUB-01", f"schema version {version} matches")
 
+    workers = worker_classes()
+    report.expect_floor("SUB-02", len(workers), MINIMUMS["SUB-02"], noun="Workers")
     report.expect_covered(
-        "SUB-02", expected=worker_classes(), haystack=sub_doc, doc=SUBSYSTEMS,
+        "SUB-02", expected=workers, haystack=sub_doc, doc=SUBSYSTEMS,
         noun="Workers", fix="add it to the worker list in §3 (Background work)",
     )
+    services = service_classes()
+    report.expect_floor("SUB-03", len(services), MINIMUMS["SUB-03"], noun="Services")
     report.expect_covered(
-        "SUB-03", expected=service_classes(), haystack=sub_doc, doc=SUBSYSTEMS,
+        "SUB-03", expected=services, haystack=sub_doc, doc=SUBSYSTEMS,
         noun="Services", fix="document it in the owning section (§1 audio, §12 announcements, …)",
     )
+    widgets = widget_packages()
+    report.expect_floor("SUB-04", len(widgets), MINIMUMS["SUB-04"], noun="widget packages")
     report.expect_covered(
-        "SUB-04", expected=[f"widget/{p}/" for p in widget_packages()], haystack=sub_doc,
+        "SUB-04", expected=[f"widget/{p}/" for p in widgets], haystack=sub_doc,
         doc=SUBSYSTEMS, noun="widget packages", fix="add a row to the widget table in §2",
     )
+    channels = notification_channel_ids()
+    report.expect_floor("SUB-05", len(channels), MINIMUMS["SUB-05"], noun="notification channels")
     report.expect_covered(
-        "SUB-05", expected=notification_channel_ids(), haystack=sub_doc, doc=SUBSYSTEMS,
+        "SUB-05", expected=channels, haystack=sub_doc, doc=SUBSYSTEMS,
         noun="notification channels", fix="add a row to the channel table in §4",
     )
+    datastores = datastore_names()
+    report.expect_floor("SUB-06", len(datastores), MINIMUMS["SUB-06"], noun="DataStore files")
+    report.expect_floor(
+        "SUB-06-PREFS", len(preferences_datastore_names()), MINIMUMS["SUB-06-PREFS"],
+        noun="preferencesDataStore files",
+    )
+    report.expect_floor(
+        "SUB-06-GLANCE", len(glance_state_file_names()), MINIMUMS["SUB-06-GLANCE"],
+        noun="Glance widget state files",
+    )
     report.expect_covered(
-        "SUB-06", expected=datastore_names(), haystack=sub_doc, doc=SUBSYSTEMS,
-        noun="DataStore files", fix="add a row to the DataStore table in §6",
+        "SUB-06", expected=datastores, haystack=sub_doc, doc=SUBSYSTEMS,
+        noun="DataStore files", fix="add a row to the DataStore table in §0.5",
     )
     announcements = section(sub_doc, "Engagement announcements")
     report.expect_covered(
@@ -584,7 +817,10 @@ def main() -> int:
         print("The docs have drifted from the code. Update the doc named in each failure —")
         print("see docs/DOCUMENTATION.md for which doc owns what.")
         return 1
-    print(f"All {len(report.passes)} documentation checks passed.")
+    print(
+        f"All {len(report.passes)} documentation checks passed"
+        f" ({len(report.floors_met)} scan floors met)."
+    )
     return 0
 
 

--- a/scripts/test_check_docs.py
+++ b/scripts/test_check_docs.py
@@ -1,0 +1,497 @@
+"""Tests for scripts/check_docs.py — the doc-drift checker's own safety net.
+
+The checker asserts that the docs still describe the code. Its own failure mode is
+silence: a scan that finds nothing reports that everything it found is documented.
+The migration to Gradle modules (#551) makes that failure reachable — code moves out
+of `app/` and the scans, rooted there, come back smaller. These tests pin the two
+properties that stop it: the scans span **every** module, and each one has a floor
+below which it fails instead of passing.
+
+Run: python3 -m pytest scripts/test_check_docs.py -v
+"""
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent / "check_docs.py"
+
+
+def _load():
+    """Import check_docs.py fresh, so one test's monkeypatching cannot leak."""
+    spec = importlib.util.spec_from_file_location("check_docs_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def check_docs():
+    return _load()
+
+
+def _module_root(tmp_path: Path, gradle_module: str, lang: str = "java") -> Path:
+    """Create `<gradle_module>/src/main/<lang>/com/arshadshah/nimaz` and return it."""
+    root = tmp_path / gradle_module / "src/main" / lang / "com/arshadshah/nimaz"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+    return path
+
+
+def _rebase(module, tmp_path: Path) -> None:
+    """Point the checker at a fixture tree instead of the real repo."""
+    module.ROOT = tmp_path
+    module.DOCS = tmp_path / "docs"
+    module.DOCS.mkdir(parents=True, exist_ok=True)
+    module.ARCHITECTURE = module.DOCS / "ARCHITECTURE.md"
+    module.NAVIGATION = module.DOCS / "NAVIGATION.md"
+    module.SUBSYSTEMS = module.DOCS / "SUBSYSTEMS.md"
+    module.DOCS_INDEX = module.DOCS / "README.md"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# source_roots — the scans must span every module
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_source_roots_finds_every_module(check_docs, tmp_path: Path):
+    _rebase(check_docs, tmp_path)
+    _module_root(tmp_path, "app")
+    _module_root(tmp_path, "feature/widget")
+    _module_root(tmp_path, "core/domain", lang="kotlin")
+
+    roots = check_docs.source_roots()
+
+    assert [str(r.relative_to(tmp_path)) for r in roots] == [
+        "app/src/main/java/com/arshadshah/nimaz",
+        "core/domain/src/main/kotlin/com/arshadshah/nimaz",
+        "feature/widget/src/main/java/com/arshadshah/nimaz",
+    ]
+
+
+def test_source_roots_ignores_build_output(check_docs, tmp_path: Path):
+    """A generated copy under build/ would double every count."""
+    _rebase(check_docs, tmp_path)
+    _module_root(tmp_path, "app")
+    _module_root(tmp_path, "app/build/generated/source")
+
+    roots = check_docs.source_roots()
+
+    assert len(roots) == 1
+    assert "build" not in roots[0].parts
+
+
+def test_source_roots_refuses_to_return_an_empty_list(check_docs, tmp_path: Path):
+    """No roots is a broken checkout, never a clean bill of health."""
+    _rebase(check_docs, tmp_path)
+
+    with pytest.raises(SystemExit, match="no Kotlin source roots"):
+        check_docs.source_roots()
+
+
+def test_workers_are_found_across_two_modules(check_docs, tmp_path: Path):
+    """The exact shape of the migration: half the Workers move to :feature:widget."""
+    _rebase(check_docs, tmp_path)
+    app = _module_root(tmp_path, "app")
+    widget = _module_root(tmp_path, "feature/widget")
+    _write(app, "data/audio/AdhanDownloadWorker.kt", "class AdhanDownloadWorker\n")
+    _write(widget, "widget/khatam/KhatamWidgetWorker.kt", "class KhatamWidgetWorker\n")
+
+    assert check_docs.worker_classes() == ["AdhanDownloadWorker", "KhatamWidgetWorker"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# find_one — the single-file readers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_find_one_returns_the_single_match(check_docs, tmp_path: Path):
+    _rebase(check_docs, tmp_path)
+    _module_root(tmp_path, "app")
+    nav = _module_root(tmp_path, "core/navigation")
+    expected = _write(nav, "core/navigation/Routes.kt", "object Routes\n")
+
+    assert check_docs.find_one("core/navigation/Routes.kt") == expected
+
+
+def test_find_one_fails_loudly_when_the_file_moved_away(check_docs, tmp_path: Path):
+    _rebase(check_docs, tmp_path)
+    _module_root(tmp_path, "app")
+
+    with pytest.raises(SystemExit, match="could not find core/navigation/Routes.kt"):
+        check_docs.find_one("core/navigation/Routes.kt")
+
+
+def test_find_one_fails_loudly_when_two_modules_declare_it(check_docs, tmp_path: Path):
+    """Reading whichever came first alphabetically would be a coin toss."""
+    _rebase(check_docs, tmp_path)
+    for module in ("app", "core/navigation"):
+        _write(_module_root(tmp_path, module), "core/navigation/Routes.kt", "object Routes\n")
+
+    with pytest.raises(SystemExit, match="matches 2 files"):
+        check_docs.find_one("core/navigation/Routes.kt")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NAV-03 / NAV-04 — the nav graph after it is split into per-feature files
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_a_nav_graph_split_across_files_still_counts_every_destination(
+    check_docs, tmp_path: Path
+):
+    _rebase(check_docs, tmp_path)
+    app = _module_root(tmp_path, "app")
+    feature = _module_root(tmp_path, "feature/prayer")
+    _write(app, "core/navigation/NavGraph.kt", """\
+        fun NavGraphBuilder.appGraph() {
+            taggedComposable<Route.Home>(ScreenTags.Home) { }
+        }
+    """)
+    _write(feature, "presentation/prayer/PrayerGraph.kt", """\
+        fun NavGraphBuilder.prayerGraph() {
+            taggedComposable<Route.PrayerTimes>(ScreenTags.PrayerTimes) { }
+            taggedComposable<Route.PrayerTracker>(ScreenTags.PrayerTracker) { }
+        }
+    """)
+
+    graph = check_docs.nav_graph_source()
+
+    assert check_docs.wired_destination_count(graph) == 3
+
+
+def test_a_bare_composable_in_a_feature_module_trips_nav_04(check_docs, tmp_path: Path):
+    """The check that goes vacuous, not red, if the scan stays rooted at app/."""
+    _rebase(check_docs, tmp_path)
+    _write(_module_root(tmp_path, "app"), "core/navigation/NavGraph.kt", """\
+        fun NavGraphBuilder.appGraph() {
+            taggedComposable<Route.Home>(ScreenTags.Home) { }
+        }
+    """)
+    _write(_module_root(tmp_path, "feature/qibla"), "presentation/qibla/QiblaGraph.kt", """\
+        fun NavGraphBuilder.qiblaGraph() {
+            composable<Route.Qibla> { }
+        }
+    """)
+
+    graph = check_docs.nav_graph_source()
+
+    assert check_docs.bare_composable_destinations(graph) == ["Qibla"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# expect_covered / expect_floor — an empty or shrunken scan must fail
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_an_empty_scan_fails_instead_of_reporting_ok_zero(check_docs, tmp_path: Path):
+    """`ok 0 Workers documented` was the bug: nothing found, so nothing missing."""
+    _rebase(check_docs, tmp_path)
+    _module_root(tmp_path, "app")
+    report = check_docs.Report()
+
+    report.expect_covered(
+        "SUB-02", expected=[], haystack="whatever", doc=check_docs.SUBSYSTEMS,
+        noun="Workers", fix="…",
+    )
+
+    assert report.passes == []
+    assert len(report.failures) == 1
+    check, detail = report.failures[0]
+    assert check == "SUB-02"
+    assert "matched nothing" in detail
+
+
+def test_expect_floor_fails_when_the_scan_shrinks(check_docs):
+    report = check_docs.Report()
+
+    report.expect_floor("SUB-02", 6, 7, noun="Workers")
+
+    assert report.floors_met == []
+    assert report.failures[0][0] == "SUB-02"
+    assert "only 6 Workers found, floor is 7" in report.failures[0][1]
+
+
+def test_expect_floor_allows_the_inventory_to_grow(check_docs):
+    report = check_docs.Report()
+
+    report.expect_floor("SUB-02", 9, 7, noun="Workers")
+
+    assert report.failures == []
+    assert report.floors_met == ["SUB-02 9 >= 7 Workers"]
+
+
+def test_every_minimum_is_a_positive_integer(check_docs):
+    """A floor of 0 is not a floor."""
+    assert check_docs.MINIMUMS
+    assert all(v > 0 for v in check_docs.MINIMUMS.values())
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SUB-06 — the fourth DataStore, built with DataStoreFactory rather than named
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_a_hand_built_datastore_is_part_of_the_inventory(check_docs, tmp_path: Path):
+    """`preferencesDataStore(name = …)` alone missed the Glance widget state store."""
+    _rebase(check_docs, tmp_path)
+    app = _module_root(tmp_path, "app")
+    _write(app, "data/local/datastore/PreferencesDataStore.kt",
+           'val x = preferencesDataStore(name = "nimaz_preferences")\n')
+    _write(app, "widget/core/JsonGlanceStateDefinition.kt",
+           "val store = DataStoreFactory.create(serializer = s) { file }\n")
+
+    assert check_docs.preferences_datastore_names() == ["nimaz_preferences"]
+    assert check_docs.datastore_names() == ["JsonGlanceStateDefinition", "nimaz_preferences"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A whole post-migration tree, and the negative test this PR exists for
+#
+# These go through `check_sub(report)` rather than calling `expect_floor` directly.
+# A test that builds its own Report and asserts on it proves the floor *function*
+# works while saying nothing about whether it is still wired into the check — so a
+# later PR could delete the `expect_floor(...)` call to make a refactor go green
+# and the suite would stay 100% green. Running the real entry point is the only
+# assertion that catches that.
+# ──────────────────────────────────────────────────────────────────────────────
+
+SCHEMA_VERSION = 25
+
+# (gradle module, package path, class name) — deliberately split across two modules,
+# which is what the tree looks like after :feature:widget exists.
+WORKERS = [
+    ("app", "data/audio/AdhanDownloadWorker.kt", "AdhanDownloadWorker"),
+    ("feature/widget", "widget/nextprayer/NextPrayerWorker.kt", "NextPrayerWorker"),
+    ("feature/widget", "widget/prayertimes/PrayerTimesWorker.kt", "PrayerTimesWorker"),
+    ("feature/widget", "widget/prayertracker/PrayerTrackerWorker.kt", "PrayerTrackerWorker"),
+    ("feature/widget", "widget/hijridate/HijriDateWorker.kt", "HijriDateWorker"),
+    ("feature/widget", "widget/hijricalendar/HijriCalendarWorker.kt", "HijriCalendarWorker"),
+    ("feature/widget", "widget/khatam/KhatamWorker.kt", "KhatamWorker"),
+]
+
+SERVICES = [
+    ("app", "data/audio/AdhanPlaybackService.kt", "AdhanPlaybackService"),
+    ("app", "data/audio/QuranPlaybackService.kt", "QuranPlaybackService"),
+    ("app", "data/audio/DuaPlaybackService.kt", "DuaPlaybackService"),
+    ("app", "data/announcement/NimazMessagingService.kt", "NimazMessagingService"),
+]
+
+WIDGET_PACKAGES = [
+    ("nextprayer", "next_prayer_widget"),
+    ("prayertimes", "prayer_times_widget"),
+    ("prayertracker", "prayer_tracker_widget"),
+    ("hijridate", "hijri_date_widget"),
+    ("hijricalendar", "hijri_calendar_widget"),
+    ("khatam", "khatam_widget"),
+]
+
+# The channel-id regex is `const val CHANNEL_ID[A-Z_]* = "…"`, so the constant
+# suffixes have to be letters — digits would not match, and a fixture that quietly
+# fails to trip a scan proves nothing.
+CHANNELS = [f"channel_{chr(c)}" for c in range(ord("a"), ord("a") + 12)]
+PREFERENCE_STORES = ["nimaz_preferences", "nimaz_announcements", "nimaz_ai_device"]
+PAYLOAD_KEYS = ["title", "body", "route"]
+ANNOUNCEMENT_TYPES = ["info", "celebration"]
+CELEBRATION_EVENTS = ["eid_al_fitr", "eid_al_adha"]
+
+
+def _build_tree(check_docs, tmp_path: Path) -> dict[str, Path]:
+    """A two-module tree that satisfies every SUB check, and the doc describing it."""
+    _rebase(check_docs, tmp_path)
+    app = _module_root(tmp_path, "app")
+    widget = _module_root(tmp_path, "feature/widget")
+    written: dict[str, Path] = {}
+
+    for gradle_module, relative, name in WORKERS:
+        root = app if gradle_module == "app" else widget
+        written[name] = _write(root, relative, f"class {name} : CoroutineWorker()\n")
+    for _, relative, name in SERVICES:
+        written[name] = _write(app, relative, f"class {name} : Service()\n")
+
+    _write(app, "core/util/PrayerNotificationScheduler.kt", "object Channels {\n" + "".join(
+        f'    const val CHANNEL_ID_{cid[-1].upper()} = "{cid}"\n' for cid in CHANNELS
+    ) + "}\n")
+
+    for store in PREFERENCE_STORES:
+        _write(app, f"data/local/datastore/{store}.kt",
+               f'private val Context.store by preferencesDataStore(name = "{store}")\n')
+
+    _write(widget, "widget/core/JsonGlanceStateDefinition.kt",
+           "abstract class JsonGlanceStateDefinition<T>(private val fileName: String) {\n"
+           "    fun store() = DataStoreFactory.create(serializer = s) { file }\n}\n")
+    for package_name, file_name in WIDGET_PACKAGES:
+        written[file_name] = _write(
+            widget, f"widget/{package_name}/StateDefinition.kt",
+            f'object StateDefinition : JsonGlanceStateDefinition<S>(\n'
+            f'    fileName = "{file_name}",\n)\n',
+        )
+
+    _write(app, "data/local/database/NimazDatabase.kt",
+           f"const val NIMAZ_DATABASE_VERSION = {SCHEMA_VERSION}\n")
+    _write(app, "data/announcement/AnnouncementPayloadMapper.kt", "object Keys {\n" + "".join(
+        f'    const val KEY_{k.upper()} = "{k}"\n' for k in PAYLOAD_KEYS
+    ) + "}\n")
+    _write(app, "domain/model/Announcement.kt",
+           "enum class AnnouncementType(val key: String) {\n"
+           + "".join(f'    {k.upper()}("{k}"),\n' for k in ANNOUNCEMENT_TYPES)
+           + "}\n\nenum class CelebrationEvent(val key: String) {\n"
+           + "".join(f'    {k.upper()}("{k}"),\n' for k in CELEBRATION_EVENTS)
+           + "}\n")
+
+    documented = (
+        [name for _, _, name in WORKERS]
+        + [name for _, _, name in SERVICES]
+        + [f"widget/{package_name}/" for package_name, _ in WIDGET_PACKAGES]
+        + CHANNELS
+        + PREFERENCE_STORES
+        + ["JsonGlanceStateDefinition"]
+        + [file_name for _, file_name in WIDGET_PACKAGES]
+    )
+    check_docs.SUBSYSTEMS.write_text(
+        f"# Subsystems\n\n## 0. Inventory\n\n**Current schema version:** `{SCHEMA_VERSION}`\n\n"
+        + "\n".join(f"- `{item}`" for item in documented)
+        + "\n\n## 12. Engagement announcements (FCM)\n\n"
+        + "\n".join(
+            f"- `{key}`" for key in PAYLOAD_KEYS + ANNOUNCEMENT_TYPES + CELEBRATION_EVENTS
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return written
+
+
+def _run_check_sub(check_docs):
+    report = check_docs.Report()
+    check_docs.check_sub(report)
+    return report
+
+
+def test_the_full_two_module_fixture_passes_every_sub_check(check_docs, tmp_path: Path):
+    """The tree as it looks after :feature:widget exists — no check notices the move."""
+    _build_tree(check_docs, tmp_path)
+
+    report = _run_check_sub(check_docs)
+
+    assert report.failures == [], report.failures
+    assert len(report.passes) == 9  # SUB-01 … SUB-09
+
+
+def test_the_fixture_meets_every_sub_floor_exactly(check_docs, tmp_path: Path):
+    """If the fixture had slack, the negative tests below would prove nothing."""
+    _build_tree(check_docs, tmp_path)
+
+    report = _run_check_sub(check_docs)
+
+    met = {line.split()[0]: line for line in report.floors_met}
+    for check in ("SUB-02", "SUB-03", "SUB-04", "SUB-05", "SUB-06", "SUB-06-PREFS",
+                  "SUB-06-GLANCE"):
+        actual, _, floor = met[check].split()[1:4]
+        assert actual == floor, met[check]
+
+
+def test_removing_one_worker_turns_sub_02_red(check_docs, tmp_path: Path):
+    """The PR's stated exit criterion, run through the real check_sub().
+
+    Before this change, a Worker moving out of the scan's reach left SUB-02 green:
+    it documented every Worker it could still see. It still does — the pass below is
+    real — which is exactly why the floor has to exist, and why this asserts on the
+    output of `check_sub` rather than on a Report it built itself.
+    """
+    written = _build_tree(check_docs, tmp_path)
+    written["KhatamWorker"].unlink()  # the widget module the scan cannot reach
+
+    report = _run_check_sub(check_docs)
+
+    assert any("6 Workers documented" in line for line in report.passes)
+    assert [check for check, _ in report.failures] == ["SUB-02"]
+    assert "only 6 Workers found, floor is 7" in report.failures[0][1]
+
+
+def test_removing_a_glance_state_file_turns_sub_06_red(check_docs, tmp_path: Path):
+    """The six per-widget DataStore files are checked literals, not prose."""
+    written = _build_tree(check_docs, tmp_path)
+    written["khatam_widget"].unlink()
+
+    report = _run_check_sub(check_docs)
+
+    # SUB-04 stays green — the widget/khatam/ package is still there. Only the
+    # DataStore file it declares is gone, which is precisely what SUB-06 now sees.
+    failed = {check for check, _ in report.failures}
+    assert failed == {"SUB-06", "SUB-06-GLANCE"}
+    detail = dict(report.failures)["SUB-06-GLANCE"]
+    assert "only 5 Glance widget state files found, floor is 6" in detail
+
+
+def test_deleting_a_service_turns_sub_03_red(check_docs, tmp_path: Path):
+    written = _build_tree(check_docs, tmp_path)
+    written["QuranPlaybackService"].unlink()
+
+    report = _run_check_sub(check_docs)
+
+    assert [check for check, _ in report.failures] == ["SUB-03"]
+    assert "only 3 Services found, floor is 4" in report.failures[0][1]
+
+
+def test_an_empty_app_fails_every_sub_scan_rather_than_passing(check_docs, tmp_path: Path):
+    """The end state of the migration if nothing here worked: app/ emptied out."""
+    _build_tree(check_docs, tmp_path)
+    for path in (tmp_path / "feature/widget").rglob("*Worker.kt"):
+        path.unlink()
+    (tmp_path / "app/src/main/java/com/arshadshah/nimaz"
+     "/data/audio/AdhanDownloadWorker.kt").unlink()
+
+    report = _run_check_sub(check_docs)
+
+    details = dict(report.failures)
+    assert "SUB-02" in details
+    # Both guards fire: the floor, and the empty-expected-set rule.
+    assert "matched nothing" in details["SUB-02"] or "only 0 Workers" in details["SUB-02"]
+    assert not any("0 Workers documented" in line for line in report.passes)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Smoke — the real script against the real repo
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_the_real_repo_passes_every_check():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "All 23 documentation checks passed" in result.stdout
+
+
+def test_every_floor_is_still_wired_into_a_check():
+    """Pins the floor *count*, not just that floors exist.
+
+    A floor only guards anything while its `expect_floor(...)` call is still in
+    `check_nav`/`check_sub`. Deleting one is the cheapest possible way to make a
+    refactor go green, and it leaves no trace in the check output — the run still
+    says all 23 passed. Counting them is what makes that deletion fail here.
+    """
+    module = _load()
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True
+    )
+
+    assert f"({len(module.MINIMUMS)} scan floors met)" in result.stdout, result.stdout
+
+
+def test_no_check_reports_a_zero_count_against_the_real_repo():
+    """A passing line that says `0` is the silent failure in written form."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True
+    )
+
+    zeroes = [
+        line for line in result.stdout.splitlines()
+        if line.strip().startswith("ok") and " 0 " in line
+    ]
+    assert zeroes == []


### PR DESCRIPTION
**PR 2 of 22** · Milestone 0 — Foundations · Closes #553
Base: `epic/multi-module` (PR 1 merged) · Next in stack: `mm/02-baseline-metrics` (#554)

> **The epic calls this the highest-priority item in the whole migration, and it must land before any file moves.** Red CI is fine. Green CI that checks less is not.

`scripts/check_docs.py` rooted every scan at `APP = ROOT / "app/src/main/java/com/arshadshah/nimaz"`. Six of the seven Workers live in `widget/` and three of the four Services in `data/audio/` — both move in Milestone 5. When they do, those globs return a smaller set and *"every Worker is documented"* passes **because there are fewer Workers to find**.

### The bug, shown rather than described
With one Worker moved out of the tree, the current script prints:

```
ok   SUB-02  6 Workers documented in docs/SUBSYSTEMS.md
```

That is the whole failure. Every Worker it can still see *is* documented, so the check is honestly green while guarding nothing. After this PR the same tree prints that line — and then:

```
FAIL SUB-02  only 6 Workers found, floor is 7 — the scan shrank.
       → code moved out of every source root, or a pattern stopped matching. Fix the scan.
         Lowering the floor in MINIMUMS is only correct when the thing was genuinely deleted,
         and needs saying so in the commit message (see docs/DOCUMENTATION.md §4).
```

### What changed
| Area | Change |
|---|---|
| `APP` / `NAV_DIR` | Deleted. `source_roots()` walks every `*/src/main/{java,kotlin}/com/arshadshah/nimaz`, pruning `build`/`.git`/`.gradle`/`.idea`/`node_modules`/`.kotlin`/`generated`; exits if empty. Full run 0.5 s. |
| Single-file readers | `find_one(relative)` searches all roots and **fails on 0 *and* on >1 match** — a loud ambiguity beats a quiet guess. |
| `nav_graph_source()` | Concatenates every `.kt` containing `taggedComposable<Route.` or `composable<Route.` across all roots. |
| `expect_covered` | Now **fails on an empty expected set** — the `ok 0 Workers documented` case. |
| `MINIMUMS` | 13 floors, applied via `expect_floor`. |
| SUB-06 | Split into `preferences_datastore_names()`, `typed_datastore_owners()` and `glance_state_file_names()`. |

### 🚨 The NavGraph hole the issue did not mention
`nav_graph_source()` read the single file `NavGraph.kt`, which **PR 12 deliberately dissolves**. NAV-03 would have gone loudly red — tempting someone to "fix" the documented count — while **NAV-04, the bare-`composable` detector, went silently vacuous.** PR 12's own exit criterion in `EPIC.md` is literally *"NAV-03 and NAV-04 green"*, which it would have been, meaninglessly.

Verified by simulation: splitting `NavGraph.kt` across two feature files with one planted bare `composable<Route.HadithBookmarks>` now gives `wired: 94` (NAV-03 green, correctly) and **NAV-04 red** with `bare: ['HadithBookmarks']`.

### 🚨 SUB-06 has always been checking three of four DataStores
`widget/.../JsonGlanceStateDefinition.kt:94` creates per-widget Glance state via `DataStoreFactory.create`, which the `preferencesDataStore(name = …)` regex cannot see. The widened scan went **red on first run** — an undocumented DataStore that had been invisible since it was written. It is now documented in `SUBSYSTEMS.md` §0.5, and the six state file names are checked literals rather than prose, with their own floor.

Scoped to files containing `JsonGlanceStateDefinition<`: a bare `fileName = "…"` regex also matches `adhan_makkah.mp3` and three other adhan audio files, which are not DataStores.

### Also fixed
`docs_check.yml`'s `paths:` were five narrow `app/src/main/java/...` globs — so the lane would have stopped firing on the very files it guards the moment they moved. They are now one module-agnostic `'**/src/main/java/com/arshadshah/nimaz/**'` (plus the `kotlin` twin). Separately, **no filter covered `data/audio/**`, where three of the four Services SUB-03 guards actually live** — a Service change never triggered the lane that checks Services.

### Tests — the guard is now itself guarded
`check_docs.py` had **no tests**, and `scripts/test_coverage_summary.py` — the repo's only pytest file — **was run by no workflow**. Both now run via a `pytest scripts/` step in `docs_check.yml`.

23 new cases. The negative tests build a two-module fixture (`app/` + `feature/widget/`) and assert **through `check_sub(report)`**, not a hand-built `Report` — because review caught that the first version called `expect_floor` directly, so deleting a floor from the script left all tests green. That is the same class of bug this PR exists to prevent, one level up. Proof it is closed — with `report.expect_floor("SUB-02", …)` deleted from the script:

```
FAILED test_the_fixture_meets_every_sub_floor_exactly
FAILED test_removing_one_worker_turns_sub_02_red
FAILED test_every_floor_is_still_wired_into_a_check
E       assert '(13 scan floors met)' in '… All 23 documentation checks passed (12 scan floors met).'
3 failed, 24 passed
```

`test_every_floor_is_still_wired_into_a_check` pins the floor *count* in stdout, so a silently removed floor fails even if no individual test covers it.

### Floors, all measured
SUB-02 = 7 · SUB-03 = 4 · SUB-04 = 6 · SUB-05 = 12 · SUB-06 = 10 · SUB-06-PREFS = 3 · SUB-06-GLANCE = 6 · NAV-01 = 94 · NAV-03 = 94 (0 bare) · NAV-05 = **104** · NAV-06 = 57 · NAV-08 = 67 · NAV-09 = 22.

NAV-05 counts `ScreenTags` entries, not routes — 104, not 94. The 10-entry gap is real: tabs inside a parent screen are tagged but own no `Route`.

### Gates
```
python3 scripts/check_docs.py    All 23 documentation checks passed (13 scan floors met).
python3 -m pytest scripts/ -q    27 passed
node scripts/check_mermaid.mjs   All 14 mermaid diagrams parse.
./gradlew :app:testDebugUnitTest  BUILD SUCCESSFUL — 43 actionable tasks: 43 up-to-date
./gradlew :app:lintDebug          BUILD SUCCESSFUL
./gradlew :app:assembleRelease    BUILD SUCCESSFUL
```
The three Gradle gates report UP-TO-DATE against PR 1's cache. The diff touches only `.github/`, `docs/` and `scripts/` — zero Kotlin, resource or Gradle files — so that is legitimate, but it is not a fresh execution and is not claimed as one.

### Post-migration survival, verified
Review built a synthetic 8-root tree replicating every file into `core/{navigation,database,datastore,domain,announcement}/`, `feature/widget/`, `feature/prayer/.../data/audio/` plus a stray `feature/widget/build/generated/`, and ran the real script: **7 Workers, 4 Services, 6 widget packages, 12 channels, 94/94/0 nav, schema 25, 57/67/22 nav keys** — identical to the single-module tree, zero failures. `find_one` resolved `Routes.kt` from `core/navigation`.

`scripts/check_tajweed_contrast.py` also hardcodes `presentation/theme`, but it fails **loudly**, so it stays with PR 10, which moves that path.
