### PR TITLE
test(feature:onboarding): clear 80% and lock the module

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,6 +42,7 @@ Two on-device/JVM test surfaces exist:
   - [The Firebase wrappers and the formatters (`:core:common/src/test`)](#the-firebase-wrappers-and-the-formatters-corecommonsrctest)
   - [The Islamic calendar (`:feature:calendar/src/test`)](#the-islamic-calendar-featurecalendarsrctest)
   - [Every preference, read back (`:core:datastore/src/test`)](#every-preference-read-back-coredatastoresrctest)
+  - [The first run, drawn and driven (`:feature:onboarding/src/test` and `src/testDebug`)](#the-first-run-drawn-and-driven-featureonboardingsrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -256,10 +257,11 @@ floors in its own `build.gradle.kts`.
 
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common` and `:core:datastore` are locked at 80/80 — none of them draws
-anything, so every branch is one somebody wrote and a test can take both sides of. So is `:feature:calendar`, which
-*is* a Compose module: the unreachable branch below is emitted **per parameter of every
-restartable composable**, so its weight scales with how many composables a module has, and six
-files never accumulate enough of them to move the number. Only `:feature:quran` is softened, to
+anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar` and
+`:feature:onboarding`, which *are* Compose modules: the unreachable branch below is emitted **per
+parameter of every restartable composable**, so its weight scales with how many composables a
+module has, and six files — or eight — never accumulate enough of them to move the number.
+`:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here. Only `:feature:quran` is softened, to
 80% lines and **60%** branches, because the Compose compiler
 emits a `$dirty` bitmask branch per parameter of every restartable composable — the skippability
 check — and neither side of one is reachable from a test: which side runs depends on what the
@@ -278,6 +280,7 @@ split, and should say so where it sets its floors.
 | `:core:common` | 92.7% | 82.3% | **locked** at 80/80 |
 | `:feature:calendar` | 94.0% | 82.4% | **locked** at 80/80 |
 | `:core:datastore` | 96.1% | 84.3% | **locked** at 80/80 |
+| `:feature:onboarding` | 94.3% | 90.3% | **locked** at 80/80 (#605) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:core:data` | 39.0% | 31.2% | |
 | `:feature:prayer` | 38.1% | 23.7% | |
@@ -287,7 +290,6 @@ split, and should say so where it sets its floors.
 | `:feature:tools` | 18.0% | 29.3% | |
 | `:feature:about` | 17.8% | 23.0% | |
 | `:feature:widget` | 16.8% | 28.1% | |
-| `:feature:onboarding` | 12.9% | 12.3% | |
 | `:feature:settings` | 11.3% | 14.9% | |
 
 `:app` is absent because its own suite needs the private content artifact and cannot be measured
@@ -528,6 +530,47 @@ that is the failure the round-trip table is for.
 | The one-shot migration | same | it runs once, and **never resets a choice the reader has since made** |
 | The announcement store | `AnnouncementLocalDataSourceTest` | an FCM payload surviving JSON and a later build; an unknown type resolving to no banner rather than a half-built one; an unknown *occasion* falling back to the generic treatment rather than costing the banner; dismissal being permanent |
 | The AI install id | `DeviceIdProviderTest` | stable across process restarts, and a generated UUID — **never** a hardware identifier |
+
+### The first run, drawn and driven (`:feature:onboarding/src/test` and `src/testDebug`)
+
+The eighth module locked, and the one with the furthest to travel: **12.9% lines to 94.3%**, from
+97 covered lines to 711. Two files were 600 of the 657 that were missing, and both were missing for
+the same reason — nothing had ever composed the screen, and nothing had ever *drawn* it.
+
+The stakes are unlike any other screen's. `NavGraph` reads `onboardingCompleted` **once**, when it
+builds the graph, to choose a start destination. A walkthrough that fails to emit
+`CompleteOnboarding` does not cost the user a screen; it puts them back in onboarding on every
+launch, for ever. The two halves of finishing — the event and the navigation — are dispatched from
+two different buttons on two different pages, each behind a page comparison, and no ViewModel test
+can see whether the right button is on the right page.
+
+**The art is covered by drawing it, not by declaring it uncoverable.** #605 flagged
+`OnboardingArt.kt` (226 lines of `Canvas` geometry) as possibly unreachable, and left at zero the
+module could not have passed 80% at all — 528 coverable lines out of 754 is 70% with everything
+else perfect. Composing the tree is not enough: `Canvas(modifier)` runs, its `DrawScope` lambda —
+which is the whole file — does not. `OnboardingArtTest` asks the `ComposeView` to draw itself into
+a software `android.graphics.Canvas` under `@GraphicsMode(NATIVE)`, which makes Compose's
+`RenderNodeLayer` invoke the draw block directly instead of replaying a render node, and reads the
+pixels back. `captureToImage()` is the route it does **not** take — that goes through `PixelCopy`
+on a real window and hangs under Robolectric.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| The way out of onboarding | `OnboardingScreenTest` | `CompleteOnboarding` and the navigation fire together, **once**, and only from the last page or Skip; Skip is gone from the last page, so there are never two buttons that both end the flow |
+| Paging | same | each page carries its own copy, Back returns to the previous one, and the last page swaps Next for Get Started |
+| The funnel | same | every page reached is reported in order — the analytic that fired zero times in production while the pager drove itself locally |
+| The permission cards | same | a granted permission says so and stops asking; a detected location is **named** rather than shown the generic granted label; a permission granted while the page is open updates in place |
+| The notification permission, both platforms | same | it asks the system from Tiramisu, and grants itself below it — where there is no `POST_NOTIFICATIONS` to request and a launcher would leave the card stuck |
+| The location dialog's answer | same | **coarse alone counts as granted**: an AND across the two results would tell a user who picked "approximate" that they had refused |
+| Short screens | same | both pages switch to a compact layout below 500dp of usable height, and the way forward stays on screen |
+| The four emblems | `OnboardingArtTest` | each paints something, and each paints *its own* artwork — a `when` arm that fell through, or the shield's lost `return@Canvas`, ships the wrong drawing and compiles fine |
+| The mihrab's geometry | same | letterboxed rather than stretched when its box is the wrong shape, and centred in it — the `min(w/116, h/150)` scale and the halved offsets |
+| The khatam band | same | it tiles the full measured width, and fades downwards instead of reading as a solid gold bar over the title |
+| The illuminated field | same | three gradient stops, not a flat teal fill |
+| The first-run flag | `OnboardingViewModelTest` | read back at construction; a read that fails **ends the loading state** and does not guess `true`, which would skip the first run outright |
+| A completion that cannot be persisted | same | reported as a failure, and **not** counted in the funnel — a completion the user will be shown again next launch makes the first-run denominator disagree with the step funnel above it |
+| Permission results | same | each updates only the field it answered for; granting location detects a location without waiting to be asked again |
+| The graph | `OnboardingGraphTest` | `Route.Onboarding` registers, and the graph builds with it as the start destination — the failure here is thrown on the first frame of the first launch |
 
 ## Conventions
 

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -25,6 +25,30 @@ android {
     }
 }
 
+/**
+ * Locked. See `COVERAGE_EXCLUSIONS` and `coverageFloor` in `build-logic` for what is measured and
+ * how the ratchet works.
+ *
+ * **80/80, at 94.3% lines and 90.3% branches** — a Compose module holding the full branch floor,
+ * like `:feature:calendar` and unlike `:feature:quran`. The unreachable `$dirty` bitmask branch
+ * the Compose compiler emits is one per parameter of every restartable composable, so its weight
+ * scales with how many composables a module has; there are eight here, and the ratio never
+ * becomes the number.
+ *
+ * **Nothing is excluded, and nothing is left at zero.** The 226 lines of `OnboardingArt.kt` are
+ * pure `Canvas` geometry, which #605 flagged as possibly uncoverable — and would be, if a test
+ * only composed the tree: `Canvas(modifier)` runs, its `DrawScope` lambda does not.
+ * `OnboardingArtTest` asks the `ComposeView` to draw itself into a software
+ * `android.graphics.Canvas` under `@GraphicsMode(NATIVE)` and reads the pixels back, which runs
+ * the draw blocks for real and makes the art assertable rather than merely covered. What remains
+ * uncovered is the two `@Preview` functions in each file — private, so no test can call them —
+ * and the `onComplete` lambda inside `onboardingGraph`, which only a composed `NavHost` reaches.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
 // The first-run flow: three screens and the ViewModel behind them.
 //
 // **The cleanest extraction in the epic so far — zero couplings to resolve.** Not luck: it is what
@@ -66,4 +90,16 @@ dependencies {
     // RecordingTelemetry — the Telemetry seam's recording fake, beside its port.
     testImplementation(testFixtures(project(":core:common")))
     testImplementation(libs.turbine)
+
+    // The screen, the art and the graph are all exercised under Robolectric, so this module needs
+    // the same harness `:feature:calendar` and `:feature:quran` use — including
+    // `src/testDebug/resources/robolectric.properties`, which pins the SDK and the Application
+    // class. A properties file is a resource of its source set and does not travel with the tests
+    // that need it.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(testFixtures(project(":core:ui")))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/onboarding/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreenTest.kt
+++ b/feature/onboarding/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingScreenTest.kt
@@ -1,0 +1,423 @@
+package com.arshadshah.nimaz.presentation.screens.onboarding
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.platform.LocalContext
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.onboarding.OnboardingEvent
+import com.arshadshah.nimaz.presentation.viewmodel.onboarding.OnboardingUiState
+import com.arshadshah.nimaz.presentation.viewmodel.onboarding.OnboardingViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The first-run walkthrough: three info pages, a permissions page, and exactly one way out.
+ *
+ * **The stakes are asymmetric here in a way no other screen's are.** `NavGraph` reads
+ * `onboardingCompleted` once, when the graph is built, to choose its start destination — so a
+ * flow that fails to emit `CompleteOnboarding` does not cost the user a screen, it puts them
+ * back in onboarding on every launch for ever. The two events that decide it (`CompleteOnboarding`
+ * and the `onComplete` navigation) are dispatched from two different buttons, on two different
+ * pages, and both are guarded by a page comparison; there is no ViewModel test that can see
+ * whether the right button is on the right page.
+ *
+ * The other half is the funnel. `OnboardingEvent.SetCurrentPage` is emitted by a `snapshotFlow`
+ * watching the pager, not by the buttons — the KDoc in `OnboardingScreen` records that this
+ * analytic fired zero times in production while the pager drove itself locally — so what is
+ * pinned below is that *paging* reports the step, whichever way the page was reached.
+ *
+ * The ViewModel is a relaxed mock over a real `MutableStateFlow`, per #604: the screen takes it as
+ * a parameter, so nothing here needs Hilt.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class OnboardingScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(OnboardingUiState(isLoading = false))
+    private val events = mutableListOf<OnboardingEvent>()
+    private var completed = 0
+
+    private val viewModel: OnboardingViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@OnboardingScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<OnboardingEvent>() }
+    }
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    /** The host activity, captured from the composition — the screen itself reaches for it. */
+    private lateinit var activity: ComponentActivity
+
+    private fun launch() {
+        composeRule.setThemedContent {
+            activity = LocalContext.current as ComponentActivity
+            OnboardingScreen(onComplete = { completed++ }, viewModel = viewModel)
+        }
+        composeRule.waitForIdle()
+    }
+
+    /** Advances the pager the way a user does — the Next button, one page at a time. */
+    private fun tapNext(times: Int = 1) = repeat(times) {
+        composeRule.onNodeWithText(str(R.string.onboarding_next)).performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun pagesReached(): List<Int> =
+        events.filterIsInstance<OnboardingEvent.SetCurrentPage>().map { it.page }
+
+    // ------------------------------------------------------------------
+    // Paging
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the walkthrough opens on the welcome page with nothing to go back to`() {
+        launch()
+
+        composeRule.onNodeWithText(str(R.string.onboarding_welcome_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_feature_quran)).assertIsDisplayed()
+        // Back is hidden rather than disabled on the first page: a Back that did nothing would
+        // read as a flow that has already broken.
+        composeRule.onAllNodesWithText(str(R.string.onboarding_back)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `each page carries its own copy`() {
+        // Three pages built from one `InfoPage` list. An off-by-one in the pager's
+        // `if (page < infoPages.size)` shows up as the wrong page's title, or the permissions
+        // page appearing one step early.
+        launch()
+
+        tapNext()
+        composeRule.onNodeWithText(str(R.string.onboarding_prayer_title)).assertIsDisplayed()
+
+        tapNext()
+        composeRule.onNodeWithText(str(R.string.onboarding_quran_title)).assertIsDisplayed()
+
+        tapNext()
+        composeRule.onNodeWithText(str(R.string.onboarding_permissions_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `every page reached is reported to the funnel, in order`() {
+        // The drop-off graph is read by comparing consecutive steps, so a step that is skipped or
+        // reported twice makes the whole measurement unreadable.
+        launch()
+
+        tapNext(3)
+
+        assertThat(pagesReached()).containsExactly(0, 1, 2, 3).inOrder()
+    }
+
+    @Test
+    fun `back returns to the previous page and reports it`() {
+        launch()
+        tapNext(2)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_back)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.onboarding_prayer_title)).assertIsDisplayed()
+        assertThat(pagesReached()).containsExactly(0, 1, 2, 1).inOrder()
+    }
+
+    // ------------------------------------------------------------------
+    // The one way out
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the last page swaps Next for Get Started`() {
+        launch()
+
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_get_started)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.onboarding_next)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `finishing persists completion and navigates away exactly once`() {
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_get_started)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<OnboardingEvent.CompleteOnboarding>()).hasSize(1)
+        assertThat(completed).isEqualTo(1)
+    }
+
+    @Test
+    fun `no page before the last one completes onboarding`() {
+        // `Next` and `Get Started` are the same button under a page comparison. Get that
+        // comparison wrong and the walkthrough ends on page one — or, the other way round,
+        // never ends at all.
+        launch()
+
+        tapNext(3)
+
+        assertThat(events.filterIsInstance<OnboardingEvent.CompleteOnboarding>()).isEmpty()
+        assertThat(completed).isEqualTo(0)
+    }
+
+    @Test
+    fun `skip finishes the flow from an early page`() {
+        launch()
+
+        composeRule.onNodeWithText(str(R.string.onboarding_skip)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<OnboardingEvent.CompleteOnboarding>()).hasSize(1)
+        assertThat(completed).isEqualTo(1)
+    }
+
+    @Test
+    fun `skip is gone from the last page`() {
+        // Two buttons that both complete onboarding, side by side, is how a flow ends up
+        // dispatching completion twice and navigating twice.
+        launch()
+
+        tapNext(3)
+
+        composeRule.onAllNodesWithText(str(R.string.onboarding_skip)).assertCountEquals(0)
+    }
+
+    // ------------------------------------------------------------------
+    // The permissions page
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `an ungranted permission offers a way to grant it`() {
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_location_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_notification_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_battery_title)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).assertCountEquals(3)
+    }
+
+    @Test
+    fun `a granted permission says so and stops asking`() {
+        state.value = state.value.copy(
+            locationPermissionGranted = true,
+            notificationPermissionGranted = true,
+            batteryOptimizationDisabled = true,
+        )
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_location_granted)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_notification_granted))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_battery_granted)).assertIsDisplayed()
+        // A Grant button beside "Granted" is the state the card is designed to rule out.
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a detected location is named on the card instead of the generic label`() {
+        // The card's whole job at this point is to show the location detection actually worked;
+        // falling back to "Location Access Granted" when a name is in hand hides the one piece
+        // of evidence the user has.
+        state.value = state.value.copy(
+            locationPermissionGranted = true,
+            locationDetected = true,
+            locationName = "Dublin, Ireland",
+        )
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText("Dublin, Ireland").assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.onboarding_location_granted))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `a permission granted while the page is open updates the card in place`() {
+        launch()
+        tapNext(3)
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).assertCountEquals(3)
+
+        // What the permission launchers' callbacks do: dispatch UpdatePermissionStatus, which
+        // moves the state. The user comes back from the system dialog to this page.
+        state.value = state.value.copy(notificationPermissionGranted = true)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.onboarding_notification_granted))
+            .assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).assertCountEquals(2)
+    }
+
+    @Test
+    @Config(sdk = [32])
+    fun `below Tiramisu the notification card grants itself with no system prompt`() {
+        // There is no POST_NOTIFICATIONS permission to request before API 33, so launching the
+        // request contract there would prompt for a permission the platform does not have and
+        // leave the card stuck at "not granted" on every older device.
+        state.value = state.value.copy(
+            locationPermissionGranted = true,
+            batteryOptimizationDisabled = true,
+        )
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_grant)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(OnboardingEvent.UpdatePermissionStatus(notification = true))
+    }
+
+    @Test
+    fun `from Tiramisu the notification card asks the system rather than granting itself`() {
+        // The mirror of the test above. Marking the permission granted locally on a platform
+        // that does have POST_NOTIFICATIONS would leave the card green while every prayer
+        // notification is silently dropped.
+        state.value = state.value.copy(
+            locationPermissionGranted = true,
+            batteryOptimizationDisabled = true,
+        )
+        launch()
+        tapNext(3)
+
+        composeRule.onNodeWithText(str(R.string.onboarding_grant)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<OnboardingEvent.UpdatePermissionStatus>()).isEmpty()
+    }
+
+    @Test
+    fun `coarse location alone counts as granted`() {
+        // The launcher's callback ORs the two results. A user who picks "approximate" in the
+        // system dialog — the default on the modern dialog — grants only ACCESS_COARSE_LOCATION,
+        // and an AND here would tell them the permission was refused and never detect a location.
+        launch()
+        tapNext(3)
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).onFirst().performClick()
+        composeRule.waitForIdle()
+
+        answerPermissionRequest(
+            granted = mapOf(
+                Manifest.permission.ACCESS_FINE_LOCATION to false,
+                Manifest.permission.ACCESS_COARSE_LOCATION to true,
+            )
+        )
+
+        assertThat(events).contains(OnboardingEvent.UpdatePermissionStatus(location = true))
+    }
+
+    @Test
+    fun `a refused location dialog is reported as refused`() {
+        launch()
+        tapNext(3)
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).onFirst().performClick()
+        composeRule.waitForIdle()
+
+        answerPermissionRequest(
+            granted = mapOf(
+                Manifest.permission.ACCESS_FINE_LOCATION to false,
+                Manifest.permission.ACCESS_COARSE_LOCATION to false,
+            )
+        )
+
+        assertThat(events).contains(OnboardingEvent.UpdatePermissionStatus(location = false))
+    }
+
+    /**
+     * Delivers a system permission dialog's answer back to the launcher that opened it.
+     *
+     * `onRequestPermissionsResult` is deprecated in favour of the result APIs — which is exactly
+     * what the screen uses. This is the platform callback underneath them, and it is how a
+     * Robolectric test plays the part of the system dialog.
+     */
+    @Suppress("DEPRECATION")
+    private fun answerPermissionRequest(granted: Map<String, Boolean>) {
+        val request = shadowOf(activity).lastRequestedPermission
+        assertThat(request).isNotNull()
+        activity.onRequestPermissionsResult(
+            request.requestCode,
+            request.requestedPermissions,
+            request.requestedPermissions.map {
+                if (granted[it] == true) PackageManager.PERMISSION_GRANTED
+                else PackageManager.PERMISSION_DENIED
+            }.toIntArray(),
+        )
+        composeRule.waitForIdle()
+    }
+
+    // ------------------------------------------------------------------
+    // Small screens
+    //
+    // Both pages switch to a compact layout below 500dp of usable height —
+    // tighter spacing, a smaller emblem, smaller type. It is not cosmetic:
+    // the pages are a centred, scrollable column, and at the roomy sizes the
+    // permission cards alone are taller than a short screen.
+    // ------------------------------------------------------------------
+
+    @Test
+    @Config(qualifiers = "w411dp-h480dp")
+    fun `a short screen keeps the whole walkthrough usable`() {
+        launch()
+
+        composeRule.onNodeWithText(str(R.string.onboarding_welcome_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.onboarding_feature_duas)).assertExists()
+        // The way forward has to survive the squeeze — it is the only control on the page that
+        // the user cannot scroll to, because the nav row sits outside the scrolling column.
+        composeRule.onNodeWithText(str(R.string.onboarding_next)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h480dp")
+    fun `a short screen still offers all three permissions and the way out`() {
+        launch()
+
+        tapNext(3)
+
+        composeRule.onAllNodesWithText(str(R.string.onboarding_grant)).assertCountEquals(3)
+        composeRule.onNodeWithText(str(R.string.onboarding_get_started)).assertIsDisplayed()
+    }
+
+    // ------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `an error is shown to the user and then cleared`() {
+        // Without the DismissError that follows the snackbar, `state.error` stays set, the
+        // `LaunchedEffect` key never changes, and the next failure of the same kind is silent.
+        launch()
+
+        state.value = state.value.copy(error = "Could not detect location")
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Could not detect location").assertIsDisplayed()
+
+        // The dismissal is dispatched once the snackbar has run its course, not when it appears.
+        composeRule.mainClock.advanceTimeBy(10_000)
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(OnboardingEvent.DismissError)
+    }
+}

--- a/feature/onboarding/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/onboarding/OnboardingViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -64,10 +65,17 @@ class OnboardingViewModelTest {
         override fun isIgnoringBatteryOptimizations() = exempt
     }
 
-    private class FakeAppSettings(completed: Boolean = false) : AppSettings {
+    private class FakeAppSettings(
+        completed: Boolean = false,
+        private val readFailsWith: Throwable? = null,
+        private val writeFailsWith: Throwable? = null,
+    ) : AppSettings {
         val completedFlow = MutableStateFlow(completed)
-        override val onboardingCompleted: Flow<Boolean> = completedFlow
+        override val onboardingCompleted: Flow<Boolean> =
+            readFailsWith?.let { failure -> flow<Boolean> { throw failure } } ?: completedFlow
+
         override suspend fun setOnboardingCompleted(completed: Boolean) {
+            writeFailsWith?.let { throw it }
             completedFlow.value = completed
         }
 
@@ -306,5 +314,181 @@ class OnboardingViewModelTest {
 
             assertThat(telemetry.exceptions).contains(boom)
             assertThat(telemetry.errors.map { it.type }).contains("detect_location")
+        }
+
+    // ---------------------------------------------------------------------
+    // Reading the flag back. This is the state `NavGraph` consults exactly
+    // once, to pick a start destination, so both outcomes matter and the
+    // failure has to end the loading state — a screen stuck on `isLoading`
+    // is a first run that never renders.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `a stored completion flag is read back at construction`() = runTest(dispatcher) {
+        val vm = viewModel(appSettings = FakeAppSettings(completed = true))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.onboardingCompleted).isTrue()
+        assertThat(vm.state.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a flag that cannot be read still lets the screen render`() = runTest(dispatcher) {
+        val telemetry = RecordingTelemetry()
+        val boom = IllegalStateException("datastore corrupt")
+        val vm = viewModel(
+            appSettings = FakeAppSettings(readFailsWith = boom),
+            telemetry = telemetry,
+        )
+        advanceUntilIdle()
+
+        // Not "onboarding is complete" — a read that failed says nothing about the flag, and
+        // guessing `true` would skip the first run entirely.
+        assertThat(vm.state.value.onboardingCompleted).isFalse()
+        assertThat(vm.state.value.isLoading).isFalse()
+        assertThat(vm.state.value.error).isEqualTo("datastore corrupt")
+        assertThat(telemetry.exceptions).contains(boom)
+    }
+
+    @Test
+    fun `re-checking the status after a failure picks up a flag that now reads`() =
+        runTest(dispatcher) {
+            val appSettings = FakeAppSettings(completed = true)
+            val vm = viewModel(appSettings = appSettings)
+            advanceUntilIdle()
+
+            vm.onEvent(OnboardingEvent.CheckOnboardingStatus)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.onboardingCompleted).isTrue()
+        }
+
+    /**
+     * A write that fails must not report the funnel's completion event.
+     *
+     * The two are read together: `onboarding_completed` is the denominator for every
+     * first-run question, and counting a user who will be shown onboarding again on the
+     * next launch makes it disagree with the step funnel that precedes it.
+     */
+    @Test
+    fun `a completion that cannot be persisted is reported as a failure, not a completion`() =
+        runTest(dispatcher) {
+            val telemetry = RecordingTelemetry()
+            val vm = viewModel(
+                appSettings = FakeAppSettings(writeFailsWith = IllegalStateException("disk full")),
+                telemetry = telemetry,
+            )
+            advanceUntilIdle()
+
+            vm.onEvent(OnboardingEvent.CompleteOnboarding)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.onboardingCompleted).isFalse()
+            assertThat(vm.state.value.error).isEqualTo("disk full")
+            assertThat(telemetry.calls.filterIsInstance<TelemetryCall.OnboardingCompleted>())
+                .isEmpty()
+            assertThat(telemetry.errors.map { it.type }).contains("complete")
+        }
+
+    // ---------------------------------------------------------------------
+    // The permission round trip. The screen's launchers report their result
+    // through `UpdatePermissionStatus`, one field at a time — the other two
+    // are null and must be left alone, because the launcher that answers has
+    // no knowledge of the two permissions it was not asked about.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `a permission result updates only the permission it answered for`() =
+        runTest(dispatcher) {
+            val vm = viewModel(
+                permissions = FakePermissions(location = false, notification = false),
+                power = FakePower(exempt = true),
+            )
+            advanceUntilIdle()
+
+            vm.onEvent(OnboardingEvent.UpdatePermissionStatus(notification = true))
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.notificationPermissionGranted).isTrue()
+            assertThat(vm.state.value.locationPermissionGranted).isFalse()
+            // Left as it was rather than reset to the null the event carried.
+            assertThat(vm.state.value.batteryOptimizationDisabled).isTrue()
+        }
+
+    @Test
+    fun `granting location detects the location without waiting to be asked again`() =
+        runTest(dispatcher) {
+            // The user has just come back from the system dialog. Nothing else prompts a fix,
+            // so without this the permissions page shows "granted" and no place name, and the
+            // first prayer times are computed for wherever the app last thought it was.
+            val settings = RecordingLocationSettings()
+            val vm = viewModel(locationSettings = settings)
+            advanceUntilIdle()
+
+            vm.onEvent(OnboardingEvent.UpdatePermissionStatus(location = true))
+            advanceUntilIdle()
+
+            assertThat(settings.saved).isEqualTo(Triple(51.5074, -0.1278, "London"))
+            assertThat(vm.state.value.locationDetected).isTrue()
+        }
+
+    @Test
+    fun `a denied location result does not go looking for a fix`() = runTest(dispatcher) {
+        val settings = RecordingLocationSettings()
+        val vm = viewModel(locationSettings = settings)
+        advanceUntilIdle()
+
+        vm.onEvent(OnboardingEvent.UpdatePermissionStatus(location = false))
+        advanceUntilIdle()
+
+        assertThat(settings.saved).isNull()
+        assertThat(vm.state.value.locationDetected).isFalse()
+    }
+
+    @Test
+    fun `each re-check reads the seam again rather than a cached answer`() = runTest(dispatcher) {
+        // `checkAllPermissions` runs once, at construction. Everything after it — returning from
+        // a system dialog, coming back from Settings with battery optimisation turned off — is
+        // one of these three events, and each has to consult the seam a second time.
+        val permissions = object : PermissionChecker {
+            var location = false
+            var notification = false
+            override fun hasLocationPermission() = location
+            override fun hasNotificationPermission() = notification
+        }
+        val power = object : PowerSettings {
+            var exempt = false
+            override fun isIgnoringBatteryOptimizations() = exempt
+        }
+        val vm = viewModel(permissions = permissions, power = power)
+        advanceUntilIdle()
+        assertThat(vm.state.value.locationPermissionGranted).isFalse()
+
+        permissions.location = true
+        permissions.notification = true
+        power.exempt = true
+        vm.onEvent(OnboardingEvent.CheckLocationPermission)
+        vm.onEvent(OnboardingEvent.CheckNotificationPermission)
+        vm.onEvent(OnboardingEvent.CheckBatteryOptimization)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.locationPermissionGranted).isTrue()
+        assertThat(vm.state.value.notificationPermissionGranted).isTrue()
+        assertThat(vm.state.value.batteryOptimizationDisabled).isTrue()
+    }
+
+    @Test
+    fun `the permission queries the screen calls directly answer from the seam`() =
+        runTest(dispatcher) {
+            // `hasLocationPermission` / `hasNotificationPermission` are public because the
+            // screen's launcher callbacks consult them; they must not answer from state that
+            // was read at construction.
+            val vm = viewModel(
+                permissions = FakePermissions(location = true, notification = false),
+            )
+            advanceUntilIdle()
+
+            assertThat(vm.hasLocationPermission()).isTrue()
+            assertThat(vm.hasNotificationPermission()).isFalse()
         }
 }

--- a/feature/onboarding/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingArtTest.kt
+++ b/feature/onboarding/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingArtTest.kt
@@ -1,0 +1,197 @@
+package com.arshadshah.nimaz.presentation.screens.onboarding
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The onboarding artwork, drawn for real and read back off a bitmap.
+ *
+ * **These are the first pixels anyone sees of the app**, and there is no image asset behind them
+ * to eyeball in a resource folder — the mihrab, the four emblems and the khatam band are all
+ * `Canvas` geometry, so "the arch renders" is a claim only a draw pass can settle. A `when` that
+ * fell through to the wrong emblem, or a `return@Canvas` lost from the shield branch, compiles
+ * and previews fine and ships a first-run screen with the wrong drawing on it.
+ *
+ * The draw pass is the whole technique here. Composing the tree runs the `Canvas(modifier)` call
+ * and nothing inside its `DrawScope` lambda, which is where every line of this file lives, so the
+ * test asks the `ComposeView` to draw itself into a software `android.graphics.Canvas`: Compose's
+ * `RenderNodeLayer` invokes the draw block directly rather than replaying a render node when the
+ * canvas it is handed is not hardware-accelerated. `NATIVE` graphics because the assertions are
+ * about *pixels* — under Robolectric's legacy shadow canvas every draw is a no-op and the bitmap
+ * would come back uniformly blank whether the art worked or not.
+ *
+ * `captureToImage()` is the route this does **not** take: it goes through `PixelCopy` on a real
+ * window and hangs under Robolectric (see #604).
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w411dp-h891dp")
+class OnboardingArtTest {
+
+    // The v1 rule, as everywhere else in the repo: `createComponentComposeRule()` cannot be used
+    // here because these tests need the activity's view to draw, and migrating the whole codebase
+    // to the v2 rule swaps the test dispatcher and is a separate change.
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    /** Composes [content] over a black field, then draws the result into a bitmap. */
+    private fun draw(content: @Composable () -> Unit): Bitmap {
+        composeRule.setContent {
+            MaterialTheme {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Black)) { content() }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val root: View = composeRule.activity
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0)
+        val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+        root.draw(Canvas(bitmap))
+        return bitmap
+    }
+
+    private fun Bitmap.rows(top: Int, count: Int): IntArray =
+        IntArray(width * count).also { getPixels(it, 0, width, 0, top, width, count) }
+
+    private fun Bitmap.columns(left: Int, count: Int): IntArray =
+        IntArray(count * height).also { getPixels(it, 0, count, left, 0, count, height) }
+
+    /** Pixels that are not the black backdrop — i.e. paint the art actually laid down. */
+    private fun IntArray.ink(): Int = count { it != android.graphics.Color.BLACK }
+
+    /** Mean luminance, for comparing how strongly a region was painted. */
+    private fun IntArray.brightness(): Double = map {
+        (android.graphics.Color.red(it) + android.graphics.Color.green(it) +
+            android.graphics.Color.blue(it)) / 3.0
+    }.average()
+
+    private fun emblemBands(): List<IntArray> {
+        val kinds = OnboardingEmblem.entries
+        val bitmap = draw {
+            Column(modifier = Modifier.fillMaxSize()) {
+                kinds.forEach { kind ->
+                    OnboardingEmblem(
+                        kind = kind,
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                    )
+                }
+            }
+        }
+        val band = bitmap.height / kinds.size
+        return kinds.indices.map { bitmap.rows(top = it * band, count = band) }
+    }
+
+    @Test
+    fun `every emblem paints something`() {
+        // A kind that drew nothing is the failure this catches: the page still lays out, the
+        // titles and the feature list still render, and the user gets an empty rectangle where
+        // the mihrab should be.
+        emblemBands().forEach { assertThat(it.ink()).isGreaterThan(0) }
+    }
+
+    @Test
+    fun `each emblem draws its own artwork`() {
+        // The four kinds share one Canvas and are told apart by a `when`. If a branch fell
+        // through — or the shield's `return@Canvas` were dropped, which would leave it drawing
+        // the mihrab arch as well — two pages would show the same picture. Comparing the drawn
+        // pixels is the only way to see that; both versions type-check.
+        val bands = emblemBands()
+
+        bands.indices.forEach { a ->
+            (a + 1 until bands.size).forEach { b ->
+                assertThat(bands[a]).isNotEqualTo(bands[b])
+            }
+        }
+    }
+
+    @Test
+    fun `the emblem is letterboxed rather than stretched when its box is too tall`() {
+        // Art is authored in a 116x150 box and scaled by `min(w/116, h/150)`. Take the height
+        // as the limit instead of the smaller of the two and the mihrab is drawn wider than its
+        // arch is tall — a squashed arch, on a portrait phone, on first launch.
+        val bitmap = draw { OnboardingEmblem(OnboardingEmblem.MOSQUE, Modifier.fillMaxSize()) }
+        val margin = bitmap.height / 8
+
+        assertThat(bitmap.rows(top = 0, count = margin).ink()).isEqualTo(0)
+        assertThat(bitmap.rows(top = bitmap.height - margin, count = margin).ink()).isEqualTo(0)
+        // ...and it is genuinely drawn in between, so the blank margins are not a blank screen.
+        assertThat(bitmap.rows(top = bitmap.height / 2, count = 1).ink()).isGreaterThan(0)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h400dp")
+    fun `the emblem stays centred when its box is too wide`() {
+        // The other half of the same arithmetic: `ox = (width - 116*scale) / 2`. Drop the
+        // halving and the art hugs the left edge of a tablet-width page.
+        val bitmap = draw { OnboardingEmblem(OnboardingEmblem.QURAN, Modifier.fillMaxSize()) }
+        val margin = bitmap.width / 8
+
+        assertThat(bitmap.columns(left = 0, count = margin).ink()).isEqualTo(0)
+        assertThat(bitmap.columns(left = bitmap.width - margin, count = margin).ink()).isEqualTo(0)
+        assertThat(bitmap.columns(left = bitmap.width / 2, count = 1).ink()).isGreaterThan(0)
+    }
+
+    @Test
+    fun `the khatam band tiles the full width`() {
+        // The band is a `while (x < size.width)` over a 34dp tile. A loop that ran once — or one
+        // that stopped at the authored width rather than the measured one — leaves the motif in
+        // the top-left corner and bare background across the rest of the header.
+        val bitmap = draw { KhatamBand(Modifier.fillMaxWidth().height(96.dp)) }
+        val strip = bitmap.width / 10
+
+        assertThat(bitmap.columns(left = 0, count = strip).ink()).isGreaterThan(0)
+        assertThat(bitmap.columns(left = bitmap.width - strip, count = strip).ink())
+            .isGreaterThan(0)
+    }
+
+    @Test
+    fun `the khatam band fades downwards into the background`() {
+        // `fade = 1 - y/height` is what lets the band sit under the page title without competing
+        // with it. Inverted or dropped, the motif reads as a solid gold bar across the top.
+        val bitmap = draw { KhatamBand(Modifier.fillMaxWidth().height(96.dp)) }
+        val slice = bitmap.height / 4
+
+        val top = bitmap.rows(top = 0, count = slice).brightness()
+        val bottom = bitmap.rows(top = bitmap.height - slice, count = slice).brightness()
+
+        assertThat(top).isGreaterThan(bottom)
+    }
+
+    @Test
+    fun `the illuminated field is a vertical gradient, not a flat fill`() {
+        // Three stops, top to bottom. A brush that collapsed to one colour is the difference
+        // between the depth the intro is designed around and a flat teal rectangle.
+        val bitmap = draw { Box(Modifier.fillMaxSize().background(illuminatedBackground)) }
+
+        val top = bitmap.rows(top = 0, count = 1).brightness()
+        val middle = bitmap.rows(top = bitmap.height / 2, count = 1).brightness()
+        val bottom = bitmap.rows(top = bitmap.height - 1, count = 1).brightness()
+
+        assertThat(top).isNotEqualTo(middle)
+        assertThat(middle).isNotEqualTo(bottom)
+    }
+}

--- a/feature/onboarding/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingGraphTest.kt
+++ b/feature/onboarding/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/onboarding/OnboardingGraphTest.kt
@@ -1,0 +1,64 @@
+package com.arshadshah.nimaz.presentation.screens.onboarding
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The onboarding feature's slice of the route graph — one destination, and the one the app cannot
+ * start without.
+ *
+ * `NavGraph` resolves its start destination from `onboardingCompleted` exactly once, so on a
+ * first run `Route.Onboarding` *is* the start destination. A destination that fails to register
+ * throws `IllegalArgumentException: navigation destination … is not a direct child of this
+ * NavGraph`, and nothing catches that at build time: here it would be thrown on the first frame
+ * of the first launch, before the user has seen anything at all.
+ *
+ * The graph is built without a `NavHost`, so nothing is composed and the screen needs no Hilt
+ * ViewModel. This asserts registration; `OnboardingScreenTest` asserts that the screen renders.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OnboardingGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.Onboarding) {
+            onboardingGraph(navController)
+        }.toList()
+
+    @Test
+    fun `the onboarding destination is registered`() {
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(1)
+        assertThat(routes.single()).contains(Route.Onboarding::class.qualifiedName)
+    }
+
+    @Test
+    fun `the graph can be built with onboarding as the start destination`() {
+        // The first-run case: `NavGraph` picks this start destination when `onboardingCompleted`
+        // is false, and `createGraph` throws here if the route it is given is not among the
+        // destinations the builder registered.
+        val graph = navController.createGraph(startDestination = Route.Onboarding) {
+            onboardingGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/onboarding/src/testDebug/resources/robolectric.properties
+++ b/feature/onboarding/src/testDebug/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application


### PR DESCRIPTION
Closes #605. Part of #604 — the eighth module locked.

## Before / after

| | Before | After | Floor |
|---|---|---|---|
| Line | 12.9% (97 / 754) | **94.3%** (711 / 754) | 0.80 |
| Branch | 12.3% | **90.3%** (139 / 154) | 0.80 |

`80/80`. No softened branch floor, and **`COVERAGE_EXCLUSIONS` is untouched**.

## The load-bearing decision: the art

`OnboardingArt.kt` is 226 lines of `Canvas` geometry, and #605 flagged it as possibly
uncoverable. That is not a free choice here — the module is 754 measurable lines, so leaving 226
at zero caps it at **70%** with everything else perfect. 80% is unreachable without it.

Composing the tree is not enough: `Canvas(modifier)` runs, and its `DrawScope` lambda — which is
the entire file — does not. `OnboardingArtTest` asks the `ComposeView` to draw itself into a
software `android.graphics.Canvas` under `@GraphicsMode(NATIVE)`. Compose's `RenderNodeLayer`
invokes the draw block directly rather than replaying a render node when the canvas it is handed
is not hardware-accelerated, so the geometry runs for real and the pixels can be read back and
asserted on.

`captureToImage()` is the route this deliberately does **not** take — it goes through `PixelCopy`
on a real window and hangs under Robolectric (#604).

## What the new tests pin, and the failure each catches

**`OnboardingScreenTest`** (`src/test`, 20 tests) — the screen with a mocked ViewModel.

The stakes here are unlike any other screen's: `NavGraph` reads `onboardingCompleted` **once**, to
choose a start destination, so a flow that fails to emit `CompleteOnboarding` does not cost the
user a screen — it puts them back in onboarding on every launch, for ever. The event and the
navigation are dispatched from two different buttons, on two different pages, each behind a page
comparison.

- Completion fires **once**, from the last page or Skip, and from nowhere earlier — the page
  comparison that decides whether `Next` is `Get Started` is the only thing keeping the walkthrough
  from ending on page one, or never ending.
- Skip is gone from the last page: two buttons that both complete is how a flow dispatches
  completion twice and navigates twice.
- Every page reached is reported to the funnel **in order** — the analytic whose KDoc records that
  it fired zero times in production while the pager drove itself locally. A skipped or duplicated
  step makes a drop-off graph unreadable.
- **Coarse location alone counts as granted.** The launcher callback ORs the two results; an AND
  would tell a user who picked "approximate" — the default on the modern dialog — that they had
  refused, and never detect a location. Delivered by playing the part of the system dialog through
  `onRequestPermissionsResult`.
- The notification card asks the system from Tiramisu and **grants itself below it**, where there
  is no `POST_NOTIFICATIONS` to request and a launcher would leave the card stuck at "not granted"
  on every older device.
- Granted permissions say so and stop offering `Grant`; a detected location is **named** rather
  than shown the generic label, which is the user's only evidence detection worked.
- Both pages keep working below 500dp of usable height, where the permission cards alone are
  taller than the screen.

**`OnboardingArtTest`** (`src/testDebug`, 7 tests) — pixels.

- Each of the four emblems paints **its own** artwork. They share one `Canvas` and are told apart
  by a `when`; an arm that fell through, or the shield's `return@Canvas` being dropped so it also
  draws the mihrab arch, compiles, previews fine and ships the wrong drawing on a first-run page.
- The mihrab is letterboxed rather than stretched, and centred — the `min(w/116, h/150)` scale and
  the halved offsets. Taking height as the limit squashes the arch on a portrait phone.
- The khatam band tiles the **measured** width and fades downwards; without the fade it reads as a
  solid gold bar competing with the page title.
- The illuminated field is a three-stop gradient, not a flat teal fill.

**`OnboardingGraphTest`** (`src/testDebug`) — `Route.Onboarding` registers and the graph builds
with it as the start destination. A destination that fails to register throws on the first frame of
the first launch, before the user has seen anything.

**`OnboardingViewModelTest`** (extended) — the first-run flag read back; a read that fails **ends
the loading state** and does not guess `true`, which would skip the first run outright; a
completion that cannot be persisted reported as a failure and **kept out of the funnel**, so the
first-run denominator cannot disagree with the step funnel above it; each permission result
updating only the field it answered for.

## What is left uncovered

The two `@Preview` functions in each file — private, so no test can call them — and the
`onComplete` lambda inside `onboardingGraph`, which only a composed `NavHost` reaches. Recorded in
the build file's KDoc and in `docs/TESTING.md`.

## The gate bites

Floor temporarily set to `0.99`:

```
* What went wrong:
Execution failed for task ':feature:onboarding:coverageFloor'.
> :feature:onboarding:coverageFloor: line coverage 94.3% is below the floor this module is
  locked at (99.0%), covering 711/754 (94.3%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to
  it is not meant to come back down.
```

Restored to `0.80` in the commit.

## Verification

| Command | Result |
|---|---|
| `./gradlew :feature:onboarding:testDebugUnitTest` | ✅ BUILD SUCCESSFUL (37 tests) |
| `./gradlew :feature:onboarding:check` | ✅ BUILD SUCCESSFUL in 2m 22s |
| `./gradlew :feature:onboarding:lintDebug` | ✅ BUILD SUCCESSFUL |
| `./gradlew coverageFloor` | ✅ BUILD SUCCESSFUL in 7m 5s — no locked module regressed |
| `python3 scripts/check_docs.py` | ✅ All 23 documentation checks passed |

`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` and **were not run** — they
cannot be, in this environment. No `androidTest` was added, so nothing here is waiting on an
emulator.

## Docs

`docs/TESTING.md`: snapshot-table row (moved to the locked block), the branch-floor paragraph
updated — `:feature:onboarding` is the second Compose module to hold 80/80, and at 90.3% branches
the highest of any Compose module here — and a new audit section listing what each test file pins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZKVudh4Qmw97Smh2cWpk6)_