### PR TITLE
test(feature:tools): clear 80% and lock the module

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,7 @@ Two on-device/JVM test surfaces exist:
   - [The Islamic calendar (`:feature:calendar/src/test`)](#the-islamic-calendar-featurecalendarsrctest)
   - [Every preference, read back (`:core:datastore/src/test`)](#every-preference-read-back-coredatastoresrctest)
   - [The first run, drawn and driven (`:feature:onboarding/src/test` and `src/testDebug`)](#the-first-run-drawn-and-driven-featureonboardingsrctest-and-srctestdebug)
+  - [The zakat calculator and its history (`:feature:tools/src/test` and `src/testDebug`)](#the-zakat-calculator-and-its-history-featuretoolssrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -257,10 +258,11 @@ floors in its own `build.gradle.kts`.
 
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common` and `:core:datastore` are locked at 80/80 — none of them draws
-anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar` and
-`:feature:onboarding`, which *are* Compose modules: the unreachable branch below is emitted **per
-parameter of every restartable composable**, so its weight scales with how many composables a
-module has, and six files — or eight — never accumulate enough of them to move the number.
+anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
+`:feature:onboarding` and `:feature:tools`, which *are* Compose modules: the unreachable branch
+below is emitted **per parameter of every restartable composable**, so its weight scales with how
+many composables a module has, and six files — or eight, or the two screens in `:feature:tools` —
+never accumulate enough of them to move the number.
 `:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here. Only `:feature:quran` is softened, to
 80% lines and **60%** branches, because the Compose compiler
 emits a `$dirty` bitmask branch per parameter of every restartable composable — the skippability
@@ -281,13 +283,13 @@ split, and should say so where it sets its floors.
 | `:feature:calendar` | 94.0% | 82.4% | **locked** at 80/80 |
 | `:core:datastore` | 96.1% | 84.3% | **locked** at 80/80 |
 | `:feature:onboarding` | 94.3% | 90.3% | **locked** at 80/80 (#605) |
+| `:feature:tools` | 97.5% | 83.6% | **locked** at 80/80 (#606) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:core:data` | 39.0% | 31.2% | |
 | `:feature:prayer` | 38.1% | 23.7% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
 | `:feature:content` | 28.8% | 19.5% | |
 | `:feature:search` | 18.8% | 13.9% | |
-| `:feature:tools` | 18.0% | 29.3% | |
 | `:feature:about` | 17.8% | 23.0% | |
 | `:feature:widget` | 16.8% | 28.1% | |
 | `:feature:settings` | 11.3% | 14.9% | |
@@ -571,6 +573,65 @@ on a real window and hangs under Robolectric.
 | A completion that cannot be persisted | same | reported as a failure, and **not** counted in the funnel — a completion the user will be shown again next launch makes the first-run denominator disagree with the step funnel above it |
 | Permission results | same | each updates only the field it answered for; granting location detects a location without waiting to be asked again |
 | The graph | `OnboardingGraphTest` | `Route.Onboarding` registers, and the graph builds with it as the start destination — the failure here is thrown on the first frame of the first launch |
+
+### The zakat calculator and its history (`:feature:tools/src/test` and `src/testDebug`)
+
+The ninth module locked: **18.0% lines to 97.5%**, from 181 covered lines to 981, and 29.3% to
+83.6% branches. Two screens were 727 of the 825 that were missing. The ViewModel was already the
+best-covered part, so nothing here was a matter of finding tests filed in the wrong module — the
+gap was that nothing had ever composed either screen.
+
+Zakat is the one feature in the app where a wrong number has a religious and financial consequence,
+and **the arithmetic was never the exposed part**. `ZakatCalculator` has had its own tests in
+`:core:domain` since it was written, and neither screen does a sum. What had no coverage at all was
+everything between the user and that calculation: which asset a typed figure is filed against,
+whether the symbol on the fields is the one beside the total, whether the threshold that decides
+"you owe this" from "you owe nothing" is even reported on the form, and whether a write that failed
+says so. The calculator is thirteen near-identical `InputCard` call sites; a copy-paste between any
+two of them takes input in the right box, files it against the wrong asset, and looks correct.
+
+Two component contracts shaped the tests rather than the other way round. `ZakatSummaryHero` puts
+`clearAndSetSemantics` over its plinth and over each stat tile, so that TalkBack reads "Zakat Due,
+$450.00, Above nisab" as one phrase instead of three fragments — which means the hero is
+addressable *only* by that content description, and the assertions here are on the accessibility
+contract itself. And the hero's collapse-on-scroll can only be exercised on a phone-height
+`@Config`: the rest of the class runs at `w411dp-h2200dp` so the `LazyColumn` composes every row,
+and on a viewport that tall the whole form fits and there is nothing to scroll.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| Every asset row | `ZakatCalculatorScreenTest` | each of the nine files its figure against **its own** asset — distinct values per row, so any two crossed shows |
+| Every liability row | same | the same for the four deducted rows, and that none of them lands on the asset side — the sign error that doubles someone's zakat |
+| Weight versus money | same | gold and silver take **grams**; the money rows lead with the currency symbol and the weight rows follow with `g`. The field these replaced chose between the two by comparing its suffix against `"$"`, so every non-dollar currency rendered a dollar sign |
+| The chosen currency | same | the symbol on the fields and the figure beside the total come from the same code, and no dollar total survives on a euro form |
+| The nisab basis | same | reported on the form before anything is typed, follows a basis change, and opens the settings screen rather than being editable mid-entry — a reader who cannot see the threshold cannot tell why the total says zero |
+| The verdict | same | above the nisab the hero says so and states the amount; below it, the *other* verdict is asserted absent — "Above nisab" over a zero reads as a calculation that failed rather than an answer |
+| The hero's tiles | same | the net wealth and the threshold it was measured against, without which the headline figure has to be taken on trust |
+| The collapsing hero | same | collapses on scroll, re-expands **only at a true top**, and never takes the amount with it. The asymmetry is the fix: the hero sits above the list and the list takes the height the hero leaves, so one symmetric threshold is a loop that presented as a hero which never collapsed |
+| The breakdown | same | shows the working, renders liabilities as a subtraction, keeps its header when collapsed, and is absent entirely over an empty form — the defect where clearing the last field left a zakat figure over a blank form |
+| A failed calculation | same | reported **inline**, with every typed figure still on the form, and its retry re-runs the sum rather than asking the user to retype anything |
+| The action bar | same | save and share are disabled until there is a calculation — an enabled share over a null one is what produces a card of zeroes — and enabled together once there is |
+| The top bar | same | reset goes through the ViewModel; history and settings **navigate**, keeping the destination decision out of the ViewModel |
+| The wide layout | same | assets and liabilities side by side with no accordion to open, the same action bar, the same basis row, and input still reaching the right event |
+| The three history states, in order | `ZakatHistoryScreenTest` | the error branch is checked **before** the empty one: a failed read also leaves the list empty, so the other order tells someone with years of records that they have none |
+| A saved calculation | same | renders its own stored figures and its own basis — recomputing would silently restate last year's zakat at today's gold price |
+| Paid versus unpaid | same | the badge tracks `isPaid`, "mark as paid" is **not** offered on something already paid, the paid date comes from `paidAt` rather than `calculatedAt`, and an entry with no recorded date does not invent one |
+| Which entry was acted on | same | mark-paid and delete carry the id of the row that was tapped, not of the first row |
+| The list's identity | same | one card per recorded calculation — a key collision collapses several years into one, and the only symptom is a history shorter than it should be |
+| Saving | `ZakatPersistenceTest` | writes the calculation **on screen** rather than recomputing at save time, which would re-read the metal prices and file a figure the user never saw; an empty form writes nothing |
+| A write that fails | same | reported on the screen the user is actually on — a save failure never touches the history state and never clears the form, a mark-paid or delete failure never touches the calculator |
+| Marking paid | same | stamps the time of payment, not the time of calculation — for zakat those can be a lunar year apart |
+| Reading the history back | same | the running total is the repository's paid total, not a client-side sum over the list, which would report the whole history as paid |
+| A history stream that fails first | same | **ends the spinner** and sets an error: `isLoading` used to be cleared only inside the collect, so a missing table left the screen spinning for the life of the ViewModel |
+| The form's lifecycle | same | the thirteen typed figures survive process death and recompute on restore; clearing reaches the saved state too; a reset keeps the persisted basis and prices, which decide whether anything is owed at all |
+| The graph | `ToolsGraphTest` | both zakat destinations register and either can be a start destination — the two navigate to each other, so a missing registration is a crash on a tap the user made deliberately |
+
+**Nothing is excluded, and the twenty-five uncovered lines are recorded in the module's build
+file**: the lambda bodies inside `toolsGraph` (reachable only from a composed `NavHost`, which
+would need Hilt ViewModels for both screens), each screen's `hiltViewModel()` default argument, and
+`ZakatViewModel.calculate`'s `catch` — arithmetic over `Double`s with no user-supplied divisor, so
+no input reaches it. `ZakatPersistenceTest` covers the identical handler shape on all four write
+paths, where failures do happen.
 
 ## Conventions
 

--- a/feature/tools/build.gradle.kts
+++ b/feature/tools/build.gradle.kts
@@ -21,6 +21,36 @@ android {
     }
 }
 
+/**
+ * Locked. See `COVERAGE_EXCLUSIONS` and `coverageFloor` in `build-logic` for what is measured and
+ * how the ratchet works.
+ *
+ * **80/80, at 97.5% lines and 83.6% branches** — the third Compose module in a row to hold the
+ * full branch floor, after `:feature:calendar` (82.4%) and `:feature:onboarding` (90.3%). The
+ * unreachable `$dirty` bitmask branch the Compose compiler emits is one per parameter of every
+ * restartable composable, so its weight scales with how many composables a module has rather than
+ * with how much Compose is in it: there are two screens here, and the ratio never becomes the
+ * number. `:feature:quran`, with ninety-odd files, is still the only module softened to 0.60.
+ *
+ * **Nothing is excluded.** Twenty-five lines are uncovered and they fall into three groups, none
+ * of which is worth a production change to reach:
+ *
+ *  - the eleven lambda bodies inside `toolsGraph` (`popBackStack`, three `navigate` calls), which
+ *    only a composed `NavHost` reaches — and composing one means giving both screens a Hilt
+ *    ViewModel. `ToolsGraphTest` covers the registrations, which is where the crash-on-tap lives;
+ *  - each screen's `viewModel: ZakatViewModel = hiltViewModel()` default argument, evaluated only
+ *    when the graph omits it;
+ *  - `ZakatViewModel.calculate`'s `catch`. `ZakatCalculator.calculate` is arithmetic over
+ *    `Double`s with no division by a user-supplied figure, so no input reaches it. The handler is
+ *    still right to exist — it is what keeps a future arithmetic fault an inline error beside the
+ *    form rather than a crash mid-calculation — and `ZakatPersistenceTest` covers the identical
+ *    shape on all four write paths, where failures do happen.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
 // The zakat calculator and its history — `screens/zakat`, `screens/tools` (the graph) and
 // `viewmodel/tools`.
 //
@@ -55,4 +85,16 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(testFixtures(project(":core:domain")))
     testImplementation(testFixtures(project(":core:common")))
+
+    // The two zakat screens and the graph are exercised under Robolectric, the same harness
+    // `:feature:calendar` and `:feature:onboarding` use — including
+    // `src/testDebug/resources/robolectric.properties`, which pins the SDK and the Application
+    // class. A properties file is a resource of its source set and does not travel with the
+    // tests that need it.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(testFixtures(project(":core:ui")))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreenTest.kt
+++ b/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/zakat/ZakatCalculatorScreenTest.kt
@@ -1,0 +1,782 @@
+package com.arshadshah.nimaz.presentation.screens.zakat
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.currencySymbolOf
+import com.arshadshah.nimaz.core.common.formatCurrency
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.ZakatAssets
+import com.arshadshah.nimaz.domain.model.ZakatCalculation
+import com.arshadshah.nimaz.domain.model.ZakatLiabilities
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatCalculatorUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The zakat calculator: thirteen inputs, one derived total, and a threshold that flips the answer
+ * between "you owe this" and "you owe nothing".
+ *
+ * **The arithmetic is not what is tested here** — `ZakatCalculator` has its own tests in
+ * `:core:domain`, and this screen never does a sum. What is tested is everything between the user
+ * and that calculation, none of which any ViewModel test can see:
+ *
+ *  - that a figure typed into a row reaches the event for *that* row (thirteen near-identical
+ *    `InputCard` call sites, where a copy-paste sends someone's gold into their bank balance and
+ *    nothing on screen looks wrong);
+ *  - that the symbol on the fields is the one beside the total, and that gold and silver are
+ *    weights rather than money — the field this replaced picked between the two by comparing its
+ *    suffix against the string `"$"`, so every non-dollar currency rendered a dollar sign;
+ *  - that the nisab basis is *reported* on the form, because a reader who cannot see the
+ *    threshold cannot tell why the total says zero;
+ *  - that a failed calculation is reported **inline**, with the form intact, rather than by
+ *    replacing a screen holding an afternoon of typed figures.
+ *
+ * The ViewModel is a relaxed mock over real `MutableStateFlow`s, per #604: the screen takes it as
+ * a parameter, so nothing here needs Hilt. The tall `@Config` is the LazyColumn — a phone-height
+ * viewport composes a screenful and the asset rows below the fold never exist.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class ZakatCalculatorScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(ZakatCalculatorUiState())
+    private val events = mutableListOf<ZakatEvent>()
+    private var backs = 0
+    private var historyOpens = 0
+    private var settingsOpens = 0
+
+    private val viewModel: ZakatViewModel = mockk(relaxed = true) {
+        every { calculatorState } returns this@ZakatCalculatorScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<ZakatEvent>() }
+    }
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun render() {
+        composeRule.setThemedContent {
+            ZakatCalculatorScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToHistory = { historyOpens++ },
+                onNavigateToSettings = { settingsOpens++ },
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    /** A finished calculation, above the gold nisab unless told otherwise. */
+    private fun calculation(
+        totalAssets: Double = 20_000.0,
+        totalLiabilities: Double = 2_000.0,
+        isAboveNisab: Boolean = true,
+        nisabType: NisabType = NisabType.GOLD,
+        nisabValue: Double = 5_686.2,
+    ) = ZakatCalculation(
+        calculatedAt = 1_700_000_000_000L,
+        totalAssets = totalAssets,
+        totalLiabilities = totalLiabilities,
+        netWorth = totalAssets - totalLiabilities,
+        nisabType = nisabType,
+        nisabValue = nisabValue,
+        isAboveNisab = isAboveNisab,
+        zakatDue = if (isAboveNisab) (totalAssets - totalLiabilities) * 0.025 else 0.0,
+    )
+
+    /** Every value dispatched by events of type [T], in order. */
+    private inline fun <reified T : ZakatEvent> amountsOf(select: (T) -> Double): List<Double> =
+        events.filterIsInstance<T>().map(select)
+
+    /**
+     * The plinth's spoken form — "Zakat Due, $450.00, Above nisab".
+     *
+     * `ZakatSummaryHero` puts `clearAndSetSemantics` over the whole plinth so that the eyebrow,
+     * the figure and the verdict are announced as one phrase instead of three, which means this
+     * description is both the accessibility contract and the only way a test can address it.
+     */
+    private fun plinth(amount: String, above: Boolean) = str(
+        R.string.zakat_a11y_plinth_status_format,
+        str(R.string.zakat_due),
+        amount,
+        str(if (above) R.string.zakat_status_above_nisab else R.string.zakat_status_below_nisab),
+    )
+
+    /** Opens the "Deducted" accordion, which starts closed — assets is the one that starts open. */
+    private fun openLiabilities() {
+        composeRule.onNodeWithText(str(R.string.zakat_section_deducted)).performClick()
+        composeRule.waitForIdle()
+    }
+
+    // ------------------------------------------------------------------
+    // The form reaches the right event
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `every asset row is on the form, labelled and hinted`() {
+        render()
+
+        // Nine rows, and the hint is what distinguishes two that otherwise read alike — "Gold"
+        // wants grams and "Investments" wants money, and only the hint says so.
+        composeRule.onNodeWithText(str(R.string.cash_on_hand)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.bank_balance)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.gold)).onFirst().assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.silver)).onFirst().assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.investments)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.business_inventory)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.receivables)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.rental_income)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.other_assets)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.hint_weight_in_grams)).assertExists()
+    }
+
+    @Test
+    fun `every liability row is under the deducted section`() {
+        render()
+
+        // Closed by default, so none of these exists until the header is tapped — which is the
+        // arrangement being asserted as much as the rows themselves.
+        composeRule.onAllNodesWithText(str(R.string.debts_owed)).assertCountEquals(0)
+
+        openLiabilities()
+
+        composeRule.onNodeWithText(str(R.string.debts_owed)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.loans)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.bills_due)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.other_liabilities)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `typing into the cash row updates cash and nothing else`() {
+        // The row-to-event mapping is thirteen near-identical call sites. Crossing two of them
+        // takes input in the right box and files it against the wrong asset — the total moves,
+        // the screen looks correct, and only the breakdown disagrees.
+        render()
+
+        fieldBeside(str(R.string.cash_on_hand)).performTextInput("1200")
+        composeRule.waitForIdle()
+
+        val updates = events.filterIsInstance<ZakatEvent.UpdateCash>()
+        assertThat(updates.map { it.amount }).contains(1200.0)
+        assertThat(events.none { it is ZakatEvent.UpdateBankBalance }).isTrue()
+    }
+
+    @Test
+    fun `every asset row files its figure against its own asset`() {
+        // Nine `InputCard` call sites that differ only in which event they construct. A
+        // copy-paste between any two takes input in the right box and files it against the wrong
+        // asset: the row accepts the figure, the screen looks correct, and the total is wrong by
+        // however far the two rows differ. Distinct values per row make any crossing visible.
+        render()
+
+        fieldBeside(str(R.string.cash_on_hand)).performTextInput("11")
+        fieldBeside(str(R.string.bank_balance)).performTextInput("22")
+        fieldBeside(str(R.string.gold)).performTextInput("33")
+        fieldBeside(str(R.string.silver)).performTextInput("44")
+        fieldBeside(str(R.string.investments)).performTextInput("55")
+        fieldBeside(str(R.string.business_inventory)).performTextInput("66")
+        fieldBeside(str(R.string.receivables)).performTextInput("77")
+        fieldBeside(str(R.string.rental_income)).performTextInput("88")
+        fieldBeside(str(R.string.other_assets)).performTextInput("99")
+        composeRule.waitForIdle()
+
+        assertThat(amountsOf<ZakatEvent.UpdateCash> { it.amount }).contains(11.0)
+        assertThat(amountsOf<ZakatEvent.UpdateBankBalance> { it.amount }).contains(22.0)
+        assertThat(amountsOf<ZakatEvent.UpdateGold> { it.grams }).contains(33.0)
+        assertThat(amountsOf<ZakatEvent.UpdateSilver> { it.grams }).contains(44.0)
+        assertThat(amountsOf<ZakatEvent.UpdateInvestments> { it.amount }).contains(55.0)
+        assertThat(amountsOf<ZakatEvent.UpdateBusinessInventory> { it.amount }).contains(66.0)
+        assertThat(amountsOf<ZakatEvent.UpdateReceivables> { it.amount }).contains(77.0)
+        assertThat(amountsOf<ZakatEvent.UpdateRentalIncome> { it.amount }).contains(88.0)
+        assertThat(amountsOf<ZakatEvent.UpdateOtherAssets> { it.amount }).contains(99.0)
+    }
+
+    @Test
+    fun `every liability row files its figure against its own liability`() {
+        render()
+        openLiabilities()
+
+        fieldBeside(str(R.string.debts_owed)).performTextInput("11")
+        fieldBeside(str(R.string.loans)).performTextInput("22")
+        fieldBeside(str(R.string.bills_due)).performTextInput("33")
+        fieldBeside(str(R.string.other_liabilities)).performTextInput("44")
+        composeRule.waitForIdle()
+
+        assertThat(amountsOf<ZakatEvent.UpdateDebts> { it.amount }).contains(11.0)
+        assertThat(amountsOf<ZakatEvent.UpdateLoans> { it.amount }).contains(22.0)
+        assertThat(amountsOf<ZakatEvent.UpdateBillsDue> { it.amount }).contains(33.0)
+        assertThat(amountsOf<ZakatEvent.UpdateOtherLiabilities> { it.amount }).contains(44.0)
+        // And none of them landed on the asset side, which would add the debt to the wealth
+        // being taxed instead of subtracting it — the sign error that doubles someone's zakat.
+        assertThat(events.none { it is ZakatEvent.UpdateCash }).isTrue()
+    }
+
+    @Test
+    fun `silver is entered as grams too`() {
+        // The other weight row. The silver nisab works out roughly an order of magnitude below
+        // the gold one, so it is the basis that applies to more people — a silver row that took
+        // a currency amount would be wrong for the majority of the users who choose it.
+        render()
+
+        fieldBeside(str(R.string.silver)).performTextInput("612.36")
+        composeRule.waitForIdle()
+
+        assertThat(amountsOf<ZakatEvent.UpdateSilver> { it.grams }).contains(612.36)
+    }
+
+    @Test
+    fun `gold is entered as grams, not as money`() {
+        // Gold and silver are the two rows the calculator stores as *weight*. If they took a
+        // currency amount the valuation would be out by the whole gold price — and the nisab
+        // threshold is derived from that same price, so it changes whether zakat is owed at all.
+        render()
+
+        fieldBeside(str(R.string.gold)).performTextInput("87.48")
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<ZakatEvent.UpdateGold>().map { it.grams })
+            .contains(87.48)
+    }
+
+    @Test
+    fun `a liability typed into the deducted section becomes a liability event`() {
+        render()
+        openLiabilities()
+
+        fieldBeside(str(R.string.debts_owed)).performTextInput("500")
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<ZakatEvent.UpdateDebts>().map { it.amount })
+            .contains(500.0)
+        // An asset event from a liability row would add the debt to the wealth being taxed
+        // rather than subtracting it — the sign error that doubles someone's zakat.
+        assertThat(events.none { it is ZakatEvent.UpdateCash }).isTrue()
+    }
+
+    // ------------------------------------------------------------------
+    // The currency the user chose
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the fields and the total agree on the currency`() {
+        // `currencySymbolOf` is tested in `:core:common`. What is untested — and what actually
+        // shipped wrong — is the screen using it for *both*: the money fields lead with the
+        // symbol and the hero renders the same currency, so a euro form must not carry dollar
+        // prefixes over a euro total.
+        state.value = ZakatCalculatorUiState(
+            currency = "EUR",
+            assets = ZakatAssets(cashOnHand = 20_000.0),
+            calculation = calculation().copy(currency = "EUR"),
+        )
+        render()
+
+        composeRule.onAllNodesWithText(currencySymbolOf("EUR")).onFirst().assertExists()
+        composeRule.onAllNodesWithText(formatCurrency(450.0, "EUR")).onFirst().assertExists()
+        // And no dollar total anywhere: the bug this replaces formatted every zakat figure with
+        // `$` whatever the user had chosen.
+        composeRule.onAllNodesWithText(formatCurrency(450.0, "USD")).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a weight row carries its unit instead of a currency symbol`() {
+        state.value = ZakatCalculatorUiState(currency = "EUR")
+        render()
+
+        // "$ 1,200" and "1,200 g" are how each is read. The field these replaced chose between
+        // them by comparing its suffix against `"$"`.
+        composeRule.onAllNodesWithText(str(R.string.zakat_unit_grams)).onFirst().assertExists()
+    }
+
+    // ------------------------------------------------------------------
+    // The nisab threshold
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the basis is reported on the form before anything is typed`() {
+        // `nisabValue` is derived on the state even with an empty form, precisely so this row can
+        // say what the threshold is. Someone who cannot see it cannot tell why their total is 0.
+        state.value = ZakatCalculatorUiState(nisabType = NisabType.GOLD, currency = "USD")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_section_nisab)).assertIsDisplayed()
+        val expected = str(
+            R.string.settings_value_with_qualifier,
+            str(R.string.gold),
+            formatCurrency(state.value.nisabValue, "USD"),
+        )
+        composeRule.onNodeWithText(expected).assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching the basis to silver changes the threshold the form reports`() {
+        // The silver nisab works out roughly an order of magnitude lower than the gold one, so it
+        // applies to far more people. A basis change that did not reach this row would leave the
+        // screen quoting a threshold the calculation is not using.
+        state.value = ZakatCalculatorUiState(nisabType = NisabType.GOLD)
+        render()
+        val goldThreshold = state.value.nisabValue
+
+        state.value = ZakatCalculatorUiState(nisabType = NisabType.SILVER)
+        composeRule.waitForIdle()
+
+        val silverThreshold = state.value.nisabValue
+        assertThat(silverThreshold).isNotEqualTo(goldThreshold)
+        composeRule.onNodeWithText(
+            str(
+                R.string.settings_value_with_qualifier,
+                str(R.string.silver),
+                formatCurrency(silverThreshold, "USD"),
+            )
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the basis row opens the settings screen rather than editing in place`() {
+        // Deliberate: the basis and the metal prices are persisted preferences, not figures typed
+        // per calculation, and they used to be an accordion in the middle of thirteen inputs.
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_section_nisab)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(settingsOpens).isEqualTo(1)
+    }
+
+    // ------------------------------------------------------------------
+    // The result the user is reading
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `above the nisab the hero states the amount owed and says so`() {
+        state.value = ZakatCalculatorUiState(calculation = calculation(isAboveNisab = true))
+        render()
+
+        // The plinth is read as one phrase — `ZakatSummaryHero` puts `clearAndSetSemantics` over
+        // it so TalkBack says "Zakat Due, $450.00, Above nisab" rather than three loose fragments,
+        // which is also the only handle a test has on it.
+        composeRule.onNodeWithContentDescription(plinth(formatCurrency(450.0, "USD"), above = true))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the hero's tiles carry the net wealth and the threshold it was measured against`() {
+        // The three figures that make the headline checkable: without the net wealth and the
+        // threshold beside it, "$450.00" is a number the user has to take on trust.
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        composeRule.onNodeWithContentDescription(
+            str(R.string.zakat_a11y_stat_format, str(R.string.zakat_stat_net), formatCurrency(18_000.0, "USD"))
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            str(
+                R.string.zakat_a11y_stat_format,
+                str(R.string.zakat_stat_nisab_format, str(R.string.gold)),
+                formatCurrency(5_686.2, "USD"),
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `below the nisab the hero says why the figure is zero`() {
+        // The one place the screen has to explain itself. "2.5% of eligible wealth" over a $0.00
+        // reads as a broken calculation; "no zakat is due below the nisab threshold" is the
+        // answer, and it is a different string on a different branch.
+        state.value = ZakatCalculatorUiState(
+            calculation = calculation(totalAssets = 100.0, isAboveNisab = false)
+        )
+        render()
+
+        composeRule.onNodeWithContentDescription(plinth(formatCurrency(0.0, "USD"), above = false))
+            .assertIsDisplayed()
+        // And emphatically not the other verdict: a hero that said "Above nisab" over a zero
+        // would read as a calculation that had failed rather than as an answer.
+        composeRule.onAllNodesWithContentDescription(
+            plinth(formatCurrency(0.0, "USD"), above = true)
+        ).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the breakdown shows the working the total came from`() {
+        state.value = ZakatCalculatorUiState(
+            calculation = calculation(),
+            showBreakdown = true,
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.total_assets)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.total_liabilities)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.net_zakatable_wealth)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.nisab_threshold)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.meets_nisab)).assertIsDisplayed()
+        // Liabilities are rendered as a subtraction. A bare figure in a column of additions
+        // reads as wealth rather than as something taken off it.
+        composeRule.onNodeWithText("- ${formatCurrency(2_000.0, "USD")}").assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.yes)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a collapsed breakdown keeps its header and drops its rows`() {
+        // `showBreakdown` is ViewModel state rather than local `remember`, so that the choice
+        // survives rotation. The header has to stay: a section that vanishes entirely is not
+        // collapsed, it is missing.
+        state.value = ZakatCalculatorUiState(calculation = calculation(), showBreakdown = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.calculation_breakdown)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.total_assets)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `tapping the breakdown header asks the ViewModel to toggle it`() {
+        state.value = ZakatCalculatorUiState(calculation = calculation(), showBreakdown = true)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.calculation_breakdown)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(ZakatEvent.ToggleBreakdown)
+    }
+
+    @Test
+    fun `an empty form shows no breakdown at all`() {
+        // The defect this pins: clearing the last field used to leave the previous calculation on
+        // screen, so the user read a zakat figure over a blank form — and the redesign pins that
+        // total to a sticky hero, which would have made it permanent.
+        state.value = ZakatCalculatorUiState(calculation = null)
+        render()
+
+        composeRule.onAllNodesWithText(str(R.string.calculation_breakdown)).assertCountEquals(0)
+    }
+
+    // ------------------------------------------------------------------
+    // Failure, reported without losing the form
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `a failed calculation is reported inline with every figure still on the form`() {
+        state.value = ZakatCalculatorUiState(
+            assets = ZakatAssets(cashOnHand = 20_000.0),
+            liabilities = ZakatLiabilities(debts = 2_000.0),
+            error = UiError(message = R.string.zakat_calculate_failed, details = "overflow"),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_calculate_failed)).assertIsDisplayed()
+        // The form is still a form. An error state that replaced the screen would take an
+        // afternoon of asset entry with it, and no button brings that back.
+        composeRule.onNodeWithText(str(R.string.cash_on_hand)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.zakat_section_nisab)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `try again re-runs the sum over what is already typed`() {
+        state.value = ZakatCalculatorUiState(
+            assets = ZakatAssets(cashOnHand = 20_000.0),
+            error = UiError(message = R.string.zakat_calculate_failed),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.try_again)).performClick()
+        composeRule.waitForIdle()
+
+        // Recalculate, not a clear: the retry must not ask the user to retype anything.
+        assertThat(events).contains(ZakatEvent.Recalculate)
+    }
+
+    // ------------------------------------------------------------------
+    // The action bar
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `save and share are disabled until there is something to act on`() {
+        // Saving a calculation that does not exist writes an empty row; sharing one shares a card
+        // of zeroes. Both are worse than a button that does nothing.
+        state.value = ZakatCalculatorUiState(calculation = null)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_save_this_year)).assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription(str(R.string.zakat_share)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `saving a finished calculation asks the ViewModel to write it`() {
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_save_this_year)).assertIsEnabled()
+        composeRule.onNodeWithText(str(R.string.zakat_save_this_year)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(ZakatEvent.SaveCalculation)
+    }
+
+    @Test
+    fun `share is offered once there is a calculation and does not go through the ViewModel`() {
+        // Sharing is a composition-scoped action, not an event: the card is rendered from state
+        // the screen already holds. What matters is that it becomes available in step with save —
+        // an enabled share over a null calculation is what produces a card of zeroes.
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.zakat_share)).assertIsEnabled()
+        composeRule.onNodeWithContentDescription(str(R.string.zakat_share)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events.none { it is ZakatEvent.SaveCalculation }).isTrue()
+    }
+
+    // ------------------------------------------------------------------
+    // The top bar
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the top bar offers reset, history and settings`() {
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_reset)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(str(R.string.cd_history)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(str(R.string.zakat_settings)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `reset clears the form through the ViewModel`() {
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_reset)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(ZakatEvent.ClearAll)
+    }
+
+    @Test
+    fun `history and settings navigate rather than emitting events`() {
+        // Both are navigation, and routing either through `onEvent` would put a destination
+        // decision inside the ViewModel — the coupling `NavControllerConfinementTest` exists for.
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_history)).performClick()
+        composeRule.onNodeWithContentDescription(str(R.string.zakat_settings)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(historyOpens).isEqualTo(1)
+        assertThat(settingsOpens).isEqualTo(1)
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `back leaves the calculator`() {
+        render()
+
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_back)).onFirst()
+            .performClick()
+        composeRule.waitForIdle()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    // ------------------------------------------------------------------
+    // Subtotals
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the assets header values gold and silver rather than counting their grams`() {
+        // `assets.total` counts only the cash-like rows — gold and silver are stored as *grams*.
+        // Without the two multiplications the header reports a figure that disagrees with the
+        // breakdown by the whole value of someone's jewellery.
+        state.value = ZakatCalculatorUiState(
+            assets = ZakatAssets(cashOnHand = 1_000.0, goldGrams = 10.0, silverGrams = 100.0),
+            goldPricePerGram = 65.0,
+            silverPricePerGram = 0.80,
+        )
+        render()
+
+        // 1,000 + (10 × 65) + (100 × 0.80) = 1,730 — not the 1,110 a grams-as-money sum gives.
+        composeRule.onAllNodesWithText(formatCurrency(1_730.0, "USD")).onFirst().assertExists()
+        composeRule.onAllNodesWithText(formatCurrency(1_110.0, "USD")).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the deducted header carries the liabilities subtotal`() {
+        state.value = ZakatCalculatorUiState(
+            liabilities = ZakatLiabilities(debts = 300.0, loans = 200.0, billsDue = 100.0),
+        )
+        render()
+
+        composeRule.onAllNodesWithText(formatCurrency(600.0, "USD")).onFirst().assertExists()
+    }
+
+    // ------------------------------------------------------------------
+    // The hero above a scrolling form
+    // ------------------------------------------------------------------
+
+    @Test
+    // A phone-height viewport, unlike the rest of this class: the collapse is driven by the
+    // list's scroll offset, and on a 2,200dp screen the whole form fits, so there is nothing to
+    // scroll and the trigger never fires.
+    @Config(qualifiers = "w411dp-h891dp")
+    fun `scrolling the form collapses the hero and returning to the top restores it`() {
+        // The asymmetry is the fix, not a nicety. The hero sits above the list and the list takes
+        // the height the hero leaves, so the trigger reads a scroll position its own outcome
+        // changes. With one symmetric threshold that is a loop — collapse frees height, the list
+        // clamps its offset back under the threshold, the hero expands, the offset goes back over
+        // it — which presented as a hero that simply never collapsed. Re-expanding only at a true
+        // top breaks it, because clamping can lower an offset but never raise it.
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        // Expanded: the three tiles are the part that folds away.
+        composeRule.onNodeWithContentDescription(netTile()).assertExists()
+
+        composeRule.onNode(hasScrollAction()).performScrollToIndex(3)
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithContentDescription(netTile()).assertCountEquals(0)
+        // The amount itself never goes: on this screen it is the one figure the whole task is
+        // about, and losing sight of it mid-entry is what a hero that scrolled away got wrong.
+        composeRule.onNodeWithContentDescription(plinth(formatCurrency(450.0, "USD"), above = true))
+            .assertExists()
+
+        composeRule.onNode(hasScrollAction()).performScrollToIndex(0)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(netTile()).assertExists()
+    }
+
+    /** The "Net" tile's spoken form — present only while the hero is expanded. */
+    private fun netTile() = str(
+        R.string.zakat_a11y_stat_format,
+        str(R.string.zakat_stat_net),
+        formatCurrency(18_000.0, "USD"),
+    )
+
+    // ------------------------------------------------------------------
+    // The wide layout
+    // ------------------------------------------------------------------
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the tablet layout puts assets and liabilities side by side, both open`() {
+        // The wide layout has no accordions: both columns are `NimazSectionHeader` + rows, so
+        // every liability row exists without anything being tapped. That is the difference the
+        // size class makes, and it is the arm no compact test reaches.
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        composeRule.onNodeWithText(str(R.string.assets)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.liabilities)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.cash_on_hand)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.debts_owed)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the tablet layout keeps the same action bar`() {
+        // One place to look for save and share whatever the size class. A wide layout that
+        // dropped them would leave a finished calculation with no way to keep it.
+        state.value = ZakatCalculatorUiState(calculation = calculation())
+        render()
+
+        // The wide layout scrolls as one column, so the bar sits below the fold on a form this
+        // long — reaching it is part of what is being asserted.
+        composeRule.onNodeWithText(str(R.string.zakat_save_this_year)).performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(ZakatEvent.SaveCalculation)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the tablet layout reports the nisab basis and opens settings from it`() {
+        state.value = ZakatCalculatorUiState(nisabType = NisabType.SILVER)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_section_nisab)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.zakat_section_nisab)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(settingsOpens).isEqualTo(1)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the tablet layout still draws the breakdown and takes input`() {
+        state.value = ZakatCalculatorUiState(calculation = calculation(), showBreakdown = true)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.net_zakatable_wealth)).performScrollTo()
+            .assertIsDisplayed()
+
+        fieldBeside(str(R.string.cash_on_hand)).performTextInput("750")
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<ZakatEvent.UpdateCash>().map { it.amount })
+            .contains(750.0)
+    }
+
+    /**
+     * The amount field belonging to the row carrying [label].
+     *
+     * Rows are `NimazIconWell` + label/hint + `NimazAmountField`, and the fields carry no text of
+     * their own until something is typed — so they are addressed positionally, by index among all
+     * editable nodes, in the order the rows are declared.
+     */
+    private fun fieldBeside(label: String) = composeRule.onAllNodes(
+        hasSetTextAction(),
+        useUnmergedTree = true,
+    )[fieldIndex(label)]
+
+    private fun fieldIndex(label: String): Int = when (label) {
+        str(R.string.cash_on_hand) -> 0
+        str(R.string.bank_balance) -> 1
+        str(R.string.gold) -> 2
+        str(R.string.silver) -> 3
+        str(R.string.investments) -> 4
+        str(R.string.business_inventory) -> 5
+        str(R.string.receivables) -> 6
+        str(R.string.rental_income) -> 7
+        str(R.string.other_assets) -> 8
+        // The liability rows compose after the asset ones in both layouts.
+        str(R.string.debts_owed) -> 9
+        str(R.string.loans) -> 10
+        str(R.string.bills_due) -> 11
+        str(R.string.other_liabilities) -> 12
+        else -> error("no input row labelled $label")
+    }
+}

--- a/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreenTest.kt
+++ b/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/zakat/ZakatHistoryScreenTest.kt
@@ -1,0 +1,373 @@
+package com.arshadshah.nimaz.presentation.screens.zakat
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatCurrency
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatHistoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tools.ZakatViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The zakat history: the record of what was worked out, and what has actually been paid.
+ *
+ * Three states share one screen and their order is the whole design. A failed read leaves the list
+ * empty too, so if the empty branch were checked first the app would tell someone with years of
+ * records that they have none — the worst available answer, because it reads as data loss rather
+ * than as a load that failed. The error branch is deliberately first, and that ordering is a
+ * rendering fact no ViewModel test can see.
+ *
+ * The rest is the per-entry card: a paid badge that must track `isPaid` rather than the presence
+ * of a payment date, and a "mark as paid" action that must not be offered on something already
+ * paid — an obligation discharged twice is a real loss to whoever discharged it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class ZakatHistoryScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(ZakatHistoryUiState(isLoading = false))
+    private val events = mutableListOf<ZakatEvent>()
+    private var backs = 0
+    private var calculatorOpens = 0
+
+    private val viewModel: ZakatViewModel = mockk(relaxed = true) {
+        every { historyState } returns this@ZakatHistoryScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<ZakatEvent>() }
+    }
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun render() {
+        composeRule.setThemedContent {
+            ZakatHistoryScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToCalculator = { calculatorOpens++ },
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    /** 20 March 2026, in the device's default zone — the date the cards render. */
+    private val marchTwentieth = 1_774_000_000_000L
+
+    private fun entry(
+        id: Long = 1L,
+        zakatDue: Double = 450.0,
+        netWorth: Double = 18_000.0,
+        nisabType: NisabType = NisabType.GOLD,
+        nisabValue: Double = 5_686.2,
+        isPaid: Boolean = false,
+        paidAt: Long? = null,
+    ) = ZakatHistoryEntry(
+        id = id,
+        calculatedAt = marchTwentieth,
+        totalAssets = 20_000.0,
+        totalLiabilities = 2_000.0,
+        netWorth = netWorth,
+        zakatDue = zakatDue,
+        nisabType = nisabType,
+        nisabValue = nisabValue,
+        isPaid = isPaid,
+        paidAt = paidAt,
+    )
+
+    // ------------------------------------------------------------------
+    // The three states, in the order that matters
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `with nothing recorded the screen invites a first calculation`() {
+        state.value = ZakatHistoryUiState(isLoading = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.no_zakat_history)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.zakat_history_empty_message)).assertIsDisplayed()
+        // The empty state carries the way out. Without it the screen is a dead end reached from a
+        // top-bar icon, with only Back to leave by.
+        composeRule.onNodeWithText(str(R.string.zakat_calculate)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the empty state's action opens the calculator`() {
+        state.value = ZakatHistoryUiState(isLoading = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_calculate)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(calculatorOpens).isEqualTo(1)
+    }
+
+    @Test
+    fun `while loading it says neither empty nor broken`() {
+        // `isLoading` starts true, and the empty branch is guarded on it. Dropping that guard puts
+        // "No Zakat History" on screen for the length of every read, so a slow disk looks exactly
+        // like a wiped history.
+        state.value = ZakatHistoryUiState(isLoading = true)
+        render()
+
+        composeRule.onAllNodesWithText(str(R.string.no_zakat_history)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a failed read is reported as a failure, not as an empty history`() {
+        // The ordering this pins: a read that threw also leaves `history` empty, so an empty
+        // check placed first would tell someone with years of records that they have none.
+        state.value = ZakatHistoryUiState(
+            isLoading = false,
+            error = UiError(message = R.string.zakat_history_load_failed, details = "no table"),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_history_load_failed)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.no_zakat_history)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the error offers a retry that re-reads the history`() {
+        state.value = ZakatHistoryUiState(
+            isLoading = false,
+            error = UiError(message = R.string.zakat_history_load_failed),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.try_again)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(ZakatEvent.LoadHistory)
+    }
+
+    // ------------------------------------------------------------------
+    // A saved calculation, rendered
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `a saved calculation renders its own figures`() {
+        // Every figure on this card comes off the entry rather than being recomputed, so a record
+        // filed under one set of metal prices still reads back as what it was — recomputing would
+        // silently restate last year's zakat at today's gold price.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(zakatDue = 450.0, netWorth = 18_000.0)),
+            totalZakatPaid = 0.0,
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onAllNodesWithText(formatCurrency(450.0)).onFirst().assertExists()
+        composeRule.onNodeWithText(formatCurrency(18_000.0)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.net_worth)).assertIsDisplayed()
+        composeRule.onNodeWithText(
+            str(R.string.nisab_label_format, "Gold", formatCurrency(5_686.2))
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the running total counts what was paid, not what was calculated`() {
+        // `totalZakatPaid` is read from the repository per emission — only paid entries count
+        // towards it. A client-side sum over the list would report the whole history as paid.
+        state.value = ZakatHistoryUiState(
+            history = listOf(
+                entry(id = 1L, zakatDue = 450.0, isPaid = true, paidAt = marchTwentieth),
+                entry(id = 2L, zakatDue = 300.0),
+            ),
+            totalZakatPaid = 450.0,
+            isLoading = false,
+        )
+        render()
+
+        // The plinth is announced as one phrase — `ZakatSummaryHero` clears its children's
+        // semantics so TalkBack reads "Total Zakat Paid, $450.00" rather than two fragments,
+        // which is also the only handle a test has on it.
+        composeRule.onNodeWithContentDescription(
+            str(
+                R.string.zakat_a11y_stat_format,
+                str(R.string.zakat_history_total_paid),
+                formatCurrency(450.0),
+            )
+        ).assertIsDisplayed()
+        // 450 paid, not the 750 the two rows add up to.
+        composeRule.onAllNodesWithContentDescription(
+            str(
+                R.string.zakat_a11y_stat_format,
+                str(R.string.zakat_history_total_paid),
+                formatCurrency(750.0),
+            )
+        ).assertCountEquals(0)
+    }
+
+    @Test
+    fun `every recorded calculation gets its own row under the heading`() {
+        // The list is keyed by entry id. A key collision — or a `key` taken from anything the
+        // rows share — silently collapses several years of records into one card, and the only
+        // symptom is a history shorter than it should be.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(id = 1L), entry(id = 2L), entry(id = 3L)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_history_calculation_history))
+            .assertIsDisplayed()
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_delete)).assertCountEquals(3)
+    }
+
+    @Test
+    fun `an entry filed against the silver basis says silver`() {
+        // The basis is stored per entry, so a history spanning a change of madhhab has to report
+        // each year against the basis it was actually calculated on — restating an old record
+        // under today's basis would misstate what was owed then.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(nisabType = NisabType.SILVER, nisabValue = 489.9)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onNodeWithText(
+            str(R.string.nisab_label_format, "Silver", formatCurrency(489.9))
+        ).assertIsDisplayed()
+    }
+
+    // ------------------------------------------------------------------
+    // Paid, unpaid, and the action between them
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `an unpaid entry is badged unpaid and offers to be marked paid`() {
+        state.value = ZakatHistoryUiState(history = listOf(entry(isPaid = false)), isLoading = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_unpaid)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.zakat_mark_as_paid)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a paid entry is badged paid and cannot be paid again`() {
+        // The action is behind `if (!entry.isPaid)`. Leaving it up on a paid row invites someone
+        // to discharge the same obligation twice, and the app would record it as though they had.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(isPaid = true, paidAt = marchTwentieth)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_paid)).assertIsDisplayed()
+        composeRule.onAllNodesWithText(str(R.string.zakat_mark_as_paid)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a paid entry shows when it was paid`() {
+        // Rendered from `paidAt`, which is separate from `calculatedAt`: zakat is owed on a lunar
+        // year, so the two can be a year apart and labelling the payment with the calculation
+        // date would misreport which year's obligation was discharged.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(isPaid = true, paidAt = marchTwentieth)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onAllNodesWithText(str(R.string.zakat_paid_on_format, ""), substring = true)
+            .onFirst().assertExists()
+    }
+
+    @Test
+    fun `a paid entry with no recorded date does not invent one`() {
+        // `paidAt` is nullable and the line is inside a `?.let`. An entry migrated from a build
+        // that did not record the date must show no date rather than "Paid on: 1 Jan 1970".
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(isPaid = true, paidAt = null)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.zakat_paid)).assertIsDisplayed()
+        composeRule.onAllNodesWithText("1970", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun `marking an entry paid names that entry`() {
+        // The id travels with the event. A card that emitted the wrong one marks a different
+        // year's zakat as paid, and the entry the user tapped stays outstanding.
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(id = 11L), entry(id = 22L)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onAllNodesWithText(str(R.string.zakat_mark_as_paid))[1].performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).containsExactly(ZakatEvent.MarkAsPaid(22L))
+    }
+
+    @Test
+    fun `deleting an entry names that entry`() {
+        state.value = ZakatHistoryUiState(
+            history = listOf(entry(id = 11L), entry(id = 22L)),
+            isLoading = false,
+        )
+        render()
+
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_delete))[0].performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).containsExactly(ZakatEvent.DeleteCalculation(11L))
+    }
+
+    // ------------------------------------------------------------------
+    // Getting in and out
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the FAB opens the calculator`() {
+        state.value = ZakatHistoryUiState(history = listOf(entry()), isLoading = false)
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_new_calculation)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(calculatorOpens).isEqualTo(1)
+        // Navigation, not an event — the destination decision stays out of the ViewModel.
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `back leaves the history`() {
+        render()
+
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_back)).onFirst().performClick()
+        composeRule.waitForIdle()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatPersistenceTest.kt
+++ b/feature/tools/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tools/ZakatPersistenceTest.kt
@@ -1,0 +1,456 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tools
+
+import androidx.lifecycle.SavedStateHandle
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.ZakatHistoryEntry
+import com.arshadshah.nimaz.domain.repository.FakeZakatSettings
+import com.arshadshah.nimaz.domain.usecase.ZakatUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What happens to a zakat figure **after** it has been worked out: saving it, marking it paid,
+ * deleting it, and what the user is told when any of those does not land.
+ *
+ * `ZakatViewModelTest` covers the arithmetic reaching state. This covers the write paths, which
+ * had no test at all and are where the consequences are least recoverable — a save that silently
+ * did nothing loses a calculation the user spent an afternoon assembling, and a "mark as paid"
+ * that fails without saying so leaves someone believing an obligation is discharged when the app
+ * still has it outstanding.
+ *
+ * Every write goes through `launchSafely` with an `onFailure`, and the two `onFailure`s are
+ * deliberately **different**: a calculator-side failure must not clear the form, and a
+ * history-side failure must not touch the calculator at all. Both halves are asserted below,
+ * because the wrong one is a single-word mistake at the call site that nothing else catches.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ZakatPersistenceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private val settings = FakeZakatSettings()
+    private lateinit var useCases: ZakatUseCases
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        every { useCases.getAllHistory() } returns flowOf(emptyList())
+        coEvery { useCases.getTotalPaid() } returns 0.0
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(saved: SavedStateHandle = SavedStateHandle()) =
+        ZakatViewModel(useCases, settings, telemetry, saved)
+
+    private fun entry(
+        id: Long,
+        zakatDue: Double = 250.0,
+        isPaid: Boolean = false,
+    ) = ZakatHistoryEntry(
+        id = id,
+        calculatedAt = 1_700_000_000_000L,
+        totalAssets = 10_000.0,
+        totalLiabilities = 0.0,
+        netWorth = 10_000.0,
+        zakatDue = zakatDue,
+        nisabType = NisabType.GOLD,
+        nisabValue = 5_686.2,
+        isPaid = isPaid,
+    )
+
+    // ------------------------------------------------------------------
+    // Saving
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `saving writes the calculation the user is looking at, not a recomputed one`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        advanceUntilIdle()
+        val onScreen = vm.calculatorState.value.calculation!!
+
+        vm.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        // The history row has to carry the same six figures the hero and the breakdown showed.
+        // `saveCalculation` builds the entry from `state.calculation` rather than calling
+        // `ZakatCalculator` again; recomputing at save time would re-read the metal prices, so a
+        // settings write that landed between reading the total and pressing Save would file a
+        // figure the user never saw.
+        coVerify {
+            useCases.insertCalculation(
+                match {
+                    it.totalAssets == onScreen.totalAssets &&
+                            it.totalLiabilities == onScreen.totalLiabilities &&
+                            it.netWorth == onScreen.netWorth &&
+                            it.zakatDue == onScreen.zakatDue &&
+                            it.nisabType == onScreen.nisabType &&
+                            it.nisabValue == onScreen.nisabValue &&
+                            it.calculatedAt == onScreen.calculatedAt
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `saving an empty form writes nothing`() = runTest {
+        // `recalculate()` clears `calculation` when every field is empty, and `saveCalculation`
+        // returns on the null. Without that guard the action bar's disabled state would be the
+        // only thing standing between an untouched form and a history full of zero rows.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { useCases.insertCalculation(any()) }
+    }
+
+    @Test
+    fun `a save that fails reports it without clearing the form`() = runTest {
+        coEvery { useCases.insertCalculation(any()) } throws IllegalStateException("disk full")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        vm.onEvent(ZakatEvent.UpdateDebts(500.0))
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        val state = vm.calculatorState.value
+        assertThat(state.error?.message).isEqualTo(R.string.zakat_save_failed)
+        assertThat(state.error?.details).isEqualTo("disk full")
+        // The whole point of the inline error: every figure typed is still there and still
+        // valid. Reporting a failed write by resetting the form would cost the user far more
+        // than the failure did.
+        assertThat(state.assets.cashOnHand).isEqualTo(10_000.0)
+        assertThat(state.liabilities.debts).isEqualTo(500.0)
+        assertThat(state.calculation).isNotNull()
+    }
+
+    @Test
+    fun `a failed save leaves the history screen alone`() = runTest {
+        // The two error channels are separate state objects. A save failure routed to
+        // `historyWriteFailed` would put "couldn't be saved" on a screen the user is not on,
+        // and leave the calculator — where they are — showing nothing wrong at all.
+        coEvery { useCases.insertCalculation(any()) } throws IllegalStateException("disk full")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateCash(10_000.0))
+        advanceUntilIdle()
+        vm.onEvent(ZakatEvent.SaveCalculation)
+        advanceUntilIdle()
+
+        assertThat(vm.historyState.value.error).isNull()
+    }
+
+    // ------------------------------------------------------------------
+    // Marking paid and deleting
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `marking an entry paid stamps the time it was paid`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        val before = System.currentTimeMillis()
+        vm.onEvent(ZakatEvent.MarkAsPaid(entryId = 42L))
+        advanceUntilIdle()
+
+        // The history card renders "Paid on <date>" from this stamp, so passing 0 — or the
+        // calculation's own timestamp — would label a payment made today with the date the
+        // figure was worked out, which for zakat can be a lunar year earlier.
+        coVerify { useCases.markAsPaid(42L, match { it >= before }) }
+    }
+
+    @Test
+    fun `a mark-as-paid that fails says so on the history screen`() = runTest {
+        coEvery { useCases.markAsPaid(any(), any()) } throws IllegalStateException("no row")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.MarkAsPaid(entryId = 7L))
+        advanceUntilIdle()
+
+        // Silence here is the dangerous outcome: the badge stays "Unpaid" either way, so
+        // without the error the user cannot tell a write that failed from one they imagined.
+        assertThat(vm.historyState.value.error?.message).isEqualTo(R.string.zakat_mark_paid_failed)
+        assertThat(vm.historyState.value.error?.details).isEqualTo("no row")
+        assertThat(vm.calculatorState.value.error).isNull()
+    }
+
+    @Test
+    fun `deleting an entry removes exactly the one asked for`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.DeleteCalculation(entryId = 9L))
+        advanceUntilIdle()
+
+        coVerify { useCases.deleteCalculation(9L) }
+        coVerify(exactly = 0) { useCases.markAsPaid(any(), any()) }
+    }
+
+    @Test
+    fun `a delete that fails says so on the history screen`() = runTest {
+        coEvery { useCases.deleteCalculation(any()) } throws IllegalStateException("locked")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.DeleteCalculation(entryId = 9L))
+        advanceUntilIdle()
+
+        assertThat(vm.historyState.value.error?.message).isEqualTo(R.string.zakat_delete_failed)
+    }
+
+    // ------------------------------------------------------------------
+    // Reading the history back
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the history and its running total arrive together`() = runTest {
+        every { useCases.getAllHistory() } returns
+                flowOf(listOf(entry(1L, zakatDue = 250.0, isPaid = true), entry(2L)))
+        coEvery { useCases.getTotalPaid() } returns 250.0
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        val state = vm.historyState.value
+        assertThat(state.history.map { it.id }).containsExactly(1L, 2L).inOrder()
+        // The total is read per emission rather than summed from the list — only paid entries
+        // count towards it, so a client-side sum of `zakatDue` would report 500 against 250
+        // actually paid.
+        assertThat(state.totalZakatPaid).isEqualTo(250.0)
+        assertThat(state.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a history stream that fails before its first emission stops the spinner`() = runTest {
+        // The defect this pins: `isLoading` defaults to true and used to be cleared only
+        // *inside* the collect, so a stream that threw first — a missing table after a content
+        // database replacement — left the screen spinning for the life of the ViewModel with
+        // nothing on it to say why.
+        every { useCases.getAllHistory() } returns flow { throw IllegalStateException("no table") }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        val state = vm.historyState.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.error?.message).isEqualTo(R.string.zakat_history_load_failed)
+        assertThat(state.error?.details).isEqualTo("no table")
+    }
+
+    @Test
+    fun `LoadHistory re-reads after a failure`() = runTest {
+        // The retry button on the history error state emits exactly this. If it did not start a
+        // fresh collection the button would clear nothing and the screen would stay broken until
+        // the process restarted.
+        val stream = MutableSharedFlow<List<ZakatHistoryEntry>>(replay = 1)
+        every { useCases.getAllHistory() } returns stream
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.LoadHistory)
+        stream.emit(listOf(entry(3L)))
+        advanceUntilIdle()
+
+        assertThat(vm.historyState.value.history.map { it.id }).containsExactly(3L)
+    }
+
+    // ------------------------------------------------------------------
+    // The form's own lifecycle
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `the typed form survives process death`() = runTest {
+        // Thirteen figures, several of which have to be looked up. Before this the form lived
+        // only in a `MutableStateFlow`, so a phone call during data entry returned the user to
+        // an empty form with nothing to say anything had been lost.
+        val saved = SavedStateHandle()
+        val first = viewModel(saved)
+        advanceUntilIdle()
+
+        first.onEvent(ZakatEvent.UpdateCash(1_200.0))
+        first.onEvent(ZakatEvent.UpdateGold(50.0))
+        first.onEvent(ZakatEvent.UpdateLoans(300.0))
+        advanceUntilIdle()
+
+        val restored = viewModel(saved)
+        advanceUntilIdle()
+
+        val state = restored.calculatorState.value
+        assertThat(state.assets.cashOnHand).isEqualTo(1_200.0)
+        assertThat(state.assets.goldGrams).isEqualTo(50.0)
+        assertThat(state.liabilities.loans).isEqualTo(300.0)
+        // And the restored form recomputes rather than coming back with a blank total.
+        assertThat(state.calculation).isNotNull()
+    }
+
+    @Test
+    fun `clearing the form reaches the saved state too`() = runTest {
+        // Clearing that stopped at the in-memory state would bring the cleared figures back on
+        // the next process death — the one moment the user is least able to explain it.
+        val saved = SavedStateHandle()
+        val first = viewModel(saved)
+        advanceUntilIdle()
+        first.onEvent(ZakatEvent.UpdateCash(1_200.0))
+        advanceUntilIdle()
+
+        first.onEvent(ZakatEvent.ClearAll)
+        advanceUntilIdle()
+
+        val restored = viewModel(saved)
+        advanceUntilIdle()
+        assertThat(restored.calculatorState.value.assets.cashOnHand).isEqualTo(0.0)
+        assertThat(restored.calculatorState.value.calculation).isNull()
+    }
+
+    @Test
+    fun `clearing keeps the basis the settings screen chose`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        settings.setZakatCurrency("EUR")
+        settings.setZakatGoldPricePerGram(80.0)
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateCash(1_000.0))
+        advanceUntilIdle()
+        vm.onEvent(ZakatEvent.ClearAll)
+        advanceUntilIdle()
+
+        // Reset empties the *form*. The currency and the metal prices are persisted settings, so
+        // resetting them here would silently return the user's zakat to dollars at a stale gold
+        // price — and `ZakatCalculator` derives the nisab threshold from that price, so it
+        // changes whether anything is owed at all.
+        val state = vm.calculatorState.value
+        assertThat(state.currency).isEqualTo("EUR")
+        assertThat(state.goldPricePerGram).isEqualTo(80.0)
+        assertThat(state.assets.cashOnHand).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `the breakdown toggle flips both ways`() = runTest {
+        // It starts open, and it is ViewModel state rather than local `remember` precisely so
+        // that a rotation does not silently re-open what the user closed.
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertThat(vm.calculatorState.value.showBreakdown).isTrue()
+
+        vm.onEvent(ZakatEvent.ToggleBreakdown)
+        assertThat(vm.calculatorState.value.showBreakdown).isFalse()
+
+        vm.onEvent(ZakatEvent.ToggleBreakdown)
+        assertThat(vm.calculatorState.value.showBreakdown).isTrue()
+    }
+
+    @Test
+    fun `Recalculate re-runs the sum over what is already on the form`() = runTest {
+        // What the inline error's "Try again" emits. It must not need the user to retype a
+        // figure to re-trigger the calculation.
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(ZakatEvent.UpdateCash(20_000.0))
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.Recalculate)
+        advanceUntilIdle()
+
+        val calculation = vm.calculatorState.value.calculation
+        assertThat(calculation).isNotNull()
+        assertThat(calculation!!.totalAssets).isEqualTo(20_000.0)
+        assertThat(vm.calculatorState.value.error).isNull()
+    }
+
+    @Test
+    fun `every asset row reaches the total it belongs to`() = runTest {
+        // Thirteen events, thirteen fields, and the mapping is written out by hand in the
+        // `when`. A copy-paste that pointed two events at the same field would be invisible on
+        // screen — the row would take input and the total would simply be wrong.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateCash(1.0))
+        vm.onEvent(ZakatEvent.UpdateBankBalance(2.0))
+        vm.onEvent(ZakatEvent.UpdateInvestments(4.0))
+        vm.onEvent(ZakatEvent.UpdateBusinessInventory(8.0))
+        vm.onEvent(ZakatEvent.UpdateReceivables(16.0))
+        vm.onEvent(ZakatEvent.UpdateRentalIncome(32.0))
+        vm.onEvent(ZakatEvent.UpdateOtherAssets(64.0))
+        advanceUntilIdle()
+
+        val assets = vm.calculatorState.value.assets
+        assertThat(assets.cashOnHand).isEqualTo(1.0)
+        assertThat(assets.bankBalance).isEqualTo(2.0)
+        assertThat(assets.investments).isEqualTo(4.0)
+        assertThat(assets.businessInventory).isEqualTo(8.0)
+        assertThat(assets.receivables).isEqualTo(16.0)
+        assertThat(assets.rentalIncome).isEqualTo(32.0)
+        assertThat(assets.otherAssets).isEqualTo(64.0)
+        // The powers of two make the sum decide the mapping: any two rows crossed and it moves.
+        assertThat(assets.total).isEqualTo(127.0)
+    }
+
+    @Test
+    fun `every liability row reaches the total it belongs to`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateDebts(1.0))
+        vm.onEvent(ZakatEvent.UpdateLoans(2.0))
+        vm.onEvent(ZakatEvent.UpdateBillsDue(4.0))
+        vm.onEvent(ZakatEvent.UpdateOtherLiabilities(8.0))
+        advanceUntilIdle()
+
+        val liabilities = vm.calculatorState.value.liabilities
+        assertThat(liabilities.debts).isEqualTo(1.0)
+        assertThat(liabilities.loans).isEqualTo(2.0)
+        assertThat(liabilities.billsDue).isEqualTo(4.0)
+        assertThat(liabilities.otherLiabilities).isEqualTo(8.0)
+        assertThat(liabilities.total).isEqualTo(15.0)
+    }
+
+    @Test
+    fun `a liability alone still produces a calculation`() = runTest {
+        // `recalculate()` checks assets *or* liabilities. Checking only assets — the easier
+        // reading of "is the form empty" — would leave someone who typed their debts first
+        // staring at a form that produced nothing.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(ZakatEvent.UpdateDebts(500.0))
+        advanceUntilIdle()
+
+        val calculation = vm.calculatorState.value.calculation
+        assertThat(calculation).isNotNull()
+        assertThat(calculation!!.totalLiabilities).isEqualTo(500.0)
+        assertThat(calculation.isAboveNisab).isFalse()
+    }
+}

--- a/feature/tools/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/tools/ToolsGraphTest.kt
+++ b/feature/tools/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/tools/ToolsGraphTest.kt
@@ -1,0 +1,79 @@
+package com.arshadshah.nimaz.presentation.screens.tools
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Tools feature's slice of the route graph — the zakat calculator and its history.
+ *
+ * A destination that fails to register throws `IllegalArgumentException: navigation destination …
+ * is not a direct child of this NavGraph`, and nothing catches that at build time. The two here
+ * navigate to each other — the calculator's top bar opens the history, the history's FAB opens the
+ * calculator — so a missing registration is not a dead entry point but a **crash on tap**, from a
+ * screen the user reached deliberately. It surfaces first on a device, in the middle of someone's
+ * zakat.
+ *
+ * The graph is built without a `NavHost`, so nothing is composed and neither screen needs a Hilt
+ * ViewModel. This asserts registration; `ZakatCalculatorScreenTest` and `ZakatHistoryScreenTest`
+ * assert that the screens render.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ToolsGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.ZakatCalculator) {
+            toolsGraph(navController)
+        }.toList()
+
+    @Test
+    fun `both zakat destinations are registered`() {
+        // Two, and exactly two: the KDoc on `toolsGraph` says "the 2 Tools destinations", and a
+        // third arriving without its own test is how a route ships unreachable.
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(2)
+        assertThat(routes.any { it.contains(Route.ZakatCalculator::class.qualifiedName!!) }).isTrue()
+        assertThat(routes.any { it.contains(Route.ZakatHistory::class.qualifiedName!!) }).isTrue()
+    }
+
+    @Test
+    fun `the calculator can be the start destination`() {
+        // `createGraph` throws here if the route it is handed is not among the destinations the
+        // builder registered — the same failure the app would hit on the first frame.
+        val graph = navController.createGraph(startDestination = Route.ZakatCalculator) {
+            toolsGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+
+    @Test
+    fun `the history can be the start destination`() {
+        // Not symmetry for its own sake: the history is what the announcement deep link and the
+        // calculator's own top-bar action open, so it has to resolve as a destination in its own
+        // right rather than only as somewhere the calculator happens to push.
+        val graph = navController.createGraph(startDestination = Route.ZakatHistory) {
+            toolsGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/tools/src/testDebug/resources/robolectric.properties
+++ b/feature/tools/src/testDebug/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application


### PR DESCRIPTION
Closes #606. Part of #604 — the ninth module locked.

## Before / after

| | Before | After | Floor |
|---|---|---|---|
| Line | **18.0%** (181 / 1006) | **97.5%** (981 / 1006) | 0.80 |
| Branch | **29.3%** (68 / 232) | **83.6%** (194 / 232) | 0.80 |

**80/80, not softened.** Third Compose module in a row to hold the full branch floor, after `:feature:calendar` (82.4%) and `:feature:onboarding` (90.3%). The unreachable `$dirty` bitmask branch is one per parameter of every restartable composable, so its weight scales with how many composables a module has — there are two screens here, and the ratio never becomes the number.

**`COVERAGE_EXCLUSIONS` is untouched.**

## What was missing, and why it mattered

Two screens were 727 of the 825 uncovered lines, and neither had ever been composed. The ViewModel was already the best-covered part, so unlike `:core:navigation` and `:core:domain` there were no tests filed in the wrong module to recover.

Zakat is the one feature in the app where a wrong number has a religious and financial consequence — and **the arithmetic was never the exposed part**. `ZakatCalculator` has had its own tests in `:core:domain` since it was written, and neither screen does a sum. What had no coverage at all was everything between the user and that calculation.

## What the new tests pin

**`ZakatCalculatorScreenTest`** — the form is thirteen near-identical `InputCard` call sites that differ only in which event they build:

- **Each row files its figure against its own asset.** A copy-paste between any two takes input in the right box, files it against the wrong asset, and looks entirely correct — the total is wrong by however far the two rows differ. Distinct values per row make any crossing visible.
- **Gold and silver take grams, the money rows take money.** The field these replaced picked between the two by comparing its suffix against the string `"$"`, so every non-dollar currency rendered a dollar sign.
- **The symbol on the fields is the one beside the total.** `currencySymbolOf` is tested in `:core:common`; that the screen uses it for *both* was not.
- **The nisab basis is reported on the form** and follows a basis change. Someone who cannot see the threshold cannot tell why their total says zero.
- **Below the nisab, the *other* verdict is asserted absent.** "Above nisab" over a zero reads as a calculation that failed rather than as an answer.
- **The breakdown is absent over an empty form** — the defect where clearing the last field left a zakat figure hanging over a blank form, which the sticky hero would have made permanent.
- **A failed calculation is inline, with every typed figure still on the form**, and its retry re-runs the sum rather than asking for a retype.
- **The collapsing hero re-expands only at a true top.** The asymmetry is the fix, not a nicety: the hero sits above the list and the list takes the height the hero leaves, so one symmetric threshold is a feedback loop that presented as a hero which never collapsed.
- The wide layout: both columns open with no accordion, the same action bar, input still reaching the right event.

**`ZakatHistoryScreenTest`**:

- **The error branch is checked before the empty one.** A failed read also leaves the list empty, so the other order tells someone with years of records that they have none — which reads as data loss, not as a load that failed.
- **"Mark as paid" is not offered on something already paid.** An obligation discharged twice is a real loss to whoever discharged it.
- The paid date comes from `paidAt`, not `calculatedAt` — for zakat those can be a lunar year apart — and an entry migrated without one does not invent `1 Jan 1970`.
- Mark-paid and delete carry the id of the row that was tapped, not of the first row.

**`ZakatPersistenceTest`**:

- **Saving writes the calculation on screen**, not a recomputed one. Recomputing at save time re-reads the metal prices, so a settings write landing between reading the total and pressing Save would file a figure the user never saw.
- **The two error channels stay separate.** A save failure never touches the history state and never clears the form; a mark-paid or delete failure never touches the calculator. Both directions are asserted, because the wrong one is a single-word mistake at the call site.
- **A history stream that fails before its first emission ends the spinner.** `isLoading` used to be cleared only inside the collect, so a missing table left the screen spinning for the life of the ViewModel.
- The thirteen typed figures survive process death; a reset clears the form but keeps the persisted basis and prices, which decide whether anything is owed at all.

**`ToolsGraphTest`** — both destinations register and either can be a start destination. They navigate to each other, so a missing registration is not a dead entry point but a crash on a tap the user made deliberately.

## Two component contracts shaped the tests

`ZakatSummaryHero` puts `clearAndSetSemantics` over its plinth and over each stat tile, so TalkBack reads "Zakat Due, $450.00, Above nisab" as one phrase rather than three fragments. That makes the hero addressable *only* by that content description — so the assertions here are on the accessibility contract itself. And the collapse-on-scroll needs a phone-height `@Config`: the rest of the class runs at `w411dp-h2200dp` so the `LazyColumn` composes every row, and on a viewport that tall the whole form fits and there is nothing to scroll.

## The gate bites

Floor temporarily set to `0.99`:

```
* What went wrong:
Execution failed for task ':feature:tools:coverageFloor'.
> :feature:tools:coverageFloor: line coverage 97.5% is below the floor this module is locked at (99.0%), covering 981/1006 (97.5%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to it is not meant to come back down.
```

Restored to `0.80` in this branch.

## What is left uncovered, and why

25 lines, recorded in the module's build file:

- the eleven lambda bodies inside `toolsGraph` (`popBackStack`, three `navigate` calls) — only a composed `NavHost` reaches them, and composing one means giving both screens a Hilt ViewModel;
- each screen's `viewModel: ZakatViewModel = hiltViewModel()` default argument;
- `ZakatViewModel.calculate`'s `catch`. `ZakatCalculator.calculate` is arithmetic over `Double`s with no user-supplied divisor, so no input reaches it. The handler is still right to exist, and `ZakatPersistenceTest` covers the identical shape on all four write paths, where failures do happen.

## Verification

| Command | Result |
|---|---|
| `./gradlew :feature:tools:testDebugUnitTest` | ✅ 89 tests, 0 failures |
| `./gradlew :feature:tools:check` | ✅ BUILD SUCCESSFUL |
| `./gradlew :feature:tools:lintDebug` | ✅ (via `:check`) |
| `./gradlew coverageFloor` | ✅ BUILD SUCCESSFUL — no locked module regressed |
| `python3 scripts/check_docs.py` | ✅ all 23 checks passed |

`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` and **were not run here** — not claiming they pass.

No `androidTest` changes in this PR, so nothing is waiting on an emulator.

## Docs

`docs/TESTING.md`: snapshot row moved to locked at 97.5%/83.6%, the 80/80-vs-softened paragraph now names `:feature:tools`, and a new audit section lists what each test file pins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMbLBtvJggJ2Y9af8LEAUn)_