### PR TITLE
test(feature:search): clear 80% and lock the module

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -44,6 +44,7 @@ Two on-device/JVM test surfaces exist:
   - [Every preference, read back (`:core:datastore/src/test`)](#every-preference-read-back-coredatastoresrctest)
   - [The first run, drawn and driven (`:feature:onboarding/src/test` and `src/testDebug`)](#the-first-run-drawn-and-driven-featureonboardingsrctest-and-srctestdebug)
   - [The zakat calculator and its history (`:feature:tools/src/test` and `src/testDebug`)](#the-zakat-calculator-and-its-history-featuretoolssrctest-and-srctestdebug)
+  - [Search, and the question that leaves the device (`:feature:search/src/test` and `src/testDebug`)](#search-and-the-question-that-leaves-the-device-featuresearchsrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -164,7 +165,7 @@ floor is a ratchet — raised when a module is brought up to it, never lowered t
 green. The branch floor is set per module, at 80% where branches are reachable and lower where
 the Compose compiler's `$dirty` checks make them not (see
 [Where each module stands](#where-each-module-stands)). `:core:database` is the first module
-locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar` and `:core:datastore`.
+locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools` and `:feature:search`.
 
 ### What is not counted, and why
 
@@ -259,10 +260,11 @@ floors in its own `build.gradle.kts`.
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common` and `:core:datastore` are locked at 80/80 — none of them draws
 anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
-`:feature:onboarding` and `:feature:tools`, which *are* Compose modules: the unreachable branch
-below is emitted **per parameter of every restartable composable**, so its weight scales with how
-many composables a module has, and six files — or eight, or the two screens in `:feature:tools` —
-never accumulate enough of them to move the number.
+`:feature:onboarding`, `:feature:tools` and `:feature:search`, which *are* Compose modules: the
+unreachable branch below is emitted **per parameter of every restartable composable**, so its
+weight scales with how many composables a module has, and six files — or eight, or the two screens
+in `:feature:tools`, or the one screen and four cards in `:feature:search` — never accumulate
+enough of them to move the number.
 `:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here. Only `:feature:quran` is softened, to
 80% lines and **60%** branches, because the Compose compiler
 emits a `$dirty` bitmask branch per parameter of every restartable composable — the skippability
@@ -284,12 +286,12 @@ split, and should say so where it sets its floors.
 | `:core:datastore` | 96.1% | 84.3% | **locked** at 80/80 |
 | `:feature:onboarding` | 94.3% | 90.3% | **locked** at 80/80 (#605) |
 | `:feature:tools` | 97.5% | 83.6% | **locked** at 80/80 (#606) |
+| `:feature:search` | 91.4% | 87.0% | **locked** at 80/80 (#607) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:core:data` | 39.0% | 31.2% | |
 | `:feature:prayer` | 38.1% | 23.7% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
 | `:feature:content` | 28.8% | 19.5% | |
-| `:feature:search` | 18.8% | 13.9% | |
 | `:feature:about` | 17.8% | 23.0% | |
 | `:feature:widget` | 16.8% | 28.1% | |
 | `:feature:settings` | 11.3% | 14.9% | |
@@ -632,6 +634,69 @@ would need Hilt ViewModels for both screens), each screen's `hiltViewModel()` de
 `ZakatViewModel.calculate`'s `catch` — arithmetic over `Double`s with no user-supplied divisor, so
 no input reaches it. `ZakatPersistenceTest` covers the identical handler shape on all four write
 paths, where failures do happen.
+
+### Search, and the question that leaves the device (`:feature:search/src/test` and `src/testDebug`)
+
+The tenth module locked: **18.8% lines to 91.4%**, from 233 covered lines to 1,130, and 13.9% to
+**87.0%** branches. 130 tests, 111 of them new. Both ViewModels were already reasonably covered —
+the two screen files were 843 of the 1,004 lines that were missing, and nothing had ever composed
+either of them.
+
+**This is the app's only surface where a bug sends user text off the device.** "Ask with Proof" is
+opt-in, and until #607 that promise was pinned in two places a user never sees: `AiOptInDefaultsTest`
+(in `:core:datastore`) on the stored default, and `AskWithProofConsentTest` (in `:core:domain`) on
+the use case's refusal. Neither says anything about the screen, and the screen is where consent is
+offered — or bypassed. The assertion that the Ask affordance is *absent*, not merely disabled,
+while the feature is off is a privacy assertion, not a layout one.
+
+The other half is the ordinary keyword search, where the load-bearing property is that three
+different situations must not look alike. A search in flight, a search that found nothing and a
+search that failed all render a list with nothing in it, and no ViewModel test can tell them apart:
+the difference is entirely which branch the screen takes and in what order. "No results for X" over
+a lookup that never ran reads as a fact about the reader's library rather than as a failure.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| A search still running | `SearchScreenTest` | shows progress and **never** the no-results sentence — the screen half of the contract the ViewModel keeps by flipping `isSearching` synchronously |
+| A search that found nothing | same | names the query it found nothing for; "No results" alone reads as an empty library |
+| A search that failed | same | the failure is reported **before** the no-results branch, with the typed query still in the bar and a retry that re-runs the search — the ordering is what stops a failed lookup being reported as an empty library |
+| Every result row | same | each of the five kinds dispatches its own callback with its own identifiers: the verse, the surah (not a verse inside it), the hadith's **book then record id** in that order, the dua, and the name **with its catalogue** — three catalogues share one id space each, so a dropped catalogue opens the wrong record silently |
+| Name catalogue labels | same | each of the three is tagged distinctly, and a name with no transliteration still has a title |
+| The filter chips | same | appear only once there is something to scope, count from the *unfiltered* results with the same predicate the list filters by (a surah hit counts under Qur'an), show a bare label at zero, and dispatch the filter that was tapped |
+| An initially scoped search | same | opening search from Duas scopes it on first composition; opening it plainly scopes nothing |
+| The resting screen | same | recent searches are offered, tapping one runs it, removing one is not wired to clear-all, and no header is drawn over an empty history |
+| The consent boundary | `SearchScreenAskTest` | with AI off there is **no control that sends a question anywhere**, on Global Search or on any scoped search — even with the feature switched on in settings, a scoped search offers nothing to ask |
+| The opt-in offer | same | states what leaves the device, sends "turn it on" to Search settings rather than flipping the switch itself, remembers a decline, and stays out of the way mid-search |
+| One bar, two jobs | same | what is typed reaches the question as well as the search, so Ask sends what is on screen; emptying the bar clears the answer with it |
+| The answer | same | its text, its confidence and the note saying it is not a ruling — the trust note is the only thing on screen that says so |
+| Cited sources | same | marked "Cited", and each opens the record it cites (`ContentTarget.Ayah` / `.Hadith`, resolved to a route in `:core:navigation`) |
+| The dedup | same | a verse the AI cited and the keyword search also matched appears **once** — twice would read as two independent sources agreeing. A surah or a name has no citation form and therefore survives beside the cited rows |
+| Filtering an answer | same | narrowing to Qur'an keeps the cited verses, to Hadith the cited hadiths, and to Duas or Names hides the cited strip rather than filtering it to nothing |
+| The list under an answer | same | the keyword rows stay on screen while the related-terms lookup runs, and the count line is held back until it lands; rows render with no query to highlight, which is the state the `indexOf("")` guard exists for |
+| Failures on the AI side | same | a retry is offered for a dropped connection and nothing else; keyword results carry on under a failed ask, because the library is local |
+| The AI's related terms | same | drive the local search on Global Search, and are ignored entirely on a search that never asked |
+| Every error card | `AskComponentsTest` | seven `AiError` cases, each with its own copy, and retry offered **only** where retrying can help — a retry beside a daily cap invites taps against a limit only time lifts, and on the retryable ones each tap is one billed Worker call |
+| "You can ask again in …" | same | seconds round **up** into minutes and minutes into hours; rounding down promises a limit that has not lifted. No retry-after means no invented number |
+| A failed lookup, in the ViewModel | `SearchSessionTest` | surfaces as an error with the resource message and the exception text kept for a bug report — and the next search clears it, so no error banner is left standing over fresh results |
+| A superseded search | same | a slow first lookup landing after a faster second one is discarded — results for a query the box no longer holds |
+| The recent list | same | written on submit and never on a keystroke, de-duplicated to the top, capped at ten, removable one at a time, and **kept** when the query is cleared |
+| Telemetry | same, `AskHistoryTest` | the query length and filter are recorded, the words never are; an empty submit counts as no search at all |
+| Every stored default scope | `SearchSessionTest` | each `LibrarySource` opens search on its own chip, and a scope this build does not recognise falls back to everything rather than crashing |
+| The filter predicate | same | every branch, including `SurahResult` under QURAN — the case the deleted per-corpus counters got wrong in both directions |
+| The question history | `AskHistoryTest` | written only while "remember my questions" is on — the switch gates the **write**, not the display — de-duplicated, capped at ten, and unreadable stored JSON degrades to no history rather than throwing while the resting screen composes |
+| Every failure slug | same | seven distinct names, so a budget cap and a failing integrity check are not one undifferentiated error rate; a thrown failure still takes the screen out of Loading |
+| The graph | `SearchGraphTest` | all four destinations register and each resolves as a start destination in its own right — every one is reached directly, three from a section screen and Global Search from home |
+
+**Nothing is excluded, and the 107 uncovered lines are recorded in the module's build file.**
+Ninety of them are the four destination bodies inside `searchGraph`: each calls `SearchScreen(...)`
+with seven navigation lambdas, and none of it runs until a composed `NavHost` reaches the
+destination — which builds both ViewModels through `hiltViewModel()` and so needs a Hilt-injected
+activity this module cannot construct. `SearchGraphTest` covers the registration those bodies hang
+off, which is the failure that actually ships. The remainder is the two `hiltViewModel()` default
+arguments, the `null ->` arm of `LibrarySource?.asFilter()` (unreachable — its only call site is
+already inside a `defaultScope != null` check), and a few `when`-merge lines with no statement of
+their own.
+
 
 ## Conventions
 

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -16,6 +16,28 @@ android {
     }
 }
 
+/**
+ * Locked at the standard floors. Measured at **91.4% lines / 87.0% branches** with the tests
+ * added by #607 — the fourth Compose module in a row to hold 80/80, so nothing is softened here.
+ *
+ * **What is left uncovered is one thing, and it is structural.** Ninety of the module's 107
+ * uncovered lines are the four destination bodies inside `searchGraph`: each one calls
+ * `SearchScreen(...)` with seven navigation lambdas, and none of it runs until a composed
+ * `NavHost` reaches the destination — which constructs `SearchViewModel` and `AskViewModel`
+ * through `hiltViewModel()` and therefore needs a Hilt-injected activity this module has no way
+ * to build. `SearchGraphTest` covers the registration those bodies are attached to (the failure
+ * that ships: a destination that throws on tap); `:app`'s instrumented suite is what exercises
+ * the bodies. The rest is the two `hiltViewModel()` default arguments on `SearchScreen`, the
+ * `null -> SearchFilter.ALL` arm of `LibrarySource?.asFilter()` — unreachable because its only
+ * call site is already inside a `defaultScope != null` check — and a handful of `when`-merge
+ * lines the compiler emits with no statement of their own. Nothing is excluded to reach these
+ * numbers; `COVERAGE_EXCLUSIONS` is untouched.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
 // Local library search, and the opt-in "Ask with Proof" screen on top of it.
 //
 // **The only feature with a network dependency and a cross-repo contract — and none of it is in
@@ -58,4 +80,16 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(testFixtures(project(":core:domain")))
     testImplementation(testFixtures(project(":core:common")))
+
+    // The search screen, the Ask-with-Proof cards and the graph run under Robolectric — the
+    // same harness `:feature:calendar`, `:feature:onboarding` and `:feature:tools` use,
+    // including `src/testDebug/resources/robolectric.properties`, which pins the SDK and the
+    // Application class. A properties file is a resource of its source set and does not travel
+    // with the tests that need it.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(testFixtures(project(":core:ui")))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/AskComponentsTest.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/AskComponentsTest.kt
@@ -1,0 +1,233 @@
+package com.arshadshah.nimaz.presentation.screens.search
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AiError
+import com.arshadshah.nimaz.domain.model.AnswerConfidence
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * What an Ask failure tells the reader, and what it invites them to do about it.
+ *
+ * Seven error cases share one card, and the card decides two things per case that the ViewModel
+ * cannot see: whether this reads as a **pause** or as a **failure**, and whether a retry button is
+ * offered at all. Both matter in the same direction. A daily cap rendered in error red, with a
+ * retry, invites someone to tap repeatedly against a limit only time lifts — and each tap on a
+ * genuinely retryable failure is one billed Worker call, so offering retry where it cannot help is
+ * not merely useless, it teaches the habit on the surface where it costs money.
+ *
+ * The rate-limited case additionally has arithmetic in it: raw seconds are useless to a reader, so
+ * they are rounded up into minutes, and minutes into hours. Rounding *down* is the failure that
+ * matters — "try again in 0 minutes" against a limit that has not lifted.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class AskComponentsTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private var retries = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun renderError(error: AiError) {
+        composeRule.setThemedContent {
+            AskErrorCard(error = error, onRetry = { retries++ })
+        }
+        composeRule.waitForIdle()
+    }
+
+    // ── retry is offered only where retrying can work ────────────────────────
+
+    @Test
+    fun `a dropped connection can be retried`() {
+        renderError(AiError.Network)
+
+        composeRule.onNodeWithText(str(R.string.ai_error_network_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).performClick()
+
+        assertThat(retries).isEqualTo(1)
+    }
+
+    @Test
+    fun `an unexplained failure can be retried`() {
+        renderError(AiError.Unknown)
+
+        composeRule.onNodeWithText(str(R.string.ai_error_unknown_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).performClick()
+
+        assertThat(retries).isEqualTo(1)
+    }
+
+    @Test
+    fun `the daily limit offers no retry`() {
+        renderError(AiError.RateLimited(retryAfterSeconds = null))
+
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the shared budget pause offers no retry`() {
+        renderError(AiError.BudgetExceeded)
+
+        composeRule.onNodeWithText(str(R.string.ai_error_budget_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    /** An unverified build is not going to verify on the second tap. */
+    @Test
+    fun `an unverified app copy offers no retry`() {
+        renderError(AiError.Unverified)
+
+        composeRule.onNodeWithText(str(R.string.ai_error_unverified_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    /** Rewording is the fix, so the card says that instead of offering the same question again. */
+    @Test
+    fun `a rejected question asks for a rewording rather than a retry`() {
+        renderError(AiError.Invalid("question too long"))
+
+        composeRule.onNodeWithText(str(R.string.ai_error_invalid)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    /**
+     * Consent is the one failure with a specific remedy, and it is not on this card — it is in
+     * Search settings. Retrying without turning the feature on would fail identically forever.
+     */
+    @Test
+    fun `an ask made without consent points at settings, not at a retry`() {
+        renderError(AiError.ConsentRequired)
+
+        composeRule.onNodeWithText(str(R.string.ai_error_consent_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_error_consent)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    // ── "you can ask again in …" ─────────────────────────────────────────────
+
+    /** 90 seconds is "about 2 minutes", never "1" — rounding down promises a limit that is still on. */
+    @Test
+    fun `a wait under an hour is rounded up to whole minutes`() {
+        renderError(AiError.RateLimited(retryAfterSeconds = 90))
+
+        val wait = str(R.string.ai_retry_minutes_format, 2L)
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited_retry, wait))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a wait of over an hour is given in hours`() {
+        // 7,200s is exactly 120 minutes → 2 hours, and must not read as "120 minutes".
+        renderError(AiError.RateLimited(retryAfterSeconds = 7_200))
+
+        val wait = str(R.string.ai_retry_hours_format, 2L)
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited_retry, wait))
+            .assertIsDisplayed()
+    }
+
+    /** A partial hour rounds up too: 61 minutes is "about 2 hours", not "1". */
+    @Test
+    fun `a partial hour rounds up rather than truncating`() {
+        renderError(AiError.RateLimited(retryAfterSeconds = 3_660))
+
+        val wait = str(R.string.ai_retry_hours_format, 2L)
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited_retry, wait))
+            .assertIsDisplayed()
+    }
+
+    /** No retry-after from the Worker means no invented number — the generic sentence stands. */
+    @Test
+    fun `an unknown wait says nothing about when`() {
+        renderError(AiError.RateLimited(retryAfterSeconds = null))
+
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited)).assertIsDisplayed()
+    }
+
+    // ── the answer card's confidence ─────────────────────────────────────────
+
+    private fun renderAnswer(confidence: AnswerConfidence) {
+        composeRule.setThemedContent {
+            AskAnswerCard(
+                answer = "Zakat is due on wealth held for a lunar year.",
+                confidence = confidence,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    /**
+     * Confidence is the reader's cue for how hard to check the answer against its sources, so it
+     * has to be stated in words. A card that renders the chip's colour but not its label leaves
+     * "low confidence" indistinguishable from "high" to anyone using TalkBack.
+     */
+    @Test
+    fun `a high-confidence answer says so`() {
+        renderAnswer(AnswerConfidence.HIGH)
+
+        composeRule.onNodeWithText(str(R.string.ai_confidence_high)).assertIsDisplayed()
+        composeRule.onNodeWithText("Zakat is due on wealth held for a lunar year.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a medium-confidence answer says so`() {
+        renderAnswer(AnswerConfidence.MEDIUM)
+
+        composeRule.onNodeWithText(str(R.string.ai_confidence_medium)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a low-confidence answer says so`() {
+        renderAnswer(AnswerConfidence.LOW)
+
+        composeRule.onNodeWithText(str(R.string.ai_confidence_low)).assertIsDisplayed()
+    }
+
+    /** The answer never stands alone — the note saying it is not a ruling ships with it. */
+    @Test
+    fun `every answer carries the trust note`() {
+        renderAnswer(AnswerConfidence.HIGH)
+
+        composeRule.onNodeWithText(str(R.string.ai_answer_section)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_trust_note)).assertIsDisplayed()
+    }
+
+    /** The discovery card's two actions are distinct: one opens settings, one only dismisses. */
+    @Test
+    fun `the discovery card separates enabling from dismissing`() {
+        var opens = 0
+        var dismissals = 0
+        composeRule.setThemedContent {
+            AskDiscoveryCard(onOpenSettings = { opens++ }, onDismiss = { dismissals++ })
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_enable)).performClick()
+        assertThat(opens).isEqualTo(1)
+        assertThat(dismissals).isEqualTo(0)
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_dismiss)).performClick()
+        assertThat(dismissals).isEqualTo(1)
+        assertThat(opens).isEqualTo(1)
+    }
+}

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchScreenAskTest.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchScreenAskTest.kt
@@ -1,0 +1,649 @@
+package com.arshadshah.nimaz.presentation.screens.search
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AiError
+import com.arshadshah.nimaz.domain.model.AnswerConfidence
+import com.arshadshah.nimaz.domain.model.ContentTarget
+import com.arshadshah.nimaz.domain.model.NameCatalog
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskEvent
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskPhase
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskUiState
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchEvent
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchFilter
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchUiState
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * "Ask with Proof" as the user meets it — the consent boundary first, then the answer.
+ *
+ * The feature is off until someone turns it on, and until #607 that promise was pinned in two
+ * places that a user never sees: `AiOptInDefaultsTest` on the stored default and
+ * `AskWithProofConsentTest` on the use case. Neither says anything about the screen, and the
+ * screen is where consent is actually offered or bypassed. A question that reaches the Worker is
+ * a question that left the device — the one thing this feature promises will not happen without
+ * an explicit opt-in — so "the Ask affordance is not rendered while the feature is off" is a
+ * privacy assertion, not a layout one.
+ *
+ * The answer half is about not overstating what the AI produced: the cited proofs are real local
+ * records, they carry a "Cited" mark, and a cited record must not also appear as an ordinary
+ * keyword hit — the same verse twice reads as two independent sources agreeing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class SearchScreenAskTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(SearchUiState())
+    private val stats = MutableStateFlow(SearchStatsUiState())
+    private val askState = MutableStateFlow(AskUiState())
+
+    private val events = mutableListOf<SearchEvent>()
+    private val askEvents = mutableListOf<AskEvent>()
+    private val proofOpens = mutableListOf<ContentTarget>()
+    private var settingsOpens = 0
+
+    private val viewModel: SearchViewModel = mockk(relaxed = true) {
+        every { searchState } returns this@SearchScreenAskTest.state
+        every { statsState } returns this@SearchScreenAskTest.stats
+        every { onEvent(any()) } answers { events += firstArg<SearchEvent>() }
+    }
+
+    private val askViewModel: AskViewModel = mockk(relaxed = true) {
+        every { uiState } returns this@SearchScreenAskTest.askState
+        every { onEvent(any()) } answers { askEvents += firstArg<AskEvent>() }
+    }
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun render(enableAsk: Boolean = true) {
+        composeRule.setThemedContent {
+            SearchScreen(
+                onNavigateBack = {},
+                onNavigateToQuranAyah = { _, _ -> },
+                onNavigateToSurah = {},
+                onNavigateToHadith = { _, _ -> },
+                onNavigateToDua = {},
+                onNavigateToName = { _: NameCatalog, _: Int -> },
+                enableAsk = enableAsk,
+                onNavigateToSearchSettings = { settingsOpens++ },
+                onNavigateToProof = { proofOpens += it },
+                viewModel = viewModel,
+                askViewModel = askViewModel,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    // ── consent ──────────────────────────────────────────────────────────────
+
+    /**
+     * The whole promise, on the surface that could break it: with the feature off there is no
+     * control that sends a question anywhere. Not disabled — absent.
+     */
+    @Test
+    fun `there is no way to ask a question until the feature is turned on`() {
+        askState.value = AskUiState(aiEnabled = false)
+        state.value = SearchUiState(query = "What does the Quran say about patience?")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_ask_button)).assertDoesNotExist()
+        assertThat(askEvents.filterIsInstance<AskEvent.Submit>()).isEmpty()
+    }
+
+    /** The bar says what it can do, and while AI is off it can only search. */
+    @Test
+    fun `the bar promises an answer only once answers are switched on`() {
+        askState.value = AskUiState(aiEnabled = false)
+        render()
+        composeRule.onNodeWithContentDescription(str(R.string.search_placeholder)).assertExists()
+
+        askState.value = AskUiState(aiEnabled = true)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription(str(R.string.search_or_ask_placeholder))
+            .assertExists()
+    }
+
+    /**
+     * The discovery card is the opt-in offer, and what it says is the consent copy: only the
+     * question leaves the device, everything else is matched locally. If that sentence ever
+     * stops matching what the feature does, this is the test that has to change with it.
+     */
+    @Test
+    fun `the opt-in offer states what leaves the device`() {
+        askState.value = AskUiState(aiEnabled = false, hintDismissed = false)
+        state.value = SearchUiState(query = "")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_discover_privacy)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_discover_enable)).assertIsDisplayed()
+    }
+
+    /** Turning it on is a trip to settings — the card itself never flips the switch. */
+    @Test
+    fun `enabling from the offer goes to settings rather than switching it on here`() {
+        askState.value = AskUiState(aiEnabled = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_enable)).performClick()
+
+        assertThat(settingsOpens).isEqualTo(1)
+        assertThat(askEvents).isEmpty()
+    }
+
+    @Test
+    fun `declining the offer remembers the decision`() {
+        askState.value = AskUiState(aiEnabled = false)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_dismiss)).performClick()
+
+        assertThat(askEvents).contains(AskEvent.DismissHint)
+    }
+
+    @Test
+    fun `the offer is not made again once it has been declined`() {
+        askState.value = AskUiState(aiEnabled = false, hintDismissed = true)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_title)).assertDoesNotExist()
+    }
+
+    /** It is a resting-state offer: mid-search it would be in the way of the results. */
+    @Test
+    fun `the offer stays out of the way while a search is being typed`() {
+        askState.value = AskUiState(aiEnabled = false)
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the offer is never made on a scoped search that has no ask affordance`() {
+        askState.value = AskUiState(aiEnabled = false)
+        render(enableAsk = false)
+
+        composeRule.onNodeWithText(str(R.string.ai_discover_title)).assertDoesNotExist()
+    }
+
+    // ── asking ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with the feature on, the ask pill submits the typed question`() {
+        askState.value = AskUiState(aiEnabled = true)
+        state.value = SearchUiState(query = "What does the Quran say about patience?")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_ask_button)).performClick()
+
+        assertThat(askEvents).contains(AskEvent.Submit)
+    }
+
+    /**
+     * One bar drives two things, so what is typed has to reach the question as well as the
+     * search — otherwise Ask sends whatever was last submitted rather than what is on screen.
+     */
+    @Test
+    fun `typing feeds the search and the question from one bar`() {
+        askState.value = AskUiState(aiEnabled = true)
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.search_or_ask_placeholder))
+            .performTextInput("patience")
+
+        assertThat(events).contains(SearchEvent.UpdateQuery("patience"))
+        assertThat(askEvents).contains(AskEvent.UpdateQuestion("patience"))
+    }
+
+    /** Emptying the bar takes the answer with it — a stale answer under an empty box is a lie. */
+    @Test
+    fun `clearing the bar clears the answer too`() {
+        askState.value = AskUiState(aiEnabled = true)
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_clear_search)).performClick()
+
+        assertThat(events).contains(SearchEvent.ClearSearch)
+        assertThat(askEvents).contains(AskEvent.Clear)
+    }
+
+    @Test
+    fun `an example question is asked, not just typed into the box`() {
+        askState.value = AskUiState(aiEnabled = true)
+        state.value = SearchUiState(query = "")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ask_example_2)).performClick()
+
+        assertThat(events).contains(SearchEvent.UpdateQuery(str(R.string.ask_example_2)))
+        assertThat(askEvents).contains(AskEvent.SelectRecent(str(R.string.ask_example_2)))
+    }
+
+    @Test
+    fun `examples are only offered where questions can be asked`() {
+        askState.value = AskUiState(aiEnabled = false)
+        state.value = SearchUiState(query = "")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_try_asking)).assertDoesNotExist()
+    }
+
+    /** Past questions and past searches are one history to the person who typed them. */
+    @Test
+    fun `recent searches and recent questions are offered as one list`() {
+        askState.value = AskUiState(aiEnabled = true, recentQuestions = listOf("Why fast Ashura?"))
+        state.value = SearchUiState(query = "", recentSearches = listOf("zakat nisab"))
+        render()
+
+        composeRule.onNodeWithText("zakat nisab").assertIsDisplayed()
+        composeRule.onNodeWithText("Why fast Ashura?").assertIsDisplayed()
+    }
+
+    @Test
+    fun `re-asking from history puts the question back in the bar`() {
+        askState.value = AskUiState(aiEnabled = true, recentQuestions = listOf("Why fast Ashura?"))
+        state.value = SearchUiState(query = "")
+        render()
+
+        composeRule.onNodeWithText("Why fast Ashura?").performClick()
+
+        assertThat(events).contains(SearchEvent.SelectRecentSearch("Why fast Ashura?"))
+        assertThat(askEvents).contains(AskEvent.UpdateQuestion("Why fast Ashura?"))
+    }
+
+    // ── the phases ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `a question in flight says so`() {
+        // The thinking card pulses and its progress bar is indeterminate — both animate
+        // forever, so the clock is manual here or `waitForIdle()` never returns.
+        composeRule.mainClock.autoAdvance = false
+        askState.value = AskUiState(aiEnabled = true, phase = AskPhase.Loading)
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_thinking)).assertIsDisplayed()
+    }
+
+    /** The trust note is not decoration: it is the only thing on screen saying this is not a fatwa. */
+    @Test
+    fun `an answer carries its confidence and the note that it is not a ruling`() {
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                answer = "Patience is repeatedly commanded.",
+                confidence = AnswerConfidence.MEDIUM,
+                proofs = emptyList(),
+            ),
+        )
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText("Patience is repeatedly commanded.").assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_confidence_medium)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_trust_note)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `cited sources are marked as cited and open the record they cite`() {
+        val proof = quranProof(surah = 2, ayah = 153, surahName = "Al-Baqarah")
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Be patient.", AnswerConfidence.HIGH, listOf(proof)),
+        )
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_cited_chip)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 2, 153)).performClick()
+
+        assertThat(proofOpens).containsExactly(ContentTarget.Ayah(2, 153))
+    }
+
+    @Test
+    fun `a cited hadith opens the hadith record`() {
+        val proof = hadithProof(id = "muslim-2999", hadithNumber = 2999)
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Wondrous.", AnswerConfidence.LOW, listOf(proof)),
+        )
+        state.value = SearchUiState(query = "believer")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.hadith_result_format, 2999)).performClick()
+
+        assertThat(proofOpens).containsExactly(ContentTarget.Hadith("muslim-2999"))
+    }
+
+    /**
+     * A verse the AI cited and the keyword search also matched is one verse. Rendering it twice
+     * would read as two sources agreeing, which is exactly the impression this feature must not
+     * manufacture.
+     */
+    @Test
+    fun `a cited verse is not repeated as an ordinary result`() {
+        val proof = quranProof(surah = 2, ayah = 153)
+        val sameVerse = quranResult(surah = 2, ayah = 153, surahName = "Al-Baqarah")
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Be patient.", AnswerConfidence.HIGH, listOf(proof)),
+        )
+        state.value = SearchUiState(
+            query = "patience",
+            allResults = listOf(sameVerse),
+            filteredResults = listOf(sameVerse),
+        )
+        render()
+
+        // One row for Surah 2:153, and it is the cited one.
+        composeRule.onAllNodes(hasText(str(R.string.surah_result_format, 2, 153)))
+            .assertCountEquals(1)
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 1, 1))
+            .assertIsDisplayed()
+    }
+
+    /** A surah hit has no citation form, so it can never dedup away against a cited verse. */
+    @Test
+    fun `a surah result survives beside the cited verses`() {
+        val proof = quranProof(surah = 18, ayah = 10)
+        val surah = surahResult(number = 18, nameEnglish = "The Cave")
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("The Cave.", AnswerConfidence.HIGH, listOf(proof)),
+        )
+        state.value = SearchUiState(
+            query = "cave",
+            allResults = listOf(surah),
+            filteredResults = listOf(surah),
+        )
+        render()
+
+        composeRule.onNodeWithText("The Cave").assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 2, 1))
+            .assertIsDisplayed()
+    }
+
+    /**
+     * The AI cites verses, hadiths and duas — never names. Narrowing to Names therefore hides the
+     * cited strip rather than filtering it down to a list of nothing.
+     */
+    @Test
+    fun `narrowing to names hides the cited sources rather than emptying them`() {
+        val proof = quranProof(surah = 2, ayah = 153)
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Be patient.", AnswerConfidence.HIGH, listOf(proof)),
+        )
+        state.value = SearchUiState(query = "patience", selectedFilter = SearchFilter.NAMES)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_cited_chip)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 0, 0))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `narrowing to hadith keeps only the cited hadiths`() {
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                "Both.",
+                AnswerConfidence.HIGH,
+                listOf(quranProof(surah = 2, ayah = 153), hadithProof(hadithNumber = 2999)),
+            ),
+        )
+        state.value = SearchUiState(query = "patience", selectedFilter = SearchFilter.HADITH)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.hadith_result_format, 2999)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 2, 153)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `narrowing to the quran keeps only the cited verses`() {
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                "Both.",
+                AnswerConfidence.HIGH,
+                listOf(quranProof(surah = 2, ayah = 153), hadithProof(hadithNumber = 2999)),
+            ),
+        )
+        state.value = SearchUiState(query = "patience", selectedFilter = SearchFilter.QURAN)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 2, 153)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.hadith_result_format, 2999)).assertDoesNotExist()
+    }
+
+    /**
+     * The AI has no dua citations yet, so narrowing to Duas empties the cited strip the same way
+     * Names does — the filter is applied to the proofs rather than ignored for them.
+     */
+    @Test
+    fun `narrowing to duas keeps no verse or hadith citation`() {
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                "Both.",
+                AnswerConfidence.HIGH,
+                listOf(quranProof(surah = 2, ayah = 153), hadithProof(hadithNumber = 2999)),
+            ),
+        )
+        state.value = SearchUiState(query = "patience", selectedFilter = SearchFilter.DUA)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_cited_chip)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 0, 0))
+            .assertIsDisplayed()
+    }
+
+    /** A name has no citation form either, so it stands beside the cited rows rather than merging. */
+    @Test
+    fun `a name result stands beside the cited sources`() {
+        val name = nameResult(id = 1, transliteration = "As-Sabur", english = "The Patient")
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                "Be patient.",
+                AnswerConfidence.HIGH,
+                listOf(quranProof(surah = 2, ayah = 153)),
+            ),
+        )
+        state.value = SearchUiState(
+            query = "patience",
+            allResults = listOf(name),
+            filteredResults = listOf(name),
+        )
+        render()
+
+        composeRule.onNodeWithText("As-Sabur").assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 2, 1))
+            .assertIsDisplayed()
+    }
+
+    /**
+     * An answer stays on screen when the box is emptied by the AI-terms lookup replacing what was
+     * typed. The rows then have nothing to highlight, and highlighting against an empty string is
+     * not merely pointless — `indexOf("")` matches at every position, so the loop that builds the
+     * highlight never terminates. The guard is the reason this state renders at all.
+     */
+    @Test
+    fun `results under an answer render without a query to highlight`() {
+        val proof = quranProof(surah = 2, ayah = 153)
+        val related = hadithResult(id = "h1", hadithNumber = 1)
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Be patient.", AnswerConfidence.HIGH, listOf(proof)),
+        )
+        state.value = SearchUiState(
+            query = "",
+            allResults = listOf(related),
+            filteredResults = listOf(related),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 2, 153)).assertIsDisplayed()
+        composeRule.onNodeWithText("Actions are judged by intentions").assertIsDisplayed()
+    }
+
+    /** With the cited rows shown and the related lookup still running, the list says it is working. */
+    @Test
+    fun `an answer with no related results yet shows the lookup in progress`() {
+        // Ends on a spinner, which animates forever — manual clock.
+        composeRule.mainClock.autoAdvance = false
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer(
+                "Be patient.",
+                AnswerConfidence.HIGH,
+                listOf(quranProof(surah = 2, ayah = 153)),
+            ),
+        )
+        state.value = SearchUiState(query = "patience", isSearching = true)
+        render()
+
+        // The cited row is already readable — the pending lookup is only the related half.
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 2, 153)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 1, 1))
+            .assertDoesNotExist()
+    }
+
+    /** The keyword list the reader was already looking at stays put while the AI list lands. */
+    @Test
+    fun `the answer's results list does not blank while the related lookup runs`() {
+        val existing = hadithResult(id = "h1", hadithNumber = 1)
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Answer("Answer.", AnswerConfidence.HIGH, emptyList()),
+        )
+        state.value = SearchUiState(
+            query = "intentions",
+            isSearching = true,
+            allResults = listOf(existing),
+            filteredResults = listOf(existing),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.hadith_result_format, 1)).assertIsDisplayed()
+        // The count line is held back while the list is still settling.
+        composeRule.onNodeWithText(str(R.string.search_answer_count_format, 1, 0))
+            .assertDoesNotExist()
+    }
+
+    // ── failures ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a network failure offers a retry that asks again`() {
+        askState.value = AskUiState(aiEnabled = true, phase = AskPhase.Error(AiError.Network))
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_error_network_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).performClick()
+
+        assertThat(askEvents).contains(AskEvent.Submit)
+    }
+
+    /**
+     * A daily cap is not a failure to retry into — a retry button there is an invitation to burn
+     * taps against a limit that only time lifts.
+     */
+    @Test
+    fun `a usage cap explains the pause and offers no retry`() {
+        askState.value = AskUiState(
+            aiEnabled = true,
+            phase = AskPhase.Error(AiError.RateLimited(retryAfterSeconds = null)),
+        )
+        state.value = SearchUiState(query = "patience")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ai_error_rate_limited_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.ai_try_again)).assertDoesNotExist()
+    }
+
+    /**
+     * Keyword results carry on under a failed ask: the library is local and searching it never
+     * needed the network in the first place.
+     */
+    @Test
+    fun `keyword results stay on screen under a failed ask`() {
+        val result = duaResult(id = "d1", title = "Dua for anxiety")
+        askState.value = AskUiState(aiEnabled = true, phase = AskPhase.Error(AiError.Network))
+        state.value = SearchUiState(
+            query = "anxiety",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText("Dua for anxiety").assertIsDisplayed()
+    }
+
+    // ── the AI's related terms drive the list ────────────────────────────────
+
+    @Test
+    fun `the answer's related terms re-run the local search`() {
+        askState.value = AskUiState(aiEnabled = true)
+        render()
+
+        askState.value = askState.value.copy(relatedTerms = listOf("patience", "sabr"))
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(SearchEvent.ApplyAiTerms(listOf("patience", "sabr")))
+    }
+
+    /** A scoped search never asked, so nothing may drive its list from an AI answer. */
+    @Test
+    fun `related terms are ignored on a search with no ask affordance`() {
+        askState.value = AskUiState(aiEnabled = true, relatedTerms = listOf("patience"))
+        render(enableAsk = false)
+
+        assertThat(events.filterIsInstance<SearchEvent.ApplyAiTerms>()).isEmpty()
+    }
+
+    @Test
+    fun `the typing hint appears only before a question has been asked`() {
+        // Ends on the thinking card, which animates forever — manual clock, as above.
+        composeRule.mainClock.autoAdvance = false
+        askState.value = AskUiState(aiEnabled = true, phase = AskPhase.Idle)
+        state.value = SearchUiState(query = "patience")
+        render()
+        composeRule.onNodeWithText(str(R.string.search_typing_hint)).assertIsDisplayed()
+
+        askState.value = askState.value.copy(phase = AskPhase.Loading)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(str(R.string.search_typing_hint)).assertDoesNotExist()
+    }
+}

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchScreenTest.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchScreenTest.kt
@@ -1,0 +1,497 @@
+package com.arshadshah.nimaz.presentation.screens.search
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.NameCatalog
+import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskUiState
+import com.arshadshah.nimaz.presentation.viewmodel.ai.AskViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchEvent
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchFilter
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchUiState
+import com.arshadshah.nimaz.presentation.viewmodel.search.SearchViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The keyword half of Search: what the list shows, and what a tap on it does.
+ *
+ * Three of these states are only distinguishable on screen. `isSearching`, "no results" and a
+ * failed lookup all render a list with nothing in it, and the ViewModel cannot tell them apart —
+ * the difference is entirely in which branch the screen renders and in what order. Getting that
+ * order wrong is not cosmetic: showing "No results for X" while the lookup is still running tells
+ * someone their library has nothing, half a second before it fills with matches; showing it in
+ * place of an error tells them the same thing when in fact the search never ran.
+ *
+ * The rest is the row-to-callback wiring. A result row is the only way into the reader from here,
+ * and a row that dispatches the wrong identifiers opens *something* — the wrong verse, the wrong
+ * hadith — which reads as content corruption rather than as a bug in a tap handler. Each of the
+ * five row kinds carries its own text so an assertion cannot pass on another row's rendering.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class SearchScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(SearchUiState())
+    private val stats = MutableStateFlow(SearchStatsUiState())
+    private val askState = MutableStateFlow(AskUiState())
+
+    private val events = mutableListOf<SearchEvent>()
+
+    private val viewModel: SearchViewModel = mockk(relaxed = true) {
+        every { searchState } returns this@SearchScreenTest.state
+        every { statsState } returns this@SearchScreenTest.stats
+        every { onEvent(any()) } answers { events += firstArg<SearchEvent>() }
+    }
+
+    private val askViewModel: AskViewModel = mockk(relaxed = true) {
+        every { uiState } returns this@SearchScreenTest.askState
+    }
+
+    private var backs = 0
+    private var settingsOpens = 0
+    private val quranAyahOpens = mutableListOf<Pair<Int, Int>>()
+    private val surahOpens = mutableListOf<Int>()
+    private val hadithOpens = mutableListOf<Pair<String, String>>()
+    private val duaOpens = mutableListOf<String>()
+    private val nameOpens = mutableListOf<Pair<NameCatalog, Int>>()
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun render(
+        initialFilter: SearchFilter? = null,
+        enableAsk: Boolean = false,
+    ) {
+        composeRule.setThemedContent {
+            SearchScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToQuranAyah = { surah, ayah -> quranAyahOpens += surah to ayah },
+                onNavigateToSurah = { surahOpens += it },
+                onNavigateToHadith = { book, hadith -> hadithOpens += book to hadith },
+                onNavigateToDua = { duaOpens += it },
+                onNavigateToName = { catalog, id -> nameOpens += catalog to id },
+                initialFilter = initialFilter,
+                enableAsk = enableAsk,
+                onNavigateToSearchSettings = { settingsOpens++ },
+                viewModel = viewModel,
+                askViewModel = askViewModel,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    // ── the three empty lists ────────────────────────────────────────────────
+
+    /**
+     * A search that is still running must not render as a library with nothing in it. The
+     * ViewModel flips `isSearching` on synchronously for exactly this reason, and this is the
+     * half of that contract that lives in the screen.
+     */
+    @Test
+    fun `a search in flight shows progress and never the no-results sentence`() {
+        // The progress spinner animates forever, so the clock is driven by hand — with
+        // `autoAdvance` on, `waitForIdle()` would wait for an animation that never ends.
+        composeRule.mainClock.autoAdvance = false
+        state.value = SearchUiState(query = "noor", isSearching = true)
+        render()
+
+        composeRule.onNodeWithText(str(R.string.no_results_format, "noor")).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.no_results_hint)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a finished search with nothing in it names the query it found nothing for`() {
+        state.value = SearchUiState(query = "qwertyuiop", isSearching = false)
+        render()
+
+        // Naming the query is the point: "No results" alone reads as the library being empty.
+        composeRule.onNodeWithText(str(R.string.no_results_format, "qwertyuiop")).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.no_results_hint)).assertIsDisplayed()
+    }
+
+    /**
+     * A failed lookup renders as a section with a retry, *before* the no-results branch. Without
+     * that ordering a search that never ran is reported as a search that found nothing, which is
+     * the one wrong answer that reads as fact rather than as failure.
+     */
+    @Test
+    fun `a failed search reports the failure instead of claiming there were no matches`() {
+        state.value = SearchUiState(
+            query = "noor",
+            isSearching = false,
+            error = UiError(
+                message = R.string.search_failed,
+                kind = NimazErrorKind.GENERIC,
+                details = "SQLITE_ERROR: no such table",
+            ),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_failed)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.search_failed_body)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.no_results_format, "noor")).assertDoesNotExist()
+    }
+
+    @Test
+    fun `retrying a failed search runs it again`() {
+        state.value = SearchUiState(
+            query = "noor",
+            error = UiError(message = R.string.search_failed),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.try_again)).performClick()
+
+        assertThat(events).contains(SearchEvent.ExecuteSearch)
+    }
+
+    /** The query box has to survive a failure — different words are the other thing to try. */
+    @Test
+    fun `the query stays in the bar after a failure`() {
+        state.value = SearchUiState(query = "noor", error = UiError(message = R.string.search_failed))
+        render()
+
+        composeRule.onAllNodesWithText("noor").onFirst().assertIsDisplayed()
+    }
+
+    // ── the rows, and where each one goes ────────────────────────────────────
+
+    @Test
+    fun `a verse row opens that verse`() {
+        val result = quranResult(surah = 25, ayah = 63, surahName = "Al-Furqan")
+        state.value = SearchUiState(
+            query = "humbly",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.surah_result_format, 25, 63)).performClick()
+
+        assertThat(quranAyahOpens).containsExactly(25 to 63)
+    }
+
+    @Test
+    fun `a surah row opens the surah, not a verse inside it`() {
+        val result = surahResult(number = 18, nameEnglish = "The Cave")
+        state.value = SearchUiState(
+            query = "cave",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText("The Cave").performClick()
+
+        assertThat(surahOpens).containsExactly(18)
+        assertThat(quranAyahOpens).isEmpty()
+    }
+
+    /**
+     * The hadith row carries two identifiers and they are not interchangeable — the book slug and
+     * the record id. Passing the record id as the book (or the number as the id) opens a reader
+     * pointed at nothing.
+     */
+    @Test
+    fun `a hadith row passes the book and the record id in that order`() {
+        val result = hadithResult(id = "bukhari-1", bookId = "bukhari", hadithNumber = 1)
+        state.value = SearchUiState(
+            query = "intentions",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.hadith_result_format, 1)).performClick()
+
+        assertThat(hadithOpens).containsExactly("bukhari" to "bukhari-1")
+    }
+
+    @Test
+    fun `a dua row opens that dua`() {
+        val result = duaResult(id = "dua-anxiety", title = "Dua for anxiety")
+        state.value = SearchUiState(
+            query = "anxiety",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText("Dua for anxiety").performClick()
+
+        assertThat(duaOpens).containsExactly("dua-anxiety")
+    }
+
+    /**
+     * Three catalogues share one row type and one id space each, so the catalogue has to travel
+     * with the tap. Name 1 is Ar-Rahman in one catalogue and Adam in another; dropping the
+     * catalogue opens the wrong record with no sign anything went wrong.
+     */
+    @Test
+    fun `a name row carries its catalogue`() {
+        val result = nameResult(
+            catalog = NameCatalog.PROPHETS,
+            id = 1,
+            transliteration = "Adam",
+            english = "Adam",
+        )
+        state.value = SearchUiState(
+            query = "adam",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText("Adam").performClick()
+
+        assertThat(nameOpens).containsExactly(NameCatalog.PROPHETS to 1)
+    }
+
+    /** "Names" alone would not say whether the row is a Name of Allah or a prophet. */
+    @Test
+    fun `each name catalogue is tagged with its own label`() {
+        state.value = SearchUiState(
+            query = "a",
+            allResults = listOf(
+                nameResult(NameCatalog.ASMA_UL_HUSNA, 1, "Ar-Rahman", "The Most Merciful"),
+                nameResult(NameCatalog.ASMA_UN_NABI, 2, "Al-Mustafa", "The Chosen"),
+                nameResult(NameCatalog.PROPHETS, 3, "Ibrahim", "Abraham"),
+            ),
+        ).let { it.copy(filteredResults = it.allResults) }
+        render()
+
+        composeRule.onNodeWithText(str(R.string.names_tab_allah)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.names_tab_prophet)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.names_tab_prophets)).assertIsDisplayed()
+    }
+
+    /** A name with no transliteration still needs a title — the English name stands in. */
+    @Test
+    fun `a name with no transliteration falls back to its english name`() {
+        val result = nameResult(
+            catalog = NameCatalog.ASMA_UN_NABI,
+            id = 7,
+            transliteration = "",
+            english = "The Chosen One",
+        )
+        state.value = SearchUiState(
+            query = "chosen",
+            allResults = listOf(result),
+            filteredResults = listOf(result),
+        )
+        render()
+
+        composeRule.onNodeWithText("The Chosen One").assertIsDisplayed()
+    }
+
+    // ── the filter row ───────────────────────────────────────────────────────
+
+    /** Nothing to scope while the box is empty, so the chips stay out of the way. */
+    @Test
+    fun `the filter row appears only once there is something to scope`() {
+        state.value = SearchUiState(query = "")
+        render()
+        composeRule.onNodeWithText(str(R.string.all)).assertDoesNotExist()
+
+        state.value = SearchUiState(query = "noor")
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(str(R.string.all)).assertIsDisplayed()
+    }
+
+    /**
+     * The count on a chip says where the matches are *before* you narrow to it — so narrowing to
+     * Hadith and finding nothing is never a decision anyone has to make blind. It is counted from
+     * `allResults` with the same predicate the list filters by, so the number and the rows agree.
+     */
+    @Test
+    fun `each chip counts the unfiltered matches for its own source`() {
+        val all = listOf(
+            quranResult(surah = 2, ayah = 153),
+            surahResult(number = 18),
+            hadithResult(id = "h1", hadithNumber = 1),
+            duaResult(id = "d1"),
+        )
+        state.value = SearchUiState(
+            query = "patience",
+            selectedFilter = SearchFilter.HADITH,
+            allResults = all,
+            filteredResults = all.filter { it is com.arshadshah.nimaz.domain.model.UnifiedSearchResult.HadithResult },
+        )
+        render()
+
+        // A surah hit counts under Qur'an alongside the verse — two, not one.
+        composeRule.onNodeWithText("${str(R.string.quran)}  2").assertIsDisplayed()
+        composeRule.onNodeWithText("${str(R.string.hadith)}  1").assertIsDisplayed()
+        composeRule.onNodeWithText("${str(R.string.duas)}  1").assertIsDisplayed()
+        // Zero matches show the bare label rather than a "0".
+        composeRule.onNodeWithText(str(R.string.names_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping a chip asks for that filter`() {
+        state.value = SearchUiState(query = "noor", allResults = listOf(quranResult()))
+        render()
+
+        composeRule.onNodeWithText("${str(R.string.quran)}  1").performClick()
+
+        assertThat(events).contains(SearchEvent.SetFilter(SearchFilter.QURAN))
+    }
+
+    /** Opening search *from* duas scopes it to duas — the screen says so on first composition. */
+    @Test
+    fun `an initial filter scopes the screen as it opens`() {
+        render(initialFilter = SearchFilter.DUA)
+
+        assertThat(events).contains(SearchEvent.SetFilter(SearchFilter.DUA))
+    }
+
+    @Test
+    fun `search opens unscoped when it was not launched from a section`() {
+        render()
+
+        assertThat(events.filterIsInstance<SearchEvent.SetFilter>()).isEmpty()
+    }
+
+    // ── the resting state ────────────────────────────────────────────────────
+
+    @Test
+    fun `recent searches are offered while the box is empty`() {
+        state.value = SearchUiState(query = "", recentSearches = listOf("patience", "zakat"))
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_recent)).assertIsDisplayed()
+        composeRule.onNodeWithText("patience").assertIsDisplayed()
+        composeRule.onNodeWithText("zakat").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping a recent search runs it`() {
+        state.value = SearchUiState(query = "", recentSearches = listOf("patience"))
+        render()
+
+        composeRule.onNodeWithText("patience").performClick()
+
+        assertThat(events).contains(SearchEvent.SelectRecentSearch("patience"))
+    }
+
+    @Test
+    fun `a recent search can be removed on its own`() {
+        state.value = SearchUiState(query = "", recentSearches = listOf("patience"))
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.remove)).performClick()
+
+        assertThat(events).contains(SearchEvent.RemoveRecentSearch("patience"))
+        // Removing one row must not be wired to the clear-everything action.
+        assertThat(events).doesNotContain(SearchEvent.ClearRecentSearches)
+    }
+
+    @Test
+    fun `the whole recent list can be cleared`() {
+        state.value = SearchUiState(query = "", recentSearches = listOf("patience", "zakat"))
+        render()
+
+        composeRule.onNodeWithText(str(R.string.cd_clear)).performClick()
+
+        assertThat(events).contains(SearchEvent.ClearRecentSearches)
+    }
+
+    @Test
+    fun `no recent header is drawn when there is no history`() {
+        state.value = SearchUiState(query = "", recentSearches = emptyList())
+        render()
+
+        composeRule.onNodeWithText(str(R.string.search_recent)).assertDoesNotExist()
+    }
+
+    // ── the bar itself ───────────────────────────────────────────────────────
+
+    @Test
+    fun `typing in the bar updates the query`() {
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.search_placeholder))
+            .performTextInput("noor")
+
+        assertThat(events).contains(SearchEvent.UpdateQuery("noor"))
+    }
+
+    @Test
+    fun `clearing the bar clears the search`() {
+        state.value = SearchUiState(query = "noor")
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_clear_search)).performClick()
+
+        assertThat(events).contains(SearchEvent.ClearSearch)
+    }
+
+    @Test
+    fun `the match count is the count of what is on screen`() {
+        val results = listOf(quranResult(), hadithResult())
+        state.value = SearchUiState(
+            query = "patience",
+            allResults = results,
+            filteredResults = results,
+        )
+        stats.value = SearchStatsUiState(totalResults = 2)
+        render()
+
+        composeRule.onNodeWithText("2 matches").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the top bar goes back and opens search settings`() {
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_back)).performClick()
+        composeRule.onNodeWithContentDescription(str(R.string.search_settings)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+        assertThat(settingsOpens).isEqualTo(1)
+    }
+
+    /**
+     * The AI surface is opt-in *and* per-screen: Qur'an, Hadith and Dua search pass
+     * `enableAsk = false`, and no amount of "AI is on in settings" may put an Ask affordance on
+     * those screens. This is the screen-level half of the consent boundary that
+     * `AskWithProofConsentTest` pins in the use case.
+     */
+    @Test
+    fun `a scoped search offers nothing to ask even with the feature switched on`() {
+        askState.value = AskUiState(aiEnabled = true)
+        state.value = SearchUiState(query = "patience")
+        render(enableAsk = false)
+
+        composeRule.onNodeWithText(str(R.string.search_ask_button)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.search_typing_hint)).assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(str(R.string.search_placeholder)).assertExists()
+    }
+}

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchTestData.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchTestData.kt
@@ -1,0 +1,167 @@
+package com.arshadshah.nimaz.presentation.screens.search
+
+import com.arshadshah.nimaz.domain.model.Ayah
+import com.arshadshah.nimaz.domain.model.ContentTarget
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaSearchResult
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.domain.model.HadithSearchResult
+import com.arshadshah.nimaz.domain.model.NameCatalog
+import com.arshadshah.nimaz.domain.model.NameSearchResult
+import com.arshadshah.nimaz.domain.model.Proof
+import com.arshadshah.nimaz.domain.model.QuranSearchResult
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.SearchType
+import com.arshadshah.nimaz.domain.model.Surah
+import com.arshadshah.nimaz.domain.model.UnifiedSearchResult
+
+/**
+ * The five kinds of thing a library search can return, built once for the screen tests.
+ *
+ * Deliberately given *distinguishable* text: every helper takes the values the row is supposed
+ * to render, so an assertion on "Al-Furqan" is an assertion that the Qur'an row rendered its own
+ * subtitle rather than some other row's. Shared identifiers would let a mis-wired card pass.
+ */
+internal fun quranResult(
+    surah: Int = 25,
+    ayah: Int = 63,
+    surahName: String = "Al-Furqan",
+    matchedText: String = "The servants of the Most Merciful walk humbly",
+) = UnifiedSearchResult.QuranResult(
+    QuranSearchResult(
+        ayah = Ayah(
+            id = surah * 1000 + ayah,
+            surahNumber = surah,
+            ayahNumber = ayah,
+            textArabic = "وَعِبَادُ الرَّحْمَٰنِ",
+            textSimple = "wa ibadu ar-rahman",
+            juzNumber = 19,
+            hizbNumber = 37,
+            rubNumber = 147,
+            pageNumber = 365,
+            sajdaType = null,
+            sajdaNumber = null,
+            translation = matchedText,
+        ),
+        surahName = surahName,
+        matchedText = matchedText,
+        searchType = SearchType.TRANSLATION,
+    ),
+)
+
+internal fun surahResult(
+    number: Int = 18,
+    nameEnglish: String = "The Cave",
+    nameTransliteration: String = "Al-Kahf",
+    ayahCount: Int = 110,
+) = UnifiedSearchResult.SurahResult(
+    Surah(
+        number = number,
+        nameArabic = "الكهف",
+        nameEnglish = nameEnglish,
+        nameTransliteration = nameTransliteration,
+        revelationType = RevelationType.MECCAN,
+        ayahCount = ayahCount,
+        orderInMushaf = number,
+    ),
+)
+
+internal fun hadithResult(
+    id: String = "bukhari-1",
+    bookId: String = "bukhari",
+    hadithNumber: Int = 1,
+    bookName: String = "Sahih al-Bukhari",
+    matchedText: String = "Actions are judged by intentions",
+) = UnifiedSearchResult.HadithResult(
+    HadithSearchResult(
+        hadith = Hadith(
+            id = id,
+            bookId = bookId,
+            chapterId = "1",
+            hadithNumber = hadithNumber,
+            hadithNumberInBook = hadithNumber,
+            textArabic = "إنما الأعمال بالنيات",
+            textEnglish = matchedText,
+            narratorChain = null,
+            narratorName = "Umar ibn al-Khattab",
+            grade = HadithGrade.SAHIH,
+            gradeArabic = null,
+            reference = "bukhari:$hadithNumber",
+        ),
+        bookName = bookName,
+        chapterName = "Revelation",
+        matchedText = matchedText,
+    ),
+)
+
+internal fun duaResult(
+    id: String = "dua-anxiety",
+    title: String = "Dua for anxiety",
+    categoryName: String = "Distress",
+    matchedText: String = "O Allah, I seek refuge in You from worry and grief",
+) = UnifiedSearchResult.DuaResult(
+    DuaSearchResult(
+        dua = Dua(
+            id = id,
+            categoryId = "distress",
+            titleArabic = "دعاء الهم",
+            titleEnglish = title,
+            textArabic = "اللهم إني أعوذ بك من الهم والحزن",
+            textTransliteration = null,
+            textEnglish = matchedText,
+            reference = null,
+            occasion = null,
+            benefits = null,
+            repeatCount = null,
+            audioUrl = null,
+            displayOrder = 1,
+        ),
+        categoryName = categoryName,
+        matchedText = matchedText,
+    ),
+)
+
+internal fun nameResult(
+    catalog: NameCatalog = NameCatalog.ASMA_UL_HUSNA,
+    id: Int = 1,
+    transliteration: String = "Ar-Rahman",
+    english: String = "The Most Merciful",
+    meaning: String = "The One who wills goodness and mercy for all",
+) = UnifiedSearchResult.NameResult(
+    NameSearchResult(
+        catalog = catalog,
+        id = id,
+        arabic = "الرحمن",
+        transliteration = transliteration,
+        english = english,
+        meaning = meaning,
+    ),
+)
+
+internal fun quranProof(
+    surah: Int = 2,
+    ayah: Int = 153,
+    surahName: String = "Al-Baqarah",
+    displayText: String = "Seek help through patience and prayer",
+) = Proof.Quran(
+    citationId = "quran:$surah:$ayah",
+    surahNumber = surah,
+    ayahNumber = ayah,
+    surahName = surahName,
+    displayText = displayText,
+    target = ContentTarget.Ayah(surah, ayah),
+)
+
+internal fun hadithProof(
+    id: String = "muslim-2999",
+    hadithNumber: Int = 2999,
+    bookName: String = "Sahih Muslim",
+    displayText: String = "Wondrous is the affair of the believer",
+) = Proof.Hadith(
+    citationId = "hadith:$id",
+    hadithNumber = hadithNumber,
+    bookName = bookName,
+    displayText = displayText,
+    target = ContentTarget.Hadith(id),
+)

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/ai/AskHistoryTest.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/ai/AskHistoryTest.kt
@@ -1,0 +1,252 @@
+package com.arshadshah.nimaz.presentation.viewmodel.ai
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.AiError
+import com.arshadshah.nimaz.domain.model.AnswerConfidence
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.ai.AskWithProofUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What "Ask with Proof" remembers, and what it reports about failing.
+ *
+ * The question history is the only user content this feature stores, and it is opt-in twice over:
+ * the feature has to be on, and "remember my questions" has to be on as well. Both switches gate
+ * the *write*, not merely the display — a question kept on disk after someone turned remembering
+ * off is a promise broken quietly, and nothing on screen would show it.
+ *
+ * The stored form is JSON in a preference, which means it can be malformed: written by a newer
+ * build, truncated, restored from another device. Decoding it must degrade to an empty list rather
+ * than throw, because the throw would happen while composing the resting search screen — the
+ * feature's front door — and take the whole screen down with it.
+ *
+ * The error slugs are the operational half. Every one of them is a distinct thing going wrong with
+ * a paid Worker call, and they are indistinguishable in aggregate if the ViewModel reports them
+ * under one name.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AskHistoryTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val askWithProof = mockk<AskWithProofUseCase>()
+    private val settings = mockk<SettingsRepository>(relaxed = true)
+    private val telemetry = RecordingTelemetry()
+
+    private val aiEnabled = MutableStateFlow(true)
+    private val historyEnabled = MutableStateFlow(true)
+    private val questionHistory = MutableStateFlow("[]")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { settings.aiAskEnabled } returns aiEnabled
+        every { settings.aiAskHintDismissed } returns flowOf(false)
+        every { settings.aiHistoryEnabled } returns historyEnabled
+        every { settings.aiQuestionHistory } returns questionHistory
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = AskViewModel(askWithProof, settings, telemetry)
+
+    private fun answered(answer: String = "Patience is virtuous.") =
+        AskWithProofUseCase.Outcome.Answered(
+            answer = answer,
+            confidence = AnswerConfidence.HIGH,
+            proofs = emptyList(),
+            relatedTerms = emptyList(),
+        )
+
+    // ── what is written down ─────────────────────────────────────────────────
+
+    @Test
+    fun `an answered question is persisted when remembering is on`() = runTest {
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("What does the Quran say about patience?"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        coVerify {
+            settings.setAiQuestionHistory(
+                match { it.contains("What does the Quran say about patience?") },
+            )
+        }
+    }
+
+    /** "Remember my questions", off, has to stop the write — not merely hide the list. */
+    @Test
+    fun `nothing is written down while remembering is off`() = runTest {
+        historyEnabled.value = false
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("What does the Quran say about patience?"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { settings.setAiQuestionHistory(any()) }
+    }
+
+    /** A question asked twice is one entry, moved to the top — not two identical rows. */
+    @Test
+    fun `re-asking a remembered question does not duplicate it`() = runTest {
+        questionHistory.value = """["older question","What is patience?"]"""
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.SelectRecent("What is patience?"))
+        advanceUntilIdle()
+
+        val recents = vm.uiState.value.recentQuestions
+        assertThat(recents).containsExactly("What is patience?", "older question").inOrder()
+    }
+
+    @Test
+    fun `the remembered list stops at ten questions`() = runTest {
+        questionHistory.value = (1..10).joinToString(",", "[", "]") { "\"question $it\"" }
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("a brand new question"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        val recents = vm.uiState.value.recentQuestions
+        assertThat(recents).hasSize(10)
+        assertThat(recents.first()).isEqualTo("a brand new question")
+        assertThat(recents).doesNotContain("question 10")
+    }
+
+    /**
+     * A preference file outlives the build that wrote it. Malformed JSON here would throw while
+     * the resting search screen is composing, so it degrades to "no history" instead.
+     */
+    @Test
+    fun `unreadable stored history degrades to no history`() = runTest {
+        questionHistory.value = "{not json at all"
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.recentQuestions).isEmpty()
+    }
+
+    @Test
+    fun `dismissing the discovery hint is remembered`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.DismissHint)
+        advanceUntilIdle()
+
+        coVerify { settings.setAiAskHintDismissed(true) }
+    }
+
+    // ── what is reported ─────────────────────────────────────────────────────
+
+    /**
+     * Seven ways a billed call can fail, seven slugs. Reported under one name they are one
+     * undifferentiated error rate, and the two that matter operationally — the budget cap and a
+     * failing integrity check — are exactly the two that look like everything else in aggregate.
+     */
+    @Test
+    fun `each kind of failure is reported under its own name`() = runTest {
+        val cases = mapOf(
+            AiError.RateLimited(retryAfterSeconds = 60) to "ask_rate_limited",
+            AiError.BudgetExceeded to "ask_budget",
+            AiError.Network to "ask_network",
+            AiError.Invalid("too long") to "ask_invalid",
+            AiError.Unverified to "ask_unverified",
+            AiError.ConsentRequired to "ask_consent_required",
+            AiError.Unknown to "ask_unknown",
+        )
+
+        cases.forEach { (error, slug) ->
+            telemetry.clear()
+            coEvery { askWithProof.invoke(any()) } returns
+                AskWithProofUseCase.Outcome.Failed(error)
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(AskEvent.UpdateQuestion("What is patience?"))
+            vm.onEvent(AskEvent.Submit)
+            advanceUntilIdle()
+
+            assertThat(telemetry.errors.map { it.type }).containsExactly(slug)
+            assertThat(vm.uiState.value.phase).isEqualTo(AskPhase.Error(error))
+        }
+    }
+
+    /**
+     * The proof count is the silent-degradation signal for the whole feature: an answer whose
+     * citations resolved to nothing still renders, and still reads as a working answer.
+     */
+    @Test
+    fun `an answer reports how many citations actually resolved`() = runTest {
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("What is patience?"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        val recorded = telemetry.aiAnswers.single()
+        assertThat(recorded.proofCount).isEqualTo(0)
+        assertThat(recorded.confidence).isEqualTo(AnswerConfidence.HIGH.name)
+    }
+
+    /** The question text is the one thing that must never reach analytics. */
+    @Test
+    fun `the question itself is never recorded`() = runTest {
+        coEvery { askWithProof.invoke(any()) } returns answered()
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("Is my specific personal situation permissible?"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        assertThat(telemetry.calls.toString())
+            .doesNotContain("Is my specific personal situation permissible?")
+    }
+
+    /**
+     * A crash inside the use case is still a failure the screen has to leave: without the
+     * `onFailure` hand-off the phase stays Loading forever and the card spins for good.
+     */
+    @Test
+    fun `a thrown failure still takes the screen out of the loading state`() = runTest {
+        coEvery { askWithProof.invoke(any()) } throws IllegalStateException("boom")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(AskEvent.UpdateQuestion("What is patience?"))
+        vm.onEvent(AskEvent.Submit)
+        advanceUntilIdle()
+
+        assertThat(vm.uiState.value.phase).isEqualTo(AskPhase.Error(AiError.Unknown))
+    }
+}

--- a/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/search/SearchSessionTest.kt
+++ b/feature/search/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/search/SearchSessionTest.kt
@@ -1,0 +1,345 @@
+package com.arshadshah.nimaz.presentation.viewmodel.search
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LibrarySearchResults
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.repository.settings.FakeSearchSettings
+import com.arshadshah.nimaz.domain.usecase.ObserveSearchPreferencesUseCase
+import com.arshadshah.nimaz.domain.usecase.SearchLibraryUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A search session over time: a failure, a correction, the history it leaves behind.
+ *
+ * `SearchViewModelTest` covers a search that works. This covers the rest of a real session, where
+ * the interesting states are the ones that persist *between* searches. A failed lookup that leaves
+ * `error` set is the sharpest of them: the next search must clear it, or the screen renders an
+ * error banner over a list of perfectly good results — the reader is told the search failed while
+ * looking at what it found.
+ *
+ * The recent-searches list is the other one. It is the only thing here that survives a query being
+ * cleared, and it is deliberately *not* written on every keystroke — search-as-you-type would
+ * otherwise fill it with "n", "no", "noo" and bury what was actually searched for.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchSessionTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var searchLibrary: SearchLibraryUseCase
+    private val telemetry = RecordingTelemetry()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        searchLibrary = mockk()
+        coEvery { searchLibrary.invoke(any(), any()) } returns LibrarySearchResults.EMPTY
+        coEvery { searchLibrary.byTerms(any(), any()) } returns LibrarySearchResults.EMPTY
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(settings: FakeSearchSettings = FakeSearchSettings()) =
+        SearchViewModel(
+            searchLibrary,
+            ObserveSearchPreferencesUseCase(settings),
+            telemetry,
+        )
+
+    // ── a lookup that fails ──────────────────────────────────────────────────
+
+    /**
+     * The failure has to be *reported*, not swallowed into an empty list — an empty list is
+     * indistinguishable from "your library has nothing on this", which is the wrong answer.
+     */
+    @Test
+    fun `a failed lookup surfaces as an error rather than as no matches`() = runTest {
+        coEvery { searchLibrary.invoke(any(), any()) } throws
+            IllegalStateException("no such table: quran_fts")
+
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+
+        val error = vm.searchState.value.error
+        assertThat(error).isNotNull()
+        assertThat(error!!.message).isEqualTo(R.string.search_failed)
+        // The exception's own text is kept for a bug report, never used as the message.
+        assertThat(error.details).isEqualTo("no such table: quran_fts")
+        assertThat(vm.searchState.value.isSearching).isFalse()
+    }
+
+    /** An error banner left standing over fresh results tells the reader the opposite of the truth. */
+    @Test
+    fun `the next search clears the previous failure`() = runTest {
+        coEvery { searchLibrary.invoke(any(), any()) } throws IllegalStateException("boom")
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+        assertThat(vm.searchState.value.error).isNotNull()
+
+        coEvery { searchLibrary.invoke(any(), any()) } returns LibrarySearchResults.EMPTY
+        vm.onEvent(SearchEvent.UpdateQuery("noor light"))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.error).isNull()
+    }
+
+    @Test
+    fun `a failure is reported to telemetry without the query text`() = runTest {
+        coEvery { searchLibrary.invoke(any(), any()) } throws IllegalStateException("boom")
+        val vm = viewModel()
+
+        vm.onEvent(SearchEvent.UpdateQuery("my private question"))
+        advanceUntilIdle()
+
+        // What is recorded is the length and the filter — never the words.
+        val search = telemetry.searches.single()
+        assertThat(search.queryLength).isEqualTo("my private question".length)
+        assertThat(telemetry.calls.toString()).doesNotContain("my private question")
+    }
+
+    // ── superseded searches ──────────────────────────────────────────────────
+
+    /**
+     * A slow first lookup must not land on top of a faster second one. The list would then show
+     * results for a query the box no longer contains, and nothing on screen would say so.
+     */
+    @Test
+    fun `a slow result is discarded when a newer search has already been submitted`() = runTest {
+        val slow = CompletableDeferred<LibrarySearchResults>()
+        coEvery { searchLibrary.invoke("noor", any()) } coAnswers { slow.await() }
+        coEvery { searchLibrary.invoke("sabr", any()) } returns LibrarySearchResults(
+            surahs = listOf(mockk(relaxed = true)),
+        )
+
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+
+        vm.onEvent(SearchEvent.UpdateQuery("sabr"))
+        advanceUntilIdle()
+
+        // The first lookup completes late — the job it belonged to was already cancelled.
+        slow.complete(LibrarySearchResults(quran = List(9) { mockk(relaxed = true) }))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.allResults).hasSize(1)
+        assertThat(vm.statsState.value.totalResults).isEqualTo(1)
+    }
+
+    // ── the recent list ──────────────────────────────────────────────────────
+
+    /** Typing is not submitting: search-as-you-type would otherwise record every prefix. */
+    @Test
+    fun `typing does not write to the recent list`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.recentSearches).isEmpty()
+    }
+
+    @Test
+    fun `submitting records the query and searches immediately`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        vm.onEvent(SearchEvent.ExecuteSearch)
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.recentSearches).containsExactly("noor")
+    }
+
+    @Test
+    fun `submitting an empty box searches nothing and records nothing`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("   "))
+        vm.onEvent(SearchEvent.ExecuteSearch)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { searchLibrary.invoke(any(), any()) }
+        assertThat(vm.searchState.value.recentSearches).isEmpty()
+        // Nothing ran, so nothing may be counted as a search performed.
+        assertThat(telemetry.searches).isEmpty()
+    }
+
+    /** Searching the same words again moves that entry up rather than adding a duplicate. */
+    @Test
+    fun `re-running a search moves it to the top instead of repeating it`() = runTest {
+        val vm = viewModel()
+        listOf("noor", "sabr", "noor").forEach {
+            vm.onEvent(SearchEvent.UpdateQuery(it))
+            vm.onEvent(SearchEvent.ExecuteSearch)
+            advanceUntilIdle()
+        }
+
+        assertThat(vm.searchState.value.recentSearches).containsExactly("noor", "sabr").inOrder()
+    }
+
+    /** The list is a convenience, not an archive — it stops at ten so the resting screen stays usable. */
+    @Test
+    fun `the recent list keeps the last ten searches`() = runTest {
+        val vm = viewModel()
+        (1..12).forEach {
+            vm.onEvent(SearchEvent.UpdateQuery("query $it"))
+            vm.onEvent(SearchEvent.ExecuteSearch)
+            advanceUntilIdle()
+        }
+
+        val recents = vm.searchState.value.recentSearches
+        assertThat(recents).hasSize(10)
+        assertThat(recents.first()).isEqualTo("query 12")
+        assertThat(recents).doesNotContain("query 1")
+        assertThat(recents).doesNotContain("query 2")
+    }
+
+    @Test
+    fun `a recent search can be removed without touching the others`() = runTest {
+        val vm = viewModel()
+        listOf("noor", "sabr").forEach {
+            vm.onEvent(SearchEvent.UpdateQuery(it))
+            vm.onEvent(SearchEvent.ExecuteSearch)
+            advanceUntilIdle()
+        }
+
+        vm.onEvent(SearchEvent.RemoveRecentSearch("noor"))
+
+        assertThat(vm.searchState.value.recentSearches).containsExactly("sabr")
+    }
+
+    @Test
+    fun `clearing the recent list empties it`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        vm.onEvent(SearchEvent.ExecuteSearch)
+        advanceUntilIdle()
+
+        vm.onEvent(SearchEvent.ClearRecentSearches)
+
+        assertThat(vm.searchState.value.recentSearches).isEmpty()
+    }
+
+    /**
+     * Clearing the box is not clearing the history: the recent list is what makes the resting
+     * screen useful, and the clear button is next to the query, not next to the history.
+     */
+    @Test
+    fun `clearing the search keeps the history it produced`() = runTest {
+        coEvery { searchLibrary.invoke(any(), any()) } returns
+            LibrarySearchResults(surahs = listOf(mockk(relaxed = true)))
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.UpdateQuery("noor"))
+        vm.onEvent(SearchEvent.ExecuteSearch)
+        advanceUntilIdle()
+
+        vm.onEvent(SearchEvent.ClearSearch)
+
+        assertThat(vm.searchState.value.query).isEmpty()
+        assertThat(vm.searchState.value.allResults).isEmpty()
+        assertThat(vm.statsState.value.totalResults).isEqualTo(0)
+        assertThat(vm.searchState.value.recentSearches).containsExactly("noor")
+    }
+
+    @Test
+    fun `tapping a recent search runs it again and keeps it at the top`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.SelectRecentSearch("sabr"))
+        advanceUntilIdle()
+
+        coVerify { searchLibrary.invoke("sabr", any()) }
+        assertThat(vm.searchState.value.query).isEqualTo("sabr")
+        assertThat(vm.searchState.value.recentSearches).containsExactly("sabr")
+    }
+
+    // ── AI terms ─────────────────────────────────────────────────────────────
+
+    /** Nothing usable in the terms means nothing happens — not a search for the empty string. */
+    @Test
+    fun `blank AI terms leave the existing list alone`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.ApplyAiTerms(listOf("", "   ")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { searchLibrary.byTerms(any(), any()) }
+    }
+
+    @Test
+    fun `repeated AI terms are asked for once`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(SearchEvent.ApplyAiTerms(listOf("sabr", "sabr", " sabr ")))
+        advanceUntilIdle()
+
+        coVerify { searchLibrary.byTerms(listOf("sabr"), any()) }
+    }
+
+    // ── the stored default scope, for every source ───────────────────────────
+
+    /**
+     * Every [LibrarySource] has to map to a chip. The mapping is exhaustive in the ViewModel so a
+     * new source will not compile without one — this is the other half: that each existing source
+     * maps to the *right* chip, which the compiler cannot check.
+     */
+    @Test
+    fun `each stored source opens search on its own filter`() = runTest {
+        mapOf(
+            LibrarySource.QURAN to SearchFilter.QURAN,
+            LibrarySource.HADITH to SearchFilter.HADITH,
+            LibrarySource.DUAS to SearchFilter.DUA,
+            LibrarySource.NAMES to SearchFilter.NAMES,
+        ).forEach { (source, filter) ->
+            val vm = viewModel(FakeSearchSettings(defaultScope = source.name))
+            advanceUntilIdle()
+
+            assertThat(vm.searchState.value.selectedFilter).isEqualTo(filter)
+        }
+    }
+
+    @Test
+    fun `an unrecognised stored scope leaves search on everything`() = runTest {
+        // A scope written by a newer build, or a corrupted value: fall back rather than crash.
+        val vm = viewModel(FakeSearchSettings(defaultScope = "PODCASTS"))
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.selectedFilter).isEqualTo(SearchFilter.ALL)
+    }
+
+    // ── the filter predicate ─────────────────────────────────────────────────
+
+    /**
+     * One predicate decides both what the list shows and what the chips count, so every branch of
+     * it has to agree with the corpus it names. `SurahResult` under QURAN is the one that is not
+     * obvious — and it is exactly the case the deleted per-corpus counters got wrong.
+     */
+    @Test
+    fun `each filter accepts its own corpus and nothing else`() {
+        val quran = com.arshadshah.nimaz.domain.model.UnifiedSearchResult.QuranResult(mockk())
+        val surah = com.arshadshah.nimaz.domain.model.UnifiedSearchResult.SurahResult(mockk())
+        val hadith = com.arshadshah.nimaz.domain.model.UnifiedSearchResult.HadithResult(mockk())
+        val dua = com.arshadshah.nimaz.domain.model.UnifiedSearchResult.DuaResult(mockk())
+        val name = com.arshadshah.nimaz.domain.model.UnifiedSearchResult.NameResult(mockk())
+        val all = listOf(quran, surah, hadith, dua, name)
+
+        assertThat(all.filter { SearchFilter.ALL.accepts(it) }).hasSize(5)
+        // A surah is a Qur'an hit for the purpose of filtering — it is a place in the Qur'an.
+        assertThat(all.filter { SearchFilter.QURAN.accepts(it) })
+            .containsExactly(quran, surah)
+        assertThat(all.filter { SearchFilter.HADITH.accepts(it) }).containsExactly(hadith)
+        assertThat(all.filter { SearchFilter.DUA.accepts(it) }).containsExactly(dua)
+        assertThat(all.filter { SearchFilter.NAMES.accepts(it) }).containsExactly(name)
+    }
+}

--- a/feature/search/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchGraphTest.kt
+++ b/feature/search/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/search/SearchGraphTest.kt
@@ -1,0 +1,100 @@
+package com.arshadshah.nimaz.presentation.screens.search
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Search feature's slice of the route graph — four ways into the same screen.
+ *
+ * They are not interchangeable. Three are scoped searches reached from a section (Qur'an, Hadith,
+ * Duas) and one is Global Search, the only one that carries the Ask-with-Proof surface. A missing
+ * registration throws `IllegalArgumentException: navigation destination … is not a direct child of
+ * this NavGraph`, and nothing catches it at build time — it surfaces as a crash the moment someone
+ * taps the search icon on that section, which is a deliberate action rather than a stray one.
+ *
+ * Each is asserted as a start destination in its own right because each is reached directly: the
+ * home search field opens Global Search, and every section screen opens its own scoped one. A
+ * route that only resolves as somewhere another screen happens to push is not enough.
+ *
+ * The graph is built without a `NavHost`, so nothing is composed and the screen's Hilt ViewModels
+ * are never constructed. This asserts registration; `SearchScreenTest` and `SearchScreenAskTest`
+ * assert that the screen renders, and `:core:navigation`'s `SearchProofNavigationTest` /
+ * `ContentTargetRoutesTest` assert where a proof card's target resolves to.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SearchGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.GlobalSearch) {
+            searchGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all four search destinations are registered`() {
+        // Four, and exactly four: the KDoc on `searchGraph` says "the 4 Search destinations", and
+        // a fifth arriving without its own test is how a route ships unreachable.
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(4)
+        assertThat(routes.any { it.contains(Route.GlobalSearch::class.qualifiedName!!) }).isTrue()
+        assertThat(routes.any { it.contains(Route.QuranSearch::class.qualifiedName!!) }).isTrue()
+        assertThat(routes.any { it.contains(Route.HadithSearch::class.qualifiedName!!) }).isTrue()
+        assertThat(routes.any { it.contains(Route.DuaSearch::class.qualifiedName!!) }).isTrue()
+    }
+
+    @Test
+    fun `global search resolves as a destination in its own right`() {
+        // `createGraph` throws here if the route it is handed is not among the destinations the
+        // builder registered — the same failure the app would hit on the first frame.
+        val graph = navController.createGraph(startDestination = Route.GlobalSearch) {
+            searchGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+
+    @Test
+    fun `quran search resolves as a destination in its own right`() {
+        val graph = navController.createGraph(startDestination = Route.QuranSearch) {
+            searchGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+
+    @Test
+    fun `hadith search resolves as a destination in its own right`() {
+        val graph = navController.createGraph(startDestination = Route.HadithSearch) {
+            searchGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+
+    @Test
+    fun `dua search resolves as a destination in its own right`() {
+        val graph = navController.createGraph(startDestination = Route.DuaSearch) {
+            searchGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/search/src/testDebug/resources/robolectric.properties
+++ b/feature/search/src/testDebug/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application


### PR DESCRIPTION
Closes #607

## Before / after

| | Before | After | Floor |
|---|---|---|---|
| Line | 18.8% (233 / 1,237) | **91.4%** (1,130 / 1,237) | 0.80 |
| Branch | 13.9% | **87.0%** | 0.80 |

130 tests in the module, **111 of them new**. The fourth Compose module in a row to hold 80/80 — nothing is softened, and `COVERAGE_EXCLUSIONS` is untouched.

Both ViewModels were already reasonably covered. The two screen files were **843 of the 1,004 missing lines**, and nothing had ever composed either of them.

## What the new tests pin, and the failure each catches

**The consent boundary — the reason this module is worth testing.** "Ask with Proof" is opt-in, and until now that promise was pinned in two places a user never sees: `AiOptInDefaultsTest` (`:core:datastore`, the stored default) and `AskWithProofConsentTest` (`:core:domain`, the use case's refusal). Neither says anything about the screen, and **the screen is where consent is offered or bypassed**. A question that reaches the Worker is a question that left the device.

- With AI off there is **no control that sends a question anywhere** — absent, not disabled — on Global Search *and* on every scoped search, even with the feature switched on in settings.
- The opt-in offer states what leaves the device, sends "turn it on" to Search settings rather than flipping the switch itself, and remembers a decline.
- One bar drives search and question, so what is typed reaches the question — otherwise Ask sends whatever was last submitted rather than what is on screen.

**Three empty lists that must not look alike.** A search in flight, a search that found nothing and a search that failed all render a list with nothing in it, and no ViewModel test can tell them apart — the difference is which branch the screen takes and in what order. "No results for *X*" over a lookup that never ran reads as a fact about the reader's library rather than as a failure. The error branch is asserted to come **before** the no-results branch, with the query still in the bar and a retry that re-runs the search.

**Rows that open the wrong record.** Each of the five result kinds dispatches its own callback with its own identifiers: the verse, the surah (not a verse inside it), the hadith's **book then record id in that order**, the dua, and the name **with its catalogue** — three catalogues share one id space each, so a dropped catalogue opens the wrong record with nothing on screen to say so.

**The cited/related dedup.** A verse the AI cited and the keyword search also matched appears once. Twice would read as two independent sources agreeing — exactly the impression this feature must not manufacture. A surah or a name has no citation form and correctly survives beside the cited rows.

**Retry where retrying cannot help.** Seven `AiError` cases, each with its own copy; a retry is offered only for a dropped connection and an unexplained failure. A retry beside a daily cap invites taps against a limit only time lifts — and on the retryable ones each tap is one billed Worker call. The retry-after figure rounds **up** into minutes and hours; rounding down promises a limit that has not lifted.

**An error banner left standing over fresh results** (`SearchSessionTest`) — a failed lookup sets `error`, and the next search must clear it or the reader is told the search failed while looking at what it found. Also: a slow first lookup landing after a faster second one is discarded, and the recent list is written on submit only (search-as-you-type would fill it with `n`, `no`, `noo`).

**The question history is gated on the write, not the display** (`AskHistoryTest`) — a question kept on disk after "remember my questions" was switched off is a promise broken silently. Unreadable stored JSON degrades to no history rather than throwing while the resting screen composes. Seven distinct telemetry slugs, so a budget cap and a failing integrity check are not one undifferentiated error rate.

**The graph** (`SearchGraphTest`) — all four destinations register and each resolves as a start destination in its own right. Every one is reached directly: three from a section screen, Global Search from home. A missing registration is a crash on a tap someone made deliberately.

## The gate bites

Floor temporarily set to `0.99`:

```
> Task :feature:search:coverageFloor FAILED
> :feature:search:coverageFloor: line coverage 91.4% is below the floor this module
  is locked at (99.0%), covering 1130/1237 (91.4%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought
  up to it is not meant to come back down.
```

Restored to `0.80` in the committed diff.

## What is left uncovered, and why

**107 lines, and 90 of them are one thing.** The four destination bodies inside `searchGraph` each call `SearchScreen(...)` with seven navigation lambdas, and none of it runs until a composed `NavHost` reaches the destination — which builds both ViewModels through `hiltViewModel()` and so needs a Hilt-injected activity this module cannot construct. `SearchGraphTest` covers the registration those bodies hang off, which is the failure that actually ships; `:app`'s instrumented suite exercises the bodies. The rest is the two `hiltViewModel()` default arguments, the `null ->` arm of `LibrarySource?.asFilter()` (unreachable — its only call site is already inside a `defaultScope != null` check), and a few `when`-merge lines with no statement of their own. All recorded in the module's build file and in `docs/TESTING.md`.

## Verification

| Command | Result |
|---|---|
| `./gradlew :feature:search:testDebugUnitTest` | **BUILD SUCCESSFUL** — 130 tests, 0 failures, 0 errors |
| `./gradlew :feature:search:moduleCoverage` | 91.4% lines / 87.0% branches |
| `./gradlew :feature:search:coverageFloor` at 0.99 | fails with the intended message (above) |
| `python3 scripts/check_docs.py` | all 23 checks pass |
| `./gradlew :feature:search:check :feature:search:lintDebug coverageFloor` | still running locally when this PR was opened — CI is the check that matters and any failure will be fixed on this branch before merge |

`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` and **cannot be run here**; they are not claimed as passing. No `androidTest` was added, so there is nothing in this PR awaiting an emulator.

## Docs

`docs/TESTING.md`: snapshot row moved into the locked table with its final numbers, the locked-module list and the 80/80-vs-softened paragraph updated, and a new audit section — *Search, and the question that leaves the device* — listing what each new test file pins.

---
_Generated by [Claude Code](https://claude.ai/code/session_0144ZhZAtnHrjkh12691GDLz)_