### PR TITLE
test(feature:prayer): clear 80% and lock the module

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -46,6 +46,7 @@ Two on-device/JVM test surfaces exist:
   - [The zakat calculator and its history (`:feature:tools/src/test` and `src/testDebug`)](#the-zakat-calculator-and-its-history-featuretoolssrctest-and-srctestdebug)
   - [Search, and the question that leaves the device (`:feature:search/src/test` and `src/testDebug`)](#search-and-the-question-that-leaves-the-device-featuresearchsrctest-and-srctestdebug)
   - [The six widgets, composed for real (`:feature:widget/src/test`)](#the-six-widgets-composed-for-real-featurewidgetsrctest)
+  - [Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)](#prayer-times-the-month-table-and-the-qibla-featureprayersrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -166,7 +167,7 @@ floor is a ratchet — raised when a module is brought up to it, never lowered t
 green. The branch floor is set per module, at 80% where branches are reachable and lower where
 the Compose compiler's `$dirty` checks make them not (see
 [Where each module stands](#where-each-module-stands)). `:core:database` is the first module
-locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search` and `:feature:widget`.
+locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget` and `:feature:prayer`.
 
 ### What is not counted, and why
 
@@ -268,7 +269,16 @@ in `:feature:tools`, or the one screen and four cards in `:feature:search` — n
 enough of them to move the number.
 `:feature:widget` is Compose of a different kind — six **Glance** widgets — and holds **89.3%**
 branches, which settles the question for the widget surface too.
-`:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here. Only `:feature:quran` is softened, to
+`:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here.
+
+**Two modules are softened to 80 line / 60 branch, and for two different reasons.**
+`:feature:prayer` is the second, and its reason is arithmetic rather than Compose:
+`PrayerTimesPdfExporter` cannot execute under Robolectric at all, and it carries **103 of the
+224 branches the module still misses**. Discount that one file and the module stands at 81.6%
+branches, over the standard; count it — which the gate does, because nothing is excluded to
+reach these numbers — and 80% is out of reach whatever else is tested. The remaining 121 are
+spread over six Compose screens and twelve components, where the `$dirty` bitmask below takes
+its usual share. `:feature:quran` is the first, softened to
 80% lines and **60%** branches, because the Compose compiler
 emits a `$dirty` bitmask branch per parameter of every restartable composable — the skippability
 check — and neither side of one is reachable from a test: which side runs depends on what the
@@ -291,9 +301,9 @@ split, and should say so where it sets its floors.
 | `:feature:tools` | 97.5% | 83.6% | **locked** at 80/80 (#606) |
 | `:feature:search` | 91.4% | 87.0% | **locked** at 80/80 (#607) |
 | `:feature:widget` | 97.6% | 89.3% | **locked** at 80/80 (#608) |
+| `:feature:prayer` | 84.1% | 70.5% | **locked** at 80 line / 60 branch (#609) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:core:data` | 39.0% | 31.2% | |
-| `:feature:prayer` | 38.1% | 23.7% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
 | `:feature:content` | 28.8% | 19.5% | |
 | `:feature:about` | 17.8% | 23.0% | |
@@ -761,6 +771,90 @@ being right. Every render test below is a guard against exactly that silence.
 are the `$dirty` bitmask branch the Compose compiler emits per composable parameter, which no test
 can take both sides of; the rest are a handful of `when`-merge lines with no statement of their
 own. No `COVERAGE_EXCLUSIONS` entry was added or widened.
+
+
+### Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)
+
+The twelfth module locked: **38.1% lines to 84.1%**, from 1,086 covered lines to 2,398, and 23.7%
+to **70.5%** branches. 62 tests added across ten new classes. Three screens — the month timetable,
+the day pager and the qibla compass — were at **0%** between them, 855 lines of the 1,767 missing,
+and nothing had ever composed one.
+
+**This is the second module locked at a softened branch floor, and the first where the reason is
+not Compose.** `PrayerTimesPdfExporter` cannot run under Robolectric — `PdfDocument` throws
+`"document is closed!"` on the first `startPage` — and it holds 296 lines and 116 branches, 103 of
+them still missing. `:feature:quran` settled the same problem the same way for `TafseerPdfExporter`
+in #598: leave it at zero, make the 80% up elsewhere, record it. Nothing is excluded to reach these
+numbers; the file is counted in full against both floors.
+
+**Three things here are worth knowing before adding a test to this module.**
+
+- **The PDF export path is still testable — the failure arm is.** `MonthlyPrayerTimesScreen`
+  renders a month's PDF *inside a click handler* and reports start-then-outcome through the
+  ViewModel. Under Robolectric the render always fails, which makes this the one place the
+  `onFailure` arm runs for real: the assertion is that a month whose PDF cannot be produced still
+  reports, still leaves the timetable on screen, and never throws out of composition.
+- **`ArQiblaView` is the app's only camera surface, and CameraX does not clean up after itself.**
+  `ProcessCameraProvider.getInstance()` cannot complete with no camera: it leaves a pending
+  listener on the main looper and a half-initialised provider behind it, and Robolectric runs a
+  module's classes in one JVM, so that state lands on whichever class launches an activity next —
+  as `FutureGarbageCollectedException: CameraX initInternal` raised from an unrelated screen's
+  test, or as `lightZ must be a finite positive, given=Infinity` out of `ThreadedRenderer.setup`
+  before that class runs a line of its own. Neither names CameraX; both depend on class order and
+  on when a GC happens to run. **This module therefore forks a JVM per test class**
+  (`unitTests.all { it.setForkEvery(1) }`), which is the only thing that actually contains it, at
+  a cost of about three minutes. No other module needs it, and none of them has a camera
+  dependency. Every activity-launching class here also pins its **density** in `@Config`, because
+  `lightZ` is a theme dimension resolved against `DisplayMetrics.density`.
+- **The AR overlay's geometry is covered by drawing it, per the campaign's canvas technique.**
+  `QiblaArtTest` asks the `ComposeView` to draw into a software `android.graphics.Canvas` under
+  `@GraphicsMode(NATIVE)` and reads the pixels back; composing the tree alone runs `Canvas(modifier)`
+  and none of its `DrawScope` lambda. Not `captureToImage()`, which hangs.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| The month header against the month's rows | `MonthlyPrayerTimesScreenTest` | header and grid are two renderings of one fact drawn from different places — `currentMonth` and each row's own date. `:feature:calendar` shipped exactly this bug; a header naming the wrong month over a correct timetable reads as the prayer times being wrong |
+| One row per day, and the right day expanded | same | a row dispatches **its own** date, and only the expanded row draws the six times — a card ignoring `expandedDay` opens every row at once |
+| What the header calls the place | same | `isUsingFallbackLocation` wins over any name still in state, and a blank name reads as "Not set". `FallbackLocation` exists so a surface can say it is using a stand-in rather than caption a timetable with a city the reader has never been to |
+| The export chooser | same | offered only once there is a month to export, counts the days it would produce, and offers the Ramadan row only in Ramadan |
+| A PDF that cannot be rendered | same | start is reported, then exactly one outcome, and the timetable stays on screen. A silent failure here is a share button that does nothing |
+| The Ramadan timetable | same | the row *asks* — a month of astronomy belongs off the click handler — and the result arriving in state is shared once and then acknowledged, or a recomposition re-opens the share sheet |
+| What a single day row claims | `MonthlyPrayerTimesEventRowTest` | "today" compared against the system date inside the row; the highest-priority Islamic event matched by Hijri date; the fast length shown in Ramadan and nowhere else. Dates are derived from `HijriDateCalculator`, not hardcoded, so nothing starts failing the year the Hijri calendar moves past it |
+| A day with no computable times | `MonthlyPrayerTimesScreenTest` | six `--:--` cells rather than six blanks, and the row still present. At high latitudes this is a real day, not a rendering bug |
+| Which day the pager is on, and how it says so | `PrayerTimesScreenTest` | the relative label, the "Today" chip that renders only `if (!isToday)`, and the arrows. A screen that loses the chip strands a reader on a day they browsed to |
+| Tracking toggles on a future day | same | withheld — five toggles today (sunrise is not a prayer), none on a day that has not happened |
+| Swiping between days | same | the gesture, not just the arrows: a drag threshold read with the wrong sign pages backwards, which is indistinguishable from the arrows being swapped |
+| The day-info card and the month picker | same | daylight, sun and method are reported; `--:--` when there is no sunrise at all; picking a date in the sheet reports the choice |
+| Marking a prayer from the pager | `PrayerTimesTrackingTest` | the future is refused, a marked prayer clears (and drops its timestamp), yesterday is keyed to *yesterday*, sunrise is never recorded, and it reports as `prayer_tracked` — #359's third site, the one that made dashboards under-count |
+| The compass lifecycle | `QiblaScreenTest` | `StartCompass` on entry and `StopCompass` on disposal. A screen that never sends stop leaves the magnetometer registered after the reader has left — a drain nobody can see |
+| The qibla error surface | same | shown only when there is no bearing to draw, and carrying both a retry and a route to setting a location. An error replacing a working compass is worse than the stale refresh behind it |
+| The camera gate | same | AR is `state.isArMode && cameraPermissionGranted`, held in local state no ViewModel test can reach. The permission is requested rather than assumed, a denial is explained, and a grant enters AR |
+| Where the compass thinks it is | `QiblaViewModelLocationTest` | a stored location yields bearing, distance and declination; 0,0 is an error rather than a compass pointing north; a nameless location still gets a name to show; an explicitly chosen location recomputes rather than only being stored |
+| The confirmation haptic | same | a rising edge — once on the way in, again only after turning away and back — and silent when vibration is off, without losing the reported alignment |
+| The bearing/status capsule | `QiblaStatusCapsuleTest` | three states from two booleans: the turn hint is withheld until the compass settles, alignment is announced even before it does, and the **sign** of `rotationToQibla` decides the direction. Dropping the sign is confidently wrong half the time |
+| The compass view's two layouts | `CompassQiblaViewLayoutTest` | the tablet branch is a second copy of the same children and must lose none of them; `needsCalibration` is `UNRELIABLE || LOW`, not `UNRELIABLE` alone; with no location the dial draws but claims no bearing |
+| The calibration sheet | `QiblaCalibrationSheetTest` | every accuracy the sensor can report has its own word — the label changing as you wave the phone is the whole point of the sheet — plus the gesture, the three steps and the way out. The frame clock is pinned manually: the figure-8 animation never lets it idle |
+| The AR overlay's words | `ArQiblaViewTest` | outside the 60° field of view the overlay says so in words and names the shorter way round. A beam clamped to the screen edge is indistinguishable from one pointing just off frame, so someone with their back to Mecca is shown an arrow that looks right |
+| The AR overlay's geometry | `QiblaArtTest` | drawn into a bitmap: nothing at all without a location, a beam that lands where the qibla is rather than in the middle of the screen, a sweep arc when it is behind you, and a dimmed — not dropped — beam on an unreliable compass |
+| The night-worship window's other two states | `NightWorshipScreenTest` | loading is guarded on `lastThirdAt == null` too, so a refresh does not blank a live countdown; a failure is reported **inline** so the hub's other cards survive it, with a retry that dispatches |
+| The manual retry and the failed night | `NightWorshipRefreshTest` | `Refresh` is the only way out of a failed hub without leaving the screen, and it is a separate path from the observation `init` starts, with its own error handling. A settings read that throws is reported rather than reaching `viewModelScope`'s uncaught handler |
+| The five prayer destinations | `PrayerGraphTest` | all five register, and each resolves as a start destination in its own right. `Qibla` is registered twice over under two routes — a graph registering only one works from the tools hub and crashes from the bottom bar |
+
+**One production edit, and it is a real fix.** `ArQiblaView` called `cameraProviderFuture.get()`
+*outside* the `try` that guarded `bindToLifecycle`. A future that completes exceptionally — the
+provider failing to initialise at all — then throws `ExecutionException` from a listener running on
+the main executor with nothing above it to catch, and the app dies as the AR qibla opens, on
+exactly the devices whose camera stack is already unhappy. The `get()` is inside the guard now.
+
+**What stays uncovered, and why.** `PrayerTimesPdfExporter` (258 lines) for the reason above.
+Twenty-four of `PrayerGraph`'s thirty lines are the five destination bodies: each builds its screen
+through `hiltViewModel()`, which resolves only inside a composed `NavHost` on a Hilt-injected
+activity this module cannot build — the same structural gap `:feature:search` records, and `:app`'s
+instrumented suite is what exercises them. The rest is `@Preview` functions (three lines each,
+their contents hoisted into the excluded `ComposableSingletons`), the `hiltViewModel()` default
+arguments, and `QiblaCalibrationSheet`'s figure-8 `Canvas`, whose draw block needs a software
+canvas the sheet's own popup window is not part of. No `COVERAGE_EXCLUSIONS` entry was added or
+widened.
 
 
 ## Conventions

--- a/feature/prayer/build.gradle.kts
+++ b/feature/prayer/build.gradle.kts
@@ -12,8 +12,70 @@ android {
         unitTests {
             isReturnDefaultValues = true
             isIncludeAndroidResources = true
+
+            /**
+             * **One JVM per test class, only in this module.**
+             *
+             * `ArQiblaView` is the app's only CameraX surface, and `ProcessCameraProvider
+             * .getInstance()` cannot complete on a machine with no camera: it leaves a pending
+             * listener on the main looper and a half-initialised provider behind it. Robolectric
+             * runs a whole module's classes in one JVM, so that state outlives the test that
+             * created it and lands on whichever class launches an activity next — as
+             * `FutureGarbageCollectedException: CameraX initInternal` raised from an unrelated
+             * screen's test, or as `lightZ must be a finite positive, given=Infinity` thrown out
+             * of `ThreadedRenderer.setup` before that class runs a line of its own.
+             *
+             * Both failures name neither CameraX nor the test that caused them, and both depend
+             * on class order and on when a GC happens to run — so they are green locally and red
+             * in CI at a rate no amount of re-running settles. Forking per class is what actually
+             * contains it. Measured cost: this module's `testDebugUnitTest` goes from about one
+             * minute to about four. The alternative is either an intermittently red gate or
+             * leaving the AR qibla — the only camera surface in the app — untested.
+             *
+             * No other module needs this, and none of them has a camera dependency.
+             */
+            all { it.setForkEvery(1) }
         }
     }
+}
+
+/**
+ * Locked at the standard line floor with a **softened branch floor**, measured at **84.1% lines /
+ * 70.5% branches** with the tests added by #609.
+ *
+ * **The softening is one file.** `PrayerTimesPdfExporter` — 296 of the module's 2,853 lines and
+ * 116 of its 760 branches — cannot run under Robolectric at all: `PdfDocument` throws
+ * `"document is closed!"` on the first `startPage`, so every path past that point is unreachable
+ * from a JVM test. `:feature:quran` hit exactly this with `TafseerPdfExporter` (#598) and settled
+ * it the same way: leave it at zero, make the 80% up elsewhere, and say so here. Nothing is
+ * excluded to reach these numbers — `COVERAGE_EXCLUSIONS` is untouched, and the file is counted
+ * in full against both floors.
+ *
+ * The arithmetic is what decides the branch floor. 103 of the 224 branches still missing are in
+ * that one file; discount them and the module stands at **81.6%** branches, over the standard.
+ * Counting them, 80% is arithmetically out of reach — the remaining 121 are spread across six
+ * Compose screens and twelve components, where a large share is the `$dirty` bitmask branch the
+ * Compose compiler emits per parameter of every restartable composable, and no test can take both
+ * sides of those. So: `lineFloor` at the standard, `branchFloor` at 0.60, which the module clears
+ * by more than ten points.
+ *
+ * **What is *actually* uncovered, besides the exporter**, is two things and both are structural.
+ * Twenty-four of `PrayerGraph`'s thirty lines are the five destination bodies: each constructs its
+ * screen through `hiltViewModel()`, which resolves only inside a composed `NavHost` on a
+ * Hilt-injected activity this module has no way to build. `PrayerGraphTest` covers the
+ * registration those bodies hang off — the failure that ships is a destination that throws on tap
+ * — and `:app`'s instrumented suite exercises the bodies. The rest is `@Preview` functions (three
+ * lines each, their contents hoisted into the excluded `ComposableSingletons`), the
+ * `hiltViewModel()` default arguments, and `QiblaCalibrationSheet`'s figure-8 `Canvas`, whose draw
+ * block needs a software canvas the sheet's own popup window is not part of.
+ *
+ * `ArQiblaView`'s camera preview is *not* on that list: the CameraX binding cannot complete with
+ * no camera, but the overlay drawn over it is fully covered, and the provider future's failure
+ * arm is now guarded rather than crashing out of a main-thread listener.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.60)
 }
 
 // When each prayer *is*, and which way to face: prayer times, the monthly table, qibla and the

--- a/feature/prayer/src/main/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/ArQiblaView.kt
+++ b/feature/prayer/src/main/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/ArQiblaView.kt
@@ -93,17 +93,27 @@ fun ArQiblaView(
             var cameraProvider: ProcessCameraProvider? = null
 
             cameraProviderFuture.addListener({
-                cameraProvider = cameraProviderFuture.get()
-                val preview = Preview.Builder().build().also {
-                    it.surfaceProvider = previewView.surfaceProvider
-                }
-                val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-
+                // The `get()` is inside the `try`, not before it.
+                //
+                // It was outside, guarding only `bindToLifecycle`, and a future that completes
+                // *exceptionally* — the provider failing to initialise at all — makes `get()`
+                // throw `ExecutionException` from a listener running on the main executor, with
+                // nothing above it to catch: the app dies as the AR qibla opens, on exactly the
+                // devices whose camera stack is already unhappy. The bind was guarded because
+                // "camera may not be available"; the provider not arriving is the same fact,
+                // one step earlier.
                 try {
+                    cameraProvider = cameraProviderFuture.get()
+                    val preview = Preview.Builder().build().also {
+                        it.surfaceProvider = previewView.surfaceProvider
+                    }
+                    val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
                     cameraProvider?.unbindAll()
                     cameraProvider?.bindToLifecycle(lifecycleOwner, cameraSelector, preview)
                 } catch (_: Exception) {
-                    // Camera may not be available
+                    // Camera may not be available: the overlay still draws over a blank frame,
+                    // which is the same thing the reader sees while the preview is starting.
                 }
             }, androidx.core.content.ContextCompat.getMainExecutor(context))
 

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesEventRowTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesEventRowTest.kt
@@ -1,0 +1,186 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatFastLength
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.calendar.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.DayPrayerTimes
+import com.arshadshah.nimaz.domain.model.IslamicEventType
+import com.arshadshah.nimaz.domain.model.IslamicEvents
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesUiState
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
+
+/**
+ * What a single row of the month table says about its day, beyond the six times.
+ *
+ * Three things are computed per row rather than passed in, and each is a claim about the day:
+ *
+ * - **"Today"**, which is compared against the *system* date inside the composable rather than
+ *   taken from state. It is what makes one row in thirty findable at a glance, and a row that
+ *   loses it leaves the reader counting.
+ * - **The Islamic event**, matched by Hijri month and day against the shipped catalogue and
+ *   reduced to the highest-priority one. A row that showed a *lower*-priority event, or none,
+ *   would silently drop Ashura or an Eid from the timetable of the month it falls in.
+ * - **The fast length**, shown only in Ramadan. Elsewhere it is noise; in Ramadan it is the
+ *   number people plan their day around.
+ *
+ * Dates here are derived from `HijriDateCalculator`, not hardcoded: an assertion pinned to a
+ * Gregorian date would start failing on its own the year the Hijri calendar moved past it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp-mdpi")
+class MonthlyPrayerTimesEventRowTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(MonthlyPrayerTimesUiState())
+
+    private val viewModel: MonthlyPrayerTimesViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@MonthlyPrayerTimesEventRowTest.state
+        every { onEvent(any()) } answers { firstArg<MonthlyPrayerTimesEvent>(); Unit }
+    }
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun at(date: LocalDate, hour: Int, minute: Int): kotlin.time.Instant =
+        kotlin.time.Instant.fromEpochMilliseconds(
+            date.atTime(hour, minute).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+
+    private fun day(date: LocalDate, fastMinutes: Int? = null) = DayPrayerTimes(
+        date = date,
+        fajr = at(date, 5, 45),
+        sunrise = at(date, 7, 12),
+        dhuhr = at(date, 12, 30),
+        asr = at(date, 15, 15),
+        maghrib = at(date, 17, 48),
+        isha = at(date, 19, 18),
+        fastMinutes = fastMinutes,
+    )
+
+    private fun render(days: List<DayPrayerTimes>, month: YearMonth = YearMonth.from(days.first().date)) {
+        state.value = MonthlyPrayerTimesUiState(
+            currentMonth = month,
+            dayPrayerTimes = days,
+            locationName = "Dublin, Ireland",
+            methodLabel = "MWL · Standard",
+            isLoading = false,
+        )
+        composeRule.setThemedContent {
+            MonthlyPrayerTimesScreen(onNavigateBack = {}, viewModel = viewModel)
+        }
+        composeRule.waitForIdle()
+    }
+
+    /** The next Gregorian date carrying an event of [type], searched forward from today. */
+    private fun dateWithEvent(type: IslamicEventType): Pair<LocalDate, String> {
+        val hijriToday = HijriDateCalculator.toHijri(LocalDate.now())
+        for (year in hijriToday.year..(hijriToday.year + 1)) {
+            val event = IslamicEvents.events.firstOrNull { it.eventType == type } ?: continue
+            val date = HijriDateCalculator.toGregorian(event.hijriDay, event.hijriMonth, year)
+            return date to event.nameEnglish
+        }
+        error("no event of type $type in the shipped catalogue")
+    }
+
+    @Test
+    fun `today's row is labelled as today`() {
+        val today = LocalDate.now()
+        render(listOf(day(today.minusDays(1)), day(today), day(today.plusDays(1))))
+
+        // Compared against the system date inside the row, so this is the only place the "today"
+        // treatment — the label, the gradient fill and the highlighted day badge — can be
+        // checked at all.
+        composeRule.onAllNodesWithText(str(R.string.today), substring = true).onFirst()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a day with no event carries no event tag`() {
+        val (eventDate, eventName) = dateWithEvent(IslamicEventType.HOLIDAY)
+        // The day after an event is deliberately chosen: an off-by-one in the Hijri match would
+        // put the tag here instead.
+        render(listOf(day(eventDate.plusDays(1))))
+
+        composeRule.onNodeWithText(eventName, substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a holiday is tagged, and starred`() {
+        val (date, name) = dateWithEvent(IslamicEventType.HOLIDAY)
+        render(listOf(day(date)))
+
+        // Holidays get a star ahead of the name — the one event kind the row distinguishes
+        // visually rather than only by colour.
+        composeRule.onNodeWithText("★ $name").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a fasting day is tagged without the star`() {
+        val (date, name) = dateWithEvent(IslamicEventType.FAST)
+        render(listOf(day(date)))
+
+        composeRule.onNodeWithText(name).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a night of worship is tagged`() {
+        val (date, name) = dateWithEvent(IslamicEventType.NIGHT)
+        render(listOf(day(date)))
+
+        composeRule.onNodeWithText(name).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a historical day is tagged`() {
+        val (date, name) = dateWithEvent(IslamicEventType.HISTORICAL)
+        render(listOf(day(date)))
+
+        composeRule.onNodeWithText(name).assertIsDisplayed()
+    }
+
+    @Test
+    fun `in ramadan the row states the fast length`() {
+        val hijriYear = HijriDateCalculator.toHijri(LocalDate.now()).year
+        val ramadanDay = HijriDateCalculator.getFirstDayOfRamadan(hijriYear).plusDays(3)
+        render(listOf(day(ramadanDay, fastMinutes = 903)))
+
+        composeRule.onNodeWithText(
+            str(R.string.monthly_fast_length_format, formatFastLength(903)),
+            substring = true,
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `outside ramadan the fast length is not shown even when it is known`() {
+        val hijriYear = HijriDateCalculator.toHijri(LocalDate.now()).year
+        // Shawwal — the month straight after Ramadan, so the guard is `month == 9` and not
+        // "some month near Ramadan".
+        val afterRamadan = HijriDateCalculator.getLastDayOfRamadan(hijriYear).plusDays(5)
+        render(listOf(day(afterRamadan, fastMinutes = 903)))
+
+        composeRule.onNodeWithText(formatFastLength(903), substring = true).assertDoesNotExist()
+    }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreenTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/MonthlyPrayerTimesScreenTest.kt
@@ -1,0 +1,339 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.DayPrayerTimes
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesUiState
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.MonthlyPrayerTimesViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
+
+/**
+ * The month timetable: what the grid shows, and what the export chooser above it does.
+ *
+ * **The header and the grid are two renderings of one fact** — which month is on screen — and the
+ * screen draws them from different places: the header from `currentMonth`, every row from its own
+ * `DayPrayerTimes.date`. `:feature:calendar` shipped exactly this bug (fixed by
+ * `CalendarMonth.displayedMonth`): a header naming one month above a grid of another, which does
+ * not look like a bug, it looks like the prayer times are wrong. Nothing in the ViewModel test can
+ * see it, because the ViewModel holds one month and is self-consistent by construction.
+ *
+ * **The export path is the other reason this exists.** `shareRows` renders a PDF *inside a click
+ * handler* and reports the outcome through the ViewModel — start, then completed-or-failed. Under
+ * Robolectric `PdfDocument` cannot render at all (`"document is closed!"`), which makes this the
+ * one place the failure arm can be exercised for real: the assertion is that a month whose PDF
+ * cannot be produced still reports, still leaves the timetable on screen, and never throws out of
+ * composition. The exporter itself stays at 0% — see the module's `nimazCoverage` KDoc.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp-mdpi")
+class MonthlyPrayerTimesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val month = YearMonth.of(2026, 3)
+
+    private val state = MutableStateFlow(MonthlyPrayerTimesUiState())
+    private val events = mutableListOf<MonthlyPrayerTimesEvent>()
+
+    private val viewModel: MonthlyPrayerTimesViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@MonthlyPrayerTimesScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<MonthlyPrayerTimesEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun at(date: LocalDate, hour: Int, minute: Int): kotlin.time.Instant =
+        kotlin.time.Instant.fromEpochMilliseconds(
+            date.atTime(hour, minute).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+
+    private fun day(date: LocalDate) = DayPrayerTimes(
+        date = date,
+        fajr = at(date, 5, 45),
+        sunrise = at(date, 7, 12),
+        dhuhr = at(date, 12, 30),
+        asr = at(date, 15, 15),
+        maghrib = at(date, 17, 48),
+        isha = at(date, 19, 18),
+        fastMinutes = 723,
+    )
+
+    private fun daysOf(vararg dayOfMonth: Int) = dayOfMonth.map { day(month.atDay(it)) }
+
+    private fun render() {
+        composeRule.setThemedContent {
+            MonthlyPrayerTimesScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun loaded(
+        days: List<DayPrayerTimes> = daysOf(1, 2, 3),
+        locationName: String? = "Dublin, Ireland",
+        isUsingFallbackLocation: Boolean = false,
+        ramadanHijriYear: Int? = null,
+    ) {
+        state.value = MonthlyPrayerTimesUiState(
+            currentMonth = month,
+            dayPrayerTimes = days,
+            locationName = locationName,
+            isUsingFallbackLocation = isUsingFallbackLocation,
+            methodLabel = "MWL · Standard",
+            ramadanHijriYear = ramadanHijriYear,
+            isLoading = false,
+        )
+    }
+
+    @Test
+    fun `the header names the month the rows belong to`() {
+        loaded(days = daysOf(1, 2, 3))
+        render()
+
+        // "March 2026" above rows dated in March. A header drawn from a second source of truth
+        // is how a timetable ends up captioned with the wrong month.
+        composeRule.onNodeWithText("March 2026").assertIsDisplayed()
+        composeRule.onNodeWithText("Sun, 1 March", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Tue, 3 March", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `one row per day, and no more`() {
+        loaded(days = daysOf(1, 2, 3, 4))
+        render()
+
+        // Every row carries the expand affordance, so counting them counts rows — a day
+        // silently dropped from the grid is a day with no prayer times at all.
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_expand))
+            .assertCountEquals(4)
+    }
+
+    @Test
+    fun `the month arrows page in both directions`() {
+        loaded()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_next_month)).performClick()
+        composeRule.onNodeWithContentDescription(str(R.string.cd_previous_month)).performClick()
+
+        assertThat(events).containsExactly(
+            MonthlyPrayerTimesEvent.NextMonth,
+            MonthlyPrayerTimesEvent.PreviousMonth,
+        ).inOrder()
+    }
+
+    @Test
+    fun `tapping a day asks to expand that day, not another`() {
+        loaded(days = daysOf(1, 2, 3))
+        render()
+
+        composeRule.onNodeWithText("Tue, 3 March", substring = true).performClick()
+
+        // The date travels with the event: a row that dispatches its neighbour's date expands
+        // the wrong day's times, which reads as the timetable being wrong.
+        assertThat(events).containsExactly(
+            MonthlyPrayerTimesEvent.ToggleDayExpanded(month.atDay(3))
+        )
+    }
+
+    @Test
+    fun `the expanded day shows all six times and the others do not`() {
+        state.value = MonthlyPrayerTimesUiState(
+            currentMonth = month,
+            dayPrayerTimes = daysOf(1, 2),
+            locationName = "Dublin, Ireland",
+            isLoading = false,
+            expandedDay = month.atDay(2),
+        )
+        render()
+
+        // Six labels, one per prayer, and only for the expanded row: the grid is drawn per card,
+        // so a card that ignores `expandedDay` opens every row at once.
+        listOf(
+            R.string.prayer_fajr,
+            R.string.prayer_sunrise,
+            R.string.prayer_dhuhr,
+            R.string.prayer_asr,
+            R.string.prayer_maghrib,
+            R.string.prayer_isha,
+        ).forEach { composeRule.onNodeWithText(str(it)).assertIsDisplayed() }
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_collapse)).assertIsDisplayed()
+        composeRule.onAllNodesWithContentDescription(str(R.string.cd_expand)).assertCountEquals(1)
+    }
+
+    @Test
+    fun `a fallback location is named as a default, never as a city`() {
+        loaded(locationName = "Dublin, Ireland", isUsingFallbackLocation = true)
+        render()
+
+        // `isUsingFallbackLocation` wins over any name still sitting in state — the header must
+        // not caption a timetable with a city the reader has never been to.
+        composeRule.onNodeWithText(str(R.string.location_using_default)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a blank location name reads as not set rather than as an empty caption`() {
+        loaded(locationName = "  ")
+        render()
+
+        composeRule.onNodeWithText(str(R.string.location_not_set)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the ramadan badge and the ramadan export appear together, and only in ramadan`() {
+        loaded()
+        render()
+
+        composeRule.onNodeWithText(str(R.string.ramadan_month_label)).assertDoesNotExist()
+
+        state.value = state.value.copy(ramadanHijriYear = 1447)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.ramadan_month_label)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).performClick()
+        composeRule.onNodeWithText(str(R.string.ramadan_year_format, 1447)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the export action is offered only once there is a month to export`() {
+        state.value = MonthlyPrayerTimesUiState(currentMonth = month, isLoading = true)
+        render()
+
+        // Exporting an empty month produces an empty PDF and a share sheet for it.
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).assertIsNotEnabled()
+
+        loaded()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).assertIsEnabled()
+    }
+
+    @Test
+    fun `the export chooser counts the days it would export`() {
+        loaded(days = daysOf(1, 2, 3, 4, 5))
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).performClick()
+
+        composeRule.onNodeWithText(str(R.string.monthly_this_month)).assertIsDisplayed()
+        // The row says what it would produce — month and day count — so a chooser offering to
+        // export a month it does not actually hold is visible before the share sheet opens.
+        composeRule.onNodeWithText("March 2026 \u00b7 5 days").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a month export that cannot render is reported, and the timetable stays up`() {
+        loaded()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).performClick()
+        composeRule.onNodeWithText(str(R.string.monthly_this_month)).performClick()
+        composeRule.waitForIdle()
+
+        // Started first, then exactly one outcome. The screen measures the duration itself
+        // because the render runs here, on the click handler's thread; the ViewModel is the only
+        // thing that reports. A silent failure here is a share button that does nothing.
+        assertThat(events.first()).isEqualTo(MonthlyPrayerTimesEvent.ExportStarted)
+        assertThat(
+            events.count {
+                it is MonthlyPrayerTimesEvent.ExportFailed ||
+                    it is MonthlyPrayerTimesEvent.ExportCompleted
+            }
+        ).isEqualTo(1)
+        composeRule.onNodeWithText("March 2026").assertIsDisplayed()
+    }
+
+    @Test
+    fun `asking for the ramadan timetable dispatches the request rather than computing it`() {
+        loaded(ramadanHijriYear = 1447)
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.export_as_pdf)).performClick()
+        composeRule.onNodeWithText(str(R.string.ramadan_year_format, 1447)).performClick()
+        composeRule.waitForIdle()
+
+        // A month of astronomy belongs off the click handler: the row asks, the ViewModel
+        // computes, and the result comes back through state.
+        assertThat(events).contains(MonthlyPrayerTimesEvent.PrepareRamadanExport)
+        assertThat(events).doesNotContain(MonthlyPrayerTimesEvent.ExportStarted)
+    }
+
+    @Test
+    fun `a ramadan timetable that lands in state is shared once and then cleared`() {
+        loaded(ramadanHijriYear = 1447)
+        render()
+
+        state.value = state.value.copy(ramadanExport = daysOf(1, 2, 3))
+        composeRule.waitForIdle()
+
+        // Consumed explicitly, because it is a one-shot held in state: without the acknowledgment
+        // the next recomposition re-opens the share sheet.
+        assertThat(events).contains(MonthlyPrayerTimesEvent.ExportStarted)
+        assertThat(events).contains(MonthlyPrayerTimesEvent.RamadanExportConsumed)
+    }
+
+    @Test
+    fun `a day whose times could not be computed shows placeholders, not blanks`() {
+        val date = month.atDay(1)
+        state.value = MonthlyPrayerTimesUiState(
+            currentMonth = month,
+            dayPrayerTimes = listOf(
+                DayPrayerTimes(date, null, null, null, null, null, null, fastMinutes = null)
+            ),
+            locationName = "Tromso, Norway",
+            isLoading = false,
+            expandedDay = date,
+        )
+        render()
+
+        // At high latitudes a prayer can genuinely have no time on a given day. Six empty cells
+        // read as a rendering bug; six "--:--" read as what they are. The row still has to be
+        // there either way — dropping it would leave a gap in the month.
+        // The card merges its children's semantics, so the six cells are only individually
+        // addressable in the unmerged tree.
+        composeRule.onAllNodesWithText("--:--", useUnmergedTree = true).assertCountEquals(6)
+        composeRule.onNodeWithText("Sun, 1 March", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `back navigates back`() {
+        loaded()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreenTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTimesScreenTest.kt
@@ -1,0 +1,310 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.presentation.model.PrayerTimeDisplay
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesUiState
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.PrayerTimesViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * The day pager: which day is on screen, how it says so, and what the rows on it can do.
+ *
+ * **Three of these only exist on screen.** The ViewModel publishes `selectedDate` and `isToday`
+ * and nothing else about the framing; whether a reader can tell they are looking at *tomorrow's*
+ * times rather than today's — and whether they have any way back — is decided entirely here, by
+ * the relative label, by the "Today" chip that renders `if (!state.isToday)`, and by the tracking
+ * toggles that are withheld on a future day. A screen that loses the chip strands the reader on
+ * a day they browsed to; a screen that keeps the toggles invites them to tick a prayer that has
+ * not happened yet.
+ *
+ * The location line is the fourth: `FallbackLocation` exists so that a surface can *say* it is
+ * using a stand-in, and the header is the only place that promise is kept.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp-mdpi")
+class PrayerTimesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val today: LocalDate = LocalDate.now()
+
+    private val state = MutableStateFlow(PrayerTimesUiState())
+    private val events = mutableListOf<PrayerTimesEvent>()
+
+    private val viewModel: PrayerTimesViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@PrayerTimesScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<PrayerTimesEvent>() }
+    }
+
+    private var backs = 0
+    private var settingsOpens = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun at(date: LocalDate, hour: Int, minute: Int): kotlin.time.Instant =
+        kotlin.time.Instant.fromEpochMilliseconds(
+            date.atTime(hour, minute).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+
+    private fun prayersFor(date: LocalDate) = listOf(
+        PrayerTimeDisplay(PrayerType.FAJR, "Fajr", at(date, 5, 45)),
+        PrayerTimeDisplay(PrayerType.SUNRISE, "Sunrise", at(date, 7, 12)),
+        PrayerTimeDisplay(PrayerType.DHUHR, "Dhuhr", at(date, 12, 30)),
+        PrayerTimeDisplay(PrayerType.ASR, "Asr", at(date, 15, 15)),
+        PrayerTimeDisplay(PrayerType.MAGHRIB, "Maghrib", at(date, 17, 48)),
+        PrayerTimeDisplay(PrayerType.ISHA, "Isha", at(date, 19, 18)),
+    )
+
+    private fun render() {
+        composeRule.setThemedContent {
+            PrayerTimesScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToSettings = { settingsOpens++ },
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun show(
+        date: LocalDate = today,
+        isToday: Boolean = date == today,
+        locationName: String = "Dublin, Ireland",
+        isUsingFallbackLocation: Boolean = false,
+    ) {
+        state.value = PrayerTimesUiState(
+            locationName = locationName,
+            isUsingFallbackLocation = isUsingFallbackLocation,
+            selectedDate = date,
+            isToday = isToday,
+            prayers = prayersFor(date),
+            tomorrowFajrAt = at(date.plusDays(1), 5, 44),
+            sunriseAt = at(date, 7, 12),
+            sunsetAt = at(date, 17, 48),
+            daylight = "10h 36m",
+            methodLabel = "MWL · Standard",
+        )
+    }
+
+    @Test
+    fun `today's six prayers are listed`() {
+        show()
+        render()
+
+        listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha").forEach {
+            composeRule.onAllNodesWithText(it).onFirst().assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `the header names the place, and says so when it is only a default`() {
+        show(locationName = "Dublin, Ireland")
+        render()
+        composeRule.onNodeWithText("Dublin, Ireland").assertIsDisplayed()
+
+        // The stand-in must never be captioned as somewhere the reader chose. `locationName` is
+        // still populated in this state — the flag, not the emptiness of the name, is what
+        // decides the copy.
+        show(locationName = "Dublin, Ireland", isUsingFallbackLocation = true)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(str(R.string.location_using_default)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the day arrows page in both directions`() {
+        show()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_next_day)).performClick()
+        composeRule.onNodeWithContentDescription(str(R.string.cd_previous_day)).performClick()
+
+        assertThat(events).containsExactly(
+            PrayerTimesEvent.NextDay,
+            PrayerTimesEvent.PreviousDay,
+        ).inOrder()
+    }
+
+    @Test
+    fun `on today the nav bar says TODAY and offers no way back to it`() {
+        show()
+        render()
+
+        composeRule.onNodeWithText(str(R.string.today_uppercase)).assertIsDisplayed()
+        // The chip renders only `if (!state.isToday)` — offering "Today" while on today is a
+        // control that does nothing.
+        composeRule.onAllNodesWithText(str(R.string.today)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `browsing off today labels the day and offers the way back`() {
+        show(date = today.plusDays(1))
+        render()
+
+        composeRule.onNodeWithText(str(R.string.fasting_tomorrow).uppercase()).assertIsDisplayed()
+
+        composeRule.onNodeWithText(str(R.string.today)).performClick()
+        assertThat(events).containsExactly(PrayerTimesEvent.GoToToday)
+    }
+
+    @Test
+    fun `yesterday and a distant day both get a relative label`() {
+        show(date = today.minusDays(1))
+        render()
+        composeRule.onNodeWithText(str(R.string.relative_yesterday).uppercase())
+            .assertIsDisplayed()
+
+        show(date = today.plusDays(4))
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("IN 4 DAYS").assertIsDisplayed()
+
+        show(date = today.minusDays(3))
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("3 DAYS AGO").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping a prayer row toggles that prayer`() {
+        show()
+        render()
+
+        composeRule.onAllNodesWithText("Asr").onFirst().performClick()
+
+        // The row carries its own type: a card wired to a captured loop variable toggles the
+        // wrong prayer, and the reader's record is then quietly wrong.
+        assertThat(events).containsExactly(PrayerTimesEvent.TogglePrayer(PrayerType.ASR))
+    }
+
+    @Test
+    fun `a future day offers no tracking toggles`() {
+        show(date = today.plusDays(2))
+        render()
+
+        // `showToggle = !isFuture`: a prayer that has not happened cannot have been prayed, and
+        // a checkbox that says otherwise writes a record for a day that has not arrived.
+        composeRule.onAllNodesWithContentDescription(str(R.string.prayed)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `today's rows do offer them`() {
+        show()
+        render()
+
+        // Five, not six: sunrise is not a prayer and never carries a toggle.
+        composeRule.onAllNodesWithContentDescription(str(R.string.prayed)).assertCountEquals(5)
+    }
+
+    @Test
+    fun `the day info card reports the sun, the daylight and the method`() {
+        show()
+        render()
+
+        composeRule.onNodeWithText(str(R.string.prayer_info_daylight)).assertIsDisplayed()
+        composeRule.onNodeWithText("10h 36m").assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.prayer_info_method)).assertIsDisplayed()
+        composeRule.onNodeWithText("MWL · Standard").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the date opens a month picker and picking a day selects it`() {
+        show()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_pick_date)).performClick()
+        composeRule.waitForIdle()
+
+        // The calendar is the only way to reach a day more than a few taps away; a sheet that
+        // opens but does not report the choice makes the arrows the only navigation there is.
+        val target = today.withDayOfMonth(if (today.dayOfMonth == 15) 16 else 15)
+        composeRule.onAllNodesWithText(target.dayOfMonth.toString()).onFirst().performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(PrayerTimesEvent.SelectDate(target))
+    }
+
+    @Test
+    fun `a day with no sun times shows placeholders rather than an empty row`() {
+        state.value = PrayerTimesUiState(
+            locationName = "Tromso, Norway",
+            selectedDate = today,
+            isToday = true,
+            prayers = prayersFor(today),
+            sunriseAt = null,
+            sunsetAt = null,
+            daylight = "—",
+            methodLabel = "MWL · Standard",
+        )
+        render()
+
+        // Above the Arctic Circle there are days with no sunrise at all. The info card still has
+        // to say something: an empty value beside "Sunrise / Sunset" reads as a failed load.
+        composeRule.onNodeWithText("--:-- — --:--").assertIsDisplayed()
+    }
+
+    @Test
+    fun `swiping left and right pages the day`() {
+        show()
+        render()
+
+        // Swiped across the whole root, not across a label: the handler ignores drags shorter
+        // than 64dp, and a node-width swipe on a short piece of text never reaches that.
+        composeRule.onRoot().performTouchInput {
+            swipeLeft(startX = right - 1f, endX = left + 1f, durationMillis = 200)
+        }
+        composeRule.waitForIdle()
+        composeRule.onRoot().performTouchInput {
+            swipeRight(startX = left + 1f, endX = right - 1f, durationMillis = 200)
+        }
+        composeRule.waitForIdle()
+
+        // The arrows are not the only way through the pager, and the gesture is the one people
+        // actually use. A drag threshold read with the wrong sign pages the wrong way, which is
+        // indistinguishable from the arrows being swapped.
+        assertThat(events).containsExactly(
+            PrayerTimesEvent.NextDay,
+            PrayerTimesEvent.PreviousDay,
+        ).inOrder()
+    }
+
+    @Test
+    fun `the sky's back and settings pills navigate`() {
+        show()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.cd_back)).performClick()
+        assertThat(backs).isEqualTo(1)
+
+        composeRule.onNodeWithContentDescription(str(R.string.settings)).performClick()
+        assertThat(settingsOpens).isEqualTo(1)
+    }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreenTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qibla/QiblaScreenTest.kt
@@ -1,0 +1,272 @@
+package com.arshadshah.nimaz.presentation.screens.qibla
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.annotation.StringRes
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.model.CompassData
+import com.arshadshah.nimaz.domain.model.QiblaCalculator
+import com.arshadshah.nimaz.domain.model.QiblaInfo
+import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.QiblaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.QiblaUiState
+import com.arshadshah.nimaz.presentation.viewmodel.prayer.QiblaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * The qibla screen's own logic: the compass lifecycle, the error surface, and the camera gate.
+ *
+ * The compass drawing itself is `CompassQiblaView`'s (tested separately). What is *here* is the
+ * wiring around it, and every piece of it fails silently:
+ *
+ * - **The sensor lifecycle.** `StartCompass`/`StopCompass` are dispatched from a
+ *   `DisposableEffect`. A screen that never sends `Stop` leaves the magnetometer registered after
+ *   the reader has navigated away — a battery drain nobody can see and nothing else will catch.
+ * - **The error surface only shows when there is nothing to draw.** A refresh that fails while a
+ *   bearing is already on screen must not replace a working compass with a red message.
+ * - **The camera gate.** AR mode is `state.isArMode && cameraPermissionGranted`, held in local
+ *   state the ViewModel cannot see, so no ViewModel test can reach it. Getting it wrong points
+ *   the camera surface at a permission that was never granted, or strands a reader who denied it
+ *   with no explanation.
+ */
+@RunWith(RobolectricTestRunner::class)
+// Density pinned deliberately: `lightZ` is a theme dimension resolved against
+// `DisplayMetrics.density`, and a class that inherits its density can have Robolectric's renderer
+// setup reject it as `Infinity` and throw out of the compose rule's `before` — before a line of
+// this screen runs. See the `forkEvery` note in the module's build file.
+@Config(qualifiers = "w411dp-h891dp-mdpi")
+class QiblaScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(QiblaUiState())
+    private val events = mutableListOf<QiblaEvent>()
+
+    private val viewModel: QiblaViewModel = mockk(relaxed = true) {
+        every { qiblaState } returns this@QiblaScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<QiblaEvent>() }
+    }
+
+    private var backs = 0
+    private var activity: ComponentActivity? = null
+
+    /** Drives the screen out of the composition, which is the `onDispose` the sensors hang on. */
+    private val onScreen = mutableStateOf(true)
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun grantCamera() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.CAMERA)
+    }
+
+    private fun render() {
+        composeRule.setThemedContent {
+            val context = LocalContext.current
+            SideEffect { activity = context as? ComponentActivity }
+            if (onScreen.value) {
+                QiblaScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun pointing(
+        bearing: Double = 119.0,
+        accuracy: CompassAccuracy = CompassAccuracy.HIGH,
+    ) = QiblaUiState(
+        qiblaDirection = QiblaCalculator.calculateQiblaDirection(53.35, -6.26),
+        qiblaInfo = QiblaInfo(
+            direction = QiblaCalculator.calculateQiblaDirection(53.35, -6.26),
+            locationName = "Dublin, Ireland",
+            latitude = 53.35,
+            longitude = -6.26,
+            distanceToMecca = 4_900.0,
+        ),
+        compassData = CompassData(azimuth = bearing.toFloat(), accuracy = accuracy),
+        isCompassReady = true,
+        isLoading = false,
+    )
+
+    @Test
+    fun `the compass is started on entry and stopped when the screen leaves`() {
+        state.value = pointing()
+        render()
+
+        assertThat(events).containsExactly(QiblaEvent.StartCompass)
+
+        // Leaving the screen is a disposal, not a lifecycle callback the ViewModel can observe.
+        onScreen.value = false
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(QiblaEvent.StopCompass)
+    }
+
+    @Test
+    fun `with no bearing at all, the error offers a retry and a way to set a location`() {
+        state.value = QiblaUiState(
+            isLoading = false,
+            error = UiError(message = R.string.qibla_no_location, kind = NimazErrorKind.LOCATION),
+        )
+        render()
+
+        composeRule.onNodeWithText(str(R.string.qibla_no_location)).assertIsDisplayed()
+
+        // Before this the screen showed the sentence and nothing else — no retry, no route to
+        // settings, and a compass that could not be recovered from without leaving the screen.
+        composeRule.onNodeWithText(str(R.string.try_again)).performClick()
+        composeRule.onNodeWithText(str(R.string.location_set_prompt)).performClick()
+
+        assertThat(events).containsAtLeast(
+            QiblaEvent.RefreshLocation,
+            QiblaEvent.ShowLocationPicker,
+        )
+    }
+
+    @Test
+    fun `an error beside a working bearing does not replace the compass`() {
+        state.value = pointing().copy(
+            error = UiError(message = R.string.qibla_failed, kind = NimazErrorKind.LOCATION),
+        )
+        render()
+
+        // A compass already pointing somewhere is more use than a message about a refresh that
+        // failed; the error arm is gated on `qiblaInfo == null` for exactly this.
+        composeRule.onNodeWithText(str(R.string.qibla_no_location_body)).assertDoesNotExist()
+        composeRule.onNodeWithText("Dublin, Ireland").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the calibrate action opens the sheet and dismissing it is reported`() {
+        composeRule.mainClock.autoAdvance = false
+        state.value = pointing(accuracy = CompassAccuracy.LOW)
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.calibrate_compass)).performClick()
+        assertThat(events).contains(QiblaEvent.ShowCalibrationDialog)
+
+        // The sheet is rendered from state, not from a local `remember`, so the dismissal has to
+        // travel back or it can never be re-opened.
+        state.value = state.value.copy(showCalibrationDialog = true)
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.onNodeWithText(str(R.string.got_it)).performClick()
+
+        assertThat(events).contains(QiblaEvent.DismissCalibrationDialog)
+    }
+
+    @Test
+    fun `with the camera already granted, the toggle goes straight to AR`() {
+        grantCamera()
+        state.value = pointing()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.point_with_camera)).performClick()
+
+        assertThat(events).contains(QiblaEvent.SetArMode(true))
+    }
+
+    @Test
+    fun `without the camera, the toggle asks for it rather than entering AR`() {
+        state.value = pointing()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.point_with_camera)).performClick()
+        composeRule.waitForIdle()
+
+        val requested = shadowOf(activity!!).lastRequestedPermission
+        assertThat(requested.requestedPermissions.toList())
+            .contains(Manifest.permission.CAMERA)
+        // AR is not entered on the strength of the request — only on the grant.
+        assertThat(events).doesNotContain(QiblaEvent.SetArMode(true))
+    }
+
+    @Test
+    fun `denying the camera explains why AR did not open`() {
+        state.value = pointing()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.point_with_camera)).performClick()
+        composeRule.waitForIdle()
+
+        val requested = shadowOf(activity!!).lastRequestedPermission
+        activity!!.onRequestPermissionsResult(
+            requested.requestCode,
+            arrayOf(Manifest.permission.CAMERA),
+            intArrayOf(android.content.pm.PackageManager.PERMISSION_DENIED),
+        )
+        composeRule.waitForIdle()
+
+        // A denial that says nothing reads as a broken button.
+        composeRule.onNodeWithText(str(R.string.camera_permission_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.not_now)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(str(R.string.camera_permission_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `granting the camera from the prompt enters AR`() {
+        state.value = pointing()
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.point_with_camera)).performClick()
+        composeRule.waitForIdle()
+
+        val requested = shadowOf(activity!!).lastRequestedPermission
+        grantCamera()
+        activity!!.onRequestPermissionsResult(
+            requested.requestCode,
+            arrayOf(Manifest.permission.CAMERA),
+            intArrayOf(android.content.pm.PackageManager.PERMISSION_GRANTED),
+        )
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(QiblaEvent.SetArMode(true))
+    }
+
+    @Test
+    fun `AR mode is refused while the permission is not held, whatever state says`() {
+        state.value = pointing().copy(isArMode = true)
+        render()
+
+        // `isArMode && cameraPermissionGranted`: a state flag alone must not put the camera
+        // surface on screen — the top bar still offers to *enter* AR, not to leave it.
+        composeRule.onNodeWithContentDescription(str(R.string.point_with_camera))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `in AR mode the toggle offers the way back to the compass`() {
+        grantCamera()
+        state.value = pointing().copy(isArMode = true)
+        render()
+
+        composeRule.onNodeWithContentDescription(str(R.string.back_to_compass)).performClick()
+
+        assertThat(events).contains(QiblaEvent.SetArMode(false))
+    }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreenTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/worship/NightWorshipScreenTest.kt
@@ -1,0 +1,157 @@
+package com.arshadshah.nimaz.presentation.screens.worship
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.worship.NightWorshipEvent
+import com.arshadshah.nimaz.presentation.viewmodel.worship.NightWorshipUiState
+import com.arshadshah.nimaz.presentation.viewmodel.worship.NightWorshipViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * The two states of the night-worship window that carry no times: still loading, and failed.
+ *
+ * `NightWorshipContentTest` covers the three *window* states — before, open, closed — which is
+ * where the time-of-day logic lives. What it does not cover is the card before any of that:
+ *
+ * - **Loading is guarded on `lastThirdAt == null`, not on `isLoading` alone.** A refresh that
+ *   flips `isLoading` while times are already on screen must not blank the card back to a
+ *   spinner; someone watching the countdown would see it disappear for no reason.
+ * - **The failure is INLINE, inside the card.** The hub's other cards — the rakah counter, the
+ *   surah and dua shortcuts — are still correct when the astronomy fails, and a full-screen
+ *   error would take them down with it. The retry is the only way back, so it has to dispatch.
+ *
+ * It also runs the `NightWorshipScreen` wrapper against a mocked ViewModel, which is the seam
+ * between the two: the screen's only job is to collect state and forward `onEvent`, and a
+ * wrapper that forwarded neither would still compile and still render an empty hub.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp-mdpi")
+class NightWorshipScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val state = MutableStateFlow(NightWorshipUiState())
+    private val events = mutableListOf<NightWorshipEvent>()
+
+    private val viewModel: NightWorshipViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@NightWorshipScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<NightWorshipEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun render() {
+        composeRule.setThemedContent {
+            NightWorshipScreen(
+                onNavigateBack = { backs++ },
+                onOpenSurah = {},
+                onOpenDuaCategory = {},
+                onOpenHadith = {},
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `with no times yet the window card shows a spinner rather than an empty box`() {
+        // The spinner is indeterminate, so the frame clock never idles — see #604.
+        composeRule.mainClock.autoAdvance = false
+        state.value = NightWorshipUiState(isLoading = true)
+        render()
+        composeRule.mainClock.advanceTimeBy(200)
+
+        composeRule.onNodeWithTag(NightWorshipWindowTestTag).assertExists()
+        composeRule.onNodeWithText(str(R.string.night_worship_times_failed)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a refresh over times already on screen does not blank the card`() {
+        val now = Clock.System.now()
+        state.value = NightWorshipUiState(
+            isLoading = true,
+            lastThirdAt = now + 2.hours,
+            fajrAt = now + 5.hours,
+        )
+        render()
+        composeRule.waitForIdle()
+
+        // `isLoading && lastThirdAt == null` — both halves. Guarding on `isLoading` alone
+        // replaces a live countdown with a spinner every time the day rolls over.
+        composeRule.onNodeWithText(str(R.string.night_worship_last_third)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed calculation is reported in the card, with a retry that dispatches`() {
+        state.value = NightWorshipUiState(
+            isLoading = false,
+            error = UiError(
+                message = R.string.night_worship_times_failed,
+                kind = NimazErrorKind.LOCATION,
+                details = "no location",
+            ),
+        )
+        render()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.night_worship_times_failed)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.try_again)).performClick()
+
+        assertThat(events).contains(NightWorshipEvent.Refresh)
+    }
+
+    @Test
+    fun `the wrapper forwards the counter events its content raises`() {
+        val now = Clock.System.now()
+        state.value = NightWorshipUiState(
+            isLoading = false,
+            lastThirdAt = now - 1.hours,
+            fajrAt = now + 2.hours,
+        )
+        render()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(NightWorshipAddRakahTestTag).performScrollTo().performClick()
+
+        // `viewModel::onEvent` is passed as a reference; a wrapper that swallowed it would show
+        // a counter that never moves.
+        assertThat(events).contains(NightWorshipEvent.AddRakahPair)
+    }
+
+    @Test
+    fun `back navigates back`() {
+        state.value = NightWorshipUiState(isLoading = false)
+        render()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(str(R.string.cd_back)).assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(str(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesTrackingTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/prayer/PrayerTimesTrackingTest.kt
@@ -1,0 +1,210 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.PrayerCalculationSettings
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerType
+import com.arshadshah.nimaz.domain.model.ResolvedLocation
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Marking a prayer from the day pager — the third place in the app a prayer can be tracked.
+ *
+ * `PrayerTimesViewModelTest` covers the pager itself and asserts only that toggling *sunrise*
+ * does nothing. The toggle that does something is untested there, and it has three guards, all
+ * of which fail silently when wrong:
+ *
+ * - **The future is refused.** The screen hides the checkbox on a future day, but the ViewModel
+ *   is what enforces it — a swipe forward and a stale composition would otherwise write a record
+ *   for a prayer that has not happened, which then counts against a streak.
+ * - **It is a toggle, not a set.** Tapping a prayer already marked has to clear it; a handler
+ *   that always writes `PRAYED` gives a reader no way to undo a mistap.
+ * - **`prayedAt` is cleared on the way back down.** A record marked not-prayed that keeps its
+ *   timestamp is a row that disagrees with itself.
+ *
+ * The fourth is telemetry, and it is the reason this ViewModel is named in #359's follow-up: it
+ * reported a generic `toggle_prayer` while the tracker and Home reported `prayer_tracked`, so a
+ * dashboard built on the latter under-counted every prayer marked from this screen.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrayerTimesTrackingTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val today = LocalDate.of(2026, 8, 14)
+    private val telemetry = RecordingTelemetry()
+    private val records = MutableStateFlow<List<PrayerRecord>>(emptyList())
+
+    private lateinit var prayerUseCases: PrayerUseCases
+
+    private val settings = PrayerCalculationSettings(
+        location = ResolvedLocation(51.5, -0.1, "London", isFallback = false),
+        calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+        asrCalculation = AsrCalculation.STANDARD,
+        highLatitudeRule = null,
+        adjustments = emptyMap(),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        prayerUseCases = mockk(relaxed = true)
+        every { prayerUseCases.observeCalculationSettings() } returns flowOf(settings)
+        every { prayerUseCases.getPrayerRecordsForDate(any()) } returns records
+        every { prayerUseCases.getDaySchedule(any<LocalDate>(), any()) } returns emptyList()
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = PrayerTimesViewModel(
+        prayerUseCases = prayerUseCases,
+        todayProvider = FakeTodayProvider(today),
+        defaultDispatcher = dispatcher,
+        telemetry = telemetry,
+    )
+
+    private fun dateKey(date: LocalDate) = date.toEpochDay() * 86_400_000L
+
+    private fun record(name: PrayerName, status: PrayerStatus) = PrayerRecord(
+        id = 0L,
+        date = dateKey(today),
+        prayerName = name,
+        status = status,
+        prayedAt = if (status == PrayerStatus.PRAYED) 1L else null,
+        scheduledTime = 0L,
+        isJamaah = false,
+        isQadaFor = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Test
+    fun `marking an untracked prayer records it as prayed, with a time`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.ASR))
+        advanceUntilIdle()
+
+        coVerify {
+            prayerUseCases.updatePrayerStatus(
+                dateKey(today),
+                PrayerName.ASR,
+                PrayerStatus.PRAYED,
+                match { it != null },
+                false,
+            )
+        }
+    }
+
+    @Test
+    fun `marking a prayer already prayed clears it, and clears the time with it`() =
+        runTest(dispatcher) {
+            records.value = listOf(record(PrayerName.DHUHR, PrayerStatus.PRAYED))
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.DHUHR))
+            advanceUntilIdle()
+
+            coVerify {
+                prayerUseCases.updatePrayerStatus(
+                    dateKey(today),
+                    PrayerName.DHUHR,
+                    PrayerStatus.NOT_PRAYED,
+                    null,
+                    false,
+                )
+            }
+        }
+
+    @Test
+    fun `a future day cannot be tracked`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTimesEvent.NextDay)
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.FAJR))
+        advanceUntilIdle()
+
+        // The screen also hides the control, but that is a rendering decision; this is the rule.
+        coVerify(exactly = 0) {
+            prayerUseCases.updatePrayerStatus(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `a past day can still be tracked, against that day's key`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTimesEvent.PreviousDay)
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.MAGHRIB))
+        advanceUntilIdle()
+
+        // Catching up on yesterday is the common case, and the record has to land on *yesterday*:
+        // a handler that keyed on "today" would quietly rewrite the wrong day.
+        coVerify {
+            prayerUseCases.updatePrayerStatus(
+                dateKey(today.minusDays(1)),
+                PrayerName.MAGHRIB,
+                PrayerStatus.PRAYED,
+                any(),
+                false,
+            )
+        }
+    }
+
+    @Test
+    fun `sunrise is not a prayer and is never recorded`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.SUNRISE))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            prayerUseCases.updatePrayerStatus(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `tracking is reported as a tracked prayer, not as a generic toggle`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+            telemetry.clear()
+
+            vm.onEvent(PrayerTimesEvent.TogglePrayer(PrayerType.ISHA))
+            advanceUntilIdle()
+
+            // #359's third site. Reported under its own name, or every dashboard built on
+            // `prayer_tracked` under-counts by however many people mark prayers from here.
+            assertThat(telemetry.prayersTracked.map { it.prayer }).contains(PrayerName.ISHA.name)
+        }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModelLocationTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/prayer/QiblaViewModelLocationTest.kt
@@ -1,0 +1,370 @@
+package com.arshadshah.nimaz.presentation.viewmodel.prayer
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.CompassOrientation
+import com.arshadshah.nimaz.domain.repository.CompassSensors
+import com.arshadshah.nimaz.domain.repository.Haptics
+import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Where the compass thinks it is, and what it does about facing the Kaaba.
+ *
+ * `QiblaViewModelTest` covers the sensor stream — the unwrap, the accuracy plumbing, the
+ * start/stop lifecycle. This covers the other half, which is the part a reader can actually be
+ * misled by:
+ *
+ * - **No location is a *state*, not an empty compass.** With nothing stored, the needle would
+ *   otherwise spin against a bearing of zero, which is a real direction (north) and the wrong
+ *   one. The error is what lets the screen offer a way out instead.
+ * - **A location arriving recomputes everything downstream of it** — the bearing, the distance,
+ *   and the declination the drawn needle is corrected by. A ViewModel that stored the location
+ *   and not the direction leaves a compass pointing where the last place was.
+ * - **The confirmation haptic is a rising edge.** Buzzing on every reading while someone holds
+ *   the phone still is not feedback, it is a vibration that will not stop; never buzzing at all
+ *   means the one moment worth confirming passes silently.
+ * - **True-north correction is a setting.** Turned off, the reading has to stay raw — matching a
+ *   paper compass held beside the phone — rather than being silently corrected anyway.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QiblaViewModelLocationTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private class FakeCompass : CompassSensors {
+        override val isAvailable: Boolean = true
+        val readings = MutableSharedFlow<CompassOrientation>(extraBufferCapacity = 64)
+
+        override fun orientation(): Flow<CompassOrientation> = readings
+
+        suspend fun emit(azimuth: Float, accuracy: CompassAccuracy = CompassAccuracy.HIGH) =
+            readings.emit(CompassOrientation(azimuth, 0f, 0f, accuracy))
+    }
+
+    private class RecordingHaptics : Haptics {
+        var taps = 0
+            private set
+
+        override fun tap() {
+            taps++
+        }
+    }
+
+    /** A location seam whose coordinates can be left unset, which is the state at first run. */
+    private class FakeLocationSettings(
+        latitude: Double = 53.3498,
+        longitude: Double = -6.2603,
+        name: String = "Dublin",
+    ) : LocationSettings {
+        override val latitude = MutableStateFlow(latitude)
+        override val longitude = MutableStateFlow(longitude)
+        override val locationName = MutableStateFlow(name)
+        override val userPreferences: Flow<UserPreferences> =
+            MutableStateFlow(mockk(relaxed = true))
+
+        override suspend fun updateLocation(latitude: Double, longitude: Double, name: String) {
+            this.latitude.value = latitude
+            this.longitude.value = longitude
+            this.locationName.value = name
+        }
+    }
+
+    private fun location(
+        name: String = "Abbeyleix",
+        latitude: Double = 52.9167,
+        longitude: Double = -7.35,
+    ) = Location(
+        id = 1L,
+        name = name,
+        latitude = latitude,
+        longitude = longitude,
+        timezone = "Europe/Dublin",
+        country = "Ireland",
+        city = name,
+        isCurrentLocation = false,
+        isFavorite = false,
+        calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+        asrCalculation = AsrCalculation.STANDARD,
+        highLatitudeRule = null,
+        fajrAngle = null,
+        ishaAngle = null,
+    )
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(
+        compass: CompassSensors = FakeCompass(),
+        haptics: Haptics = RecordingHaptics(),
+        settings: LocationSettings = FakeLocationSettings(),
+    ) = QiblaViewModel(compass, haptics, settings, RecordingTelemetry())
+
+    @Test
+    fun `a stored location yields a bearing, a distance and a declination`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            val state = vm.qiblaState.value
+            assertThat(state.qiblaInfo).isNotNull()
+            // Dublin faces roughly ESE. The exact figure is `QiblaCalculator`'s business (tested
+            // in `:core:domain`); what this pins is that the ViewModel resolved *something* from
+            // the coordinates rather than leaving the compass at zero.
+            assertThat(state.qiblaInfo!!.direction.bearing).isWithin(15.0).of(115.0)
+            assertThat(state.qiblaInfo.distanceToMecca).isGreaterThan(3_000.0)
+            assertThat(state.isLoading).isFalse()
+            assertThat(state.error).isNull()
+        }
+
+    @Test
+    fun `an unset location is an error, not a compass pointing north`() = runTest(dispatcher) {
+        val vm = viewModel(settings = FakeLocationSettings(latitude = 0.0, longitude = 0.0))
+        advanceUntilIdle()
+
+        // 0,0 is the Gulf of Guinea and the value a store returns when nothing was written.
+        // Treating it as a place gives a confidently wrong bearing with no error to explain it.
+        assertThat(vm.qiblaState.value.error).isNotNull()
+        assertThat(vm.qiblaState.value.qiblaInfo).isNull()
+        assertThat(vm.qiblaState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a nameless stored location still gets a name to show`() = runTest(dispatcher) {
+        val vm = viewModel(settings = FakeLocationSettings(name = ""))
+        advanceUntilIdle()
+
+        // The top bar renders `qiblaInfo.locationName`; an empty string there is a blank line
+        // where the place should be, on a screen whose whole claim is "from here, that way".
+        assertThat(vm.qiblaState.value.qiblaInfo!!.locationName).isNotEmpty()
+    }
+
+    @Test
+    fun `choosing a location explicitly replaces the resolved one`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val fromSettings = vm.qiblaState.value.qiblaInfo!!.direction.bearing
+
+        vm.onEvent(QiblaEvent.SetLocation(location(name = "Kuala Lumpur", 3.139, 101.6869)))
+        advanceUntilIdle()
+
+        val state = vm.qiblaState.value
+        assertThat(state.currentLocation!!.name).isEqualTo("Kuala Lumpur")
+        assertThat(state.qiblaInfo!!.locationName).isEqualTo("Kuala Lumpur")
+        // From Malaysia the Kaaba is roughly west-north-west, not east: a `setLocation` that
+        // stored the location without recomputing would leave the needle on Dublin's bearing.
+        assertThat(state.qiblaInfo.direction.bearing).isNotWithin(1.0).of(fromSettings)
+        assertThat(state.qiblaInfo.direction.bearing).isWithin(25.0).of(285.0)
+        assertThat(state.isLoading).isFalse()
+    }
+
+    @Test
+    fun `facing the qibla buzzes once, on the way in`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val haptics = RecordingHaptics()
+        val vm = viewModel(compass = compass, haptics = haptics)
+        advanceUntilIdle()
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        val bearing = vm.qiblaState.value.qiblaInfo!!.direction.bearing.toFloat()
+        compass.emit(bearing)
+        advanceUntilIdle()
+        assertThat(haptics.taps).isEqualTo(1)
+        assertThat(vm.qiblaState.value.isFacingQibla).isTrue()
+
+        // Still facing, one degree later: a haptic per reading is a phone that will not stop
+        // buzzing for as long as it is held straight.
+        compass.emit(bearing + 0.5f)
+        advanceUntilIdle()
+        assertThat(haptics.taps).isEqualTo(1)
+    }
+
+    @Test
+    fun `turning away and back buzzes again`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val haptics = RecordingHaptics()
+        val vm = viewModel(compass = compass, haptics = haptics)
+        advanceUntilIdle()
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+        val bearing = vm.qiblaState.value.qiblaInfo!!.direction.bearing.toFloat()
+
+        compass.emit(bearing)
+        advanceUntilIdle()
+        compass.emit(bearing + 90f)
+        advanceUntilIdle()
+        assertThat(vm.qiblaState.value.isFacingQibla).isFalse()
+
+        compass.emit(bearing)
+        advanceUntilIdle()
+
+        assertThat(haptics.taps).isEqualTo(2)
+    }
+
+    @Test
+    fun `with vibration off, alignment is silent but still reported`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val haptics = RecordingHaptics()
+        val vm = viewModel(compass = compass, haptics = haptics)
+        advanceUntilIdle()
+        vm.onEvent(QiblaEvent.SetVibrationEnabled(false))
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        compass.emit(vm.qiblaState.value.qiblaInfo!!.direction.bearing.toFloat())
+        advanceUntilIdle()
+
+        assertThat(haptics.taps).isEqualTo(0)
+        assertThat(vm.qiblaState.value.isFacingQibla).isTrue()
+    }
+
+    @Test
+    fun `a wider threshold counts as facing sooner`() = runTest(dispatcher) {
+        val compass = FakeCompass()
+        val vm = viewModel(compass = compass)
+        advanceUntilIdle()
+        val bearing = vm.qiblaState.value.qiblaInfo!!.direction.bearing.toFloat()
+        vm.onEvent(QiblaEvent.StartCompass)
+        advanceUntilIdle()
+
+        compass.emit(bearing + 12f)
+        advanceUntilIdle()
+        assertThat(vm.qiblaState.value.isFacingQibla).isFalse()
+
+        // The threshold is a user setting; ignoring it makes the tolerance a constant and the
+        // setting a lie.
+        vm.onEvent(QiblaEvent.SetQiblaThreshold(20f))
+        compass.emit(bearing + 12.5f)
+        advanceUntilIdle()
+        assertThat(vm.qiblaState.value.isFacingQibla).isTrue()
+    }
+
+    @Test
+    fun `the settings toggles are held and reported`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QiblaEvent.SetTrueNorthMode(false))
+        vm.onEvent(QiblaEvent.SetSoundEnabled(true))
+        advanceUntilIdle()
+
+        assertThat(vm.settingsState.value.trueNorthMode).isFalse()
+        assertThat(vm.settingsState.value.soundEnabled).isTrue()
+    }
+
+    @Test
+    fun `the location picker and the calibration sheet are opened and closed through state`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(QiblaEvent.ShowLocationPicker)
+            assertThat(vm.qiblaState.value.showLocationPicker).isTrue()
+            vm.onEvent(QiblaEvent.HideLocationPicker)
+            assertThat(vm.qiblaState.value.showLocationPicker).isFalse()
+
+            vm.onEvent(QiblaEvent.ShowCalibrationDialog)
+            assertThat(vm.qiblaState.value.showCalibrationDialog).isTrue()
+            vm.onEvent(QiblaEvent.DismissCalibrationDialog)
+            assertThat(vm.qiblaState.value.showCalibrationDialog).isFalse()
+        }
+
+    @Test
+    fun `AR mode is a state change, and refreshing is a no-op because location is observed`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(QiblaEvent.SetArMode(true))
+            assertThat(vm.qiblaState.value.isArMode).isTrue()
+            vm.onEvent(QiblaEvent.SetArMode(false))
+            assertThat(vm.qiblaState.value.isArMode).isFalse()
+
+            // `RefreshLocation` exists for the error surface's retry button. The location flow is
+            // already collected, so the retry must not tear anything down — the assertion is
+            // that the bearing survives it.
+            val before = vm.qiblaState.value.qiblaInfo
+            vm.onEvent(QiblaEvent.RefreshLocation)
+            advanceUntilIdle()
+            assertThat(vm.qiblaState.value.qiblaInfo).isEqualTo(before)
+        }
+
+    @Test
+    fun `an accuracy reported directly is folded into the compass reading`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(QiblaEvent.UpdateAccuracy(CompassAccuracy.UNRELIABLE))
+            advanceUntilIdle()
+
+            assertThat(vm.qiblaState.value.compassData.accuracy)
+                .isEqualTo(CompassAccuracy.UNRELIABLE)
+            assertThat(vm.qiblaState.value.needsCalibration).isTrue()
+        }
+
+    @Test
+    fun `a location that arrives after the compass has started still steers it`() =
+        runTest(dispatcher) {
+            val compass = FakeCompass()
+            val settings = FakeLocationSettings(latitude = 0.0, longitude = 0.0)
+            val vm = viewModel(compass = compass, settings = settings)
+            advanceUntilIdle()
+            vm.onEvent(QiblaEvent.StartCompass)
+            advanceUntilIdle()
+
+            // Readings arrive with no direction to compare them against: the needle still has to
+            // turn, or the compass looks frozen while the location resolves.
+            compass.emit(45f)
+            advanceUntilIdle()
+            assertThat(vm.qiblaState.value.isCompassReady).isTrue()
+            assertThat(vm.qiblaState.value.isFacingQibla).isFalse()
+
+            settings.updateLocation(53.3498, -6.2603, "Dublin")
+            advanceUntilIdle()
+
+            assertThat(vm.qiblaState.value.qiblaInfo).isNotNull()
+            assertThat(vm.qiblaState.value.error).isNull()
+        }
+
+    @Test
+    fun `with true north off the heading is left as the magnetometer read it`() =
+        runTest(dispatcher) {
+            val compass = FakeCompass()
+            val vm = viewModel(compass = compass)
+            advanceUntilIdle()
+            vm.onEvent(QiblaEvent.SetTrueNorthMode(false))
+            vm.onEvent(QiblaEvent.StartCompass)
+            advanceUntilIdle()
+
+            compass.emit(90f)
+            advanceUntilIdle()
+
+            // Raw, to match a paper compass held beside the phone. (Under Robolectric-free JVM
+            // tests `GeomagneticField` returns a zero declination anyway, so this pins the
+            // *path*: the branch that must not apply a correction.)
+            assertThat(vm.qiblaState.value.compassData.azimuth).isWithin(0.01f).of(90f)
+        }
+}

--- a/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipRefreshTest.kt
+++ b/feature/prayer/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/worship/NightWorshipRefreshTest.kt
@@ -1,0 +1,147 @@
+package com.arshadshah.nimaz.presentation.viewmodel.worship
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.PrayerCalculationSettings
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.FakePrayerTimetableRepository
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.buildPrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.prayerCalculationSettings
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The manual retry, and what happens when the astronomy behind the hub cannot be worked out.
+ *
+ * `Refresh` is not a leftover: the window card renders an inline error with a retry button, and
+ * this event is what that button dispatches. It is therefore the **only** way out of a failed
+ * hub without leaving the screen — and it is a second, separate code path from the observation
+ * the ViewModel starts in `init`, with its own error handling. A retry that reported success
+ * while leaving the error in place leaves a button that visibly does nothing.
+ *
+ * The failure arm matters for the same reason it was written: a settings read that throws does
+ * so *outside* `computeNightTimes`' `runCatching`, so before `launchSafely` wrapped it the
+ * exception reached `viewModelScope`'s uncaught handler — a crash, from a screen someone opened
+ * in the middle of the night.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NightWorshipRefreshTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val today = LocalDate.of(2026, 3, 15)
+
+    private lateinit var prayers: FakePrayerTimetableRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        prayers = FakePrayerTimetableRepository(
+            prayerCalculationSettings(
+                latitude = 51.5074,
+                longitude = -0.1278,
+                highLatitudeRule = HighLatitudeRule.MIDDLE_OF_THE_NIGHT,
+            ),
+        )
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `a manual refresh recomputes the window`() = runTest(dispatcher) {
+        val vm = NightWorshipViewModel(
+            buildPrayerUseCases(prayers),
+            FakeTodayProvider(today),
+            dispatcher,
+            RecordingTelemetry(),
+        )
+        advanceUntilIdle()
+
+        vm.onEvent(NightWorshipEvent.Refresh)
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.error).isNull()
+        assertThat(state.lastThirdAt).isNotNull()
+        assertThat(state.fajrAt).isNotNull()
+    }
+
+    @Test
+    fun `a refresh whose settings read throws lands as an error, not a crash`() =
+        runTest(dispatcher) {
+            val telemetry = RecordingTelemetry()
+            val settings = MutableStateFlow<PrayerCalculationSettings?>(
+                prayerCalculationSettings(latitude = 51.5074, longitude = -0.1278)
+            )
+            val useCases = mockk<PrayerUseCases>(relaxed = true)
+            every { useCases.observeCalculationSettings() } answers {
+                val current = settings.value
+                if (current == null) {
+                    kotlinx.coroutines.flow.flow { throw IllegalStateException("settings gone") }
+                } else {
+                    flowOf(current)
+                }
+            }
+            every { useCases.getSunnahNightTimes(any(), any()) } throws
+                IllegalStateException("no times")
+
+            val vm = NightWorshipViewModel(
+                useCases,
+                FakeTodayProvider(today),
+                dispatcher,
+                telemetry,
+            )
+            advanceUntilIdle()
+
+            // The settings stream fails only on the retry, so this is the refresh path's own
+            // handler rather than the one `init` already exercised.
+            settings.value = null
+            vm.onEvent(NightWorshipEvent.Refresh)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.isLoading).isFalse()
+            assertThat(vm.state.value.error).isNotNull()
+            assertThat(telemetry.errors).isNotEmpty()
+        }
+
+    @Test
+    fun `times that cannot be computed are reported inline and counted`() = runTest(dispatcher) {
+        val telemetry = RecordingTelemetry()
+        val useCases = mockk<PrayerUseCases>(relaxed = true)
+        every { useCases.observeCalculationSettings() } returns
+            flowOf(prayerCalculationSettings(latitude = 51.5074, longitude = -0.1278))
+        every { useCases.getSunnahNightTimes(any(), any()) } throws
+            IllegalStateException("sunnah times unavailable")
+
+        val vm = NightWorshipViewModel(
+            useCases,
+            FakeTodayProvider(today),
+            dispatcher,
+            telemetry,
+        )
+        advanceUntilIdle()
+
+        // Reported through `failure`, not a bare `recordException`: the stack trace used to reach
+        // Crashlytics while the *frequency* reached nothing, so how often the hub fails to
+        // resolve a night was invisible.
+        assertThat(vm.state.value.error).isNotNull()
+        assertThat(vm.state.value.isLoading).isFalse()
+        assertThat(telemetry.errors).isNotEmpty()
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaArtTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaArtTest.kt
@@ -1,0 +1,151 @@
+package com.arshadshah.nimaz.presentation.components.molecules.qibla
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.model.QiblaCalculator
+import com.arshadshah.nimaz.domain.model.QiblaInfo
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The qibla artwork, drawn for real and read back off a bitmap.
+ *
+ * **The AR overlay is geometry with no fallback.** There is no text on it and no asset behind it:
+ * the beam and the sweep arc are `DrawScope` calls, so "it points the right way" is a claim only
+ * a draw pass can settle. The specific failure is the branch — `abs(rotationToQibla) <= HALF_FOV`
+ * decides between *a beam at the Kaaba* and *an arc telling you to keep turning*, and a beam
+ * pinned to the screen edge because the branch was missed is an overlay confidently pointing at a
+ * wall. Composing the tree runs `Canvas(modifier)` and none of its lambda, so the test asks the
+ * `ComposeView` to draw itself into a **software** `android.graphics.Canvas`; Compose's
+ * `RenderNodeLayer` then invokes the draw block directly instead of replaying a render node.
+ *
+ * `@GraphicsMode(NATIVE)` because the assertions are about pixels — under the legacy shadow canvas
+ * every draw is a no-op and the bitmap comes back blank whether the art worked or not. And not
+ * `captureToImage()`, which goes through `PixelCopy` on a real window and hangs (see #604).
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+// Density pinned, as everywhere else in this module: `lightZ` is a theme dimension resolved
+// against `DisplayMetrics.density`, and a class that inherits its density can have Robolectric's
+// renderer setup reject it. See the `forkEvery` note in the module's build file for the failure
+// this belongs to.
+@Config(qualifiers = "w400dp-h800dp-mdpi")
+class QiblaArtTest {
+
+    // The v1 rule, not the shared fixture: these tests need the activity's own view to draw.
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun draw(content: @Composable () -> Unit): Bitmap {
+        composeRule.setContent {
+            MaterialTheme {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Black)) { content() }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val root: View = composeRule.activity
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0)
+        val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+        root.draw(Canvas(bitmap))
+        return bitmap
+    }
+
+    private fun info() = QiblaInfo(
+        direction = QiblaCalculator.calculateQiblaDirection(53.35, -6.26),
+        locationName = "Dublin, Ireland",
+        latitude = 53.35,
+        longitude = -6.26,
+        distanceToMecca = 4_900.0,
+    )
+
+    /** Pixels in a vertical slice that are not the black backdrop — i.e. paint actually laid down. */
+    private fun Bitmap.inkInColumns(left: Int, count: Int): Int {
+        val pixels = IntArray(count * height)
+        getPixels(pixels, 0, count, left.coerceIn(0, width - count), 0, count, height)
+        return pixels.count { it != android.graphics.Color.BLACK }
+    }
+
+    private fun overlay(
+        rotationToQibla: Float,
+        isFacingQibla: Boolean = false,
+        accuracy: CompassAccuracy = CompassAccuracy.HIGH,
+        qiblaInfo: QiblaInfo? = info(),
+    ): Bitmap = draw {
+        QiblaArOverlay(
+            qiblaInfo = qiblaInfo,
+            isFacingQibla = isFacingQibla,
+            rotationToQibla = rotationToQibla,
+            compassAccuracy = accuracy,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+
+    @Test
+    fun `with no location the overlay draws nothing at all`() {
+        val bitmap = overlay(rotationToQibla = 0f, qiblaInfo = null)
+
+        // `return@Canvas` on a null `qiblaInfo`: a beam drawn at whatever `rotationToQibla`
+        // happened to be is a direction presented as fact before any location is known.
+        assertThat(bitmap.inkInColumns(0, bitmap.width)).isEqualTo(0)
+    }
+
+    @Test
+    fun `the beam lands where the qibla is, not in the middle of the screen`() {
+        val bitmap = overlay(rotationToQibla = 20f)
+        val third = bitmap.width / 3
+
+        // 20° right of centre, on a 60° field of view, puts the beam in the right-hand third.
+        // A beam that ignored the offset would paint the middle third instead — and would look
+        // entirely correct in a screenshot taken while facing the Kaaba.
+        val right = bitmap.inkInColumns(2 * third, third)
+        val middle = bitmap.inkInColumns(third, third)
+        assertThat(right).isGreaterThan(middle)
+    }
+
+    @Test
+    fun `a qibla behind you sweeps toward the edge instead of planting a beam`() {
+        val bitmap = overlay(rotationToQibla = 120f)
+
+        // Past the 30° half-field the beam would be clamped to the screen edge and read as
+        // "it is over there", 90° wrong. The arc is the honest rendering of "keep turning".
+        assertThat(bitmap.inkInColumns(0, bitmap.width)).isGreaterThan(0)
+    }
+
+    @Test
+    fun `an unreliable compass still draws the beam, dimmed rather than dropped`() {
+        val bitmap = overlay(rotationToQibla = 0f, accuracy = CompassAccuracy.UNRELIABLE)
+
+        // Same geometry, lower alpha: the overlay does not vanish when the magnetometer is
+        // unsure, it stops looking authoritative. An `if (lowAccuracy) return@Canvas` would
+        // leave the camera feed with nothing on it and no explanation.
+        // (One draw per test — a compose rule can only set content once.)
+        assertThat(bitmap.inkInColumns(0, bitmap.width)).isGreaterThan(0)
+    }
+
+    @Test
+    fun `facing the qibla still paints the beam`() {
+        val bitmap = overlay(rotationToQibla = 1f, isFacingQibla = true)
+
+        assertThat(bitmap.inkInColumns(0, bitmap.width)).isGreaterThan(0)
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaCalibrationSheetTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaCalibrationSheetTest.kt
@@ -1,0 +1,108 @@
+package com.arshadshah.nimaz.presentation.components.molecules.qibla
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The calibration sheet: the only thing standing between an uncalibrated magnetometer and a
+ * reader who trusts the needle.
+ *
+ * Two things here are worth pinning. The **live accuracy readout** is what tells someone whether
+ * the figure-8 they are waving is working — a sheet that renders a fixed label, or the wrong
+ * label for the reading it was handed, turns the whole gesture into superstition. And the sheet
+ * has **two ways out** (the footer button and the header close), both wired to the same
+ * `onDismiss`; a sheet whose only exit is the system back gesture is a trap on a screen the
+ * reader opened by accident.
+ *
+ * Assertions are `assertExists` rather than `assertIsDisplayed`: with the frame clock pinned the
+ * sheet's slide-in never completes, so its content is composed and attached but still parked
+ * below the viewport. What is being pinned here is *what the sheet says*, not where it sits.
+ *
+ * **The clock is pinned manually.** `Figure8Animation` runs `rememberInfiniteTransition`, which
+ * never lets the frame clock idle: with `autoAdvance` left on, `waitForIdle()` on this sheet runs
+ * until the test times out. See #604's note on indeterminate indicators.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QiblaCalibrationSheetTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private var dismissals = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun render(accuracy: CompassAccuracy) {
+        // Before `setContent`, and only in this class: the sheet always shows the figure-8.
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setThemedContent {
+            QiblaCalibrationSheet(accuracy = accuracy, onDismiss = { dismissals++ })
+        }
+        composeRule.mainClock.advanceTimeBy(2_000)
+    }
+
+    @Test
+    fun `the sheet explains the gesture and the three steps`() {
+        render(CompassAccuracy.LOW)
+
+        composeRule.onNodeWithText(str(R.string.calibrate_compass)).assertExists()
+        composeRule.onNodeWithText(str(R.string.calibration_step_1)).assertExists()
+        composeRule.onNodeWithText(str(R.string.calibration_step_2)).assertExists()
+        composeRule.onNodeWithText(str(R.string.calibration_step_3)).assertExists()
+    }
+
+    @Test
+    fun `the readout names the accuracy it was handed`() {
+        render(CompassAccuracy.LOW)
+
+        composeRule.onNodeWithText(str(R.string.accuracy_now_label)).assertExists()
+        composeRule.onNodeWithText("Low").assertExists()
+    }
+
+    @Test
+    fun `a high reading is reported as high, not as the same label for every state`() {
+        render(CompassAccuracy.HIGH)
+
+        // The label is the feedback loop: waving the phone and watching this word change from
+        // "Unreliable" to "High" is the entire point of the sheet.
+        composeRule.onNodeWithText("High").assertExists()
+        composeRule.onNodeWithText("Low").assertDoesNotExist()
+    }
+
+    @Test
+    fun `every accuracy the sensor can report has a word for it`() {
+        // `MEDIUM` and `UNRELIABLE` take their own colour arms; a `when` that misses one does not
+        // compile, but one that maps two readings to the same word ships silently.
+        render(CompassAccuracy.MEDIUM)
+        composeRule.onNodeWithText("Medium").assertExists()
+    }
+
+    @Test
+    fun `an unreliable reading is named too`() {
+        render(CompassAccuracy.UNRELIABLE)
+
+        composeRule.onNodeWithText("Unreliable").assertExists()
+    }
+
+    @Test
+    fun `the footer button closes the sheet`() {
+        render(CompassAccuracy.LOW)
+
+        composeRule.onNodeWithText(str(R.string.got_it)).performClick()
+
+        assertThat(dismissals).isEqualTo(1)
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaStatusCapsuleTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/qibla/QiblaStatusCapsuleTest.kt
@@ -1,0 +1,129 @@
+package com.arshadshah.nimaz.presentation.components.molecules.qibla
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The one element that tells a reader whether they are facing the Kaaba.
+ *
+ * It has three states and they are decided by two booleans in combination, not by an enum:
+ * `isFacingQibla` wins outright, `isCompassReady` only decides whether a *turn hint* is offered
+ * beside the bearing, and neither is `false ⇒ nothing`. The failure that matters is the middle
+ * state: a capsule that shows "Turn right 12°" while the compass has not settled is an
+ * instruction to turn away from the Kaaba, and a capsule that hides the hint once the compass
+ * *has* settled leaves a bearing with nothing to do about it.
+ *
+ * The turn direction is the other half. `rotationToQibla` is signed, and the sign is the whole
+ * message — a capsule that reads the magnitude and drops the sign sends every reader the wrong
+ * way half the time, while still looking entirely plausible.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QiblaStatusCapsuleTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private fun str(@StringRes id: Int, vararg args: Any): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id, *args)
+
+    private fun render(
+        qiblaBearing: Int = 119,
+        isFacingQibla: Boolean = false,
+        rotationToQibla: Float = 12f,
+        isCompassReady: Boolean = true,
+        onCamera: Boolean = false,
+    ) {
+        composeRule.setThemedContent {
+            QiblaStatusCapsule(
+                qiblaBearing = qiblaBearing,
+                isFacingQibla = isFacingQibla,
+                rotationToQibla = rotationToQibla,
+                isCompassReady = isCompassReady,
+                onCamera = onCamera,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `the bearing is always shown, with its cardinal direction`() {
+        render(qiblaBearing = 119)
+
+        // 119° is SE. A bearing printed without its cardinal is a number with no way to sanity
+        // check it against the sun.
+        composeRule.onNodeWithText("119° SE").assertIsDisplayed()
+    }
+
+    @Test
+    fun `before the compass settles there is a bearing and no instruction`() {
+        render(isCompassReady = false, rotationToQibla = 40f)
+
+        composeRule.onNodeWithText("119° SE").assertIsDisplayed()
+        // Neither hint: an unsettled magnetometer's rotation is noise, and rendering it as
+        // "Turn right 40°" is a confident instruction built on nothing.
+        composeRule.onNodeWithText(str(R.string.turn_right_format, 40)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a settled compass off the bearing says which way to turn`() {
+        render(isCompassReady = true, rotationToQibla = 12f)
+
+        composeRule.onNodeWithText(str(R.string.turn_right_format, 12)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a negative rotation turns the other way`() {
+        render(isCompassReady = true, rotationToQibla = -8f)
+
+        // The sign is the instruction. Dropping it — `abs` applied one call too early — is a
+        // capsule that is confidently wrong half the time.
+        composeRule.onNodeWithText(str(R.string.turn_left_format, 8)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.turn_right_format, 8)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `facing the qibla replaces the instruction rather than adding to it`() {
+        render(isFacingQibla = true, rotationToQibla = 1f)
+
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.turn_right_format, 1)).assertDoesNotExist()
+        composeRule.onNodeWithText("119° SE").assertIsDisplayed()
+    }
+
+    @Test
+    fun `facing the qibla is announced even before the compass reports itself ready`() {
+        render(isFacingQibla = true, isCompassReady = false, rotationToQibla = 0f)
+
+        // `showLeft = isFacingQibla || isCompassReady`: the alignment is the stronger fact, and
+        // an `&&` here would blank the one message the reader is waiting for.
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `over the camera the capsule still carries the same words`() {
+        render(onCamera = true, rotationToQibla = -8f)
+
+        // `onCamera` only swaps the surface it is drawn on — the legibility treatment must not
+        // become a second rendering of the message.
+        composeRule.onNodeWithText(str(R.string.turn_left_format, 8)).assertIsDisplayed()
+        composeRule.onNodeWithText("119° SE").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a northern bearing reads as N, not as an out-of-range cardinal`() {
+        render(qiblaBearing = 350)
+
+        composeRule.onNodeWithText("350° N").assertIsDisplayed()
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/ArQiblaViewTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/ArQiblaViewTest.kt
@@ -1,0 +1,117 @@
+package com.arshadshah.nimaz.presentation.components.organisms.qibla
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.domain.model.QiblaCalculator
+import com.arshadshah.nimaz.domain.model.QiblaInfo
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The AR view's chrome — everything drawn over the camera feed that is *not* the beam.
+ *
+ * The camera preview itself is not exercised: `ArQiblaView` is the app's only CameraX surface,
+ * and binding a provider under Robolectric has no device to bind to. What is exercised is the
+ * layer the reader actually reads, and its one real decision:
+ *
+ * **When the Kaaba is outside the camera's 60° field of view, the overlay has to say so in
+ * words.** A beam clamped to the screen edge is indistinguishable from a beam pointing at
+ * something just off frame, so someone standing with their back to Mecca would be shown an
+ * arrow that looks correct and is 150° wrong. The hint also has to name the *shorter* way round —
+ * the sign of `rotationToQibla`, the same sign the compass capsule depends on.
+ *
+ * The bottom HUD is the other half: it renders only with a resolved location, so an AR view
+ * opened before one is known shows the camera and no numbers, rather than a bearing of zero.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp-mdpi")
+class ArQiblaViewTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun info() = QiblaInfo(
+        direction = QiblaCalculator.calculateQiblaDirection(53.35, -6.26),
+        locationName = "Dublin, Ireland",
+        latitude = 53.35,
+        longitude = -6.26,
+        distanceToMecca = 4_900.0,
+    )
+
+    private fun render(
+        rotationToQibla: Float,
+        isFacingQibla: Boolean = false,
+        qiblaInfo: QiblaInfo? = info(),
+    ) {
+        composeRule.setThemedContent {
+            ArQiblaView(
+                azimuth = 30f,
+                qiblaInfo = qiblaInfo,
+                isFacingQibla = isFacingQibla,
+                rotationToQibla = rotationToQibla,
+                isCompassReady = true,
+                compassAccuracy = CompassAccuracy.HIGH,
+                animatedAzimuth = 30f,
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a qibla within the frame needs no turn hint`() {
+        render(rotationToQibla = 12f)
+
+        // Inside the 30° half-field the beam is the instruction; adding words on top of it would
+        // tell a reader already pointing the right way to keep turning.
+        composeRule.onNodeWithText(str(R.string.qibla_turn_right_hint)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.qibla_turn_left_hint)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a qibla off to the right says to turn right`() {
+        render(rotationToQibla = 95f)
+
+        composeRule.onNodeWithText(str(R.string.qibla_turn_right_hint)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.qibla_turn_left_hint)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a qibla off to the left says to turn left`() {
+        render(rotationToQibla = -95f)
+
+        // The sign again: a hint that read the magnitude would send everyone the same way, and
+        // be right half the time.
+        composeRule.onNodeWithText(str(R.string.qibla_turn_left_hint)).assertIsDisplayed()
+        composeRule.onNodeWithText(str(R.string.qibla_turn_right_hint)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `with no location there is neither a hint nor a readout`() {
+        render(rotationToQibla = 120f, qiblaInfo = null)
+
+        // `qiblaOffScreen` is gated on `qiblaInfo != null`: without a location the rotation is
+        // meaningless, and a "turn right" over a live camera feed is a confident instruction
+        // derived from nothing.
+        composeRule.onNodeWithText(str(R.string.qibla_turn_right_hint)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `facing the qibla renders without disturbing the hint state`() {
+        render(rotationToQibla = 1f, isFacingQibla = true)
+
+        composeRule.onNodeWithText(str(R.string.qibla_turn_right_hint)).assertDoesNotExist()
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/CompassQiblaViewLayoutTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/qibla/CompassQiblaViewLayoutTest.kt
@@ -1,0 +1,129 @@
+package com.arshadshah.nimaz.presentation.components.organisms.qibla
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The compass view's two layouts, and the three things it decides for itself.
+ *
+ * `CompassQiblaViewTest` renders it and checks it does not throw. This asserts what it *shows* —
+ * which is not the same question, because everything interesting here is conditional:
+ *
+ * - **The phone/tablet split** is chosen from the window size class, and the two branches are
+ *   near-duplicates. A tablet branch that drops the instruction row or the facts row is a
+ *   regression only a wide viewport can see, and every other test in this module runs on a phone.
+ * - **`needsCalibration` is derived here**, not passed in: `UNRELIABLE || LOW`. A magnetometer
+ *   reporting `LOW` and no banner offering to fix it is a compass that is quietly wrong.
+ * - **`hasQiblaInfo` gates the readouts**, so that a compass with no location still draws its
+ *   dial rather than showing a bearing of zero as though it meant north.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CompassQiblaViewLayoutTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private var calibrations = 0
+
+    private fun str(@StringRes id: Int): String =
+        ApplicationProvider.getApplicationContext<Context>().getString(id)
+
+    private fun render(
+        isFacingQibla: Boolean = false,
+        rotationToQibla: Float = 12f,
+        isCompassReady: Boolean = true,
+        accuracy: CompassAccuracy = CompassAccuracy.HIGH,
+        hasQiblaInfo: Boolean = true,
+    ) {
+        composeRule.setThemedContent {
+            CompassQiblaView(
+                qiblaBearing = 119f,
+                animatedAzimuth = 30f,
+                isFacingQibla = isFacingQibla,
+                rotationToQibla = rotationToQibla,
+                isCompassReady = isCompassReady,
+                accuracy = accuracy,
+                hasQiblaInfo = hasQiblaInfo,
+                onCalibrate = { calibrations++ },
+            )
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `on a phone the readouts sit under the dial`() {
+        render(isFacingQibla = true)
+
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp-mdpi")
+    fun `on a tablet the readouts move beside the dial and none of them are lost`() {
+        render(isFacingQibla = true)
+
+        // The wide branch is a second copy of the same children. A copy that forgets one is a
+        // tablet-only regression, and nothing else in this module runs wide enough to see it.
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp-mdpi")
+    fun `the tablet layout still offers calibration when the compass is unreliable`() {
+        render(accuracy = CompassAccuracy.UNRELIABLE)
+
+        composeRule.onNodeWithText(str(R.string.calibrate)).performClick()
+
+        assertThat(calibrations).isEqualTo(1)
+    }
+
+    @Test
+    fun `a low reading is treated as needing calibration, not just an unreliable one`() {
+        render(accuracy = CompassAccuracy.LOW)
+
+        // `UNRELIABLE || LOW`. Narrowing this to `UNRELIABLE` alone leaves the common case — a
+        // phone that has simply not been waved yet — pointing somewhere plausible and wrong,
+        // with nothing on screen suggesting otherwise.
+        composeRule.onNodeWithText(str(R.string.calibrate)).performClick()
+
+        assertThat(calibrations).isEqualTo(1)
+    }
+
+    @Test
+    fun `a settled, accurate compass is not nagged about calibration`() {
+        render(accuracy = CompassAccuracy.HIGH)
+
+        composeRule.onNodeWithText(str(R.string.calibrate)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `with no location the dial still draws but claims no bearing`() {
+        render(hasQiblaInfo = false, isFacingQibla = false)
+
+        // Neither the instruction nor the facts: a bearing of 0° presented as a fact reads as
+        // "face north", which is a real direction and the wrong one.
+        composeRule.onNodeWithText(str(R.string.finding_direction)).assertDoesNotExist()
+        composeRule.onNodeWithText(str(R.string.facing_qibla)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `while the compass is still finding itself the row says so`() {
+        render(hasQiblaInfo = true, isCompassReady = false)
+
+        composeRule.onNodeWithText(str(R.string.finding_direction)).assertIsDisplayed()
+    }
+}

--- a/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerGraphTest.kt
+++ b/feature/prayer/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerGraphTest.kt
@@ -1,0 +1,83 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Prayer feature's slice of the route graph.
+ *
+ * A destination that fails to register throws `IllegalArgumentException: navigation destination …
+ * is not a direct child of this NavGraph` — at *tap* time, on a device, with nothing catching it
+ * at build time. Three of the five here are reached from outside this module: `PrayerTimes` and
+ * `MonthlyPrayerTimes` from the home surface, `NightWorship` from the More menu. `Qibla` is
+ * registered twice over, under two routes, because the compass is reachable both from the tools
+ * hub and from a bottom-nav entry; a graph that registered only one of them would work from one
+ * entry point and crash from the other, which is the hardest shape of this bug to notice.
+ *
+ * Nothing is composed here — the graph is built against a bare `NavHostController` — so none of
+ * the five screens needs a Hilt ViewModel. That is also the limit of what this can assert: the
+ * destination *bodies* only run inside a composed `NavHost`, where `hiltViewModel()` resolves,
+ * which is `:app`'s instrumented suite. See the module's `nimazCoverage` KDoc.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PrayerGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.PrayerTimes) {
+            prayerGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all five prayer destinations are registered`() {
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(5)
+        listOf(
+            Route.QiblaNav::class,
+            Route.PrayerTimes::class,
+            Route.MonthlyPrayerTimes::class,
+            Route.NightWorship::class,
+            Route.Qibla::class,
+        ).forEach { route ->
+            assertThat(routes.any { it.contains(route.qualifiedName!!) }).isTrue()
+        }
+    }
+
+    @Test
+    fun `each destination resolves as a start destination in its own right`() {
+        // Not symmetry for its own sake. Every one of these is opened directly — from the home
+        // screen, from the More menu, from the bottom bar — rather than only ever being pushed
+        // on top of another prayer screen, and `createGraph` throws here if the route it is
+        // handed is not among the destinations the builder registered.
+        listOf<Any>(
+            Route.QiblaNav,
+            Route.PrayerTimes,
+            Route.MonthlyPrayerTimes,
+            Route.NightWorship,
+            Route.Qibla,
+        ).forEach { start ->
+            val graph = navController.createGraph(startDestination = start) {
+                prayerGraph(navController)
+            }
+            assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+        }
+    }
+}


### PR DESCRIPTION
Closes #609

## Before / after

| | Before | After |
|---|---|---|
| Line | 38.1% (1,086 / 2,853) | **84.1%** (2,398 / 2,853) |
| Branch | 23.7% (180 / 760) | **70.5%** (536 / 760) |

Locked at `lineFloor = 0.80`, `branchFloor = 0.60`. 62 tests added across ten new classes.

The month timetable, the day pager and the qibla screen were at **0%** between them — 855 of the 1,767 missing lines — and nothing had ever composed one of them.

## Why the branch floor is softened

**One file.** `PrayerTimesPdfExporter` cannot execute under Robolectric at all (`PdfDocument` throws `"document is closed!"` on the first `startPage`), and it carries **103 of the 224 branches the module still misses**. Discount that file and the module stands at **81.6%** branches, over the standard; count it — which the gate does, because nothing is excluded — and 80% is out of reach whatever else is tested. The remaining 121 are spread over six Compose screens and twelve components, where the `$dirty` bitmask branch takes its usual share.

`:feature:quran` settled the identical problem the identical way for `TafseerPdfExporter` in #598. **`COVERAGE_EXCLUSIONS` is untouched.**

## The gate bites

Floors temporarily set to `0.99`:

```
> Task :feature:prayer:coverageFloor FAILED
* What went wrong:
Execution failed for task ':feature:prayer:coverageFloor' (registered by plugin 'nimaz.android.library').
> :feature:prayer:coverageFloor: line coverage 84.1% is below the floor this module is locked at (99.0%), covering 2398/2853 (84.1%).
  :feature:prayer:coverageFloor: branch coverage 70.5% is below the floor this module is locked at (99.0%), covering 536/760 (70.5%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to it is not meant to come back down.
```

Restored to 0.80 / 0.60 before committing; `:feature:prayer:coverageFloor` then passes.

## What the new tests pin, and the failure each catches

**The month timetable** (`MonthlyPrayerTimesScreenTest`, `MonthlyPrayerTimesEventRowTest`)
- The header and the grid are two renderings of one fact — which month is on screen — drawn from *different places*: the header from `currentMonth`, each row from its own date. `:feature:calendar` shipped exactly this bug (fixed by `CalendarMonth.displayedMonth`). A header naming the wrong month over a correct timetable does not look like a bug; it looks like the prayer times are wrong.
- A month whose PDF cannot be rendered still reports start-then-outcome, still leaves the timetable on screen, and never throws out of composition. Robolectric's inability to render makes this the **one place the export's failure arm runs for real**. A silent failure is a share button that does nothing.
- `isUsingFallbackLocation` wins over any name still sitting in state. `FallbackLocation` exists so a surface can *say* it is using a stand-in rather than caption a timetable with a city the reader has never been to.
- A day whose times could not be computed shows six `--:--`, not six blanks — a real day above the Arctic Circle, not a rendering bug.
- The Ramadan export *asks* rather than computing: a month of astronomy inside a click handler is a visible freeze and an ANR candidate.

**The day pager** (`PrayerTimesScreenTest`, `PrayerTimesTrackingTest`)
- The "Today" chip renders only `if (!isToday)`. A screen that loses it strands a reader on a day they browsed to.
- A future day offers no tracking toggles, and the ViewModel refuses the write regardless — a checkbox that writes a record for a prayer that has not happened counts against a streak.
- Swiping pages the day: a drag threshold read with the wrong sign pages backwards, which is indistinguishable from the arrows being swapped.
- Tracking reports as `prayer_tracked`, not a generic `toggle_prayer` — **#359's third site**, the one that made every dashboard built on that event under-count.

**The qibla** (`QiblaScreenTest`, `QiblaViewModelLocationTest`, `QiblaStatusCapsuleTest`, `CompassQiblaViewLayoutTest`, `QiblaCalibrationSheetTest`, `ArQiblaViewTest`, `QiblaArtTest`)
- `StartCompass` on entry, `StopCompass` on disposal. A screen that never sends stop leaves the magnetometer registered after the reader has left — a drain nobody can see and nothing else catches.
- The error surface shows only when there is no bearing to draw, and carries both a retry and a route to setting a location.
- AR is `state.isArMode && cameraPermissionGranted`, held in local state **no ViewModel test can reach**. The permission is requested rather than assumed, a denial is explained, and only a grant enters AR.
- The turn hint is the **sign** of `rotationToQibla`. Dropping it is confidently wrong half the time.
- `needsCalibration` is `UNRELIABLE || LOW`, not `UNRELIABLE` alone — the common case is a phone that has simply not been waved yet, pointing somewhere plausible and wrong.
- Outside the 60° field of view the AR overlay says so **in words**: a beam clamped to the screen edge is indistinguishable from one pointing just off frame, so someone with their back to Mecca is shown an arrow that looks correct.
- The beam and the sweep arc are drawn into a software canvas and read back per #604's technique — composing the tree runs `Canvas(modifier)` and none of its `DrawScope` lambda.

**Night worship** (`NightWorshipScreenTest`, `NightWorshipRefreshTest`)
- Loading is guarded on `lastThirdAt == null` too, so a refresh does not blank a live countdown.
- The failure is **inline**, inside the card: the hub's other cards are still correct when the astronomy fails.
- `Refresh` is a separate path from the observation `init` starts, with its own error handling, and it is the only way out of a failed hub without leaving the screen.

**The graph** (`PrayerGraphTest`) — all five destinations register and each resolves as a start destination in its own right. `Qibla` is registered twice over under two routes; a graph registering only one works from the tools hub and crashes from the bottom bar.

## One production edit, and it is a real fix

`ArQiblaView` called `cameraProviderFuture.get()` **outside** the `try` that guarded `bindToLifecycle`. A future that completes exceptionally — the provider failing to initialise at all — then throws `ExecutionException` from a listener running on the main executor with nothing above it to catch, and the app dies as the AR qibla opens, on exactly the devices whose camera stack is already unhappy. The `get()` is inside the guard now.

## One build change: this module forks a JVM per test class

`ProcessCameraProvider.getInstance()` cannot complete on a machine with no camera. It leaves a pending listener on the main looper and a half-initialised provider behind it, and Robolectric runs a whole module's classes in one JVM — so that state outlives the test that created it and lands on whichever class launches an activity next, as `FutureGarbageCollectedException: CameraX initInternal` raised from an unrelated screen's test, or as `lightZ must be a finite positive, given=Infinity` thrown out of `ThreadedRenderer.setup` before that class runs a line of its own.

Neither failure names CameraX, and both depend on class order and on when a GC happens to run — green locally, red in CI at a rate no amount of re-running settles. `unitTests.all { it.setForkEvery(1) }` is what actually contains it. **Cost: this module's `testDebugUnitTest` goes from about one minute to about four.** No other module needs it, and none of them has a camera dependency. Every activity-launching class here also pins its **density** in `@Config`, because `lightZ` is a theme dimension resolved against `DisplayMetrics.density`.

## What stays uncovered

- `PrayerTimesPdfExporter` (258 lines) — above.
- 24 of `PrayerGraph`'s 30 lines are the five destination bodies: each builds its screen through `hiltViewModel()`, which resolves only inside a composed `NavHost` on a Hilt-injected activity this module cannot build. Same structural gap `:feature:search` records; `:app`'s instrumented suite exercises them.
- `@Preview` functions (three lines each, contents hoisted into the excluded `ComposableSingletons`), the `hiltViewModel()` default arguments, and `QiblaCalibrationSheet`'s figure-8 `Canvas`, whose draw block needs a software canvas the sheet's own popup window is not part of.

## Verification

```
./gradlew :feature:prayer:testDebugUnitTest   BUILD SUCCESSFUL  (170 tests, run 4x clean)
./gradlew :feature:prayer:check               BUILD SUCCESSFUL  (2m 12s — includes lintDebug, moduleBoundary, coverageFloor)
./gradlew :feature:prayer:lintDebug           BUILD SUCCESSFUL
./gradlew coverageFloor                       BUILD SUCCESSFUL  (6m 56s — all 18 modules, none regressed)
python3 scripts/check_docs.py                 All 23 documentation checks passed
```

**`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` and were not run** — they cannot be run in this environment. No `androidTest` source was touched, and no `Route` or `ScreenTags` entry changed, so `assembleDebugAndroidTest` is unaffected.

`docs/TESTING.md` carries the snapshot row, a rewritten branch-floor paragraph (two modules are now softened, for two different reasons), and a full audit section for the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWj8xcctosX8urXE1pJehV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWj8xcctosX8urXE1pJehV)_