### PR TITLE
docs(testing): correct the :feature:prayer test count

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -776,9 +776,9 @@ own. No `COVERAGE_EXCLUSIONS` entry was added or widened.
 ### Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)
 
 The twelfth module locked: **38.1% lines to 84.1%**, from 1,086 covered lines to 2,398, and 23.7%
-to **70.5%** branches. 62 tests added across ten new classes. Three screens — the month timetable,
-the day pager and the qibla compass — were at **0%** between them, 855 lines of the 1,767 missing,
-and nothing had ever composed one.
+to **70.5%** branches. 108 tests added across fourteen new classes, taking the module's suite from
+62 to 170. Three screens — the month timetable, the day pager and the qibla compass — were at
+**0%** between them, 855 lines of the 1,767 missing, and nothing had ever composed one.
 
 **This is the second module locked at a softened branch floor, and the first where the reason is
 not Compose.** `PrayerTimesPdfExporter` cannot run under Robolectric — `PdfDocument` throws


### PR DESCRIPTION
Follow-up to #620, one sentence.

That PR's audit section said "62 tests added across ten new classes". **62 was the module's *pre-existing* count, not what was added.** The fourteen new classes carry **108** tests, and the module's suite went from 62 to 170.

The coverage figures either side of that sentence — 38.1% → 84.1% lines, 23.7% → 70.5% branches, 855 lines across three screens that were at 0% — were measured and are unchanged. Only the test count was wrong.

`python3 scripts/check_docs.py`: all 23 checks pass. Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWj8xcctosX8urXE1pJehV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWj8xcctosX8urXE1pJehV)_