### PR TITLE
Coverage: bring :feature:about to 94.1% and lock it at 80/80

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -47,6 +47,7 @@ Two on-device/JVM test surfaces exist:
   - [Search, and the question that leaves the device (`:feature:search/src/test` and `src/testDebug`)](#search-and-the-question-that-leaves-the-device-featuresearchsrctest-and-srctestdebug)
   - [The six widgets, composed for real (`:feature:widget/src/test`)](#the-six-widgets-composed-for-real-featurewidgetsrctest)
   - [Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)](#prayer-times-the-month-table-and-the-qibla-featureprayersrctest-and-srctestdebug)
+  - [About, Help and the More menu (`:feature:about/src/test`)](#about-help-and-the-more-menu-featureaboutsrctest)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -167,7 +168,7 @@ floor is a ratchet — raised when a module is brought up to it, never lowered t
 green. The branch floor is set per module, at 80% where branches are reachable and lower where
 the Compose compiler's `$dirty` checks make them not (see
 [Where each module stands](#where-each-module-stands)). `:core:database` is the first module
-locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget` and `:feature:prayer`.
+locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:prayer` and `:feature:about`.
 
 ### What is not counted, and why
 
@@ -262,11 +263,11 @@ floors in its own `build.gradle.kts`.
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common` and `:core:datastore` are locked at 80/80 — none of them draws
 anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
-`:feature:onboarding`, `:feature:tools`, `:feature:search` and `:feature:widget`, which *are* Compose modules: the
+`:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget` and `:feature:about`, which *are* Compose modules: the
 unreachable branch below is emitted **per parameter of every restartable composable**, so its
 weight scales with how many composables a module has, and six files — or eight, or the two screens
-in `:feature:tools`, or the one screen and four cards in `:feature:search` — never accumulate
-enough of them to move the number.
+in `:feature:tools`, or the one screen and four cards in `:feature:search`, or the seven screens in
+`:feature:about` — never accumulate enough of them to move the number.
 `:feature:widget` is Compose of a different kind — six **Glance** widgets — and holds **89.3%**
 branches, which settles the question for the widget surface too.
 `:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here.
@@ -302,11 +303,11 @@ split, and should say so where it sets its floors.
 | `:feature:search` | 91.4% | 87.0% | **locked** at 80/80 (#607) |
 | `:feature:widget` | 97.6% | 89.3% | **locked** at 80/80 (#608) |
 | `:feature:prayer` | 84.1% | 70.5% | **locked** at 80 line / 60 branch (#609) |
+| `:feature:about` | 94.1% | 83.8% | **locked** at 80/80 (#610) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:core:data` | 39.0% | 31.2% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
 | `:feature:content` | 28.8% | 19.5% | |
-| `:feature:about` | 17.8% | 23.0% | |
 | `:feature:settings` | 11.3% | 14.9% | |
 
 `:app` is absent because its own suite needs the private content artifact and cannot be measured
@@ -855,6 +856,77 @@ their contents hoisted into the excluded `ComposableSingletons`), the `hiltViewM
 arguments, and `QiblaCalibrationSheet`'s figure-8 `Canvas`, whose draw block needs a software
 canvas the sheet's own popup window is not part of. No `COVERAGE_EXCLUSIONS` entry was added or
 widened.
+
+
+### About, Help and the More menu (`:feature:about/src/test`)
+
+The thirteenth module locked: **17.8% lines to 94.1%**, from 434 covered lines to 2,291, and 23.0%
+to **83.8%** branches. 139 tests added across thirteen new classes, taking the module's suite from
+58 to 197. Nine files — every screen the module owns — were at **0%**, 1,713 of the 2,000 missing
+lines, and nothing had ever composed one.
+
+**Nothing is softened.** This is the sixth Compose module in a row to hold 80/80, and it is the
+largest of them: seven screens, a bottom sheet and two renderer files. The `$dirty` bitmask
+branches are here as everywhere, and at this size they still do not add up to enough to move the
+number.
+
+**Two things here are worth knowing before adding a test to this module.**
+
+- **`hiltViewModel()` does not always need Hilt, and that is how `AdaptiveMoreScreen` got
+  covered.** `:feature:quran` (#598) and `:feature:search` (#607) both left their adaptive screens
+  at zero because the screens they embed resolve their ViewModels through `hiltViewModel()`. But
+  that function only reaches for a `HiltViewModelFactory` when the `ViewModelStoreOwner` it is
+  given supplies a **default factory**; hand it a plain owner whose `ViewModelStore` already holds
+  the ViewModel and the store lookup answers first, with no factory consulted at all.
+  `AdaptiveMoreScreenTest.seededOwner` builds exactly that, keying each mock by asking a real
+  `ViewModelProvider` for it rather than by spelling out the default-key string. It does **not**
+  rescue a destination body inside a `NavHost`: there the owner is a `NavBackStackEntry`, which
+  *is* a `HasDefaultViewModelProviderFactory`, and the Hilt factory is built — and throws — before
+  the store is read.
+- **Section headings are uppercased by the component, not by the string.** `NimazSectionTitle`
+  renders `text.uppercase()` unless told otherwise, so `onNodeWithText(getString(R.string.…))`
+  finds nothing for a heading. Both Help classes carry a `sectionTitle()` helper for it. The pin
+  labels are the mirror-image trap: `more_pin_zakat` and `zakat` are the same single word, so a
+  screen test that leaves the default pins in place finds two nodes for "Zakat" and fails on the
+  count rather than on anything real — the row tests unpin first, and `MoreMenuScreenTest` asserts
+  the collision deliberately in the one test about the defaults.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| Every More row opens its own destination | `MoreMenuScreenTest` | seventeen rows built from twenty lambdas of one type, tapped in order and asserted as a sequence. A row wired to its neighbour's lambda still opens *something*, so only the order shows it up; `FeatureNavigationTest` on the emulator taps a row and checks a tag, which cannot see a swap between two rows whose screens both exist |
+| What a More subtitle claims | same | the row renders the figure from the field that belongs to it. `MoreSubtitlesTest` pins what each mapper returns; a row passing `khatamJuz` where `qaidaLesson` belongs still resolves to a well-formed string |
+| The loading contract | same | a figure that has not arrived renders as *absent* — never a dash, a zero or a spinner. `MoreUiState`'s defaults are all null, which is the state the screen opens in |
+| The pin row | same | a pill opens the same destination its menu row does (it is a *view* of those lambdas, not a second navigation surface), an empty row says so, and every member of the enum has a pill — asserted at tablet width, because a `LazyRow` composes about four pills at phone width |
+| Coming back to More | same | `LifecycleResumeEffect` dispatches `Refresh`. The worship countdown is a snapshot over a dozen settings, so without it the row reports an hour-old "in 5h 12m" and nothing looks wrong |
+| The pin cap | `PinnedShortcutsSheetTest` | at five pins an unpinned row is disabled **and a pinned one is not** — the exception that makes the cap survivable, since otherwise the row you want gone is the one you cannot reach. Plus: a new pin is appended, never inserted, so adding one does not reshuffle an arrangement |
+| Which pane a tap moves | `AdaptiveMoreScreenTest` | About and Help push destinations on a phone and move the scaffold's detail pane on a tablet — the one difference between the two branches, and silent either way round. The licence list stays a push on both, because it has no pane |
+| The About pane's own links | same | the tablet branch rebuilds About's lambdas rather than reusing the graph's, so privacy, terms, contact and back are a second implementation that can drift from the phone's |
+| The version the app reports | `AboutScreenTest` | what `LocalAppIdentity` supplies. Its default is an em dash and build 0 on purpose; About reporting "—" on a shipped build is a support mail nobody can answer, and no crash or other test surfaces it |
+| Where an update tap goes | same | three states send it three different ways — check, start, and the `completeUpdate` lambda that arrives *inside* `Downloaded` — and three more must send it nowhere, because a tap during a download restarts it. `UpdatePromptTest` pins the labels; the row looks identical whichever method it calls |
+| A build with no update mechanism | same | a null `AppUpdateController` (a debug build, a test, a `@Preview`) renders and absorbs the tap rather than crashing |
+| The licence list's counts | `LicensesScreenTest` | read off the whole catalogue, not the filtered rows. A filter chip whose own number moves when you use it is unreadable, and "1 of 4" is the only thing telling a reader the rest still exist |
+| Three ways to end up with no rows | same | a query with no hits, an empty catalogue and a failed load are distinguishable on screen. "No libraries match" shown for an empty catalogue is a claim about a search nobody ran |
+| The list's three controls | same | search, family filter and grouping toggle dispatch rather than filtering in place; tapping the selected chip clears the filter; the chip row hides itself when everything carries one licence |
+| What a licence detail shows | `LicenseDetailScreenTest` | version, author, website and licence text are each optional in AboutLibraries' output, and each missing one has to leave the layout intact. A library with no licence text loses its **copy** button with it — copying an empty entry looks exactly like a working copy |
+| The licence text control | same | collapsed under a fade by default, and the button says which way it goes. A dual-licensed library shows both texts and is filed under the first, which is what keeps the section counts agreeing with the library count |
+| A library not in the bundled list | same | NOT\_FOUND with a way out and **no retry** — it will not be there next time either, so "try again" would be a lie |
+| The licence family vocabulary | `LicenseVisualsTest` | total and distinct: every family has its own name and tone, because the list groups, filters and colours by family. `OTHER` alone has no plain-terms gloss — a licence the app cannot place it does not paraphrase |
+| Search highlighting | same | every occurrence, case-insensitively, with the original casing intact. The list searches name, author and coordinate at once, so lighting up one of two matches reads as a search that half-worked |
+| Help's three empty-looking states | `HelpScreenTest` | searching-with-no-hits, a failed topic load and the topic grid are the same state shape with different flags. The failure renders as a **section** so the search bar above it stays usable — search is a different query and may well work |
+| A help topic's optional halves | `HelpTopicDetailScreenTest` | help content ships as data, so a topic with no questions, or no guides, or neither, is a shape the renderer meets — the headings have to be absent rather than empty. An answer stays hidden until its question is tapped, and opening one leaves the others shut |
+| Load failure versus genuine absence | same, and `HelpGuideScreenTest` | both leave the detail null, and only the branch order tells them apart. "This topic is unavailable" for a transient failure blames the catalogue, and no retry then appears to contradict it |
+| The near end of a help deep link | `HelpGuideScreenTest` | a step **with** a route renders a tappable breadcrumb and hands that route out verbatim; a step **without** one renders the same breadcrumb inert. `:core:navigation`'s `HelpDeepLinkTest` pins the far end — a screen that never calls `onDeepLink` passes every key assertion there |
+| Retry, serving three surfaces | `HelpViewModelRetryTest` | one event, and it must re-run **only** what is failing: re-running a healthy surface throws its content back into a loading state. The home retry needs `retryTick` at all because `appLanguage` is a `StateFlow` with nothing to re-emit when the language has not changed |
+| Content keys this build does not know | `HelpContentUiTest` | every `iconKey` and `colorKey` the content ships is one this build recognises, and an unknown one degrades rather than throws. A renamed key is silent — nothing logs, the screen still lays out, and every topic just starts looking the same |
+| The seven About destinations | `AboutGraphTest` | all seven register, and each resolves as a start destination in its own right. All seven are reached directly: More from the bottom bar, About and Help from the menu *and* from Settings, and the three argument-carrying ones from a row |
+
+**What stays uncovered, and why.** 122 of the 143 uncovered lines are `aboutGraph`'s seven
+destination bodies, for the structural reason in the second bullet above — the same gap
+`:feature:search` and `:feature:prayer` record, and `:app`'s instrumented suite is what exercises
+them. The rest is `LicenceCatalogueTest`'s subject staying in `:app` (the AboutLibraries plugin
+reads the *applying* project's classpath, so this module renders a catalogue it cannot produce),
+the `hiltViewModel()` default arguments, and a handful of `when`-merge lines the compiler emits
+with no statement of their own. No `COVERAGE_EXCLUSIONS` entry was added or widened.
 
 
 ## Conventions

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,13 @@ platform :android do
     # The project uses the Kotlin DSL (build.gradle.kts), which the
     # android_versioning plugin does not support, hence the manual approach.
     gradle_file = File.expand_path("../app/build.gradle.kts", __dir__)
-    contents = File.read(gradle_file)
+    # Read as UTF-8 explicitly. `File.read` otherwise tags the string with
+    # `Encoding.default_external`, which is the *runner's locale* — US-ASCII when
+    # LANG is unset — and the first `sub` over a build file whose comments contain
+    # an em dash then raises `invalid byte sequence in US-ASCII`. The lane worked
+    # for years on runners that happened to set a UTF-8 locale and broke the
+    # morning one of them did not.
+    contents = File.read(gradle_file, encoding: "UTF-8")
 
     tree_code = contents[/versionCode\s*=\s*(\d+)/, 1]
     UI.user_error!("Could not find versionCode in #{gradle_file}") if tree_code.nil?

--- a/fastlane/version_bump_spec.rb
+++ b/fastlane/version_bump_spec.rb
@@ -66,9 +66,11 @@ GRADLE_FILE = File.expand_path("../app/build.gradle.kts", __dir__)
 # Deliberate: the input is this repo's own Fastfile, and evaluating it verbatim is
 # the point — the spec tests the shipped source rather than a copy of its logic
 # that could drift. The third argument makes __dir__ resolve inside the Fastfile.
-eval(File.read(FASTFILE), TOPLEVEL_BINDING, FASTFILE)
+eval(File.read(FASTFILE, encoding: "UTF-8"), TOPLEVEL_BINDING, FASTFILE)
 
-ORIGINAL_GRADLE = File.read(GRADLE_FILE)
+# UTF-8 explicitly, for the reason the lane itself now states: the default is the
+# runner's locale, and this file's comments are not ASCII.
+ORIGINAL_GRADLE = File.read(GRADLE_FILE, encoding: "UTF-8")
 $failures = []
 
 # Tags are read with git, so give each scenario a throwaway repo holding exactly
@@ -106,7 +108,7 @@ def scenario(name, tree_code:, tree_name:, key:, play:, tags:,
       return
     end
 
-    written = File.read(GRADLE_FILE)
+    written = File.read(GRADLE_FILE, encoding: "UTF-8")
     code = written[/versionCode\s*=\s*(\d+)/, 1].to_i
     version_name = written[/versionName\s*=\s*"([^"]+)"/, 1]
 

--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -25,6 +25,35 @@ android {
     }
 }
 
+/**
+ * Locked at the standard floors. Measured at **94.1% lines / 83.8% branches** with the tests added
+ * by #610 — the sixth Compose module in a row to hold 80/80, so nothing is softened here. The
+ * module started this pass at 17.8% lines / 23.0% branches, with nine screen files at zero.
+ *
+ * **What is left uncovered is one thing, and it is structural.** 122 of the 143 uncovered lines
+ * are the seven destination bodies inside `aboutGraph`: each builds a screen with its navigation
+ * lambdas, and none of it runs until a composed `NavHost` reaches the destination — which resolves
+ * `MoreViewModel`, `HelpViewModel` and `LicensesViewModel` through `hiltViewModel()` on a
+ * *`NavBackStackEntry`* owner, and that path constructs a `HiltViewModelFactory` against the
+ * hosting activity before the store is ever consulted. A library module has no Hilt-injected
+ * activity to give it. `AboutGraphTest` covers the registration those bodies hang off — the
+ * failure that actually ships, a destination that throws the moment somebody taps its row — and
+ * `:app`'s instrumented `FeatureNavigationTest` exercises the bodies on a device.
+ *
+ * `AdaptiveMoreScreen` is **not** in that category, which is the one difference from
+ * `:feature:quran` (#598) and `:feature:search` (#607), where the adaptive screens were left at
+ * zero for the same reason. `hiltViewModel()` only reaches for a Hilt factory when the
+ * `ViewModelStoreOwner` supplies a default one, so a plain owner whose `ViewModelStore` is
+ * pre-seeded hands the mock back first — see `AdaptiveMoreScreenTest.seededOwner`. That covers the
+ * phone/tablet split, which is the whole reason About, Help and More are one module.
+ *
+ * Nothing is excluded to reach these numbers; `COVERAGE_EXCLUSIONS` is untouched.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
 // About, Help and More — one module, because they are one destination. `AdaptiveMoreScreen` puts
 // all three in a single list-detail scaffold, and `aboutGraph` registers every route for all
 // three; there is no `HelpGraph.kt` or `MoreGraph.kt` to split along.
@@ -87,4 +116,16 @@ dependencies {
     // RecordingTelemetry — the Telemetry seam's recording fake, beside its port.
     testImplementation(testFixtures(project(":core:common")))
     testImplementation(libs.turbine)
+
+    // The seven screens, the More menu and the graph run under Robolectric — the same harness
+    // `:feature:calendar`, `:feature:onboarding`, `:feature:tools`, `:feature:search` and
+    // `:feature:prayer` use, including `src/test/resources/robolectric.properties`, which pins
+    // the SDK and the Application class. A properties file is a resource of its source set and
+    // does not travel with the tests that need it.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(testFixtures(project(":core:ui")))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/AboutGraphTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/AboutGraphTest.kt
@@ -1,0 +1,104 @@
+package com.arshadshah.nimaz.presentation.screens.about
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The About feature's slice of the route graph — seven destinations for three surfaces.
+ *
+ * All seven are reached directly rather than only as somewhere another screen pushes.
+ * `Route.More` is a bottom-nav tab; `SettingsAbout` and `SettingsHelp` are opened from the menu
+ * *and* from the Settings screen; `Licenses` from About; and the three argument-carrying routes
+ * from a list row. A destination that fails to register throws
+ * `IllegalArgumentException: navigation destination … is not a direct child of this NavGraph`
+ * — at the moment a **user taps the row**, not at build time, and not in any of the four gates
+ * `CLAUDE.md` lists.
+ *
+ * The graph is built without a `NavHost`, so nothing composes and none of these screens'
+ * Hilt ViewModels is constructed. This asserts registration only; the screen tests beside it
+ * assert what each destination renders, and `:core:navigation`'s `HelpDeepLinkTest` asserts
+ * where a help deep link resolves to.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AboutGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.More) {
+            aboutGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all seven about destinations are registered`() {
+        // Seven, and exactly seven: `aboutGraph`'s KDoc says "the 7 About destinations", and an
+        // eighth arriving without its own case is how a route ships unreachable.
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(7)
+        listOf(
+            Route.More::class,
+            Route.SettingsAbout::class,
+            Route.Licenses::class,
+            Route.LicenseDetail::class,
+            Route.SettingsHelp::class,
+            Route.HelpTopicDetail::class,
+            Route.HelpGuide::class,
+        ).forEach { route ->
+            assertThat(routes.any { it.contains(route.qualifiedName!!) }).isTrue()
+        }
+    }
+
+    @Test
+    fun `the More tab resolves as a destination in its own right`() {
+        // `createGraph` throws here if the route it is handed is not among the destinations the
+        // builder registered — the same failure the app would hit on its first frame.
+        assertStartDestination(Route.More)
+    }
+
+    @Test
+    fun `about and help resolve as destinations in their own right`() {
+        // Both are reached from the More menu and from Settings, so neither is only ever a
+        // child of the other.
+        assertStartDestination(Route.SettingsAbout)
+        assertStartDestination(Route.SettingsHelp)
+    }
+
+    @Test
+    fun `the licence list and one licence resolve as destinations`() {
+        assertStartDestination(Route.Licenses)
+        assertStartDestination(Route.LicenseDetail(libraryHashCode = 42))
+    }
+
+    @Test
+    fun `a help topic and a help guide resolve as destinations`() {
+        // These two are what a help deep link lands on, so an unregistered one turns "take me
+        // there" into a crash rather than into a no-op.
+        assertStartDestination(Route.HelpTopicDetail(topicId = "prayer"))
+        assertStartDestination(Route.HelpGuide(guideId = "set-alert"))
+    }
+
+    private fun assertStartDestination(route: Route) {
+        val graph = navController.createGraph(startDestination = route) {
+            aboutGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/AboutScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/AboutScreenTest.kt
@@ -1,0 +1,263 @@
+package com.arshadshah.nimaz.presentation.screens.about
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.app.AppIdentity
+import com.arshadshah.nimaz.presentation.app.LocalAppIdentity
+import com.arshadshah.nimaz.presentation.update.AppUpdateController
+import com.arshadshah.nimaz.presentation.update.LocalAppUpdateController
+import com.arshadshah.nimaz.presentation.update.UpdateState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * About: what the app says it is, and the one row on it that does work.
+ *
+ * The version block is the reason a support mail is answerable — someone reads it aloud when a
+ * prayer time is wrong. It comes from `LocalAppIdentity` since PR 14 of #551, and the default that
+ * CompositionLocal carries is deliberately an em dash and build 0: a screen that renders without
+ * a composition root supplying identity must look unconfigured rather than quietly claim to be
+ * some release. So "the version shown is the version supplied" is worth an assertion — the failure
+ * it catches is About reporting "—" on a shipped build, which no crash and no other test surfaces.
+ *
+ * The update row is the real behaviour. `updatePrompt` decides its label, icon and whether a tap
+ * does anything, and `UpdatePromptTest` pins that mapping; what cannot be asserted there is that
+ * the tap **reaches the right method**. Three states send it three different ways — check, start,
+ * and the `completeUpdate` lambda that arrives inside `Downloaded` — and three more must send it
+ * nowhere at all, because a tap during a download restarts it. Getting that wrong is not visible:
+ * the row looks identical either way.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class AboutScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val updateState = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    private var checks = 0
+    private var starts = 0
+    private var completions = 0
+
+    private val controller = object : AppUpdateController {
+        override val updateState: StateFlow<UpdateState> = this@AboutScreenTest.updateState
+        override fun checkForUpdate() { checks++ }
+        override fun startUpdate() { starts++ }
+    }
+
+    private val openedUris = mutableListOf<String>()
+    private val uriHandler = object : UriHandler {
+        override fun openUri(uri: String) { openedUris += uri }
+    }
+
+    private val identity = AppIdentity(
+        versionName = "3.1.4",
+        versionCode = 415,
+        iconRes = R.drawable.ic_dua,
+    )
+
+    private val taps = mutableListOf<String>()
+
+    private fun setContent(controller: AppUpdateController? = this.controller) {
+        composeRule.setThemedContent {
+            Harness(controller) {
+                AboutScreen(
+                    onNavigateBack = { taps += "back" },
+                    onNavigateToPrivacyPolicy = { taps += "privacy" },
+                    onNavigateToTerms = { taps += "terms" },
+                    onNavigateToLicenses = { taps += "licenses" },
+                    onRateApp = { taps += "rate" },
+                    onShareApp = { taps += "share" },
+                    onContactUs = { taps += "contact" },
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun Harness(controller: AppUpdateController?, content: @Composable () -> Unit) {
+        CompositionLocalProvider(
+            LocalAppIdentity provides identity,
+            LocalAppUpdateController provides controller,
+            LocalUriHandler provides uriHandler,
+            content = content,
+        )
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the version block reports the identity the composition root supplied`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.version_detail_format, "3.1.4", 415))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.about_tagline)).assertExists()
+    }
+
+    @Test
+    fun `the credits name every data source the app ships`() {
+        setContent()
+
+        // Rendered uppercase by the grid, so the assertion has to be too.
+        composeRule.onNodeWithText(string(R.string.credit_aladhan)).assertExists()
+        composeRule.onNodeWithText(string(R.string.credit_tanzil)).assertExists()
+        composeRule.onNodeWithText(string(R.string.credit_sunnah)).assertExists()
+        composeRule.onNodeWithText(string(R.string.copyright_format, LocalDate.now().year))
+            .assertExists()
+    }
+
+    @Test
+    fun `each link row does its own thing`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.contact_support)).performClick()
+        composeRule.onNodeWithText(string(R.string.privacy_policy)).performClick()
+        composeRule.onNodeWithText(string(R.string.terms_of_service)).performClick()
+        composeRule.onNodeWithText(string(R.string.open_source_licenses)).performClick()
+
+        assertThat(taps).containsExactly("contact", "privacy", "terms", "licenses").inOrder()
+    }
+
+    @Test
+    fun `the website row opens the site rather than navigating`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.website)).performClick()
+
+        assertThat(openedUris).containsExactly("https://nimaz.arshadshah.com")
+        assertThat(taps).isEmpty()
+    }
+
+    @Test
+    fun `the developer links open the profiles they name`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.developer_name)).assertExists()
+    }
+
+    @Test
+    fun `the quick actions rate and share`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.about_rate)).performClick()
+        composeRule.onNodeWithText(string(R.string.about_share)).performClick()
+
+        assertThat(taps).containsExactly("rate", "share").inOrder()
+    }
+
+    @Test
+    fun `an idle row asks Play whether there is an update`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_tap_to_check)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(checks).isEqualTo(1)
+        assertThat(starts).isEqualTo(0)
+    }
+
+    @Test
+    fun `an available update starts rather than re-checking`() {
+        updateState.value = UpdateState.UpdateAvailable
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_new_version)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(starts).isEqualTo(1)
+        assertThat(checks).isEqualTo(0)
+    }
+
+    @Test
+    fun `a downloaded update completes through the lambda it arrived with`() {
+        // `completeUpdate` is not a method on the controller: it comes inside the state, so a
+        // screen cannot complete an update that has not finished downloading.
+        updateState.value = UpdateState.Downloaded(completeUpdate = { completions++ })
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_downloaded)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(completions).isEqualTo(1)
+        assertThat(checks).isEqualTo(0)
+        assertThat(starts).isEqualTo(0)
+    }
+
+    @Test
+    fun `a check in flight does not accept a second tap`() {
+        // The row is disabled while busy. Tapping a downloading update again would restart it,
+        // and the row looks the same whether or not that is guarded.
+        updateState.value = UpdateState.Downloading
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_downloading)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(checks).isEqualTo(0)
+        assertThat(starts).isEqualTo(0)
+    }
+
+    @Test
+    fun `a failed check can be retried`() {
+        // Not busy: retrying is the only thing a reader can do about a failure.
+        updateState.value = UpdateState.Error("no network")
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_check_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(checks).isEqualTo(1)
+    }
+
+    @Test
+    fun `an up-to-date check says so`() {
+        updateState.value = UpdateState.NoUpdateAvailable
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.update_up_to_date)).assertExists()
+    }
+
+    @Test
+    fun `a build with no update mechanism still renders and absorbs the tap`() {
+        // Null is a debug build, a test or a @Preview. Every call site handled it before the
+        // port moved to `:core:ui`, and the row must not become a crash on those builds.
+        setContent(controller = null)
+
+        composeRule.onNodeWithText(string(R.string.update_tap_to_check)).assertExists()
+        composeRule.onNodeWithText(string(R.string.check_for_updates)).performClick()
+
+        assertThat(checks).isEqualTo(0)
+    }
+
+    @Test
+    fun `the back arrow leaves`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(taps).containsExactly("back")
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicenseDetailScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicenseDetailScreenTest.kt
@@ -1,0 +1,327 @@
+package com.arshadshah.nimaz.presentation.screens.about
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LibraryLicense
+import com.arshadshah.nimaz.domain.model.OpenSourceLibrary
+import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicenseDetailUiState
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicensesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicensesViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowToast
+import org.robolectric.annotation.Config
+
+/**
+ * One library's licence, in full.
+ *
+ * This screen is the only place the app shows the text that actually governs use of a component,
+ * and everything above that text is a paraphrase which says so. The assertions that matter are
+ * therefore about **what is optional**: AboutLibraries publishes a version for most artifacts, an
+ * author for many, a website for some and the licence *text* for fewer still, and each missing
+ * field has to leave the layout intact rather than render a heading with nothing under it. A
+ * library with no licence text is the sharpest case — the copy button must disappear with it,
+ * because copying an empty clipboard entry looks exactly like a working copy.
+ *
+ * The collapse/expand is the other half. The text is clipped under a fade rather than hidden
+ * behind an accordion, so a reader can see what they are being offered before deciding — and the
+ * control has to say which way it goes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class LicenseDetailScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val detailState = MutableStateFlow(LicenseDetailUiState())
+    private val events = mutableListOf<LicensesEvent>()
+
+    private val viewModel: LicensesViewModel = mockk(relaxed = true) {
+        every { this@mockk.detailState } returns this@LicenseDetailScreenTest.detailState
+        every { onEvent(any()) } answers { events += firstArg<LicensesEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun setContent(libraryId: Int = 1) {
+        composeRule.setThemedContent {
+            LicenseDetailScreen(
+                libraryId = libraryId,
+                onNavigateBack = { backs++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun library(
+        name: String = "Compose UI",
+        coordinate: String = "androidx.compose.ui:ui",
+        version: String? = "1.7.0",
+        author: String? = "Google",
+        website: String? = "https://developer.android.com/jetpack/compose",
+        licenses: List<LibraryLicense> = listOf(
+            LibraryLicense("Apache License 2.0", url = null, content = LICENCE_TEXT),
+        ),
+    ) = OpenSourceLibrary(
+        id = 1,
+        name = name,
+        coordinate = coordinate,
+        version = version,
+        author = author,
+        website = website,
+        licenses = licenses,
+    )
+
+    private fun loaded(library: OpenSourceLibrary = library()) =
+        LicenseDetailUiState(library = library, isLoading = false)
+
+    @Test
+    fun `opening the screen asks for the library the route named`() {
+        detailState.value = loaded()
+        setContent(libraryId = 42)
+
+        assertThat(events).contains(LicensesEvent.LoadLibrary(42))
+    }
+
+    @Test
+    fun `a fully described library reports every field it published`() {
+        detailState.value = loaded()
+        setContent()
+
+        // The name is on the app bar as well as on the card, so both nodes carry it.
+        composeRule.onAllNodesWithText("Compose UI").onFirst().assertExists()
+        composeRule.onNodeWithText("1.7.0").assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_coordinate)).assertExists()
+        composeRule.onNodeWithText("androidx.compose.ui").assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_published_by)).assertExists()
+        composeRule.onNodeWithText("Google").assertExists()
+        // The scheme is stripped: it is noise in a row a reader scans.
+        composeRule.onNodeWithText("developer.android.com/jetpack/compose").assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_open_home_page)).assertExists()
+    }
+
+    @Test
+    fun `a library that published nothing but a name still renders`() {
+        // The common shape further down the list: no version, no author, no website. Each of
+        // those rows has to be absent rather than empty.
+        detailState.value = loaded(
+            library(
+                name = "Adhan",
+                coordinate = "adhan",
+                version = null,
+                author = null,
+                website = null,
+            ),
+        )
+        setContent()
+
+        composeRule.onAllNodesWithText("Adhan").onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_published_by)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.license_detail_home_page)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.license_detail_open_home_page)).assertDoesNotExist()
+        // A bare artifact id has no Maven group, so the coordinate row goes too.
+        composeRule.onNodeWithText(string(R.string.license_detail_coordinate)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a library with no name at all still gets a tile`() {
+        // The monogram is the library's initial. AboutLibraries occasionally reports an empty
+        // display name for an artifact with no POM name, and `first()` on that throws — the
+        // tile falls back to "?" instead of taking the screen down.
+        detailState.value = loaded(library(name = "", coordinate = "org.unknown:artifact"))
+        setContent()
+
+        composeRule.onNodeWithText("?").assertExists()
+    }
+
+    @Test
+    fun `a recognised family is glossed in plain terms above its text`() {
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_plain_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.license_plain_apache)).assertExists()
+        // And the disclaimer that the gloss is not what governs use.
+        composeRule.onNodeWithText(string(R.string.license_detail_governs_note)).assertExists()
+    }
+
+    @Test
+    fun `a family the app cannot name is not summarised`() {
+        // A licence we cannot place we do not paraphrase — a wrong one-sentence gloss of an
+        // unknown licence is worse than none.
+        detailState.value = loaded(
+            library(licenses = listOf(LibraryLicense("Bespoke EULA", url = null, content = "x"))),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_plain_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the licence text starts collapsed and the control says how to see the rest`() {
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(
+            string(R.string.license_detail_full_text_format, string(R.string.license_family_apache))
+        ).assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_show_full_text)).assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_collapse)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `expanding swaps the control to a collapse`() {
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_show_full_text)).performClick()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_collapse)).assertExists()
+        composeRule.onNodeWithText(string(R.string.license_detail_show_full_text))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the home page button opens the site the library published`() {
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_open_home_page)).performClick()
+
+        val started = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .nextStartedActivity
+        assertThat(started?.action).isEqualTo(Intent.ACTION_VIEW)
+        assertThat(started?.data?.toString())
+            .isEqualTo("https://developer.android.com/jetpack/compose")
+    }
+
+    @Test
+    fun `copying the licence text confirms it happened`() {
+        // The clipboard write is silent, so the toast is the only feedback that the tap did
+        // anything — and a copy that reports nothing reads as a copy that failed.
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.action_copy)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo(string(R.string.license_text_copied))
+    }
+
+    @Test
+    fun `a library that published no licence text says so and offers nothing to copy`() {
+        detailState.value = loaded(
+            library(licenses = listOf(LibraryLicense("MIT License", url = null, content = null))),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_no_text)).assertExists()
+        // Copying an empty entry is indistinguishable from a working copy, so the button goes.
+        composeRule.onNodeWithText(string(R.string.action_copy)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.license_detail_show_full_text))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `a dual-licensed library shows both texts and is filed under the first`() {
+        detailState.value = loaded(
+            library(
+                licenses = listOf(
+                    LibraryLicense("MIT License", url = null, content = "MIT text"),
+                    LibraryLicense("Apache License 2.0", url = null, content = "Apache text"),
+                ),
+            ),
+        )
+        setContent()
+
+        // Both texts are shown — a reader needs to see what they are actually bound by.
+        composeRule.onNodeWithText(
+            string(R.string.license_detail_full_text_format, string(R.string.license_family_mit))
+        ).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.license_detail_full_text_format, string(R.string.license_family_apache))
+        ).assertExists()
+        // …but the *family* is the first, which is what keeps the list's section counts
+        // agreeing with its library count.
+        composeRule.onNodeWithText(string(R.string.license_plain_mit)).assertExists()
+    }
+
+    @Test
+    fun `a library missing from the bundled list is reported as absent, with a way out`() {
+        // NOT_FOUND rather than a failure, and no retry: a library that is not in the bundled
+        // list will not be there next time either, so "try again" would be a lie.
+        detailState.value = LicenseDetailUiState(
+            library = null,
+            isLoading = false,
+            error = UiError(
+                message = R.string.license_detail_library_not_found,
+                kind = NimazErrorKind.NOT_FOUND,
+            ),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_library_not_found)).assertExists()
+        composeRule.onNodeWithText(string(R.string.try_again)).assertDoesNotExist()
+
+        composeRule.onNodeWithText(string(R.string.close)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `the back arrow leaves`() {
+        detailState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `a detail still loading shows neither the library nor a not-found`() {
+        composeRule.mainClock.autoAdvance = false
+        detailState.value = LicenseDetailUiState(isLoading = true)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.license_detail_library_not_found))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.license_detail_governs_note))
+            .assertDoesNotExist()
+    }
+
+    private companion object {
+        val LICENCE_TEXT = buildString {
+            appendLine("Apache License")
+            appendLine("Version 2.0, January 2004")
+            repeat(40) { appendLine("Line $it of the licence text, long enough to be clipped.") }
+        }
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicenseVisualsTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicenseVisualsTest.kt
@@ -1,0 +1,113 @@
+package com.arshadshah.nimaz.presentation.screens.about
+
+import androidx.compose.ui.text.AnnotatedString
+import com.arshadshah.nimaz.domain.model.LicenseFamily
+import com.arshadshah.nimaz.presentation.components.atoms.NimazTone
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * How a licence family is spoken and coloured, and how a search hit is painted.
+ *
+ * The family vocabulary has to be **total and distinct**. Total because every dependency the app
+ * ships lands in one of these six, and a family with no label renders an empty heading over a
+ * section of libraries; distinct because the list groups, filters and colours by family, and two
+ * families sharing a label or a tone makes a filter chip select a section a reader cannot find.
+ *
+ * `plainSummary` is the deliberate exception: [LicenseFamily.OTHER] has none. A licence we cannot
+ * place we do not paraphrase — a confident one-sentence gloss of an unrecognised licence is worse
+ * than saying nothing, and the detail screen is the one place in the app that is about what
+ * someone is legally bound by.
+ *
+ * `highlighted` marks **every** occurrence rather than the first. The list searches name, author
+ * and coordinate at once, so a two-word query that lights up only one of its matches reads as a
+ * search that half-worked.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LicenseVisualsTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    @Test
+    fun `every family carries its own tone`() {
+        val tones: Map<LicenseFamily, NimazTone> =
+            LicenseFamily.entries.associateWith { it.tone }
+
+        assertThat(tones.values.toSet()).hasSize(LicenseFamily.entries.size)
+    }
+
+    @Test
+    fun `every family has its own name`() {
+        val labels = mutableMapOf<LicenseFamily, String>()
+        composeRule.setThemedContent {
+            LicenseFamily.entries.forEach { labels[it] = it.label() }
+        }
+        composeRule.waitForIdle()
+
+        assertThat(labels.keys).containsExactlyElementsIn(LicenseFamily.entries)
+        assertThat(labels.values.map { it.trim() }).containsNoDuplicates()
+        assertThat(labels.values.none { it.isBlank() }).isTrue()
+    }
+
+    @Test
+    fun `every family the app can name is glossed, and the one it cannot is not`() {
+        val summaries = mutableMapOf<LicenseFamily, String?>()
+        composeRule.setThemedContent {
+            LicenseFamily.entries.forEach { summaries[it] = it.plainSummary() }
+        }
+        composeRule.waitForIdle()
+
+        assertThat(summaries[LicenseFamily.OTHER]).isNull()
+        LicenseFamily.entries.filter { it != LicenseFamily.OTHER }.forEach { family ->
+            assertThat(summaries[family]).isNotNull()
+        }
+    }
+
+    @Test
+    fun `a blank query paints nothing`() {
+        val painted = highlight("androidx.compose.ui:ui", query = "   ")
+
+        assertThat(painted.spanStyles).isEmpty()
+        assertThat(painted.text).isEqualTo("androidx.compose.ui:ui")
+    }
+
+    @Test
+    fun `every occurrence of the query is painted, not just the first`() {
+        // "compose" appears twice in a Maven coordinate, and a reader scanning a filtered list
+        // is looking for exactly that repetition.
+        val painted = highlight("androidx.compose.ui:compose-ui", query = "compose")
+
+        assertThat(painted.spanStyles).hasSize(2)
+        assertThat(painted.text).isEqualTo("androidx.compose.ui:compose-ui")
+    }
+
+    @Test
+    fun `the match ignores case, because nobody types a Maven coordinate in caps`() {
+        val painted = highlight("Compose UI", query = "compose")
+
+        assertThat(painted.spanStyles).hasSize(1)
+        // The original casing survives: it is a highlight, not a rewrite.
+        assertThat(painted.text).isEqualTo("Compose UI")
+    }
+
+    @Test
+    fun `a query that does not occur leaves the text alone`() {
+        val painted = highlight("Adhan", query = "compose")
+
+        assertThat(painted.spanStyles).isEmpty()
+        assertThat(painted.text).isEqualTo("Adhan")
+    }
+
+    private fun highlight(text: String, query: String): AnnotatedString {
+        lateinit var result: AnnotatedString
+        composeRule.setThemedContent { result = highlighted(text, query) }
+        composeRule.waitForIdle()
+        return result
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicensesScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/about/LicensesScreenTest.kt
@@ -1,0 +1,316 @@
+package com.arshadshah.nimaz.presentation.screens.about
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LibraryLicense
+import com.arshadshah.nimaz.domain.model.LicenseFamily
+import com.arshadshah.nimaz.domain.model.OpenSourceLibrary
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicenseGrouping
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicensesEvent
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicensesListUiState
+import com.arshadshah.nimaz.presentation.viewmodel.about.LicensesViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.about.familyCounts
+import com.arshadshah.nimaz.presentation.viewmodel.about.regrouped
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The licence list, driven from a supplied catalogue.
+ *
+ * **Not from the real plugin output, deliberately.** AboutLibraries reads the *applying project's*
+ * runtime classpath, so it stays in `:app` — this module renders a catalogue it cannot itself
+ * produce, and `LicenceCatalogueTest` over there floors the real entry count. What is testable
+ * here is the rendering: that the screen shows what it is handed, in the sections the ViewModel
+ * grouped, and that the three controls above the list (search, family filter, grouping toggle)
+ * dispatch rather than reaching into the list themselves.
+ *
+ * Two shapes are worth the assertions. The **counts** on the credit card and the chips are read
+ * off the *whole* list rather than the filtered one — a filter chip whose own number moves when
+ * you use it is unreadable, and "12 of 272" above a list of twelve is the only thing telling a
+ * reader the other 260 still exist. And **an empty result is not an empty screen**: query, filter
+ * and load-failure all end with no rows, and the reader has to be able to tell which happened.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class LicensesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val listState = MutableStateFlow(LicensesListUiState())
+    private val events = mutableListOf<LicensesEvent>()
+
+    private val viewModel: LicensesViewModel = mockk(relaxed = true) {
+        every { this@mockk.listState } returns this@LicensesScreenTest.listState
+        every { onEvent(any()) } answers { events += firstArg<LicensesEvent>() }
+    }
+
+    private val detailsOpened = mutableListOf<Int>()
+    private var backs = 0
+
+    private val compose = library(1, "Compose UI", "androidx.compose.ui:ui", "Google", "Apache License 2.0")
+    private val core = library(2, "Core Ktx", "androidx.core:core-ktx", "Google", "Apache License 2.0")
+    private val adhan = library(3, "Adhan", "com.batoulapps.adhan:adhan2", "Batoul Apps", "MIT License")
+    private val amiri = library(4, "Amiri", "org.amirifont:amiri", "Khaled Hosny", "SIL Open Font License 1.1")
+
+    private fun library(
+        id: Int,
+        name: String,
+        coordinate: String,
+        author: String?,
+        licenseName: String,
+        version: String? = "1.0.0",
+    ) = OpenSourceLibrary(
+        id = id,
+        name = name,
+        coordinate = coordinate,
+        version = version,
+        author = author,
+        website = null,
+        licenses = listOf(LibraryLicense(licenseName, url = null, content = null)),
+    )
+
+    private fun loaded(
+        libraries: List<OpenSourceLibrary> = listOf(compose, core, adhan, amiri),
+        query: String = "",
+        selectedFamily: LicenseFamily? = null,
+        grouping: LicenseGrouping = LicenseGrouping.BY_LICENCE,
+    ) = LicensesListUiState(
+        libraries = libraries,
+        query = query,
+        selectedFamily = selectedFamily,
+        grouping = grouping,
+        familyCounts = libraries.familyCounts(),
+        isLoading = false,
+    ).regrouped()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            LicensesScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToDetail = { detailsOpened += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the screen asks for the catalogue as it opens`() {
+        listState.value = loaded()
+        setContent()
+
+        assertThat(events).contains(LicensesEvent.LoadLibraries)
+    }
+
+    @Test
+    fun `every supplied library is on the list, under its licence family`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText("Compose UI").assertExists()
+        composeRule.onNodeWithText("Core Ktx").assertExists()
+        composeRule.onNodeWithText("Adhan").assertExists()
+        composeRule.onNodeWithText("Amiri").assertExists()
+
+        // Largest family first, so the screen opens on Apache rather than on whichever
+        // one-library section sorts first alphabetically.
+        composeRule.onAllNodesWithText(string(R.string.license_family_apache)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `a row renders what the library published and nothing more`() {
+        // Author, version and Maven group are each optional in AboutLibraries' output, and a
+        // row that renders an empty line for a missing one is how a licence list starts
+        // looking broken halfway down.
+        val bare = OpenSourceLibrary(
+            id = 9,
+            name = "Timber",
+            coordinate = "timber",
+            version = null,
+            author = null,
+            website = null,
+            licenses = listOf(LibraryLicense("MIT License", url = null, content = null)),
+        )
+        listState.value = loaded(libraries = listOf(bare))
+        setContent()
+
+        composeRule.onNodeWithText("Timber").assertExists()
+        composeRule.onNodeWithText("Timber").performClick()
+
+        assertThat(detailsOpened).containsExactly(9)
+    }
+
+    @Test
+    fun `the totals count the whole catalogue, not the visible rows`() {
+        listState.value = loaded(query = "adhan")
+        setContent()
+
+        // One row visible, four libraries, three licences — and the header says so.
+        composeRule.onNodeWithText(string(R.string.licenses_subtitle_format, 4, 3)).assertExists()
+        composeRule.onNodeWithText(string(R.string.licenses_visible_count_format, 1, 4)).assertExists()
+    }
+
+    @Test
+    fun `a library row opens its detail by id`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText("Adhan").performClick()
+
+        // The stable id derived from the coordinate, not the row's position: a version bump
+        // must not change which library a detail route points at.
+        assertThat(detailsOpened).containsExactly(3)
+    }
+
+    @Test
+    fun `typing dispatches a search rather than filtering in place`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.licenses_search_placeholder))
+            .performTextInput("amiri")
+
+        assertThat(events).contains(LicensesEvent.Search("amiri"))
+    }
+
+    @Test
+    fun `a family chip filters to that family and the All chip clears it`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(
+            string(R.string.licenses_chip_format, string(R.string.license_family_mit), 1)
+        ).performClick()
+        composeRule.onNodeWithText(
+            string(R.string.licenses_chip_format, string(R.string.licenses_filter_all), 4)
+        ).performClick()
+
+        assertThat(events).containsAtLeast(
+            LicensesEvent.SelectFamily(LicenseFamily.MIT),
+            LicensesEvent.SelectFamily(null),
+        ).inOrder()
+    }
+
+    @Test
+    fun `tapping the selected family chip clears the filter rather than reselecting it`() {
+        listState.value = loaded(selectedFamily = LicenseFamily.MIT)
+        setContent()
+
+        composeRule.onNodeWithText(
+            string(R.string.licenses_chip_format, string(R.string.license_family_mit), 1)
+        ).performClick()
+
+        assertThat(events).contains(LicensesEvent.SelectFamily(null))
+    }
+
+    @Test
+    fun `the filter row is hidden when everything carries one licence`() {
+        // The common case for this app — a row of one chip is a control that cannot do anything.
+        listState.value = loaded(libraries = listOf(compose, core))
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_filter_section)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the grouping toggle offers the other arrangement`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_grouped_by_licence)).assertExists()
+        composeRule.onNodeWithText(string(R.string.licenses_action_sort_alphabetically)).performClick()
+
+        assertThat(events).contains(LicensesEvent.ToggleGrouping)
+    }
+
+    @Test
+    fun `grouped alphabetically the sections are initials and the toggle reads the other way`() {
+        listState.value = loaded(grouping = LicenseGrouping.ALPHABETICAL)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_grouped_alphabetically)).assertExists()
+        composeRule.onNodeWithText(string(R.string.licenses_action_group_by_licence)).assertExists()
+        // "A" for Adhan and Amiri, "C" for the two Compose/Core entries.
+        composeRule.onAllNodesWithText("A").onFirst().assertExists()
+        composeRule.onAllNodesWithText("C").onFirst().assertExists()
+    }
+
+    @Test
+    fun `a query that matches nothing says so, and keeps the search bar`() {
+        listState.value = loaded(query = "zzzz")
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_no_matches_title)).assertExists()
+        composeRule.onNodeWithContentDescription(string(R.string.licenses_search_placeholder))
+            .assertExists()
+        composeRule.onNodeWithText("Compose UI").assertDoesNotExist()
+    }
+
+    @Test
+    fun `an empty catalogue is not the same as a query with no hits`() {
+        // Nothing loaded at all: no rows, but nothing was narrowed either, so "no libraries
+        // match" would be a claim about a search nobody ran.
+        listState.value = LicensesListUiState(isLoading = false)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_no_matches_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a failed load offers a retry`() {
+        listState.value = LicensesListUiState(
+            isLoading = false,
+            error = UiError(message = R.string.licenses_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).contains(LicensesEvent.Retry)
+    }
+
+    @Test
+    fun `the back arrow leaves`() {
+        listState.value = loaded()
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `a catalogue still loading shows neither rows nor an empty state`() {
+        composeRule.mainClock.autoAdvance = false
+        listState.value = LicensesListUiState(isLoading = true)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.licenses_no_matches_title)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.licenses_credit_title)).assertDoesNotExist()
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveMoreScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveMoreScreenTest.kt
@@ -1,0 +1,314 @@
+package com.arshadshah.nimaz.presentation.screens.adaptive
+
+import android.app.Application
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.domain.model.HelpTopic
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.app.AppIdentity
+import com.arshadshah.nimaz.presentation.app.LocalAppIdentity
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpHomeUiState
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.more.MoreUiState
+import com.arshadshah.nimaz.presentation.viewmodel.more.MoreViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * About, Help and More are **one destination**, and this is the thing that makes them one.
+ *
+ * On a phone it is the menu and nothing else; on a tablet the same menu is the list pane of a
+ * list-detail scaffold, and About and Help open *beside* it rather than on top of it. That single
+ * difference changes what a tap does: on a phone "About Nimaz" is a `navigate(Route.SettingsAbout)`
+ * that pushes a screen, and on a tablet it must **not** navigate at all — it moves the scaffold's
+ * own detail pane. A regression either way is silent. Navigating on a tablet pushes a full-screen
+ * About over a layout designed to show it beside the menu; failing to navigate on a phone makes
+ * the row do nothing.
+ *
+ * Everything else on the screen is shared between the two branches — the same `shareApp` and
+ * `rateApp` lambdas are handed to both — so the pane behaviour is the whole of what is worth
+ * testing twice.
+ *
+ * The screens inside resolve their ViewModels through `hiltViewModel()`, which is why this was
+ * left uncovered in `:feature:quran` (#598). It does not actually need Hilt: `hiltViewModel()`
+ * asks `LocalViewModelStoreOwner` for the ViewModel and only reaches for a Hilt factory when the
+ * owner supplies a default one, so an owner whose store is **pre-seeded** hands back the mock
+ * before any factory is consulted. That is what [seededOwner] does, and it is the difference
+ * between this file existing and 142 lines staying at zero.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdaptiveMoreScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val moreState = MutableStateFlow(MoreUiState())
+    private val helpState = MutableStateFlow(HelpHomeUiState(isLoading = false))
+
+    private val moreViewModel: MoreViewModel = mockk(relaxed = true) {
+        every { state } returns moreState
+    }
+    private val helpViewModel: HelpViewModel = mockk(relaxed = true) {
+        every { homeState } returns helpState
+    }
+
+    private val navigated = mutableListOf<Route>()
+
+    private fun setContent() {
+        // Unpinned: the Zakat pill and the Zakat row carry the same one word, and the pin row
+        // is `MoreMenuScreenTest`'s subject rather than this file's.
+        moreState.value = MoreUiState(pinnedShortcuts = emptyList())
+        composeRule.setThemedContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides seededOwner(),
+                LocalAppIdentity provides AppIdentity("3.1.4", 415, R.drawable.ic_dua),
+            ) {
+                AdaptiveMoreScreen(onNavigate = { navigated += it })
+            }
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone the menu is the whole screen`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).assertExists()
+        composeRule.onNodeWithText(string(R.string.help_support)).assertExists()
+        composeRule.onNodeWithText(string(R.string.prayer_tracker)).assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone About and Help push their own destinations`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).performClick()
+        composeRule.onNodeWithText(string(R.string.help_support)).performClick()
+
+        assertThat(navigated).containsExactly(Route.SettingsAbout, Route.SettingsHelp).inOrder()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `the menu rows that are not panes navigate on any size`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.settings)).performClick()
+
+        assertThat(navigated).containsExactly(Route.Settings)
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `every feature row maps to a route`() {
+        setContent()
+
+        listOf(
+            R.string.prayer_tracker, R.string.fasting, R.string.night_worship_title,
+            R.string.khatam_quran, R.string.qaida, R.string.names_title, R.string.hadith,
+            R.string.duas, R.string.tafseer, R.string.calendar, R.string.prayer_times,
+            R.string.monthly_prayer_times, R.string.zakat,
+        ).forEach { composeRule.onNodeWithText(string(it)).performClick() }
+
+        assertThat(navigated).containsExactly(
+            Route.PrayerTracker, Route.FastingHome, Route.NightWorship, Route.KhatamList,
+            Route.QaidaHome, Route.Names(), Route.HadithHome, Route.DuaHome,
+            Route.TafseerChapters, Route.IslamicCalendar, Route.PrayerTimes,
+            Route.MonthlyPrayerTimes, Route.ZakatCalculator,
+        ).inOrder()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `sharing the app opens the share sheet rather than a destination`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.share_app)).performClick()
+        composeRule.waitForIdle()
+
+        // The invite card is built and shared in place; there is no route for it, so a
+        // `navigate` here would be a bug that shows up as an empty screen.
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `rating the app stays in the app rather than navigating`() {
+        setContent()
+
+        // The Play in-app review flow needs an `Activity`, which is why the handler reaches for
+        // one from the composition rather than taking a lambda. With no Play services behind it
+        // the flow cannot complete — what must hold is that the tap is absorbed rather than
+        // throwing out of the composition or pushing a destination.
+        composeRule.onNodeWithText(string(R.string.rate_us)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `on a tablet About opens beside the menu rather than over it`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).performClick()
+        composeRule.waitForIdle()
+
+        // The pane, not a push: the About surface appears while the menu is still on screen.
+        composeRule.onAllNodesWithText(string(R.string.about_tagline)).onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.prayer_tracker)).assertExists()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `on a tablet Help opens beside the menu rather than over it`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_support)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(string(R.string.help_still_need)).onFirst().assertExists()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `on a tablet the licence list is still a push, because it is not a pane`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.open_source_licenses)).performClick()
+
+        assertThat(navigated).containsExactly(Route.Licenses)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `the About pane's own links work from inside the scaffold`() {
+        // The pane rebuilds About's lambdas rather than reusing the graph's, so each one is a
+        // second implementation that can drift from the phone's. Privacy and Terms are external
+        // pages, and contacting support is a mail intent — none of them a route.
+        setContent()
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.privacy_policy)).performClick()
+        assertThat(startedUri()).isEqualTo("https://nimaz.arshadshah.com/privacy")
+
+        composeRule.onNodeWithText(string(R.string.terms_of_service)).performClick()
+        assertThat(startedUri()).isEqualTo("https://nimaz.arshadshah.com/terms")
+
+        composeRule.onNodeWithText(string(R.string.contact_support)).performClick()
+        assertThat(shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .nextStartedActivity).isNotNull()
+
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `closing the About pane leaves the menu standing`() {
+        // Back inside a list-detail scaffold pops the *pane*, not the destination — a
+        // `popBackStack` here would take the whole More tab off the stack on a tablet.
+        setContent()
+        composeRule.onNodeWithText(string(R.string.about_nimaz)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.prayer_tracker)).assertExists()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h2400dp")
+    fun `a help topic opened from the pane is still a push`() {
+        // Help's *topics* have no pane of their own, so the row has to leave the scaffold.
+        helpState.value = HelpHomeUiState(topics = listOf(helpTopic), isLoading = false)
+        setContent()
+        composeRule.onNodeWithText(string(R.string.help_support)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Prayer times").performClick()
+
+        assertThat(navigated).containsExactly(Route.HelpTopicDetail("prayer"))
+    }
+
+    private fun startedUri(): String? =
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .nextStartedActivity?.data?.toString()
+
+    private val helpTopic = HelpTopic(
+        id = "prayer",
+        iconKey = "schedule",
+        colorKey = "indigo",
+        title = "Prayer times",
+        subtitle = "",
+        order = 0,
+        itemCount = 1,
+    )
+
+    /**
+     * A [ViewModelStoreOwner] whose store already holds the mocks, keyed the way
+     * `ViewModelProvider` itself keys them.
+     *
+     * The keys are computed by asking a real provider for each ViewModel rather than by spelling
+     * out `androidx.lifecycle.ViewModelProvider.DefaultKey:…` — a hand-written key is a string
+     * that silently stops matching when the library changes how it derives one, and the symptom
+     * would be Hilt being reached for and the test failing far from the cause.
+     *
+     * The owner deliberately does **not** implement `HasDefaultViewModelProviderFactory`: that is
+     * the exact condition `createHiltViewModelFactory` tests, and implementing it would send
+     * `hiltViewModel()` looking for a Hilt entry point on the activity.
+     */
+    private fun seededOwner(): ViewModelStoreOwner {
+        val store = ViewModelStore()
+        seed(store, MoreViewModel::class.java, moreViewModel)
+        seed(store, HelpViewModel::class.java, helpViewModel)
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    private fun <VM : ViewModel> seed(store: ViewModelStore, type: Class<VM>, instance: VM) {
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                instance as T
+        }
+        ViewModelProvider.create(store, factory)[type]
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpContentUiTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpContentUiTest.kt
@@ -1,0 +1,100 @@
+package com.arshadshah.nimaz.presentation.screens.help
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The two lookups that turn shipped help **data** into an icon and a colour.
+ *
+ * Both are `when` expressions over strings a release writes and this build reads, and both have a
+ * silent failure mode: a key that does not match falls through to the default, so a topic whose
+ * `iconKey` was renamed in the content release renders the generic question mark and a topic whose
+ * `colorKey` moved renders the theme's own primary. Nothing throws, nothing logs, and the screen
+ * still lays out — the only symptom is that every help topic starts looking the same.
+ *
+ * So the assertion that matters is not "this key maps to this icon" — that is restating the
+ * `when` — but **"every key the content actually ships is one this build knows"**. The fallbacks
+ * are asserted too, because they are the contract for content newer than the app: an unknown key
+ * must degrade to something legible rather than crash.
+ */
+@RunWith(RobolectricTestRunner::class)
+class HelpContentUiTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    /**
+     * Every `iconKey` the shipped help content uses. Adding a key to `helpIcon` without adding
+     * it here is harmless; shipping content with a key `helpIcon` does not know is not.
+     */
+    private val shippedIconKeys = listOf(
+        "schedule", "notifications_active", "explore", "menu_book", "task_alt", "build",
+        "tune", "more_time", "rocket_launch", "calculate", "favorite", "auto_stories",
+        "widgets", "language", "dark_mode", "import_contacts",
+    )
+
+    private val shippedColourKeys =
+        listOf("indigo", "gold", "teal", "green", "violet", "orange", "sky")
+
+    @Test
+    fun `every shipped icon key resolves to something other than the fallback`() {
+        val fallback = Icons.AutoMirrored.Filled.HelpOutline
+
+        val resolved: Map<String, ImageVector> = shippedIconKeys.associateWith { helpIcon(it) }
+
+        assertThat(resolved.filterValues { it == fallback }).isEmpty()
+    }
+
+    @Test
+    fun `an unknown or absent icon key degrades to the help glyph`() {
+        // Content written by a newer release, read by this one. Not a crash, and not a blank
+        // box where an icon should be.
+        assertThat(helpIcon("a_key_this_build_has_never_heard_of"))
+            .isEqualTo(Icons.AutoMirrored.Filled.HelpOutline)
+        assertThat(helpIcon(null)).isEqualTo(Icons.AutoMirrored.Filled.HelpOutline)
+    }
+
+    @Test
+    fun `the icon keys are distinct enough to tell topics apart`() {
+        // Two keys deliberately share one glyph — "menu_book" and "import_contacts" are both
+        // reading. Everything else is its own, which is what makes the topic grid scannable.
+        val icons = shippedIconKeys.map { helpIcon(it) }
+
+        assertThat(icons.toSet()).hasSize(shippedIconKeys.size - 1)
+    }
+
+    @Test
+    fun `every shipped colour key resolves to its own colour`() {
+        val resolved = mutableMapOf<String, Color>()
+        composeRule.setThemedContent {
+            shippedColourKeys.forEach { resolved[it] = helpColor(it) }
+        }
+        composeRule.waitForIdle()
+
+        assertThat(resolved.keys).containsExactlyElementsIn(shippedColourKeys)
+        assertThat(resolved.values.toSet()).hasSize(shippedColourKeys.size)
+    }
+
+    @Test
+    fun `an unknown colour key falls back to the theme's own primary`() {
+        var unknown: Color? = null
+        var themePrimary: Color? = null
+        composeRule.setThemedContent {
+            unknown = helpColor("chartreuse")
+            themePrimary = MaterialTheme.colorScheme.primary
+        }
+        composeRule.waitForIdle()
+
+        assertThat(unknown).isEqualTo(themePrimary)
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpGuideScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpGuideScreenTest.kt
@@ -1,0 +1,268 @@
+package com.arshadshah.nimaz.presentation.screens.help
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.HelpGuideDetail
+import com.arshadshah.nimaz.domain.model.HelpStep
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpEvent
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpGuideUiState
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A step-by-step guide, and the one thing on it that leaves the screen.
+ *
+ * `HelpDeepLinkTest` in `:core:navigation` pins all 22 deep-link keys and that no two resolve to
+ * the same destination. That is the far end of the wire. This is the near end: a step **with** a
+ * route renders a tappable path chip and hands that route out, and a step **without** one renders
+ * the same breadcrumb inert rather than as a control that swallows a tap. Both halves have to be
+ * true for "take me there" to work, and each is invisible from the other's test — a screen that
+ * never calls `onDeepLink` passes every key assertion in `:core:navigation`.
+ *
+ * The numbered rail is content-shaped too: guides ship as data, so a one-step guide is a real
+ * input, and the rail's "not the last one" connector must not be drawn under it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HelpGuideScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val guideState = MutableStateFlow(HelpGuideUiState())
+    private val events = mutableListOf<HelpEvent>()
+
+    private val viewModel: HelpViewModel = mockk(relaxed = true) {
+        every { this@mockk.guideState } returns this@HelpGuideScreenTest.guideState
+        every { onEvent(any()) } answers { events += firstArg<HelpEvent>() }
+    }
+
+    private val deepLinks = mutableListOf<String>()
+
+    private fun setContent(guideId: String = "set-alert") {
+        composeRule.setThemedContent {
+            HelpGuideScreen(
+                guideId = guideId,
+                onNavigateBack = {},
+                onDeepLink = { deepLinks += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun plural(res: Int, quantity: Int, vararg args: Any): String =
+        context.resources.getQuantityString(res, quantity, *args)
+
+    private fun step(
+        id: String,
+        title: String,
+        body: String = "",
+        deeplinkRoute: String? = null,
+        pathLabels: List<String> = emptyList(),
+    ) = HelpStep(
+        id = id,
+        order = 0,
+        title = title,
+        body = body,
+        deeplinkRoute = deeplinkRoute,
+        pathLabels = pathLabels,
+    )
+
+    private fun guide(steps: List<HelpStep>, minutes: Int? = 3) = HelpGuideDetail(
+        id = "set-alert",
+        title = "Set a prayer alert",
+        estimatedMinutes = minutes,
+        steps = steps,
+    )
+
+    @Test
+    fun `opening the screen asks for the guide it was routed to`() {
+        guideState.value = HelpGuideUiState(guide = guide(listOf(step("s1", "Open settings"))), isLoading = false)
+        setContent(guideId = "fix-qibla")
+
+        assertThat(events).contains(HelpEvent.LoadGuide("fix-qibla"))
+    }
+
+    @Test
+    fun `every step is numbered and rendered in order`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(
+                listOf(
+                    step("s1", "Open Settings", body = "From the More menu."),
+                    step("s2", "Choose a prayer"),
+                    step("s3", "Pick an adhan"),
+                ),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Open Settings").assertExists()
+        composeRule.onNodeWithText("From the More menu.").assertExists()
+        composeRule.onNodeWithText("Choose a prayer").assertExists()
+        composeRule.onNodeWithText("Pick an adhan").assertExists()
+        // The rail numbers from one, not from zero.
+        composeRule.onNodeWithText("1").assertExists()
+        composeRule.onNodeWithText("3").assertExists()
+        composeRule.onNodeWithText(string(R.string.help_thats_it)).assertExists()
+    }
+
+    @Test
+    fun `a one-step guide renders without a trailing connector`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(listOf(step("s1", "Tap the bell"))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Tap the bell").assertExists()
+        composeRule.onNodeWithText("1").assertExists()
+        composeRule.onNodeWithText("2").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the hero counts the steps and reports the estimate`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(listOf(step("s1", "One"), step("s2", "Two")), minutes = 4),
+            isLoading = false,
+        )
+        setContent()
+
+        val steps = plural(R.plurals.help_guide_steps_format, 2, 2)
+        val mins = string(R.string.help_guide_about_minutes_lower_format, 4)
+        composeRule.onNodeWithText("$steps · $mins").assertExists()
+    }
+
+    @Test
+    fun `a guide with no estimate reports only its step count`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(listOf(step("s1", "One")), minutes = null),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(plural(R.plurals.help_guide_steps_format, 1, 1)).assertExists()
+    }
+
+    @Test
+    fun `a step with a deeplink takes the reader there`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(
+                listOf(
+                    step(
+                        "s1", "Open prayer settings",
+                        deeplinkRoute = "prayer_settings",
+                        pathLabels = listOf("Settings", "Prayer"),
+                    ),
+                ),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Prayer").performClick()
+
+        // The route key, verbatim — `helpDeepLinkRoute` in `:core:navigation` is what turns it
+        // into a destination, and it only ever sees what this screen hands it.
+        assertThat(deepLinks).containsExactly("prayer_settings")
+    }
+
+    @Test
+    fun `a breadcrumb with no route is inert rather than a dead control`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(
+                listOf(
+                    step(
+                        "s1", "Find the widget tray",
+                        deeplinkRoute = null,
+                        pathLabels = listOf("Home screen", "Widgets"),
+                    ),
+                ),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        // Still rendered — it tells the reader where to go by hand.
+        composeRule.onNodeWithText("Widgets").assertExists()
+        composeRule.onNodeWithText("Widgets").performClick()
+
+        assertThat(deepLinks).isEmpty()
+    }
+
+    @Test
+    fun `a step with no breadcrumb renders no chip at all`() {
+        guideState.value = HelpGuideUiState(
+            guide = guide(listOf(step("s1", "Wait for dawn", deeplinkRoute = "prayer_times"))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Wait for dawn").assertExists()
+        assertThat(deepLinks).isEmpty()
+    }
+
+    @Test
+    fun `a failed load says the load failed, not that the guide is missing`() {
+        guideState.value = HelpGuideUiState(
+            guide = null,
+            isLoading = false,
+            error = UiError(message = R.string.help_guide_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_guide_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.help_guide_unavailable)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the failed load can be retried`() {
+        guideState.value = HelpGuideUiState(
+            isLoading = false,
+            error = UiError(message = R.string.help_guide_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).contains(HelpEvent.Retry)
+    }
+
+    @Test
+    fun `a guide that is genuinely absent says so`() {
+        guideState.value = HelpGuideUiState(guide = null, isLoading = false, error = null)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_guide_unavailable)).assertExists()
+    }
+
+    @Test
+    fun `a guide still loading shows neither content nor an absence`() {
+        // The spinner animates forever; pin the clock before composing or `waitForIdle` hangs.
+        composeRule.mainClock.autoAdvance = false
+        guideState.value = HelpGuideUiState(guide = null, isLoading = true)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_guide_unavailable)).assertDoesNotExist()
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpScreenTest.kt
@@ -1,0 +1,249 @@
+package com.arshadshah.nimaz.presentation.screens.help
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.HelpSearchResult
+import com.arshadshah.nimaz.domain.model.HelpTopic
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpEvent
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpHomeUiState
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Help's front door: browse, search, or write to a person.
+ *
+ * The state machine here is the part worth pinning, because three of its states render a list
+ * with nothing useful in it and the ViewModel cannot tell them apart. Searching-with-no-hits,
+ * a failed topic load and an empty catalogue are the same `HelpHomeUiState` shape with different
+ * flags, and which one the reader sees is decided entirely by the order of the branches in this
+ * screen. Two of the orderings are wrong in a way nothing else catches: showing the topic grid
+ * while a search is running makes the search look broken, and showing "no results" in place of a
+ * failed load tells someone their help catalogue is empty when in fact it never loaded.
+ *
+ * The failure is rendered as a **section** inside the list rather than over it, and that is
+ * deliberate: search reads a different code path from the topic load, so a reader whose grid
+ * failed can still find a topic by name. A full-screen error would take the search bar with it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HelpScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val homeState = MutableStateFlow(HelpHomeUiState())
+    private val events = mutableListOf<HelpEvent>()
+
+    private val viewModel: HelpViewModel = mockk(relaxed = true) {
+        every { this@mockk.homeState } returns this@HelpScreenTest.homeState
+        every { onEvent(any()) } answers { events += firstArg<HelpEvent>() }
+    }
+
+    private val topicsOpened = mutableListOf<String>()
+    private var contacts = 0
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            HelpScreen(
+                onNavigateBack = {},
+                onNavigateToTopic = { topicsOpened += it },
+                onContact = { contacts++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /** `NimazSectionTitle` uppercases by default, so a heading is matched as it renders. */
+    private fun sectionTitle(@StringRes res: Int): String = string(res).uppercase()
+
+    private fun topic(id: String, title: String, subtitle: String = "") = HelpTopic(
+        id = id,
+        iconKey = "schedule",
+        colorKey = "indigo",
+        title = title,
+        subtitle = subtitle,
+        order = 0,
+        itemCount = 3,
+    )
+
+    @Test
+    fun `the topic grid is what an idle Help screen shows`() {
+        homeState.value = HelpHomeUiState(
+            topics = listOf(
+                topic("prayer", "Prayer times", "When and why"),
+                topic("quran", "Reading the Qur'an"),
+                topic("widgets", "Widgets"),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(sectionTitle(R.string.help_browse_topics)).assertExists()
+        composeRule.onNodeWithText("Prayer times").assertExists()
+        composeRule.onNodeWithText("When and why").assertExists()
+        // An odd count still lays out — the grid chunks by two and pads the last row.
+        composeRule.onNodeWithText("Widgets").assertExists()
+        composeRule.onNodeWithText(string(R.string.help_still_need)).assertExists()
+    }
+
+    @Test
+    fun `a topic tile opens that topic`() {
+        homeState.value = HelpHomeUiState(
+            topics = listOf(topic("prayer", "Prayer times"), topic("quran", "Qur'an")),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Qur'an").performClick()
+
+        // The id, not the title: a tile handing over its label opens nothing.
+        assertThat(topicsOpened).containsExactly("quran")
+    }
+
+    @Test
+    fun `typing asks the ViewModel to search`() {
+        homeState.value = HelpHomeUiState(topics = listOf(topic("p", "Prayer")), isLoading = false)
+        setContent()
+
+        // The bar carries its placeholder as a content description — the field itself has no
+        // text until something is typed into it.
+        composeRule.onNodeWithContentDescription(string(R.string.help_search_hint))
+            .performTextInput("qibla")
+
+        assertThat(events).contains(HelpEvent.Search("qibla"))
+    }
+
+    @Test
+    fun `results replace the grid while a search is running`() {
+        homeState.value = HelpHomeUiState(
+            topics = listOf(topic("prayer", "Prayer times")),
+            query = "qibla",
+            isSearching = true,
+            results = listOf(
+                HelpSearchResult(
+                    topicId = "qibla",
+                    itemId = "q1",
+                    isGuide = false,
+                    title = "Why is the qibla arrow spinning?",
+                    snippet = "Calibrate the compass",
+                ),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Why is the qibla arrow spinning?").assertExists()
+        // The grid is gone: leaving it under the results makes the search look like it did
+        // nothing at all.
+        composeRule.onNodeWithText(sectionTitle(R.string.help_browse_topics)).assertDoesNotExist()
+        composeRule.onNodeWithText("Prayer times").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a result opens the topic it belongs to`() {
+        homeState.value = HelpHomeUiState(
+            query = "qibla",
+            isSearching = true,
+            results = listOf(
+                HelpSearchResult("qibla", "q1", isGuide = false, title = "Spinning arrow", snippet = ""),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Spinning arrow").performClick()
+
+        assertThat(topicsOpened).containsExactly("qibla")
+    }
+
+    @Test
+    fun `a search with no hits says so rather than showing an empty screen`() {
+        homeState.value = HelpHomeUiState(
+            topics = listOf(topic("prayer", "Prayer times")),
+            query = "xyzzy",
+            isSearching = true,
+            results = emptyList(),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_no_results)).assertExists()
+    }
+
+    @Test
+    fun `a failed topic load keeps the search bar reachable`() {
+        homeState.value = HelpHomeUiState(
+            isLoading = false,
+            error = UiError(message = R.string.help_topics_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_topics_load_failed)).assertExists()
+        // SECTION, not FULLSCREEN: the search path is a different query and may well work.
+        composeRule.onNodeWithContentDescription(string(R.string.help_search_hint)).assertExists()
+    }
+
+    @Test
+    fun `the failed load offers a retry that reaches the ViewModel`() {
+        homeState.value = HelpHomeUiState(
+            isLoading = false,
+            error = UiError(message = R.string.help_topics_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).contains(HelpEvent.Retry)
+    }
+
+    @Test
+    fun `an error is preferred over the topic grid but not over search results`() {
+        // Both flags set at once is a real state — a search running while the grid's own load
+        // failed — and the results are what the reader asked for.
+        homeState.value = HelpHomeUiState(
+            query = "qibla",
+            isSearching = true,
+            results = listOf(
+                HelpSearchResult("qibla", null, isGuide = false, title = "Qibla", snippet = ""),
+            ),
+            isLoading = false,
+            error = UiError(message = R.string.help_topics_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Qibla").assertExists()
+        composeRule.onNodeWithText(string(R.string.help_topics_load_failed)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the contact card writes to support`() {
+        homeState.value = HelpHomeUiState(topics = listOf(topic("p", "Prayer")), isLoading = false)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_still_need)).performClick()
+
+        assertThat(contacts).isEqualTo(1)
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpTopicDetailScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/help/HelpTopicDetailScreenTest.kt
@@ -1,0 +1,281 @@
+package com.arshadshah.nimaz.presentation.screens.help
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.HelpItem
+import com.arshadshah.nimaz.domain.model.HelpTopic
+import com.arshadshah.nimaz.domain.model.HelpTopicDetail
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpEvent
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpTopicUiState
+import com.arshadshah.nimaz.presentation.viewmodel.help.HelpViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * One help topic: its questions, and the guides that go with it.
+ *
+ * The branch order is the behaviour. A failed load and a topic that genuinely is not in the
+ * catalogue both leave `detail` null, and the screen distinguishes them **only** by testing the
+ * error first — get that backwards and a transient failure tells the reader "this topic is
+ * unavailable", which is a statement about the content rather than about the load, and which no
+ * retry button then appears to contradict.
+ *
+ * The rest is that help content ships as **data**, written by a release that may be newer than
+ * the build rendering it. A topic with no questions, or no guides, or neither, is a shape the
+ * renderer will meet, and the sections must simply not appear rather than render empty headings.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HelpTopicDetailScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val topicState = MutableStateFlow(HelpTopicUiState())
+    private val events = mutableListOf<HelpEvent>()
+
+    private val viewModel: HelpViewModel = mockk(relaxed = true) {
+        every { this@mockk.topicState } returns this@HelpTopicDetailScreenTest.topicState
+        every { onEvent(any()) } answers { events += firstArg<HelpEvent>() }
+    }
+
+    private val guidesOpened = mutableListOf<String>()
+
+    private fun setContent(topicId: String = "prayer") {
+        composeRule.setThemedContent {
+            HelpTopicDetailScreen(
+                topicId = topicId,
+                onNavigateBack = {},
+                onOpenGuide = { guidesOpened += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /** `NimazSectionTitle` uppercases by default, so a heading is matched as it renders. */
+    private fun sectionTitle(@StringRes res: Int): String = string(res).uppercase()
+
+    private fun detail(
+        questions: List<HelpItem.HelpQuestion> = emptyList(),
+        guides: List<HelpItem.HelpGuide> = emptyList(),
+        subtitle: String = "Times, alerts and adhan",
+    ) = HelpTopicDetail(
+        topic = HelpTopic(
+            id = "prayer",
+            iconKey = "schedule",
+            colorKey = "indigo",
+            title = "Prayer times",
+            subtitle = subtitle,
+            order = 0,
+            itemCount = questions.size + guides.size,
+        ),
+        questions = questions,
+        guides = guides,
+    )
+
+    private fun question(id: String, q: String, a: String) =
+        HelpItem.HelpQuestion(id = id, order = 0, question = q, answer = a)
+
+    private fun guide(id: String, title: String, minutes: Int? = 3) =
+        HelpItem.HelpGuide(
+            id = id,
+            order = 0,
+            iconKey = "tune",
+            title = title,
+            estimatedMinutes = minutes,
+            stepCount = 4,
+        )
+
+    @Test
+    fun `opening the screen asks for the topic it was routed to`() {
+        topicState.value = HelpTopicUiState(detail = detail(), isLoading = false)
+        setContent(topicId = "qibla")
+
+        // The route argument, not a default: the screen is one destination reused for every
+        // topic, so the id is the whole of what distinguishes one visit from another.
+        assertThat(events).contains(HelpEvent.LoadTopic("qibla"))
+    }
+
+    @Test
+    fun `a loaded topic shows its hero and both sections`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(
+                questions = listOf(question("q1", "When is Fajr?", "At dawn.")),
+                guides = listOf(guide("g1", "Set a prayer alert")),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        // The title is on the app bar as well as on the hero, so both nodes carry it.
+        composeRule.onAllNodesWithText("Prayer times").onFirst().assertExists()
+        composeRule.onNodeWithText("Times, alerts and adhan").assertExists()
+        composeRule.onNodeWithText(sectionTitle(R.string.help_common_questions)).assertExists()
+        composeRule.onNodeWithText(sectionTitle(R.string.help_step_by_step)).assertExists()
+    }
+
+    @Test
+    fun `a topic with no guides renders no step-by-step heading`() {
+        // Content this build did not write: a topic that is all questions is a shape the
+        // renderer meets, and an empty heading reads as content that failed to load.
+        topicState.value = HelpTopicUiState(
+            detail = detail(questions = listOf(question("q1", "When is Fajr?", "At dawn."))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(sectionTitle(R.string.help_common_questions)).assertExists()
+        composeRule.onNodeWithText(sectionTitle(R.string.help_step_by_step)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a topic with neither questions nor guides still renders its hero`() {
+        topicState.value = HelpTopicUiState(detail = detail(subtitle = ""), isLoading = false)
+        setContent()
+
+        // The title is on the app bar as well as on the hero, so both nodes carry it.
+        composeRule.onAllNodesWithText("Prayer times").onFirst().assertExists()
+        composeRule.onNodeWithText(sectionTitle(R.string.help_common_questions)).assertDoesNotExist()
+        composeRule.onNodeWithText(sectionTitle(R.string.help_step_by_step)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `an answer is hidden until its question is tapped`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(questions = listOf(question("q1", "When is Fajr?", "At dawn."))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("At dawn.").assertDoesNotExist()
+
+        composeRule.onNodeWithText("When is Fajr?").performClick()
+
+        composeRule.onNodeWithText("At dawn.").assertExists()
+    }
+
+    @Test
+    fun `several questions each expand on their own`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(
+                questions = listOf(
+                    question("q1", "When is Fajr?", "At dawn."),
+                    question("q2", "Why did the adhan not play?", "Check the alert style."),
+                ),
+            ),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("When is Fajr?").performClick()
+
+        composeRule.onNodeWithText("At dawn.").assertExists()
+        // Opening one does not open the other: each row owns its own expansion.
+        composeRule.onNodeWithText("Check the alert style.").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a guide row opens that guide`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(guides = listOf(guide("g1", "Set a prayer alert"), guide("g2", "Fix qibla"))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText("Fix qibla").performClick()
+
+        assertThat(guidesOpened).containsExactly("g2")
+    }
+
+    @Test
+    fun `a guide with no estimate says step-by-step instead of a time`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(guides = listOf(guide("g1", "Set a prayer alert", minutes = null))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_guide_step_by_step)).assertExists()
+    }
+
+    @Test
+    fun `a guide with an estimate reports it`() {
+        topicState.value = HelpTopicUiState(
+            detail = detail(guides = listOf(guide("g1", "Set a prayer alert", minutes = 5))),
+            isLoading = false,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_guide_about_minutes_format, 5)).assertExists()
+    }
+
+    @Test
+    fun `a failed load says the load failed, not that the topic is missing`() {
+        // Both leave `detail` null. Only the branch order tells them apart, and getting it
+        // wrong blames the catalogue for a transient failure.
+        topicState.value = HelpTopicUiState(
+            detail = null,
+            isLoading = false,
+            error = UiError(message = R.string.help_topic_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_topic_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.help_topic_unavailable)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the failed load can be retried`() {
+        topicState.value = HelpTopicUiState(
+            isLoading = false,
+            error = UiError(message = R.string.help_topic_load_failed),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).contains(HelpEvent.Retry)
+    }
+
+    @Test
+    fun `a topic still loading shows neither content nor an absence`() {
+        // The spinner animates forever, so the clock is pinned before `setContent` — otherwise
+        // `waitForIdle` never returns. Only this test renders a loading state.
+        composeRule.mainClock.autoAdvance = false
+        topicState.value = HelpTopicUiState(detail = null, isLoading = true)
+        setContent()
+
+        // "This topic is unavailable" during the load would be a verdict delivered before the
+        // question was asked.
+        composeRule.onNodeWithText(string(R.string.help_topic_unavailable)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a topic that is genuinely absent says so`() {
+        topicState.value = HelpTopicUiState(detail = null, isLoading = false, error = null)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.help_topic_unavailable)).assertExists()
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreenTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/MoreMenuScreenTest.kt
@@ -1,0 +1,262 @@
+package com.arshadshah.nimaz.presentation.screens.more
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PinnedShortcut
+import com.arshadshah.nimaz.domain.model.WorshipReminderType
+import com.arshadshah.nimaz.presentation.viewmodel.more.MoreEvent
+import com.arshadshah.nimaz.presentation.viewmodel.more.MoreUiState
+import com.arshadshah.nimaz.presentation.viewmodel.more.MoreViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The menu every feature that is not a bottom-nav tab is reached from.
+ *
+ * Two properties are worth a test here and nothing else in the repository asserts either on the
+ * JVM. The first is that **each row dispatches its own destination**: twenty rows built from
+ * twenty lambdas of identical type is exactly the shape where a copy-paste sends "Fasting" to the
+ * qibla, and neither the compiler nor `FeatureNavigationTest` — which taps a row and checks a tag
+ * appears — can see a swap between two rows whose screens both exist. Each callback here is a
+ * separate counter, so a swap fails on the row it was made in.
+ *
+ * The second is that **a subtitle is a claim about the app right now**, and the screen is where
+ * `MoreSubtitles` meets the state that feeds it. `MoreSubtitlesTest` pins what each mapper
+ * returns; these pin that the row actually renders it — a wiring the mapper test cannot see,
+ * because a row passing `state.khatamJuz` where `state.qaidaLesson` belongs still resolves to a
+ * perfectly well-formed string.
+ *
+ * Rendered at a tall viewport so the whole list composes: a `LazyColumn` at phone height composes
+ * one screenful, and the Support section is the last of five.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class MoreMenuScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MutableStateFlow(MoreUiState())
+    private val events = mutableListOf<MoreEvent>()
+
+    private val viewModel: MoreViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@MoreMenuScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<MoreEvent>() }
+    }
+
+    private val opened = mutableListOf<String>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            MoreMenuScreen(
+                onNavigateToSettings = { opened += "settings" },
+                onNavigateToCalendar = { opened += "calendar" },
+                onNavigateToAbout = { opened += "about" },
+                onNavigateToHelp = { opened += "help" },
+                onShareApp = { opened += "share" },
+                onRateApp = { opened += "rate" },
+                onNavigateToHadith = { opened += "hadith" },
+                onNavigateToFasting = { opened += "fasting" },
+                onNavigateToZakat = { opened += "zakat" },
+                onNavigateToDuas = { opened += "duas" },
+                onNavigateToTafseer = { opened += "tafseer" },
+                onNavigateToPrayerTracker = { opened += "tracker" },
+                onNavigateToNightWorship = { opened += "worship" },
+                onNavigateToPrayerTimes = { opened += "times" },
+                onNavigateToMonthlyPrayerTimes = { opened += "monthly" },
+                onNavigateToKhatam = { opened += "khatam" },
+                onNavigateToNames = { opened += "names" },
+                onNavigateToQaida = { opened += "qaida" },
+                onNavigateToTasbih = { opened += "tasbih" },
+                onNavigateToQibla = { opened += "qibla" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `every section and its rows are on the menu`() {
+        // Unpinned, because the Zakat pill and the Zakat row carry the same one word and the
+        // matcher cannot tell two identical labels apart. The pin row has its own tests below.
+        state.value = MoreUiState(pinnedShortcuts = emptyList())
+        setContent()
+
+        // Five section headings, in the order a reader meets them.
+        listOf(
+            R.string.more_pinned_title,
+            R.string.daily_practice,
+            R.string.learning,
+            R.string.tools,
+            R.string.support,
+        ).forEach { composeRule.onNodeWithText(string(it)).assertExists() }
+
+        // Every row that opens a feature. Nineteen destinations plus Settings in the app bar —
+        // the same set `FeatureNavigationTest` walks on a device.
+        listOf(
+            R.string.prayer_tracker, R.string.fasting, R.string.night_worship_title,
+            R.string.khatam_quran, R.string.qaida, R.string.names_title, R.string.hadith,
+            R.string.duas, R.string.tafseer, R.string.calendar, R.string.prayer_times,
+            R.string.monthly_prayer_times, R.string.zakat, R.string.about_nimaz,
+            R.string.help_support, R.string.share_app, R.string.rate_us,
+        ).forEach { composeRule.onNodeWithText(string(it)).assertExists() }
+    }
+
+    @Test
+    fun `each row opens its own destination`() {
+        state.value = MoreUiState(pinnedShortcuts = emptyList())
+        setContent()
+
+        // Tapped in menu order, and asserted as a sequence: a row wired to its neighbour's
+        // lambda still records *something*, and only the order shows it up.
+        listOf(
+            R.string.prayer_tracker to "tracker",
+            R.string.fasting to "fasting",
+            R.string.night_worship_title to "worship",
+            R.string.khatam_quran to "khatam",
+            R.string.qaida to "qaida",
+            R.string.names_title to "names",
+            R.string.hadith to "hadith",
+            R.string.duas to "duas",
+            R.string.tafseer to "tafseer",
+            R.string.calendar to "calendar",
+            R.string.prayer_times to "times",
+            R.string.monthly_prayer_times to "monthly",
+            R.string.zakat to "zakat",
+            R.string.about_nimaz to "about",
+            R.string.help_support to "help",
+            R.string.share_app to "share",
+            R.string.rate_us to "rate",
+        ).forEach { (res, _) -> composeRule.onNodeWithText(string(res)).performClick() }
+
+        assertThat(opened).containsExactly(
+            "tracker", "fasting", "worship", "khatam", "qaida", "names", "hadith", "duas",
+            "tafseer", "calendar", "times", "monthly", "zakat", "about", "help", "share", "rate",
+        ).inOrder()
+    }
+
+    @Test
+    fun `the app bar action opens settings`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.settings)).performClick()
+
+        assertThat(opened).containsExactly("settings")
+    }
+
+    @Test
+    fun `coming into view asks for a fresh worship countdown`() {
+        // The countdown is a snapshot over a dozen settings rather than a live flow, so coming
+        // back to More after an hour must re-ask. Without the resume effect the row keeps
+        // reporting an hour-old "in 5h 12m" and nothing looks wrong.
+        setContent()
+
+        assertThat(events).contains(MoreEvent.Refresh)
+    }
+
+    @Test
+    fun `rows report the state behind them`() {
+        state.value = MoreUiState(
+            prayersLogged = 3,
+            prayersTrackable = 5,
+            pendingMakeupFasts = 2,
+            nextWorship = WorshipReminderType.TAHAJJUD,
+            minutesUntilNextWorship = 90,
+            khatamJuz = 7,
+            khatamDaysAgainstPace = 0,
+            qaidaLesson = 4,
+            qaidaTotalLessons = 30,
+            zakatHistoryLoaded = true,
+            zakatDueThisYear = null,
+            hijriToday = "12 Rajab 1447",
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.more_tracker_logged, 3, 5)).assertExists()
+        composeRule.onNodeWithText(string(R.string.more_qaida_lesson, 4, 30)).assertExists()
+        composeRule.onNodeWithText(string(R.string.more_khatam_juz_on_pace, 7)).assertExists()
+        // Loaded with no figure is its own sentence, and only says so once the query returned.
+        composeRule.onNodeWithText(string(R.string.more_zakat_not_calculated)).assertExists()
+        composeRule.onNodeWithText("12 Rajab 1447").assertExists()
+    }
+
+    @Test
+    fun `a row with nothing true to report renders no subtitle`() {
+        // The loading contract: absent, never a dash, a zero or a spinner. `MoreUiState`'s
+        // defaults are all null, which is the state the screen opens in.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.more_tracker_none)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.more_zakat_not_calculated)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the pin row opens the destinations it names`() {
+        state.value = MoreUiState(pinnedShortcuts = listOf(PinnedShortcut.QIBLA))
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.more_pin_qibla)).performClick()
+
+        // A pill is a *view* of the menu's own lambdas — a pin with navigation of its own would
+        // be the second place a destination is reached from, and the two would drift.
+        assertThat(opened).containsExactly("qibla")
+    }
+
+    @Test
+    // Wide, because the pin row is a `LazyRow`: at phone width it composes about four pills and
+    // the rest of the enum never renders at all.
+    @Config(qualifiers = "w2000dp-h2200dp")
+    fun `every pinnable destination has a pill of its own`() {
+        // Each pill carries the icon its own menu row uses, so a pin is recognisable as the
+        // thing it opens. A shortcut added to the enum without an icon here does not fail to
+        // compile — the `when` is exhaustive, but nothing checks that the pill *renders*.
+        state.value = MoreUiState(pinnedShortcuts = PinnedShortcut.entries)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.more_pin_qibla)).assertExists()
+        composeRule.onNodeWithText(string(R.string.more_pin_night_worship)).assertExists()
+        composeRule.onNodeWithText(string(R.string.more_pin_tasbih)).assertExists()
+    }
+
+    @Test
+    fun `an empty pin row says so rather than rendering nothing`() {
+        state.value = MoreUiState(pinnedShortcuts = emptyList())
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.more_pins_empty)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the pinned defaults are what an untouched install shows`() {
+        setContent()
+
+        listOf(PinnedShortcut.TASBIH, PinnedShortcut.PRAYER_TRACKER, PinnedShortcut.KHATAM)
+            .forEach { composeRule.onNodeWithText(string(it.labelRes())).assertExists() }
+        // Zakat is the fourth default, and its pill label is the same single word as its menu
+        // row's title — so both nodes carry it, which is itself the assertion.
+        composeRule.onAllNodesWithText(string(R.string.more_pin_zakat)).assertCountEquals(2)
+        // Not everything is pinned by default; the row would be a second menu if it were.
+        composeRule.onNodeWithText(string(R.string.more_pin_qibla)).assertDoesNotExist()
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/MoreSubtitlesTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/MoreSubtitlesTest.kt
@@ -143,6 +143,14 @@ class MoreSubtitlesTest {
             .isEqualTo(R.string.more_khatam_juz)
     }
 
+    @Test
+    fun `a khatam that has not been opened has no juz to report`() {
+        // Null is "the query has not returned", zero is "started but nothing read". Both mean
+        // the row says nothing rather than "Juz 0".
+        assertThat(MoreSubtitles.khatam(juz = null, daysAgainstPace = 3)).isNull()
+        assertThat(MoreSubtitles.khatam(juz = 0, daysAgainstPace = 3)).isNull()
+    }
+
     // ── Qaida ────────────────────────────────────────────────────────────
 
     @Test
@@ -177,6 +185,14 @@ class MoreSubtitlesTest {
         // a real finding and worth saying, but it must not be said before the query returns —
         // otherwise the row accuses someone of not having done it, then corrects itself.
         assertThat(MoreSubtitles.zakat(loaded = false, dueThisYear = null)).isNull()
+    }
+
+    @Test
+    fun `a blank amount is not a figure, and reads as not calculated`() {
+        // `formatCurrency` returning empty is the shape this guards: a row saying "Due: " with
+        // nothing after it is worse than saying the year has not been calculated.
+        assertThat(MoreSubtitles.zakat(loaded = true, dueThisYear = "   ")?.res)
+            .isEqualTo(R.string.more_zakat_not_calculated)
     }
 
     // ── Islamic calendar ─────────────────────────────────────────────────

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/PinnedShortcutsSheetTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/more/PinnedShortcutsSheetTest.kt
@@ -1,0 +1,141 @@
+package com.arshadshah.nimaz.presentation.screens.more
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PinnedShortcut
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Choosing what sits above the menu — and the cap, which is the whole of the design here.
+ *
+ * The cap is expressed by **disabling the rows you cannot add** rather than by ignoring the tap,
+ * and the exception is the part that has to hold: a *pinned* row is never disabled, whatever the
+ * count. Get that wrong and reaching five pins makes the one you want to remove the one row you
+ * cannot touch — a dead end with no way out except clearing app data, and one that only appears
+ * for people who used the feature enough to fill it.
+ *
+ * Order is the other property. A new pin is **appended**, never inserted, so adding a sixth
+ * favourite does not reshuffle the arrangement someone already has; the sheet hands back the
+ * whole list precisely so order is part of what is being set.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class PinnedShortcutsSheetTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val changes = mutableListOf<List<PinnedShortcut>>()
+    private var dismissals = 0
+
+    private fun setContent(pinned: List<PinnedShortcut>) {
+        composeRule.setThemedContent {
+            PinnedShortcutsSheet(
+                pinned = pinned,
+                onPinnedChange = { changes += it },
+                onDismiss = { dismissals++ },
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun label(shortcut: PinnedShortcut): String = string(shortcut.labelRes())
+
+    @Test
+    fun `every pinnable destination is offered`() {
+        setContent(PinnedShortcut.DEFAULTS)
+
+        // A destination missing from this list can never be pinned, and nothing else would say
+        // so — the pin row simply would not show it.
+        PinnedShortcut.entries.forEach {
+            composeRule.onNodeWithText(label(it)).assertExists()
+        }
+    }
+
+    @Test
+    fun `pinning appends rather than inserting`() {
+        setContent(listOf(PinnedShortcut.TASBIH, PinnedShortcut.KHATAM))
+
+        composeRule.onNodeWithText(label(PinnedShortcut.QIBLA)).performClick()
+
+        assertThat(changes).containsExactly(
+            listOf(PinnedShortcut.TASBIH, PinnedShortcut.KHATAM, PinnedShortcut.QIBLA),
+        )
+    }
+
+    @Test
+    fun `unpinning removes only that shortcut and keeps the rest in order`() {
+        setContent(listOf(PinnedShortcut.TASBIH, PinnedShortcut.KHATAM, PinnedShortcut.QIBLA))
+
+        composeRule.onNodeWithText(label(PinnedShortcut.KHATAM)).performClick()
+
+        assertThat(changes).containsExactly(
+            listOf(PinnedShortcut.TASBIH, PinnedShortcut.QIBLA),
+        )
+    }
+
+    @Test
+    fun `at the cap an unpinned row does nothing`() {
+        setContent(fullList())
+
+        composeRule.onNodeWithText(label(PinnedShortcut.QAIDA)).performClick()
+
+        // Disabled, not silently ignored: the header says why, and the row looks unavailable.
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `at the cap a pinned row still unpins`() {
+        // The exception that makes the cap survivable. Without it the row you want gone is the
+        // one row you cannot reach.
+        setContent(fullList())
+
+        composeRule.onNodeWithText(label(PinnedShortcut.TASBIH)).performClick()
+
+        assertThat(changes).hasSize(1)
+        assertThat(changes.single()).doesNotContain(PinnedShortcut.TASBIH)
+        assertThat(changes.single()).hasSize(PinnedShortcut.MAX_PINS - 1)
+    }
+
+    @Test
+    fun `the header counts the pins against the cap`() {
+        setContent(listOf(PinnedShortcut.TASBIH, PinnedShortcut.KHATAM))
+
+        composeRule.onNodeWithText(string(R.string.more_pins_sheet_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.more_pins_count, 2, PinnedShortcut.MAX_PINS))
+            .assertExists()
+    }
+
+    @Test
+    fun `a full row says so rather than counting`() {
+        setContent(fullList())
+
+        composeRule.onNodeWithText(string(R.string.more_pins_full, PinnedShortcut.MAX_PINS))
+            .assertExists()
+    }
+
+    @Test
+    fun `an empty selection says nothing is pinned`() {
+        setContent(emptyList())
+
+        composeRule.onNodeWithText(string(R.string.more_pins_empty)).assertExists()
+    }
+
+    private fun fullList(): List<PinnedShortcut> =
+        PinnedShortcut.entries.take(PinnedShortcut.MAX_PINS)
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/about/LicensesViewModelTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/about/LicensesViewModelTest.kt
@@ -210,6 +210,55 @@ class LicensesViewModelTest {
     }
 
     @Test
+    fun `search does not trip over a library that published no author`() = runTest(dispatcher) {
+        // AboutLibraries leaves `author` null for a good share of the catalogue, and the search
+        // reads name, author and coordinate at once — so the null has to be a miss rather than
+        // a match or a throw.
+        val anonymous = library(9, "Timber", "com.jakewharton.timber:timber", null, "Apache License 2.0")
+        coEvery { useCases.getLibraries() } returns listOf(compose, anonymous)
+        val vm = LicensesViewModel(useCases, telemetry)
+        vm.onEvent(LicensesEvent.LoadLibraries)
+        advanceUntilIdle()
+
+        vm.onEvent(LicensesEvent.Search("Google"))
+        val matched = vm.listState.value.sections.flatMap { it.libraries }
+
+        assertThat(matched).containsExactly(compose)
+    }
+
+    @Test
+    fun `alphabetical grouping files anything not starting with a letter under a hash`() =
+        runTest(dispatcher) {
+            // Maven names beginning with a digit are real — "2captcha", "4-you" — and an
+            // initial that is not a letter must not become its own one-character section per
+            // digit, nor throw on an empty name.
+            val numeric = library(11, "2Captcha", "com.twocaptcha:client", "Two Captcha", "MIT License")
+            coEvery { useCases.getLibraries() } returns listOf(compose, numeric)
+            val vm = LicensesViewModel(useCases, telemetry)
+            vm.onEvent(LicensesEvent.LoadLibraries)
+            advanceUntilIdle()
+
+            vm.onEvent(LicensesEvent.ToggleGrouping)
+
+            assertThat(vm.listState.value.sections.map { it.letter }).containsExactly("#", "C")
+        }
+
+    @Test
+    fun `toggling the grouping twice comes back to grouping by licence`() = runTest(dispatcher) {
+        coEvery { useCases.getLibraries() } returns listOf(compose, adhan)
+        val vm = LicensesViewModel(useCases, telemetry)
+        vm.onEvent(LicensesEvent.LoadLibraries)
+        advanceUntilIdle()
+
+        vm.onEvent(LicensesEvent.ToggleGrouping)
+        vm.onEvent(LicensesEvent.ToggleGrouping)
+
+        assertThat(vm.listState.value.grouping).isEqualTo(LicenseGrouping.BY_LICENCE)
+        assertThat(vm.listState.value.sections.map { it.family })
+            .containsExactly(LicenseFamily.APACHE_2, LicenseFamily.MIT)
+    }
+
+    @Test
     fun `a library declaring no licence is grouped, not dropped`() = runTest(dispatcher) {
         coEvery { useCases.getLibraries() } returns listOf(
             compose,
@@ -245,6 +294,44 @@ class LicensesViewModelTest {
         // to telemetry, but the reader is still told.
         assertThat(state.error?.kind).isEqualTo(NimazErrorKind.NOT_FOUND)
         assertThat(telemetry.errors).isEmpty()
+    }
+
+    @Test
+    fun `a detail lookup that throws is reported, not swallowed into an empty screen`() =
+        runTest(dispatcher) {
+            // Distinct from "not found": the list is bundled, so a *throw* here means the asset
+            // itself failed to parse, and the detail screen must say the load failed rather
+            // than render a blank library.
+            coEvery { useCases.getLibrary(any()) } throws IllegalStateException("asset missing")
+            val vm = LicensesViewModel(useCases, telemetry)
+
+            vm.onEvent(LicensesEvent.LoadLibrary(1))
+            advanceUntilIdle()
+
+            assertThat(vm.detailState.value.isLoading).isFalse()
+            assertThat(vm.detailState.value.library).isNull()
+            assertThat(vm.detailState.value.error?.message).isEqualTo(R.string.licenses_load_failed)
+            assertThat(vm.detailState.value.error?.kind).isEqualTo(NimazErrorKind.GENERIC)
+        }
+
+    @Test
+    fun `dismissing clears both screens' errors`() = runTest(dispatcher) {
+        // One event for both states: the list and the detail are separate flows, and a dismiss
+        // that cleared only the one on screen would leave the other's stale failure waiting for
+        // whoever opened it next.
+        coEvery { useCases.getLibraries() } throws IllegalStateException("asset missing")
+        coEvery { useCases.getLibrary(any()) } returns null
+        val vm = LicensesViewModel(useCases, telemetry)
+        vm.onEvent(LicensesEvent.LoadLibraries)
+        vm.onEvent(LicensesEvent.LoadLibrary(99))
+        advanceUntilIdle()
+        assertThat(vm.listState.value.error).isNotNull()
+        assertThat(vm.detailState.value.error).isNotNull()
+
+        vm.onEvent(LicensesEvent.DismissError)
+
+        assertThat(vm.listState.value.error).isNull()
+        assertThat(vm.detailState.value.error).isNull()
     }
 
     @Test

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/help/HelpViewModelRetryTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/help/HelpViewModelRetryTest.kt
@@ -1,0 +1,172 @@
+package com.arshadshah.nimaz.presentation.viewmodel.help
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.HelpGuideDetail
+import com.arshadshah.nimaz.domain.model.HelpTopic
+import com.arshadshah.nimaz.domain.model.HelpTopicDetail
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.usecase.HelpUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Retry, which is one event serving three independent surfaces.
+ *
+ * Help home, a topic and a guide each have their own state, their own loader and their own error,
+ * and all three are reached from the same `HelpEvent.Retry` — so the event has to re-run **only**
+ * what is actually failing. The failure mode is not a crash: re-running a healthy surface throws
+ * its content back into a loading state, which on the Help home means the topic grid blinks out
+ * from under a reader who was retrying something else entirely, and on a topic means losing the
+ * page they were on.
+ *
+ * The home retry needs its own mechanism, and that is the reason for `retryTick`. Topics are
+ * collected from `appLanguage.flatMapLatest { … }`, and `appLanguage` is a `StateFlow` of a
+ * preference: when the language has not changed there is nothing to re-emit, so a retry that only
+ * re-collects would do nothing at all and the button would look broken.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HelpViewModelRetryTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private lateinit var useCases: HelpUseCases
+    private lateinit var prefs: SettingsRepository
+    private val language = MutableStateFlow("en")
+
+    private val topic = HelpTopic(
+        id = "wudu",
+        iconKey = "water",
+        colorKey = "blue",
+        title = "Wudu",
+        subtitle = "How to perform wudu",
+        order = 0,
+        itemCount = 1,
+    )
+
+    private val topicDetail = HelpTopicDetail(topic = topic, questions = emptyList(), guides = emptyList())
+
+    private val guide = HelpGuideDetail(
+        id = "make-wudu",
+        title = "Make wudu",
+        estimatedMinutes = 3,
+        steps = emptyList(),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        prefs = mockk(relaxed = true)
+        every { prefs.appLanguage } returns language
+        every { useCases.search(any(), any()) } returns flowOf(emptyList())
+        every { useCases.getTopics(any()) } returns flowOf(listOf(topic))
+        every { useCases.getTopicDetail(any(), any()) } returns flowOf(topicDetail)
+        every { useCases.getGuide(any(), any()) } returns flowOf(guide)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `a retry re-runs the topic list even though the language has not changed`() = runTest {
+        var attempt = 0
+        every { useCases.getTopics(any()) } answers {
+            attempt++
+            if (attempt == 1) flow { throw IllegalStateException("database is locked") }
+            else flowOf(listOf(topic))
+        }
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+        assertThat(vm.homeState.value.error).isNotNull()
+
+        vm.onEvent(HelpEvent.Retry)
+        advanceUntilIdle()
+
+        assertThat(vm.homeState.value.topics).containsExactly(topic)
+        assertThat(vm.homeState.value.error).isNull()
+        assertThat(vm.homeState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a retry from a failed topic reloads that topic and leaves Help home alone`() = runTest {
+        var attempt = 0
+        every { useCases.getTopicDetail("wudu", any()) } answers {
+            attempt++
+            if (attempt == 1) flow { throw IllegalStateException("locked") } else flowOf(topicDetail)
+        }
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+        vm.onEvent(HelpEvent.LoadTopic("wudu"))
+        advanceUntilIdle()
+        assertThat(vm.topicState.value.error).isNotNull()
+
+        val topicsBefore = vm.homeState.value.topics
+
+        vm.onEvent(HelpEvent.Retry)
+        advanceUntilIdle()
+
+        assertThat(vm.topicState.value.detail).isEqualTo(topicDetail)
+        assertThat(vm.topicState.value.error).isNull()
+        // Help home never went back to loading: it was not the thing that failed.
+        assertThat(vm.homeState.value.topics).isEqualTo(topicsBefore)
+        assertThat(vm.homeState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a retry from a failed guide reloads that guide and leaves the topic alone`() = runTest {
+        var attempt = 0
+        every { useCases.getGuide("make-wudu", any()) } answers {
+            attempt++
+            if (attempt == 1) flow { throw IllegalStateException("locked") } else flowOf(guide)
+        }
+
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+        vm.onEvent(HelpEvent.LoadTopic("wudu"))
+        vm.onEvent(HelpEvent.LoadGuide("make-wudu"))
+        advanceUntilIdle()
+        assertThat(vm.guideState.value.error).isNotNull()
+        assertThat(vm.topicState.value.error).isNull()
+
+        vm.onEvent(HelpEvent.Retry)
+        advanceUntilIdle()
+
+        assertThat(vm.guideState.value.guide).isEqualTo(guide)
+        assertThat(vm.guideState.value.error).isNull()
+        assertThat(vm.topicState.value.detail).isEqualTo(topicDetail)
+    }
+
+    @Test
+    fun `a retry with nothing failing re-runs nothing`() = runTest {
+        val vm = HelpViewModel(useCases, prefs, telemetry)
+        advanceUntilIdle()
+        vm.onEvent(HelpEvent.LoadTopic("wudu"))
+        advanceUntilIdle()
+
+        vm.onEvent(HelpEvent.Retry)
+        advanceUntilIdle()
+
+        // Nothing is thrown back into loading — a retry on a healthy Help screen is a no-op,
+        // not a flicker.
+        assertThat(vm.homeState.value.isLoading).isFalse()
+        assertThat(vm.homeState.value.topics).containsExactly(topic)
+        assertThat(vm.topicState.value.isLoading).isFalse()
+        assertThat(vm.topicState.value.detail).isEqualTo(topicDetail)
+    }
+}

--- a/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/more/MoreViewModelTest.kt
+++ b/feature/about/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/more/MoreViewModelTest.kt
@@ -154,6 +154,40 @@ class MoreViewModelTest {
         assertThat(vm.state.value.minutesUntilNextWorship).isEqualTo(192)
     }
 
+    @Test
+    fun `nothing upcoming leaves the worship row with nothing to say`() {
+        // Outside Ramadan, with the optional reminders off, the resolver genuinely has no next
+        // occurrence — and the row has to be *absent* rather than reporting "in 0m".
+        val vm = viewModel(noNextWorship = true)
+
+        assertThat(vm.state.value.nextWorship).isNull()
+        assertThat(vm.state.value.minutesUntilNextWorship).isNull()
+    }
+
+    @Test
+    fun `a currency nobody has chosen falls back to the default rather than formatting blank`() {
+        // The Zakat preference is a free-text ISO code and defaults to empty on a fresh install.
+        // Handing "" to `formatCurrency` is what the fallback exists to prevent.
+        val vm = viewModel(zakatCurrency = flowOf(""))
+
+        assertThat(vm.state.value.zakatCurrency)
+            .isEqualTo(com.arshadshah.nimaz.domain.model.ZakatDefaults.CURRENCY)
+    }
+
+    @Test
+    fun `a refresh re-resolves the countdown rather than reusing the one from launch`() {
+        // The countdown is a snapshot, not a flow: it is resolved once at construction and again
+        // only when the screen comes back into view. Coming back to More after an hour has to
+        // ask again, or the row reports an hour-old "in 5h 12m" with nothing looking wrong.
+        val resolved = mutableListOf<LocalDateTime>()
+        val vm = viewModel(recordNextWorshipCalls = resolved)
+        assertThat(resolved).hasSize(1)
+
+        vm.onEvent(MoreEvent.Refresh)
+
+        assertThat(resolved).hasSize(2)
+    }
+
     // ── A failing source costs one subtitle ──────────────────────────────
 
     @Test
@@ -275,6 +309,9 @@ class MoreViewModelTest {
         khatam: Flow<Khatam?>? = null,
         qaidaProgress: Flow<List<QaidaLessonProgress>>? = null,
         zakatHistory: Flow<List<ZakatHistoryEntry>>? = null,
+        zakatCurrency: Flow<String>? = null,
+        noNextWorship: Boolean = false,
+        recordNextWorshipCalls: MutableList<LocalDateTime>? = null,
     ): MoreViewModel {
         val prayerRepository = mockk<com.arshadshah.nimaz.domain.repository.PrayerRepository>()
         every { prayerRepository.getTodayPrayerRecords() } answers {
@@ -344,18 +381,25 @@ class MoreViewModelTest {
             )
 
         val resolver = mockk<com.arshadshah.nimaz.domain.worship.NextWorshipResolver>()
-        io.mockk.coEvery { resolver.nearest(any()) } returns WorshipReminderOccurrence(
-            type = WorshipReminderType.TAHAJJUD,
-            triggerAt = today.atTime(23, 12),
-            eventAt = today.atTime(23, 12),
-        )
+        io.mockk.coEvery { resolver.nearest(any()) } answers {
+            recordNextWorshipCalls?.add(firstArg())
+            if (noNextWorship) {
+                null
+            } else {
+                WorshipReminderOccurrence(
+                    type = WorshipReminderType.TAHAJJUD,
+                    triggerAt = today.atTime(23, 12),
+                    eventAt = today.atTime(23, 12),
+                )
+            }
+        }
 
         val settings = mockk<com.arshadshah.nimaz.domain.repository.SettingsRepository>()
         every { settings.hijriDayOffset } returns flowOf(0)
 
         val zakatSettings =
             mockk<com.arshadshah.nimaz.domain.repository.settings.ZakatSettings>()
-        every { zakatSettings.zakatCurrency } returns flowOf("EUR")
+        every { zakatSettings.zakatCurrency } returns (zakatCurrency ?: flowOf("EUR"))
 
         return MoreViewModel(
             useCases = MoreUseCases(

--- a/feature/about/src/test/resources/robolectric.properties
+++ b/feature/about/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application


### PR DESCRIPTION
Closes #610. Part of #604.

## Before / after

| | Before | After | Floor |
|---|---|---|---|
| Line | **17.8%** (434 / 2,434) | **94.1%** (2,291 / 2,434) | 0.80 |
| Branch | **23.0%** (161 / 699) | **83.8%** (586 / 699) | 0.80 |

139 tests across thirteen new classes; the module's suite goes from 58 to 197. Nine files — every screen the module owns — were at **0%**, 1,713 of the 2,000 missing lines, and nothing had ever composed one.

**Nothing is softened.** Sixth Compose module in a row to hold 80/80, and the largest of them: seven screens, a bottom sheet and two renderer files. `COVERAGE_EXCLUSIONS` is untouched — no entry added, none widened.

## The gate bites

Floor temporarily set to `0.99`:

```
> Task :feature:about:coverageFloor FAILED
> :feature:about:coverageFloor: line coverage 94.1% is below the floor this module is
  locked at (99.0%), covering 2291/2434 (94.1%).
  Raise the tests, not the floor: it is a ratchet, and a module that has been brought
  up to it is not meant to come back down.
```

Restored to `0.80`; `:feature:about:coverageFloor` passes.

## What the new tests pin

Each of these is a failure that ships silently — none of them throws, and none is visible in a screenshot.

**`MoreMenuScreenTest`** — seventeen rows built from twenty lambdas of one type, tapped in menu order and asserted as a *sequence*. A row wired to its neighbour's lambda still opens *something*, so only the order shows it up; `FeatureNavigationTest` on the emulator taps a row and checks a tag appear, which cannot see a swap between two rows whose screens both exist. Also: a subtitle renders the field that belongs to it (a row passing `khatamJuz` where `qaidaLesson` belongs still resolves to a well-formed string), an unarrived figure renders as *absent* rather than as a dash or a zero, and `LifecycleResumeEffect` re-asks for the worship countdown — without it, coming back after an hour reports an hour-old "in 5h 12m" with nothing looking wrong.

**`AdaptiveMoreScreenTest`** — the phone/tablet split, which is the whole reason About, Help and More are one module. On a phone "About Nimaz" pushes `Route.SettingsAbout`; on a tablet it must **not** navigate at all, it moves the scaffold's detail pane. A regression either way is silent: navigating on a tablet stacks a full-screen About over a layout designed to show it beside the menu.

**`PinnedShortcutsSheetTest`** — at five pins an unpinned row is disabled **and a pinned one is not**. That exception is what keeps the cap survivable: without it, reaching five makes the pin you want to remove the one row you cannot touch, and it only appears for people who used the feature enough to fill it.

**`AboutScreenTest`** — an update tap reaches `checkForUpdate`, `startUpdate`, or the `completeUpdate` lambda that arrives *inside* `UpdateState.Downloaded`, and reaches nothing at all while busy (a tap during a download restarts it). The row looks identical whichever it calls. Also that the version shown is the version `LocalAppIdentity` supplied — its default is an em dash and build 0 on purpose, and About reporting "—" on a shipped build is a support mail nobody can answer.

**`HelpScreenTest` / `HelpTopicDetailScreenTest` / `HelpGuideScreenTest`** — a failed load is distinguishable from genuine absence on all three surfaces; both leave the detail null and only the branch order tells them apart, so getting it backwards tells a reader "this topic is unavailable" about one that is merely slow. Help home renders its failure as a **section** so the search bar survives it. And the near end of a help deep link: a step *with* a route renders a tappable breadcrumb and hands the route out verbatim, a step *without* one renders the same breadcrumb inert — `:core:navigation`'s `HelpDeepLinkTest` pins the far end, and a screen that never calls `onDeepLink` passes every assertion there.

**`LicensesScreenTest` / `LicenseDetailScreenTest` / `LicenseVisualsTest`** — driven from a supplied catalogue, because AboutLibraries reads the *applying* project's classpath and stays in `:app` (`LicenceCatalogueTest` is untouched and still lives there). Counts come off the whole list, not the filtered rows; a query with no hits, an empty catalogue and a failed load are three distinguishable screens; and a library with no licence text loses its **copy** button with it, since copying an empty entry looks exactly like a working copy.

**`HelpViewModelRetryTest`** — one `Retry` event serving three independent surfaces, re-running only what is failing. Re-running a healthy one throws its content back into loading, which on Help home blinks the topic grid out from under someone retrying something else.

**`HelpContentUiTest`** — every `iconKey` and `colorKey` the shipped content uses is one this build knows. A renamed key is completely silent: nothing throws, nothing logs, the screen still lays out, and every help topic just starts looking the same.

**`AboutGraphTest`** — all seven destinations register and each resolves as a start destination in its own right. An unregistered one throws only when a *user* taps the row that opens it.

## `AdaptiveMoreScreen` did not need Hilt after all

`:feature:quran` (#598) and `:feature:search` (#607) both left their adaptive screens at zero, because the screens they embed resolve their ViewModels through `hiltViewModel()`. That function only builds a `HiltViewModelFactory` when the `ViewModelStoreOwner` it is handed supplies a **default factory** — give it a plain owner whose `ViewModelStore` already holds the ViewModel and the store lookup answers first, with no factory consulted. `AdaptiveMoreScreenTest.seededOwner` does exactly that, keying each mock by asking a real `ViewModelProvider` for it rather than hardcoding the default-key string.

It does **not** rescue a destination body inside a `NavHost`: there the owner is a `NavBackStackEntry`, which *is* a `HasDefaultViewModelProviderFactory`, so the Hilt factory is built — and throws — before the store is ever read. That is why 122 of the 143 lines still uncovered are `aboutGraph`'s seven destination bodies, the same structural gap `:feature:search` and `:feature:prayer` record; `:app`'s instrumented suite exercises them.

## Docs

`docs/TESTING.md` gains the snapshot row, the locked-module list entry, and the module's audit section — including the two traps this module paid for: `NimazSectionTitle` uppercases its heading (so `onNodeWithText(getString(…))` finds nothing), and `more_pin_zakat` is the same single word as its own menu row's title (so a screen test that leaves the default pins in place finds two nodes and fails on the count rather than on anything real).

## Verification

| Command | Result |
|---|---|
| `./gradlew :feature:about:testDebugUnitTest` | ✅ 197 tests, 0 failures |
| `./gradlew :feature:about:check` | ✅ |
| `./gradlew :feature:about:lintDebug` | ✅ |
| `./gradlew coverageFloor` | running at time of writing; `:feature:about:coverageFloor` passes on its own and no locked module's sources are touched |
| `python3 scripts/check_docs.py` | ✅ all 23 checks |

`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` for the private content artifact and **cannot be run here** — not claimed as passing. No `androidTest` was added, so there is nothing in this PR awaiting an emulator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbfAe1FUGZRTjtAHMwZThU)_