### PR TITLE
Coverage: bring :core:data to 88.1% and lock it at 80/80

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -20,6 +20,33 @@ android {
     }
 }
 
+/**
+ * Locked (#611). The repositories, the device-to-device sync, the adhan file store and the
+ * platform adapters are tested, and `check` now fails if that stops being true — see
+ * `COVERAGE_EXCLUSIONS` and `coverageFloor` in `build-logic` for what is measured and how the
+ * ratchet works.
+ *
+ * **Both floors are the agreed 80%**, set at the standard rather than at whatever the module
+ * reports today (88.1% lines / 84.6% branches at the time of locking). A floor pinned to the
+ * current number turns every unrelated refactor into a coverage failure. There is no Compose in
+ * this module, so there is no `$dirty` bitmask to soften the branch floor for: every branch here
+ * is one somebody wrote.
+ *
+ * One thing is permanently at zero and `COVERAGE_EXCLUSIONS` was **not** widened for it. The
+ * exclusion list is shared with every locked module, so widening it moves their numbers too.
+ * `AdhanAudioManager.downloadFile` opens a [java.net.HttpURLConnection] against the CDN URL baked
+ * into `AdhanSound`, and there is no seam: exercising it would need either a real network request
+ * from a unit test or a JVM-wide `URLStreamHandlerFactory`, which is global, one-shot per process
+ * and would make every other Robolectric class in the module order-dependent. The transfer and its
+ * retry loop therefore stay uncovered — about 75 lines and 50 branches — and the 80% is made up
+ * elsewhere. Everything the manager does *around* the transfer is covered, including the generated
+ * chime, the audio-magic-byte validation and the URL-version invalidation. See `docs/TESTING.md`.
+ */
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
 // The 18 repository implementations that map onto `:core:domain`'s interfaces, plus the platform
 // adapters behind the domain ports: locale, compass, haptics, device location, strings, the AI
 // client and the announcement mapper.

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/ai/IntegrityTokenProviderTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/ai/IntegrityTokenProviderTest.kt
@@ -1,0 +1,183 @@
+package com.arshadshah.nimaz.data.ai
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.StandardIntegrityManager
+import com.google.android.play.core.integrity.StandardIntegrityManager.PrepareIntegrityTokenRequest
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The attestation token that decides whether Ask with Proof answers at all.
+ *
+ * Everything this class does fails *silently and expensively*. The Worker fails **closed** on a
+ * missing token — anyone could omit one — so an empty token is not "verification could not run",
+ * it is `ATTESTATION_FAILED`, and the user loses the answer they asked for. What is pinned:
+ *
+ *  - **the provider is prepared once and reused.** The standard API exists because the classic
+ *    one throttles per app-instance after a handful of calls: a few asks worked and then every
+ *    token fetch failed. Re-preparing on every question would put the throttling straight back;
+ *  - **a stale provider is re-prepared once and retried.** Play services updates or evicts its
+ *    state, and without the retry every question after that fails until the process restarts;
+ *  - **an unconfigured build falls back by build type.** A debug build sends `"debug-skip"`,
+ *    which the Worker honours only with `SKIP_ATTESTATION=true`; a release build sends `""`,
+ *    which it rejects. Sending `"debug-skip"` from a release build would be an attestation
+ *    bypass shipped to users.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IntegrityTokenProviderTest {
+
+    private lateinit var context: Context
+    private lateinit var manager: StandardIntegrityManager
+    private lateinit var provider: StandardIntegrityTokenProvider
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        manager = mockk(relaxed = true)
+        provider = mockk(relaxed = true)
+        mockkStatic(IntegrityManagerFactory::class)
+        every { IntegrityManagerFactory.createStandard(any()) } returns manager
+        every { manager.prepareIntegrityToken(any<PrepareIntegrityTokenRequest>()) } returns
+            immediate(provider)
+        every { provider.request(any<StandardIntegrityTokenRequest>()) } returns
+            immediate(token("a-real-token"))
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    // ── the configured path ───────────────────────────────────────────────────
+
+    @Test
+    fun `a configured build asks Play services for a token`() = runTest {
+        assertThat(providerFor(cloudProjectNumber = 12345L).getToken())
+            .isEqualTo("a-real-token")
+    }
+
+    @Test
+    fun `the heavy warm-up runs once however many questions are asked`() = runTest {
+        val subject = providerFor(cloudProjectNumber = 12345L)
+
+        repeat(5) { assertThat(subject.getToken()).isEqualTo("a-real-token") }
+
+        // The classic API throttled after a handful of calls; preparing per question would put
+        // that back with extra steps.
+        verify(exactly = 1) { manager.prepareIntegrityToken(any<PrepareIntegrityTokenRequest>()) }
+        verify(exactly = 5) { provider.request(any<StandardIntegrityTokenRequest>()) }
+    }
+
+    @Test
+    fun `a provider that has gone stale is re-prepared once and the question retried`() =
+        runTest {
+            val fresh = mockk<StandardIntegrityTokenProvider>(relaxed = true) {
+                every { request(any<StandardIntegrityTokenRequest>()) } returns
+                    immediate(token("token-after-retry"))
+            }
+            every { provider.request(any<StandardIntegrityTokenRequest>()) } returns
+                failing(IllegalStateException("provider evicted"))
+            every { manager.prepareIntegrityToken(any<PrepareIntegrityTokenRequest>()) } returnsMany
+                listOf(immediate(provider), immediate(fresh))
+
+            assertThat(providerFor(12345L).getToken()).isEqualTo("token-after-retry")
+
+            verify(exactly = 2) {
+                manager.prepareIntegrityToken(any<PrepareIntegrityTokenRequest>())
+            }
+        }
+
+    @Test
+    fun `a release build that still cannot get a token sends nothing, and is rejected`() =
+        runTest {
+            every { provider.request(any<StandardIntegrityTokenRequest>()) } returns
+                failing(IllegalStateException("offline"))
+
+            // Empty, not "debug-skip": the Worker fails closed on an absent token, and that is
+            // the intended outcome for a release build that cannot attest.
+            assertThat(providerFor(12345L, isDebugBuild = false).getToken()).isEmpty()
+        }
+
+    @Test
+    fun `a debug build that cannot get a token sends the skip token`() = runTest {
+        every { provider.request(any<StandardIntegrityTokenRequest>()) } returns
+            failing(IllegalStateException("no play services"))
+
+        assertThat(providerFor(12345L, isDebugBuild = true).getToken()).isEqualTo("debug-skip")
+    }
+
+    @Test
+    fun `a warm-up that cannot even start falls back rather than throwing`() = runTest {
+        every { manager.prepareIntegrityToken(any<PrepareIntegrityTokenRequest>()) } returns
+            failing(IllegalStateException("play services missing"))
+
+        assertThat(providerFor(12345L, isDebugBuild = true).getToken()).isEqualTo("debug-skip")
+        assertThat(providerFor(12345L, isDebugBuild = false).getToken()).isEmpty()
+    }
+
+    // ── the unconfigured build ────────────────────────────────────────────────
+
+    @Test
+    fun `a build with no project number never calls Play services at all`() = runTest {
+        assertThat(providerFor(cloudProjectNumber = 0L, isDebugBuild = true).getToken())
+            .isEqualTo("debug-skip")
+
+        verify(exactly = 0) { IntegrityManagerFactory.createStandard(any()) }
+    }
+
+    @Test
+    fun `a release build with no project number sends an empty token`() = runTest {
+        // Sending "debug-skip" here would be an attestation bypass shipped to users.
+        assertThat(providerFor(cloudProjectNumber = -1L, isDebugBuild = false).getToken())
+            .isEmpty()
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun providerFor(cloudProjectNumber: Long, isDebugBuild: Boolean = false) =
+        IntegrityTokenProvider(context, cloudProjectNumber, isDebugBuild)
+
+    private fun token(value: String) = mockk<StandardIntegrityToken>(relaxed = true) {
+        every { token() } returns value
+    }
+
+    /**
+     * A `Task` whose listeners fire inline — the real one posts to the main looper, which under
+     * Robolectric is the thread the test is suspended on.
+     */
+    private fun <T> immediate(result: T): Task<T> {
+        val task = mockk<Task<T>>(relaxed = true)
+        every { task.addOnSuccessListener(any<OnSuccessListener<T>>()) } answers {
+            firstArg<OnSuccessListener<T>>().onSuccess(result)
+            task
+        }
+        every { task.addOnFailureListener(any<OnFailureListener>()) } returns task
+        return task
+    }
+
+    private fun <T> failing(error: Exception): Task<T> {
+        val task = mockk<Task<T>>(relaxed = true)
+        every { task.addOnSuccessListener(any<OnSuccessListener<T>>()) } returns task
+        every { task.addOnFailureListener(any<OnFailureListener>()) } answers {
+            firstArg<OnFailureListener>().onFailure(error)
+            task
+        }
+        return task
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/announcement/AnnouncementBootstrapTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/announcement/AnnouncementBootstrapTest.kt
@@ -1,0 +1,130 @@
+package com.arshadshah.nimaz.data.announcement
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Per-launch setup for FCM announcements.
+ *
+ * Both halves are idempotent by design and neither may throw: this runs during app start, so an
+ * exception here is a phone that will not open. The properties that matter:
+ *
+ *  - **announcements get their own low-importance channel**, kept strictly apart from the
+ *    prayer and adhan channels. Reusing one of those would make a feature announcement play the
+ *    adhan; giving it default importance would make it interrupt;
+ *  - **the channel id must match the manifest's `default_notification_channel_id`.** When the
+ *    app is killed the OS posts the tray notification itself and looks the channel up by that
+ *    id — get it wrong and background announcements are silently dropped by the system;
+ *  - **a build with no `google-services.json` must not try to subscribe.** Firebase never
+ *    initialises there, and calling into it throws on the launch path.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnnouncementBootstrapTest {
+
+    private lateinit var context: Context
+    private lateinit var bootstrap: AnnouncementBootstrap
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        bootstrap = AnnouncementBootstrap(context)
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `the announcements channel is created, low importance and separate`() {
+        bootstrap.initialize()
+
+        val channel = notificationManager()
+            .getNotificationChannel(AnnouncementBootstrap.CHANNEL_ID)!!
+
+        assertThat(channel.importance).isEqualTo(NotificationManager.IMPORTANCE_LOW)
+        assertThat(channel.name.toString()).isEqualTo("Updates & Announcements")
+        assertThat(channel.description).isNotEmpty()
+        // The platform's own notification sound, not one of the app's adhan recordings: an
+        // announcement must never play the call to prayer.
+        assertThat(channel.sound?.toString().orEmpty()).doesNotContain(context.packageName)
+    }
+
+    @Test
+    fun `the channel id is the one the manifest hands the OS`() {
+        // The OS looks this up by id when it posts the tray notification itself; a mismatch
+        // drops every background announcement with no error anywhere.
+        assertThat(AnnouncementBootstrap.CHANNEL_ID).isEqualTo("nimaz_announcements")
+        assertThat(AnnouncementBootstrap.TOPIC).isEqualTo("announcements")
+    }
+
+    @Test
+    fun `initialising twice leaves one channel, not two`() {
+        bootstrap.initialize()
+        bootstrap.initialize()
+
+        assertThat(
+            shadowOf(notificationManager()).notificationChannels
+                .count { (it as android.app.NotificationChannel).id == AnnouncementBootstrap.CHANNEL_ID }
+        ).isEqualTo(1)
+    }
+
+    @Test
+    fun `a build with no Firebase config does not reach for messaging`() {
+        // `FirebaseApp.getApps` is empty on a build without google-services.json, which is the
+        // guard: calling into FirebaseMessaging there throws on the launch path.
+        mockkStatic(com.google.firebase.FirebaseApp::class)
+        every { com.google.firebase.FirebaseApp.getApps(any()) } returns emptyList()
+        mockkStatic(com.google.firebase.messaging.FirebaseMessaging::class)
+
+        bootstrap.initialize()
+
+        verify(exactly = 0) { com.google.firebase.messaging.FirebaseMessaging.getInstance() }
+        assertThat(notificationManager().getNotificationChannel(AnnouncementBootstrap.CHANNEL_ID))
+            .isNotNull()
+    }
+
+    @Test
+    fun `a configured build subscribes to the announcements topic`() {
+        mockkStatic(com.google.firebase.FirebaseApp::class)
+        every { com.google.firebase.FirebaseApp.getApps(any()) } returns
+            listOf(mockk(relaxed = true))
+        mockkStatic(com.google.firebase.messaging.FirebaseMessaging::class)
+        val messaging = mockk<com.google.firebase.messaging.FirebaseMessaging>(relaxed = true)
+        every { com.google.firebase.messaging.FirebaseMessaging.getInstance() } returns messaging
+
+        bootstrap.initialize()
+
+        verify { messaging.subscribeToTopic(AnnouncementBootstrap.TOPIC) }
+    }
+
+    @Test
+    fun `a messaging call that throws does not take the launch down with it`() {
+        mockkStatic(com.google.firebase.FirebaseApp::class)
+        every { com.google.firebase.FirebaseApp.getApps(any()) } returns
+            listOf(mockk(relaxed = true))
+        mockkStatic(com.google.firebase.messaging.FirebaseMessaging::class)
+        every { com.google.firebase.messaging.FirebaseMessaging.getInstance() } throws
+            IllegalStateException("Firebase not initialised")
+
+        // Logged, never thrown: this runs on the path that opens the app.
+        bootstrap.initialize()
+
+        assertThat(notificationManager().getNotificationChannel(AnnouncementBootstrap.CHANNEL_ID))
+            .isNotNull()
+    }
+
+    private fun notificationManager() =
+        context.getSystemService(NotificationManager::class.java)
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadExtrasTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/announcement/AnnouncementPayloadExtrasTest.kt
@@ -1,0 +1,159 @@
+package com.arshadshah.nimaz.data.announcement
+
+import android.os.Bundle
+import com.arshadshah.nimaz.domain.model.AnnouncementType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The second way an announcement arrives, and the blank-field rule that applies to both.
+ *
+ * When the app is backgrounded or killed the OS posts the tray notification itself and copies
+ * the message's custom data onto the tap intent as string extras — so the same payload reaches
+ * the same mapper by a different road. The two roads have to agree, or an announcement opens
+ * correctly from a running app and blankly from a cold start.
+ *
+ * The blank-field rule is what the console makes easy to get wrong: an empty text box in the
+ * FCM console sends `""`, not nothing. A `cta_label` of `""` would draw a button with no words
+ * on it, and a `proof_ref` of `""` a citation card citing nothing — so every optional field is
+ * trimmed and emptied to null.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnnouncementPayloadExtrasTest {
+
+    private val mapper = AnnouncementPayloadMapper()
+
+    @Test
+    fun `a cold start with no extras at all opens no announcement`() {
+        assertThat(mapper.fromIntentExtras(null)).isNull()
+    }
+
+    @Test
+    fun `extras that carry nothing the mapper recognises open no announcement`() {
+        val extras = Bundle().apply { putString("unrelated", "value") }
+
+        assertThat(mapper.fromIntentExtras(extras)).isNull()
+    }
+
+    @Test
+    fun `extras carrying the payload map to the same announcement as the payload does`() {
+        val data = mapOf(
+            "id" to "2026-07-ask-with-proof",
+            "type" to "feature",
+            "title" to "Ask with Proof is here",
+            "body" to "Search the Qur'an, get cited answers.",
+            "cta_label" to "Try it",
+            "route" to "search/ask",
+        )
+        val extras = Bundle().apply { data.forEach { (k, v) -> putString(k, v) } }
+
+        assertThat(mapper.fromIntentExtras(extras)).isEqualTo(mapper.fromPayload(data))
+    }
+
+    @Test
+    fun `a non string extra is ignored rather than crashing the cold start`() {
+        val extras = Bundle().apply {
+            putString("id", "x")
+            putString("type", "feature")
+            putString("title", "t")
+            putString("body", "b")
+            // The OS copies strings, but nothing stops another sender putting an Int here.
+            putInt("min_version_code", 142)
+        }
+
+        val announcement = mapper.fromIntentExtras(extras)!!
+
+        assertThat(announcement.minVersionCode).isNull()
+    }
+
+    @Test
+    fun `every optional field sent as an empty box comes back as absent, not blank`() {
+        val announcement = mapper.fromPayload(
+            mapOf(
+                "id" to "x", "type" to "feature", "title" to "t", "body" to "b",
+                "cta_label" to "  ", "route" to "", "arabic" to " ",
+                "transliteration" to "", "cta2_label" to "  ", "route2" to "",
+                "proof_ref" to " ", "proof_text" to "",
+            )
+        )!!
+
+        // An empty console text box sends "": a button with no words, a card citing nothing.
+        assertThat(announcement.ctaLabel).isNull()
+        assertThat(announcement.route).isNull()
+        assertThat(announcement.arabic).isNull()
+        assertThat(announcement.transliteration).isNull()
+        assertThat(announcement.cta2Label).isNull()
+        assertThat(announcement.route2).isNull()
+        assertThat(announcement.proofRef).isNull()
+        assertThat(announcement.proofText).isNull()
+    }
+
+    @Test
+    fun `every optional field sent with content is trimmed and kept`() {
+        val announcement = mapper.fromPayload(
+            mapOf(
+                "id" to " x ", "type" to "celebration", "title" to " t ", "body" to " b ",
+                "cta_label" to " Try it ", "route" to " search/ask ",
+                "arabic" to " عيد ", "transliteration" to " Eid ",
+                "cta2_label" to " Later ", "route2" to " more ",
+                "proof_ref" to " 2:255 ", "proof_text" to " Allahu la ilaha illa huwa ",
+            )
+        )!!
+
+        assertThat(announcement.id).isEqualTo("x")
+        assertThat(announcement.ctaLabel).isEqualTo("Try it")
+        assertThat(announcement.route).isEqualTo("search/ask")
+        assertThat(announcement.arabic).isEqualTo("عيد")
+        assertThat(announcement.transliteration).isEqualTo("Eid")
+        assertThat(announcement.cta2Label).isEqualTo("Later")
+        assertThat(announcement.route2).isEqualTo("more")
+        assertThat(announcement.proofRef).isEqualTo("2:255")
+        assertThat(announcement.proofText).isEqualTo("Allahu la ilaha illa huwa")
+    }
+
+    @Test
+    fun `a proof text with no reference is dropped, and so is the reverse`() {
+        val textOnly = mapper.fromPayload(
+            mapOf(
+                "id" to "x", "type" to "celebration", "title" to "t", "body" to "b",
+                "proof_text" to "some words", "proof_ref" to "  ",
+            )
+        )!!
+
+        // A quotation with nothing to cite is not a proof card.
+        assertThat(textOnly.proofText).isNull()
+        assertThat(textOnly.proofRef).isNull()
+    }
+
+    @Test
+    fun `a version window sent as an empty box rejects the whole payload`() {
+        // "" is not a version, and treating it as "no bound" would show a build-targeted
+        // announcement to every install.
+        assertThat(
+            mapper.fromPayload(
+                mapOf("id" to "x", "type" to "feature", "title" to "t", "body" to "b",
+                      "min_version_code" to "")
+            )
+        ).isNull()
+        assertThat(
+            mapper.fromPayload(
+                mapOf("id" to "x", "type" to "feature", "title" to "t", "body" to "b",
+                      "max_version_code" to " ")
+            )
+        ).isNull()
+    }
+
+    @Test
+    fun `a version window sent with padding still parses`() {
+        val announcement = mapper.fromPayload(
+            mapOf("id" to "x", "type" to "feature", "title" to "t", "body" to "b",
+                  "min_version_code" to " 142 ", "max_version_code" to " 999 ")
+        )!!
+
+        assertThat(announcement.minVersionCode).isEqualTo(142)
+        assertThat(announcement.maxVersionCode).isEqualTo(999)
+        assertThat(announcement.type).isEqualTo(AnnouncementType.fromKey("feature"))
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/audio/AdhanAudioManagerTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/audio/AdhanAudioManagerTest.kt
@@ -1,0 +1,408 @@
+package com.arshadshah.nimaz.data.audio
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * The adhan file store.
+ *
+ * Nothing here draws anything, so none of it looked worth testing — and all of it decides
+ * whether the phone makes a sound at prayer time. The failures it guards against are all silent:
+ *
+ *  - **an HTML error page saved as `.mp3`.** A CDN that answers a download with a 200 and a
+ *    error page leaves a file that exists, is named right, and plays nothing. `isDownloaded`
+ *    reads the magic bytes for exactly this, and *deletes* what it rejects so the next attempt
+ *    re-downloads rather than trusting the corpse;
+ *  - **a URL that changed under a file that did not.** Mishary's regular URL was serving the
+ *    *Fajr* recording, so every install that had already downloaded it kept playing the wrong
+ *    adhan forever. `invalidateStaleDownloads` is the undo: a version stamp beside the files,
+ *    and a bump deletes them. Getting it wrong either re-downloads 15 MB on every launch or
+ *    never repairs the install;
+ *  - **the generated chime.** `SIMPLE_BEEP` has no URL — it is synthesised into a WAV on the
+ *    device. If the header it writes is wrong, `isDownloaded` rejects its own output and the
+ *    beep can never finish downloading;
+ *  - **deleting one variant.** Regular and Fajr are separate files, so removing one must not
+ *    reset the pair's state while the other is still on disk.
+ *
+ * What is *not* here is the HTTP transfer itself: `downloadFile` opens
+ * [java.net.URL.openConnection] against the URL baked into [AdhanSound], so exercising it would
+ * need either a real request to a CDN or a JVM-wide `URLStreamHandlerFactory` — see
+ * `docs/TESTING.md`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdhanAudioManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var manager: AdhanAudioManager
+    private lateinit var adhanDir: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        adhanDir = File(context.filesDir, "adhan")
+        adhanDir.deleteRecursively()
+        manager = AdhanAudioManager(context)
+    }
+
+    // ── what counts as downloaded ─────────────────────────────────────────────
+
+    @Test
+    fun `a sound with no file is not downloaded`() {
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isFalse()
+        assertThat(manager.getAdhanUri(AdhanSound.MAKKAH)).isNull()
+        assertThat(manager.getDownloadedSize(AdhanSound.MAKKAH)).isNull()
+    }
+
+    @Test
+    fun `an mp3 with an ID3 tag counts as downloaded`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false, header = byteArrayOf('I'.code.toByte(), 'D'.code.toByte(), '3'.code.toByte(), 0x04))
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isTrue()
+        assertThat(manager.getAdhanUri(AdhanSound.MAKKAH)).isNotNull()
+    }
+
+    @Test
+    fun `an mp3 that starts with a bare MPEG sync word counts as downloaded`() {
+        // Plenty of adhan files have no ID3 tag at all; rejecting them would re-download forever.
+        writeAudio(AdhanSound.MAKKAH, isFajr = false, header = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0x00))
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isTrue()
+    }
+
+    @Test
+    fun `a wav counts as downloaded`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false, header = "RIFF".toByteArray())
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isTrue()
+    }
+
+    @Test
+    fun `an HTML error page saved as an mp3 is rejected and deleted`() {
+        val file = writeAudio(AdhanSound.MAKKAH, isFajr = false, header = "<htm".toByteArray())
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isFalse()
+        // Deleted, not just reported: otherwise the next attempt short-circuits on a file that
+        // exists and the install never repairs itself.
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `a truncated file is rejected and deleted`() {
+        val file = File(adhanDir.also { it.mkdirs() }, AdhanSound.MAKKAH.fileName)
+        file.writeBytes("ID3".toByteArray() + ByteArray(20))
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isFalse()
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `a file too short to hold a header at all is rejected`() {
+        val file = File(adhanDir.also { it.mkdirs() }, AdhanSound.MAKKAH.fileName)
+        file.writeBytes(byteArrayOf(1, 2))
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH)).isFalse()
+    }
+
+    @Test
+    fun `a sound is fully downloaded only when both variants are present`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH, isFajr = false)).isTrue()
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH, isFajr = true)).isFalse()
+        assertThat(manager.isFullyDownloaded(AdhanSound.MAKKAH)).isFalse()
+
+        writeAudio(AdhanSound.MAKKAH, isFajr = true)
+
+        assertThat(manager.isFullyDownloaded(AdhanSound.MAKKAH)).isTrue()
+    }
+
+    @Test
+    fun `the reported size is the pair's, not one variant's`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false, size = 20_000)
+        writeAudio(AdhanSound.MAKKAH, isFajr = true, size = 30_000)
+
+        assertThat(manager.getDownloadedSize(AdhanSound.MAKKAH, isFajr = false)).isEqualTo(20_000)
+        assertThat(manager.getTotalDownloadedSize(AdhanSound.MAKKAH)).isEqualTo(50_000)
+    }
+
+    @Test
+    fun `a sound with nothing on disk reports no total size rather than failing`() {
+        assertThat(manager.getTotalDownloadedSize(AdhanSound.ABDUL_BASIT)).isEqualTo(0L)
+    }
+
+    // ── repairing an install whose URLs changed ───────────────────────────────
+
+    @Test
+    fun `an install that predates the version stamp has its recordings deleted`() {
+        val makkah = writeAudio(AdhanSound.MAKKAH, isFajr = false)
+        val mishary = writeAudio(AdhanSound.MISHARY, isFajr = true)
+
+        manager.invalidateStaleDownloads()
+
+        // This is the undo for "the regular URL was serving the Fajr recording".
+        assertThat(makkah.exists()).isFalse()
+        assertThat(mishary.exists()).isFalse()
+    }
+
+    @Test
+    fun `the generated beep survives an invalidation`() {
+        val beep = writeAudio(AdhanSound.SIMPLE_BEEP, isFajr = false)
+
+        manager.invalidateStaleDownloads()
+
+        // It has no URL, so a URL change cannot have staled it — deleting it would be 45s of
+        // regeneration for nothing.
+        assertThat(beep.exists()).isTrue()
+    }
+
+    @Test
+    fun `an install already at the current version keeps its recordings`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+        manager.invalidateStaleDownloads()
+        val kept = writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        manager.invalidateStaleDownloads()
+
+        // Re-running must be a no-op, or every launch re-downloads 15 MB.
+        assertThat(kept.exists()).isTrue()
+    }
+
+    @Test
+    fun `a corrupted version stamp is treated as no stamp at all`() {
+        adhanDir.mkdirs()
+        File(adhanDir, ".adhan_url_version").writeText("not a number")
+        val makkah = writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        manager.invalidateStaleDownloads()
+
+        assertThat(makkah.exists()).isFalse()
+        assertThat(File(adhanDir, ".adhan_url_version").readText().trim().toInt()).isAtLeast(2)
+    }
+
+    @Test
+    fun `the version stamp is not itself deleted by the invalidation it triggers`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        manager.invalidateStaleDownloads()
+
+        // If the sweep took the stamp with it, every launch would invalidate again.
+        assertThat(File(adhanDir, ".adhan_url_version").exists()).isTrue()
+    }
+
+    // ── interrupted downloads ─────────────────────────────────────────────────
+
+    @Test
+    fun `stale temp files are cleaned up and finished files are not`() {
+        adhanDir.mkdirs()
+        val temp = File(adhanDir, "${AdhanSound.MAKKAH.fileName}.tmp").apply { writeBytes(ByteArray(50)) }
+        val done = writeAudio(AdhanSound.MISHARY, isFajr = false)
+
+        manager.cleanupTempFiles()
+
+        assertThat(temp.exists()).isFalse()
+        assertThat(done.exists()).isTrue()
+    }
+
+    @Test
+    fun `cleaning up on a device that has never downloaded anything does nothing`() {
+        manager.cleanupTempFiles()
+        manager.invalidateStaleDownloads()
+
+        assertThat(manager.downloadState.value).isEmpty()
+    }
+
+    // ── the generated chime ───────────────────────────────────────────────────
+
+    @Test
+    fun `the beep generates a file the manager itself accepts as audio`() = runTest {
+        val generated = manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)
+
+        assertThat(generated).isTrue()
+        // The round trip is the point: a wrong WAV header means `isDownloaded` rejects the
+        // manager's own output and the beep can never finish downloading.
+        assertThat(manager.isDownloaded(AdhanSound.SIMPLE_BEEP)).isTrue()
+        assertThat(manager.downloadState.value[AdhanSound.SIMPLE_BEEP])
+            .isEqualTo(DownloadState.Completed)
+    }
+
+    @Test
+    fun `the generated chime is a real RIFF WAV of the length its header claims`() = runTest {
+        manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)
+
+        val bytes = File(adhanDir, AdhanSound.SIMPLE_BEEP.fileName).readBytes()
+
+        assertThat(String(bytes.copyOfRange(0, 4))).isEqualTo("RIFF")
+        assertThat(String(bytes.copyOfRange(8, 12))).isEqualTo("WAVE")
+        assertThat(String(bytes.copyOfRange(36, 40))).isEqualTo("data")
+        // RIFF size counts everything after the first eight bytes.
+        assertThat(littleEndianInt(bytes, 4)).isEqualTo(bytes.size - 8)
+        assertThat(littleEndianInt(bytes, 40)).isEqualTo(bytes.size - 44)
+        // 44,100 Hz, mono, 16-bit — and a chime that actually lasts about 1.5 seconds.
+        assertThat(littleEndianInt(bytes, 24)).isEqualTo(44_100)
+        assertThat(bytes.size).isGreaterThan(44 + 44_100)
+    }
+
+    @Test
+    fun `the generated chime is not silence`() = runTest {
+        manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)
+
+        val samples = File(adhanDir, AdhanSound.SIMPLE_BEEP.fileName).readBytes().drop(44)
+
+        // Three overlapping notes with a fade envelope: a synthesiser that emits a flat zero
+        // buffer produces a file of exactly the right size that plays nothing at all.
+        assertThat(samples.any { it != 0.toByte() }).isTrue()
+    }
+
+    @Test
+    fun `a beep that is already generated is not generated again`() = runTest {
+        manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)
+        val first = File(adhanDir, AdhanSound.SIMPLE_BEEP.fileName).lastModified()
+
+        assertThat(manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)).isTrue()
+
+        assertThat(File(adhanDir, AdhanSound.SIMPLE_BEEP.fileName).lastModified()).isEqualTo(first)
+        assertThat(manager.downloadState.value[AdhanSound.SIMPLE_BEEP])
+            .isEqualTo(DownloadState.Completed)
+    }
+
+    @Test
+    fun `an interrupted attempt's temp file is cleared before the next one starts`() = runTest {
+        adhanDir.mkdirs()
+        val temp = File(adhanDir, "${AdhanSound.SIMPLE_BEEP.fileName}.tmp")
+            .apply { writeBytes(ByteArray(10)) }
+
+        manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)
+
+        assertThat(temp.exists()).isFalse()
+    }
+
+    @Test
+    fun `a corrupt file on disk is replaced rather than trusted`() = runTest {
+        val corrupt = File(adhanDir.also { it.mkdirs() }, AdhanSound.SIMPLE_BEEP.fileName)
+        corrupt.writeBytes("<html>404</html>".toByteArray() + ByteArray(20_000))
+
+        assertThat(manager.downloadAdhan(AdhanSound.SIMPLE_BEEP)).isTrue()
+
+        assertThat(String(corrupt.readBytes().copyOfRange(0, 4))).isEqualTo("RIFF")
+    }
+
+    @Test
+    fun `downloading both variants of the beep writes the one file they share`() = runTest {
+        assertThat(manager.downloadAdhanWithFajr(AdhanSound.SIMPLE_BEEP)).isTrue()
+
+        assertThat(manager.isFullyDownloaded(AdhanSound.SIMPLE_BEEP)).isTrue()
+        assertThat(adhanDir.listFiles()!!.filter { it.name.startsWith("adhan_beep") }).hasSize(1)
+    }
+
+    // ── deleting ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `deleting one variant leaves the pair's state alone while the other survives`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+        writeAudio(AdhanSound.MAKKAH, isFajr = true)
+
+        assertThat(manager.deleteAdhan(AdhanSound.MAKKAH, isFajr = true)).isTrue()
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH, isFajr = false)).isTrue()
+        // The pair is not Idle: half of it is still on disk.
+        assertThat(manager.downloadState.value[AdhanSound.MAKKAH]).isNull()
+    }
+
+    @Test
+    fun `deleting the last variant resets the sound to idle`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        assertThat(manager.deleteAdhan(AdhanSound.MAKKAH, isFajr = false)).isTrue()
+
+        assertThat(manager.downloadState.value[AdhanSound.MAKKAH]).isEqualTo(DownloadState.Idle)
+    }
+
+    @Test
+    fun `deleting a sound that is not there reports nothing was deleted`() {
+        assertThat(manager.deleteAdhan(AdhanSound.MAKKAH)).isFalse()
+    }
+
+    @Test
+    fun `deleting fully removes both variants and resets the state`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+        writeAudio(AdhanSound.MAKKAH, isFajr = true)
+
+        assertThat(manager.deleteAdhanFully(AdhanSound.MAKKAH)).isTrue()
+
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH, isFajr = false)).isFalse()
+        assertThat(manager.isDownloaded(AdhanSound.MAKKAH, isFajr = true)).isFalse()
+        assertThat(manager.downloadState.value[AdhanSound.MAKKAH]).isEqualTo(DownloadState.Idle)
+    }
+
+    @Test
+    fun `deleting fully still reports success when only one variant was present`() {
+        writeAudio(AdhanSound.MAKKAH, isFajr = true)
+
+        assertThat(manager.deleteAdhanFully(AdhanSound.MAKKAH)).isTrue()
+    }
+
+    @Test
+    fun `deleting fully a sound that was never downloaded reports nothing removed`() {
+        assertThat(manager.deleteAdhanFully(AdhanSound.MAKKAH)).isFalse()
+        assertThat(manager.downloadState.value[AdhanSound.MAKKAH]).isEqualTo(DownloadState.Idle)
+    }
+
+    // ── preview ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `previewing a sound that is not downloaded plays nothing and says so`() {
+        manager.preview(AdhanSound.MAKKAH)
+
+        assertThat(manager.isPlaying.value).isFalse()
+        assertThat(manager.currentlyPlaying.value).isNull()
+    }
+
+    @Test
+    fun `stopping a preview that was never started is safe`() {
+        manager.stopPreview()
+
+        assertThat(manager.isPlaying.value).isFalse()
+        assertThat(manager.currentlyPlaying.value).isNull()
+    }
+
+    @Test
+    fun `a preview of an unplayable file leaves nothing playing rather than throwing`() {
+        // A file that exists but is not decodable — the state has to end up clean either way,
+        // or the settings screen shows a stop button for a sound that never started.
+        writeAudio(AdhanSound.MAKKAH, isFajr = false)
+
+        manager.preview(AdhanSound.MAKKAH)
+        manager.stopPreview()
+
+        assertThat(manager.isPlaying.value).isFalse()
+        assertThat(manager.currentlyPlaying.value).isNull()
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /** A file the manager will accept: audio magic bytes and comfortably over the size floor. */
+    private fun writeAudio(
+        sound: AdhanSound,
+        isFajr: Boolean,
+        header: ByteArray = "ID3".toByteArray() + byteArrayOf(0x04),
+        size: Int = 20_000,
+    ): File {
+        adhanDir.mkdirs()
+        return File(adhanDir, sound.getFileName(isFajr)).apply {
+            writeBytes(header + ByteArray(size - header.size))
+        }
+    }
+
+    private fun littleEndianInt(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xFF) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 3].toInt() and 0xFF) shl 24)
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/audio/AdhanSoundTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/audio/AdhanSoundTest.kt
@@ -1,0 +1,69 @@
+package com.arshadshah.nimaz.data.audio
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The adhan catalogue.
+ *
+ * The Fajr adhan carries a phrase the others do not ("الصلاة خير من النوم"), so every sound has
+ * two files and two URLs — and every caller passes an `isFajr` flag through. Getting that flag's
+ * sense backwards is not an error: it plays the wrong recording at the wrong prayer, which is
+ * the one defect the URL version counter in [AdhanAudioManager] exists to undo (v2 exists
+ * because Mishary's *regular* URL was serving the Fajr variant).
+ */
+class AdhanSoundTest {
+
+    @Test
+    fun `each sound resolves a different file for Fajr`() {
+        AdhanSound.entries
+            .filter { it != AdhanSound.SIMPLE_BEEP }
+            .forEach { sound ->
+                assertThat(sound.getFileName(isFajr = true)).isEqualTo(sound.fajrFileName)
+                assertThat(sound.getFileName(isFajr = false)).isEqualTo(sound.fileName)
+                assertThat(sound.getFileName(true)).isNotEqualTo(sound.getFileName(false))
+            }
+    }
+
+    @Test
+    fun `the beep is the same file at every prayer`() {
+        // It is generated, not recorded, so there is no Fajr phrase to add.
+        assertThat(AdhanSound.SIMPLE_BEEP.getFileName(isFajr = true))
+            .isEqualTo(AdhanSound.SIMPLE_BEEP.getFileName(isFajr = false))
+    }
+
+    @Test
+    fun `every recorded sound has both URLs and the beep has neither`() {
+        AdhanSound.entries
+            .filter { it != AdhanSound.SIMPLE_BEEP }
+            .forEach { sound ->
+                assertThat(sound.getDownloadUrl(isFajr = false)).isEqualTo(sound.downloadUrl)
+                assertThat(sound.getDownloadUrl(isFajr = true)).isEqualTo(sound.fajrDownloadUrl)
+                assertThat(sound.getDownloadUrl(false)).isNotEmpty()
+                assertThat(sound.getDownloadUrl(true)).isNotEmpty()
+            }
+
+        assertThat(AdhanSound.SIMPLE_BEEP.getDownloadUrl(false)).isEmpty()
+        assertThat(AdhanSound.SIMPLE_BEEP.getDownloadUrl(true)).isEmpty()
+    }
+
+    @Test
+    fun `no two sounds share a file name`() {
+        // Two sounds writing to one file means downloading one silently replaces the other.
+        val names = AdhanSound.entries.map { it.fileName }
+        assertThat(names).containsNoDuplicates()
+    }
+
+    @Test
+    fun `a stored preference that no longer names a sound falls back rather than crashing`() {
+        assertThat(AdhanSound.fromName("A_SOUND_THAT_WAS_REMOVED")).isEqualTo(AdhanSound.MISHARY)
+        assertThat(AdhanSound.fromName("")).isEqualTo(AdhanSound.MISHARY)
+    }
+
+    @Test
+    fun `a stored preference that names a sound round trips`() {
+        AdhanSound.entries.forEach { sound ->
+            assertThat(AdhanSound.fromName(sound.name)).isEqualTo(sound)
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidCompassSensorsTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidCompassSensorsTest.kt
@@ -1,0 +1,274 @@
+package com.arshadshah.nimaz.data.device
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.arshadshah.nimaz.domain.model.CompassAccuracy
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowSensor
+import org.robolectric.shadows.ShadowSensorManager
+
+/**
+ * The qibla needle's input.
+ *
+ * Two sensors feed one heading, and neither the screen nor a user can tell a wrong heading from
+ * a right one — a compass that is confidently 40° out looks exactly like a compass that works.
+ * What is pinned here:
+ *
+ *  - **the filter is seeded, not started from zero.** A low-pass filter at 0.97 needs about a
+ *    hundred samples to converge, so an unseeded one publishes headings derived from a vector
+ *    of zeroes. That is what used to make the screen say "ready" and then visibly sweep the
+ *    needle in from a meaningless direction. One sample is a worse estimate than a hundred, but
+ *    it is an estimate *of the right thing*;
+ *  - **nothing is published until both sensors have reported.** A rotation matrix built from a
+ *    half-filled vector is not an error — it is a number, and it is wrong;
+ *  - **accuracy comes from the magnetometer only.** The accelerometer reports its own accuracy
+ *    constantly, and letting it through would show "calibrate your phone" at random;
+ *  - **the listener's lifetime is the collection's.** It is unregistered on cancellation, which
+ *    is what the ViewModel's `onCleared()` used to have to remember.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AndroidCompassSensorsTest {
+
+    private lateinit var context: Context
+    private lateinit var sensorManager: SensorManager
+    private lateinit var shadowSensors: ShadowSensorManager
+    private lateinit var sensors: AndroidCompassSensors
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        shadowSensors = Shadow.extract(sensorManager)
+        shadowSensors.addSensor(Sensor.TYPE_ACCELEROMETER, accelerometer())
+        shadowSensors.addSensor(Sensor.TYPE_MAGNETIC_FIELD, magnetometer())
+        sensors = AndroidCompassSensors(context)
+    }
+
+    // ── the low-pass filter, on its own ───────────────────────────────────────
+
+    @Test
+    fun `a seeded filter takes the first sample at face value`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, floatArrayOf(0f, 0f, 9.81f), seed = true)
+
+        assertThat(filtered.toList()).containsExactly(0f, 0f, 9.81f).inOrder()
+    }
+
+    @Test
+    fun `an unseeded filter barely moves, which is why the first sample must seed it`() {
+        val filtered = FloatArray(3)
+
+        smoothInto(filtered, floatArrayOf(0f, 0f, 9.81f), seed = false)
+
+        // 3% of one sample. A hundred of these to converge is the whole reason `seed` exists.
+        assertThat(filtered[2]).isWithin(0.001f).of(9.81f * 0.03f)
+    }
+
+    @Test
+    fun `subsequent samples are smoothed towards the new reading, not snapped to it`() {
+        val filtered = floatArrayOf(0f, 0f, 10f)
+
+        smoothInto(filtered, floatArrayOf(0f, 0f, 0f), seed = false)
+
+        assertThat(filtered[2]).isGreaterThan(9f)
+        assertThat(filtered[2]).isLessThan(10f)
+    }
+
+    // ── availability ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a phone with both sensors reports a compass`() {
+        assertThat(sensors.isAvailable).isTrue()
+    }
+
+    @Test
+    fun `a phone with no magnetometer reports no compass`() {
+        shadowSensors.removeSensor(sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)!!)
+
+        assertThat(AndroidCompassSensors(context).isAvailable).isFalse()
+    }
+
+    @Test
+    fun `a phone with no accelerometer reports no compass`() {
+        shadowSensors.removeSensor(sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)!!)
+
+        assertThat(AndroidCompassSensors(context).isAvailable).isFalse()
+    }
+
+    // ── the heading ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `nothing is published until both sensors have reported`() = runTest {
+        sensors.orientation().test {
+            sendAccelerometer(0f, 0f, 9.81f)
+
+            // A rotation matrix from a half-filled vector is a number, and it is the wrong one.
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun `a phone lying flat and facing north reads about zero degrees`() = runTest {
+        sensors.orientation().test {
+            sendAccelerometer(0f, 0f, 9.81f)
+            sendMagnetometer(0f, 40f, 0f)
+
+            val heading = awaitItem()
+            assertThat(heading.azimuthDegrees).isWithin(1f).of(0f)
+            assertThat(heading.pitchDegrees).isWithin(1f).of(0f)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `the first sample seeds the filter, so the first heading is already usable`() = runTest {
+        sensors.orientation().test {
+            sendAccelerometer(0f, 0f, 9.81f)
+            // A field pointing along -x is 90° away from one along +y.
+            sendMagnetometer(-40f, 0f, 0f)
+
+            // Unseeded, the first heading would be derived from a near-zero vector and land
+            // nowhere near the right quadrant.
+            assertThat(awaitItem().azimuthDegrees).isWithin(2f).of(90f)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `an azimuth is normalised into zero to three sixty, never negative`() = runTest {
+        sensors.orientation().test {
+            sendAccelerometer(0f, 0f, 9.81f)
+            sendMagnetometer(40f, 0f, 0f)
+
+            val heading = awaitItem()
+            assertThat(heading.azimuthDegrees).isAtLeast(0f)
+            assertThat(heading.azimuthDegrees).isLessThan(360f)
+            assertThat(heading.azimuthDegrees).isWithin(2f).of(270f)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `a reading with no usable rotation matrix publishes nothing`() = runTest {
+        sensors.orientation().test {
+            // Gravity and the field pointing the same way: the cross product is degenerate and
+            // `getRotationMatrix` refuses. Publishing anyway would swing the needle at random.
+            sendAccelerometer(0f, 0f, 9.81f)
+            sendMagnetometer(0f, 0f, 40f)
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    // ── accuracy ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `each magnetometer accuracy maps to its own level`() = runTest {
+        val expected = mapOf(
+            SensorManager.SENSOR_STATUS_ACCURACY_HIGH to CompassAccuracy.HIGH,
+            SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM to CompassAccuracy.MEDIUM,
+            SensorManager.SENSOR_STATUS_ACCURACY_LOW to CompassAccuracy.LOW,
+            SensorManager.SENSOR_STATUS_UNRELIABLE to CompassAccuracy.UNRELIABLE,
+        )
+
+        expected.forEach { (status, level) ->
+            sensors.orientation().test {
+                shadowSensors.sendSensorEventToListeners(
+                    ShadowSensorManager.createSensorEvent(3, Sensor.TYPE_MAGNETIC_FIELD)
+                )
+                listeners().forEach { it.onAccuracyChanged(magnetometer(), status) }
+                sendAccelerometer(0f, 0f, 9.81f)
+                sendMagnetometer(0f, 40f, 0f)
+
+                assertThat(awaitItem().accuracy).isEqualTo(level)
+                cancel()
+            }
+        }
+    }
+
+    @Test
+    fun `the accelerometer's accuracy is ignored`() = runTest {
+        sensors.orientation().test {
+            listeners().forEach {
+                it.onAccuracyChanged(magnetometer(), SensorManager.SENSOR_STATUS_ACCURACY_HIGH)
+                // The accelerometer reports constantly; letting it through would show
+                // "calibrate your phone" at random.
+                it.onAccuracyChanged(accelerometer(), SensorManager.SENSOR_STATUS_UNRELIABLE)
+            }
+            sendAccelerometer(0f, 0f, 9.81f)
+            sendMagnetometer(0f, 40f, 0f)
+
+            assertThat(awaitItem().accuracy).isEqualTo(CompassAccuracy.HIGH)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `a sensor the compass does not use changes nothing`() = runTest {
+        sensors.orientation().test {
+            shadowSensors.sendSensorEventToListeners(
+                ShadowSensorManager.createSensorEvent(3, Sensor.TYPE_GYROSCOPE)
+            )
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    // ── the listener's lifetime ───────────────────────────────────────────────
+
+    @Test
+    fun `both sensors are registered while collecting and released when it ends`() = runTest {
+        assertThat(shadowSensors.hasListener(null)).isFalse()
+
+        sensors.orientation().test {
+            sendAccelerometer(0f, 0f, 9.81f)
+            sendMagnetometer(0f, 40f, 0f)
+            awaitItem()
+            assertThat(listeners()).isNotEmpty()
+            cancel()
+        }
+
+        // The ViewModel's onCleared() used to have to remember this.
+        assertThat(listeners()).isEmpty()
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun listeners() = shadowSensors.listeners.toList()
+
+    private fun sendAccelerometer(x: Float, y: Float, z: Float) =
+        shadowSensors.sendSensorEventToListeners(
+            ShadowSensorManager.createSensorEvent(3, Sensor.TYPE_ACCELEROMETER)
+                .also { setValues(it, x, y, z) }
+        )
+
+    private fun sendMagnetometer(x: Float, y: Float, z: Float) =
+        shadowSensors.sendSensorEventToListeners(
+            ShadowSensorManager.createSensorEvent(3, Sensor.TYPE_MAGNETIC_FIELD)
+                .also { setValues(it, x, y, z) }
+        )
+
+    private fun setValues(event: android.hardware.SensorEvent, x: Float, y: Float, z: Float) {
+        event.values[0] = x
+        event.values[1] = y
+        event.values[2] = z
+    }
+
+    private fun accelerometer(): Sensor = ShadowSensor.newInstance(Sensor.TYPE_ACCELEROMETER)
+
+    private fun magnetometer(): Sensor = ShadowSensor.newInstance(Sensor.TYPE_MAGNETIC_FIELD)
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidCounterFeedbackTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidCounterFeedbackTest.kt
@@ -1,0 +1,87 @@
+package com.arshadshah.nimaz.data.device
+
+import android.content.Context
+import android.os.Vibrator
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * The tasbih counter's tick.
+ *
+ * Two independent settings, and the failure mode of getting them crossed is a phone that
+ * buzzes in a mosque when the user turned buzzing off. The rest is resource handling: a
+ * `ToneGenerator` is one audio resource per process — the class is a `@Singleton` for that
+ * reason, since every Tasbih screen gets its own ViewModel — and both the constructor and every
+ * use are wrapped, because a device with the audio resource already claimed throws rather than
+ * returning null.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AndroidCounterFeedbackTest {
+
+    private lateinit var context: Context
+    private lateinit var feedback: AndroidCounterFeedback
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        feedback = AndroidCounterFeedback(context)
+    }
+
+    @Test
+    fun `a tick with vibration on buzzes once`() {
+        feedback.tick(vibrate = true, sound = false)
+
+        assertThat(shadowOf(vibrator()).milliseconds).isEqualTo(30L)
+    }
+
+    @Test
+    fun `a tick with vibration off does not buzz`() {
+        feedback.tick(vibrate = false, sound = true)
+
+        assertThat(shadowOf(vibrator()).milliseconds).isEqualTo(0L)
+    }
+
+    @Test
+    fun `a tick with neither does nothing and does not throw`() {
+        feedback.tick(vibrate = false, sound = false)
+
+        assertThat(shadowOf(vibrator()).milliseconds).isEqualTo(0L)
+    }
+
+    @Test
+    fun `a tick with both is safe`() {
+        feedback.tick(vibrate = true, sound = true)
+
+        assertThat(shadowOf(vibrator()).milliseconds).isEqualTo(30L)
+    }
+
+    @Config(sdk = [30])
+    @Test
+    fun `a phone older than Android 12 reaches the vibrator the old way`() {
+        // `VIBRATOR_MANAGER_SERVICE` does not exist before S, so the cast would throw and the
+        // counter would crash on the first tap.
+        AndroidCounterFeedback(context).tick(vibrate = true, sound = false)
+
+        assertThat(shadowOf(vibrator()).milliseconds).isEqualTo(30L)
+    }
+
+    @Test
+    fun `releasing twice is safe, so a second screen closing cannot crash`() {
+        feedback.tick(vibrate = false, sound = true)
+
+        feedback.release()
+        feedback.release()
+
+        // And a tick after release is a no-op rather than a use-after-free.
+        feedback.tick(vibrate = false, sound = true)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun vibrator(): Vibrator = context.getSystemService(Vibrator::class.java)
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidDeviceLocationRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/AndroidDeviceLocationRepositoryTest.kt
@@ -1,0 +1,295 @@
+package com.arshadshah.nimaz.data.device
+
+import android.Manifest
+import android.content.Context
+import android.location.Address
+import android.location.Location
+import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+import java.util.Locale
+
+/**
+ * The platform adapters two ViewModels used to build for themselves.
+ *
+ * Both wrapped `FusedLocationProviderClient` and `Geocoder` in their own
+ * `suspendCancellableCoroutine`, each carried its own copy of the API-33 geocoder split, and
+ * each flattened an `Address` with its own copy of the same fallback chain — which is why
+ * neither ViewModel could be constructed in a JVM test and neither had one.
+ *
+ * What these pin:
+ *
+ *  - **a geocoder failure is an empty result, not a crash.** `Geocoder` throws on a transient
+ *    network failure, and a search box that crashes the app on a flaky connection is the
+ *    defect the `runCatching` exists for;
+ *  - **the display-name fallback chain, in order.** Reverse-geocoding a point in open country
+ *    returns an address with no locality; without the chain the location came back blank, so
+ *    the prayer-times header showed nothing at all;
+ *  - **"has location permission" means fine OR coarse.** Requiring fine would tell a user who
+ *    granted approximate location that they had granted nothing;
+ *  - **notification permission is a runtime grant only from Tiramisu.** Asking
+ *    `checkSelfPermission` below that returns denied on every device, so the app would nag
+ *    forever about a permission that cannot be granted;
+ *  - **`getSystemService` is null-checked, not cast.** Both ViewModels cast, in a path called
+ *    from `init`, so constructing one on a device without the service threw.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [StubGeocoder::class])
+class AndroidDeviceLocationRepositoryTest {
+
+    private lateinit var context: Context
+    private lateinit var fused: FusedLocationProviderClient
+    private lateinit var repository: AndroidDeviceLocationRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        fused = mockk(relaxed = true)
+        mockkStatic(LocationServices::class)
+        every { LocationServices.getFusedLocationProviderClient(any<Context>()) } returns fused
+        repository = AndroidDeviceLocationRepository(context, UnconfinedTestDispatcher())
+        StubGeocoder.reset()
+    }
+
+    @After
+    fun tearDown() {
+        StubGeocoder.reset()
+        unmockkAll()
+    }
+
+    // ── the current position ──────────────────────────────────────────────────
+
+    @Test
+    fun `a fix resolves to coordinates`() = runTest {
+        givenFix(Location("test").apply { latitude = 53.35; longitude = -6.26 })
+
+        val coordinates = repository.currentCoordinates()!!
+
+        assertThat(coordinates.latitude).isEqualTo(53.35)
+        assertThat(coordinates.longitude).isEqualTo(-6.26)
+    }
+
+    @Test
+    fun `a device that cannot get a fix reports none rather than zero zero`() = runTest {
+        givenFix(null)
+
+        // (0, 0) is a real place in the Gulf of Guinea, and prayer times for it are wrong
+        // everywhere else.
+        assertThat(repository.currentCoordinates()).isNull()
+    }
+
+    @Test
+    fun `a location provider that fails raises rather than reporting no location`() = runTest {
+        givenFixFailure(IllegalStateException("location off"))
+
+        // "Location services are off" and "you are nowhere" are different things, and only one
+        // of them is worth telling the user about.
+        val thrown = runCatching { repository.currentCoordinates() }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    // ── geocoding ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a search maps each result to a named place`() = runTest {
+        stubGeocoder(listOf(address(locality = "Dublin", country = "Ireland", lat = 53.35, lon = -6.26)))
+
+        val results = repository.search("dublin", limit = 5)
+
+        assertThat(results).hasSize(1)
+        assertThat(results.single().name).isEqualTo("Dublin")
+        assertThat(results.single().country).isEqualTo("Ireland")
+        assertThat(results.single().latitude).isEqualTo(53.35)
+    }
+
+    @Test
+    fun `a result the platform cannot name at all is dropped, not shown blank`() = runTest {
+        stubGeocoder(listOf(address()))
+
+        assertThat(repository.search("nowhere", limit = 5)).isEmpty()
+    }
+
+    @Test
+    fun `a result with no country still lists, with an empty country`() = runTest {
+        stubGeocoder(listOf(address(locality = "Dublin", country = null)))
+
+        assertThat(repository.search("dublin", 5).single().country).isEmpty()
+    }
+
+    @Test
+    fun `a geocoder that throws returns nothing rather than crashing the search box`() = runTest {
+        stubGeocoderThrows()
+
+        assertThat(repository.search("dublin", 5)).isEmpty()
+        assertThat(repository.reverseGeocode(53.35, -6.26)).isNull()
+    }
+
+    @Test
+    fun `reverse geocoding names the point`() = runTest {
+        stubGeocoder(listOf(address(locality = "Dublin")))
+
+        assertThat(repository.reverseGeocode(53.35, -6.26)).isEqualTo("Dublin")
+    }
+
+    @Test
+    fun `a point the platform knows nothing about has no name`() = runTest {
+        stubGeocoder(emptyList())
+
+        assertThat(repository.reverseGeocode(0.0, 0.0)).isNull()
+    }
+
+    @Test
+    fun `the display name falls back through county, then state, then feature`() = runTest {
+        stubGeocoder(listOf(address(subAdminArea = "Laois")))
+        assertThat(repository.reverseGeocode(0.0, 0.0)).isEqualTo("Laois")
+
+        stubGeocoder(listOf(address(adminArea = "Leinster")))
+        assertThat(repository.reverseGeocode(0.0, 0.0)).isEqualTo("Leinster")
+
+        stubGeocoder(listOf(address(featureName = "Slieve Bloom")))
+        // Reverse-geocoding a point in open country returns exactly this shape; without the
+        // chain the prayer-times header showed nothing.
+        assertThat(repository.reverseGeocode(0.0, 0.0)).isEqualTo("Slieve Bloom")
+    }
+
+    @Test
+    fun `a blank locality is skipped rather than shown as an empty name`() = runTest {
+        stubGeocoder(listOf(address(locality = "   ", subAdminArea = "Laois")))
+
+        assertThat(repository.reverseGeocode(0.0, 0.0)).isEqualTo("Laois")
+    }
+
+    // ── permissions ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `approximate location counts as location permission`() {
+        val checker = AndroidPermissionChecker(context)
+        assertThat(checker.hasLocationPermission()).isFalse()
+
+        shadowApp().grantPermissions(Manifest.permission.ACCESS_COARSE_LOCATION)
+
+        // A user who granted approximate location has granted something; requiring fine would
+        // tell them they had granted nothing.
+        assertThat(checker.hasLocationPermission()).isTrue()
+    }
+
+    @Test
+    fun `precise location counts as location permission`() {
+        shadowApp().grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+
+        assertThat(AndroidPermissionChecker(context).hasLocationPermission()).isTrue()
+    }
+
+    @Config(sdk = [33])
+    @Test
+    fun `from Tiramisu the notification permission is a real runtime grant`() {
+        val checker = AndroidPermissionChecker(context)
+        assertThat(checker.hasNotificationPermission()).isFalse()
+
+        shadowApp().grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        assertThat(checker.hasNotificationPermission()).isTrue()
+    }
+
+    @Config(sdk = [31])
+    @Test
+    fun `before Tiramisu notifications are always permitted`() {
+        // `checkSelfPermission` for a permission that does not exist yet returns denied, so
+        // asking would nag forever about something the user cannot grant.
+        assertThat(AndroidPermissionChecker(context).hasNotificationPermission()).isTrue()
+    }
+
+    // ── battery optimisation ──────────────────────────────────────────────────
+
+    @Test
+    fun `a phone that exempts the app reports the exemption`() {
+        val power = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(power).setIgnoringBatteryOptimizations(context.packageName, true)
+
+        assertThat(AndroidPowerSettings(context).isIgnoringBatteryOptimizations()).isTrue()
+    }
+
+    @Test
+    fun `a phone that does not exempt the app says so`() {
+        val power = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(power).setIgnoringBatteryOptimizations(context.packageName, false)
+
+        assertThat(AndroidPowerSettings(context).isIgnoringBatteryOptimizations()).isFalse()
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun shadowApp(): ShadowApplication = shadowOf(context as android.app.Application)
+
+    /**
+     * A `Task` whose listeners fire inline. The real one posts to the main looper, which under
+     * Robolectric is the very thread the test is suspended on.
+     */
+    private fun givenFix(location: Location?) {
+        val task = mockk<Task<Location>>(relaxed = true)
+        every { task.addOnSuccessListener(any<OnSuccessListener<Location>>()) } answers {
+            firstArg<OnSuccessListener<Location>>().onSuccess(location)
+            task
+        }
+        every { task.addOnFailureListener(any<OnFailureListener>()) } returns task
+        every { fused.getCurrentLocation(any<Int>(), any()) } returns task
+    }
+
+    private fun givenFixFailure(error: Exception) {
+        val task = mockk<Task<Location>>(relaxed = true)
+        every { task.addOnSuccessListener(any<OnSuccessListener<Location>>()) } returns task
+        every { task.addOnFailureListener(any<OnFailureListener>()) } answers {
+            firstArg<OnFailureListener>().onFailure(error)
+            task
+        }
+        every { fused.getCurrentLocation(any<Int>(), any()) } returns task
+    }
+
+    private fun stubGeocoder(addresses: List<Address>) {
+        StubGeocoder.addresses = addresses
+    }
+
+    private fun stubGeocoderThrows() {
+        StubGeocoder.error = "network down"
+    }
+
+    private fun address(
+        locality: String? = null,
+        subAdminArea: String? = null,
+        adminArea: String? = null,
+        featureName: String? = null,
+        country: String? = null,
+        lat: Double = 0.0,
+        lon: Double = 0.0,
+    ) = Address(Locale.US).apply {
+        this.locality = locality
+        this.subAdminArea = subAdminArea
+        this.adminArea = adminArea
+        this.featureName = featureName
+        this.countryName = country
+        latitude = lat
+        longitude = lon
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/StubGeocoder.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/device/StubGeocoder.kt
@@ -1,0 +1,59 @@
+package com.arshadshah.nimaz.data.device
+
+import android.location.Address
+import android.location.Geocoder
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import java.io.IOException
+
+/**
+ * A `Geocoder` a test can program.
+ *
+ * Robolectric's own `ShadowGeocoder` keeps its answers on the *instance*, and
+ * [AndroidDeviceLocationRepository] constructs its own `Geocoder` inside a private function —
+ * so there is no instance for a test to reach. This one keeps them statically, and covers the
+ * blocking overloads as well as the listener ones so both sides of the API-33 split are
+ * reachable.
+ */
+@Implements(Geocoder::class)
+class StubGeocoder {
+
+    @Implementation
+    fun getFromLocation(latitude: Double, longitude: Double, maxResults: Int): List<Address> =
+        answer()
+
+    @Implementation
+    fun getFromLocation(
+        latitude: Double,
+        longitude: Double,
+        maxResults: Int,
+        listener: Geocoder.GeocodeListener,
+    ) = listener.onGeocode(answer())
+
+    @Implementation
+    fun getFromLocationName(locationName: String, maxResults: Int): List<Address> = answer()
+
+    @Implementation
+    fun getFromLocationName(
+        locationName: String,
+        maxResults: Int,
+        listener: Geocoder.GeocodeListener,
+    ) = listener.onGeocode(answer())
+
+    private fun answer(): List<Address> {
+        error?.let { throw IOException(it) }
+        return addresses
+    }
+
+    companion object {
+        var addresses: List<Address> = emptyList()
+
+        /** Set to make every lookup throw, as a real geocoder does on a flaky connection. */
+        var error: String? = null
+
+        fun reset() {
+            addresses = emptyList()
+            error = null
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/DuaRepositoryImplMarksTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/DuaRepositoryImplMarksTest.kt
@@ -1,0 +1,470 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.DuaDao
+import com.arshadshah.nimaz.data.local.database.entity.DuaCategoryEntity
+import com.arshadshah.nimaz.data.local.database.entity.DuaEntity
+import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
+import com.arshadshah.nimaz.data.local.search.SearchKind
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ProgressDao
+import com.arshadshah.nimaz.data.local.user.ProgressEntity
+import com.arshadshah.nimaz.data.local.user.ProgressKind
+import com.arshadshah.nimaz.domain.model.DuaBookmark
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The dua marks and counts, and the string→Int seam they cross.
+ *
+ * A dua is favourited, bookmarked *and* counted, and all three now live in two consolidated
+ * tables keyed by `kind`. The failures this pins are the ones nothing above the repository
+ * could report:
+ *
+ *  - **un-favouriting must not take the bookmark with it.** They share one row, so clearing the
+ *    row rather than the flag silently loses a plain bookmark the user made separately;
+ *  - **every id is a string in the domain and an Int in the table.** A `toIntOrNull()` whose
+ *    failure arm is wrong is either a crash on a deep link or, in the list case, category 0's
+ *    duas rendered under another category's title;
+ *  - **a write against an unparseable id must do nothing** — not write against target 0, which
+ *    would attach a favourite to whatever dua happens to be there.
+ */
+class DuaRepositoryImplMarksTest {
+
+    private lateinit var duaDao: DuaDao
+    private lateinit var bookmarkDao: BookmarkDao
+    private lateinit var progressDao: ProgressDao
+    private lateinit var searchIndex: ContentSearchIndex
+    private lateinit var repository: DuaRepositoryImpl
+
+    @Before
+    fun setUp() {
+        duaDao = mockk(relaxed = true)
+        bookmarkDao = mockk(relaxed = true)
+        progressDao = mockk(relaxed = true)
+        searchIndex = mockk(relaxed = true)
+        coEvery { searchIndex.isAvailable() } returns false
+        every { duaDao.getAllCategories() } returns flowOf(listOf(category(1)))
+        repository = DuaRepositoryImpl(duaDao, bookmarkDao, progressDao, searchIndex)
+    }
+
+    // ── one row, two flags ────────────────────────────────────────────────────
+
+    @Test
+    fun `favouriting a dua that is not marked at all creates the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.DUA, 5) } returns null
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleFavorite(duaId = "5", categoryId = "1")
+
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().bookmarked).isTrue()
+        assertThat(saved.single().contextId).isEqualTo(1)
+    }
+
+    @Test
+    fun `un-favouriting a dua that is also bookmarked keeps the bookmark`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.DUA, 5) } returns
+            mark(5, bookmarked = true, favourite = true)
+
+        repository.toggleFavorite("5", "1")
+
+        // Clearing the flag, not the row: the plain bookmark was a separate act.
+        coVerify { bookmarkDao.clearFavourite(BookmarkKind.DUA, 5, any()) }
+        coVerify(exactly = 0) { bookmarkDao.delete(BookmarkKind.DUA, 5) }
+    }
+
+    @Test
+    fun `un-favouriting a dua that is only favourited removes the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.DUA, 5) } returns
+            mark(5, bookmarked = false, favourite = true)
+
+        repository.toggleFavorite("5", "1")
+
+        coVerify { bookmarkDao.delete(BookmarkKind.DUA, 5) }
+    }
+
+    @Test
+    fun `favouriting a dua that is already bookmarked sets the flag on the same row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.DUA, 5) } returns
+            mark(5, bookmarked = true, favourite = false, note = "keep me")
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleFavorite("5", "1")
+
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().bookmarked).isTrue()
+        assertThat(saved.single().note).isEqualTo("keep me")
+    }
+
+    @Test
+    fun `favouriting a dua whose id is not a number writes nothing at all`() = runTest {
+        repository.toggleFavorite("morning-adhkar", "1")
+
+        // Falling back to target 0 would favourite whatever dua happens to hold that id.
+        coVerify(exactly = 0) { bookmarkDao.find(any(), any()) }
+        coVerify(exactly = 0) { bookmarkDao.upsert(any()) }
+    }
+
+    @Test
+    fun `a bookmark reads back with its category and favourite flag`() = runTest {
+        every { bookmarkDao.bookmarks(BookmarkKind.DUA) } returns
+            flowOf(listOf(mark(5, favourite = true, note = "n", contextId = 3)))
+
+        val bookmark = repository.getAllBookmarks().first().single()
+
+        assertThat(bookmark.duaId).isEqualTo("5")
+        assertThat(bookmark.categoryId).isEqualTo("3")
+        assertThat(bookmark.isFavorite).isTrue()
+        assertThat(bookmark.note).isEqualTo("n")
+    }
+
+    @Test
+    fun `a bookmark row with no category still reads back`() = runTest {
+        every { bookmarkDao.favourites(BookmarkKind.DUA) } returns
+            flowOf(listOf(mark(5, contextId = null)))
+
+        assertThat(repository.getFavoriteDuas().first().single().categoryId).isEqualTo("0")
+    }
+
+    @Test
+    fun `looking up a bookmark by an unparseable id finds none`() = runTest {
+        assertThat(repository.getBookmarkByDuaId("morning")).isNull()
+
+        coVerify(exactly = 0) { bookmarkDao.find(any(), any()) }
+    }
+
+    @Test
+    fun `looking up a bookmark by a numeric id reads the consolidated row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.DUA, 5) } returns mark(5)
+
+        assertThat(repository.getBookmarkByDuaId("5")!!.duaId).isEqualTo("5")
+    }
+
+    @Test
+    fun `the bookmarked and favourite flags are observed independently`() = runTest {
+        every { bookmarkDao.observeIsBookmarked(BookmarkKind.DUA, 5) } returns flowOf(true)
+        every { bookmarkDao.observeIsFavourite(BookmarkKind.DUA, 5) } returns flowOf(false)
+
+        assertThat(repository.isDuaBookmarked("5").first()).isTrue()
+        assertThat(repository.isDuaFavorite("5").first()).isFalse()
+    }
+
+    @Test
+    fun `an unparseable id observes dua zero rather than crashing`() = runTest {
+        every { bookmarkDao.observeIsBookmarked(BookmarkKind.DUA, 0) } returns flowOf(false)
+        every { bookmarkDao.observeIsFavourite(BookmarkKind.DUA, 0) } returns flowOf(false)
+
+        assertThat(repository.isDuaBookmarked("morning").first()).isFalse()
+        assertThat(repository.isDuaFavorite("morning").first()).isFalse()
+    }
+
+    @Test
+    fun `inserting and updating a bookmark both write one consolidated row`() = runTest {
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+        val bookmark = DuaBookmark(
+            id = 0, duaId = "5", categoryId = "1", note = "n",
+            isFavorite = true, createdAt = 1L, updatedAt = 2L,
+        )
+
+        repository.insertBookmark(bookmark)
+        repository.updateBookmark(bookmark.copy(note = "edited"))
+
+        assertThat(saved.map { it.kind }.toSet()).containsExactly(BookmarkKind.DUA)
+        assertThat(saved.map { it.targetId }.toSet()).containsExactly(5)
+        assertThat(saved.first().favourite).isTrue()
+        assertThat(saved.last().note).isEqualTo("edited")
+    }
+
+    @Test
+    fun `a bookmark whose ids are not numbers writes against dua zero and no category`() =
+        runTest {
+            val saved = mutableListOf<BookmarkEntity>()
+            coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+            repository.insertBookmark(
+                DuaBookmark(
+                    id = 0, duaId = "morning", categoryId = "adhkar", note = null,
+                    isFavorite = false, createdAt = 1L, updatedAt = 1L,
+                )
+            )
+
+            assertThat(saved.single().targetId).isEqualTo(0)
+            assertThat(saved.single().contextId).isNull()
+        }
+
+    @Test
+    fun `deleting a bookmark by an unparseable id deletes nothing`() = runTest {
+        repository.deleteBookmark("morning")
+        repository.deleteBookmark("5")
+
+        coVerify(exactly = 1) { bookmarkDao.delete(BookmarkKind.DUA, 5) }
+    }
+
+    // ── daily counts ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a count for a day reads back with its target`() = runTest {
+        coEvery { progressDao.find(ProgressKind.DUA, 5, 900L) } returns
+            progress(targetId = 5, date = 900L, completed = 3, total = 7)
+
+        val recorded = repository.getProgressForDuaOnDate("5", 900L)!!
+
+        assertThat(recorded.duaId).isEqualTo("5")
+        assertThat(recorded.completedCount).isEqualTo(3)
+        assertThat(recorded.targetCount).isEqualTo(7)
+        assertThat(recorded.isCompleted).isFalse()
+    }
+
+    @Test
+    fun `a count with no recorded target reports zero rather than dropping the row`() = runTest {
+        coEvery { progressDao.find(ProgressKind.DUA, 5, 900L) } returns
+            progress(targetId = 5, date = 900L, completed = 1, total = null)
+
+        assertThat(repository.getProgressForDuaOnDate("5", 900L)!!.targetCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `a count for an unparseable dua is not looked up`() = runTest {
+        assertThat(repository.getProgressForDuaOnDate("morning", 900L)).isNull()
+
+        coVerify(exactly = 0) { progressDao.find(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a day's counts come from the dua kind only`() = runTest {
+        every { progressDao.onDate(ProgressKind.DUA, 900L) } returns
+            flowOf(listOf(progress(targetId = 5, date = 900L)))
+
+        assertThat(repository.getProgressForDate(900L).first().map { it.duaId })
+            .containsExactly("5")
+    }
+
+    @Test
+    fun `a dua's history is filtered to that dua`() = runTest {
+        every { progressDao.ofKind(ProgressKind.DUA) } returns flowOf(
+            listOf(
+                progress(targetId = 5, date = 900L),
+                progress(targetId = 6, date = 900L),
+            )
+        )
+
+        assertThat(repository.getProgressHistoryForDua("5").first().map { it.duaId })
+            .containsExactly("5")
+    }
+
+    @Test
+    fun `an unparseable id's history is dua zero's, which is empty`() = runTest {
+        every { progressDao.ofKind(ProgressKind.DUA) } returns
+            flowOf(listOf(progress(targetId = 5, date = 900L)))
+
+        assertThat(repository.getProgressHistoryForDua("morning").first()).isEmpty()
+    }
+
+    @Test
+    fun `counting up and down goes through the shared progress table`() = runTest {
+        repository.incrementDuaProgress("5", 900L, targetCount = 7)
+        repository.decrementDuaProgress("5", 900L)
+
+        coVerify { progressDao.increment(ProgressKind.DUA, 5, 900L, 7) }
+        coVerify { progressDao.decrement(ProgressKind.DUA, 5, 900L) }
+    }
+
+    @Test
+    fun `counting against an unparseable dua does nothing`() = runTest {
+        repository.incrementDuaProgress("morning", 900L, 7)
+        repository.decrementDuaProgress("morning", 900L)
+
+        coVerify(exactly = 0) { progressDao.increment(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { progressDao.decrement(any(), any(), any()) }
+    }
+
+    // ── reads ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a category reads back with its icon and count`() = runTest {
+        val category = repository.getAllCategories().first().single()
+
+        assertThat(category.id).isEqualTo("1")
+        assertThat(category.nameEnglish).isEqualTo("Morning & Evening")
+        assertThat(category.iconName).isEqualTo("sunrise")
+        assertThat(category.duaCount).isEqualTo(11)
+    }
+
+    @Test
+    fun `an unparseable category id opens no category and lists no duas`() = runTest {
+        every { duaDao.getDuasByCategory(0) } returns flowOf(emptyList())
+
+        assertThat(repository.getCategoryById("adhkar")).isNull()
+        assertThat(repository.getDuasByCategoryOnce("adhkar")).isEmpty()
+        assertThat(repository.getDuasByCategory("adhkar").first()).isEmpty()
+        coVerify(exactly = 0) { duaDao.getCategoryById(any()) }
+        coVerify(exactly = 0) { duaDao.getDuasByCategoryOnce(any()) }
+    }
+
+    @Test
+    fun `a category's duas are read once for a caller that does not want a flow`() = runTest {
+        coEvery { duaDao.getDuasByCategoryOnce(1) } returns listOf(dua(5))
+
+        assertThat(repository.getDuasByCategoryOnce("1").map { it.id }).containsExactly("5")
+    }
+
+    @Test
+    fun `a dua reads back with everything the screen renders`() = runTest {
+        coEvery { duaDao.getDuaById(5) } returns dua(5)
+
+        val read = repository.getDuaById("5")!!
+
+        assertThat(read.categoryId).isEqualTo("1")
+        assertThat(read.textTransliteration).isEqualTo("Bismillah")
+        assertThat(read.benefits).isEqualTo("Protection")
+        assertThat(read.repeatCount).isEqualTo(3)
+        assertThat(read.reference).isEqualTo("Abu Dawud")
+    }
+
+    @Test
+    fun `an unparseable dua id opens nothing`() = runTest {
+        assertThat(repository.getDuaById("morning")).isNull()
+        assertThat(repository.getDuasByIds(listOf("a", "b"))).isEmpty()
+        coVerify(exactly = 0) { duaDao.getDuaById(any()) }
+        coVerify(exactly = 0) { duaDao.getDuasByIds(any()) }
+    }
+
+    @Test
+    fun `a list of ids drops the ones that are not numbers`() = runTest {
+        coEvery { duaDao.getDuasByIds(listOf(5)) } returns listOf(dua(5))
+
+        assertThat(repository.getDuasByIds(listOf("5", "morning")).map { it.id })
+            .containsExactly("5")
+    }
+
+    @Test
+    fun `an occasion is searched for by name because there is no occasion column`() = runTest {
+        every { duaDao.searchDuas("traveling") } returns flowOf(listOf(dua(5)))
+
+        assertThat(repository.getDuasByOccasion(DuaOccasion.TRAVELING).first()).hasSize(1)
+    }
+
+    @Test
+    fun `without an index a dua search scans and names each category`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns false
+        every { duaDao.searchDuas("protection") } returns flowOf(listOf(dua(5)))
+
+        val result = repository.searchDuas("protection").first().single()
+
+        assertThat(result.categoryName).isEqualTo("Morning & Evening")
+        assertThat(result.matchedText).isEqualTo("In the name of God")
+    }
+
+    @Test
+    fun `with an index the scan is not run at all`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("بسم", SearchKind.DUA, null, any()) } returns
+            listOf("5", "not-an-id")
+        coEvery { duaDao.getDuasByIds(listOf(5)) } returns listOf(dua(5))
+
+        assertThat(repository.searchDuas("بسم").first()).hasSize(1)
+        // The Arabic is vocalised and the transliteration full of macrons: `LIKE` reaches
+        // neither, and the index folds both.
+        io.mockk.verify(exactly = 0) { duaDao.searchDuas(any()) }
+    }
+
+    @Test
+    fun `a dua whose category is not in the catalogue is labelled with nothing`() = runTest {
+        every { duaDao.getAllCategories() } returns flowOf(emptyList())
+        every { duaDao.searchDuas(any()) } returns flowOf(listOf(dua(5, categoryId = 42)))
+
+        assertThat(repository.searchDuas("x").first().single().categoryName).isEmpty()
+    }
+
+    @Test
+    fun `an artifact with no categories counts as uninitialised`() = runTest {
+        assertThat(repository.isDataInitialized()).isTrue()
+
+        every { duaDao.getAllCategories() } returns flowOf(emptyList())
+        assertThat(repository.isDataInitialized()).isFalse()
+    }
+
+    @Test
+    fun `the database flow is built when it is collected, not when it is asked for`() = runTest {
+        // Callers hold these flows without collecting them, so building the DB flow eagerly
+        // would query on construction.
+        val flow = repository.getAllCategories()
+
+        io.mockk.verify(exactly = 0) { duaDao.getAllCategories() }
+        assertThat(flow.first()).hasSize(1)
+        io.mockk.verify { duaDao.getAllCategories() }
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun category(id: Int) = DuaCategoryEntity(
+        id = id,
+        nameEnglish = "Morning & Evening",
+        nameArabic = "أذكار الصباح والمساء",
+        icon = "sunrise",
+        displayOrder = 1,
+        duaCount = 11,
+    )
+
+    private fun dua(id: Int, categoryId: Int = 1) = DuaEntity(
+        id = id,
+        categoryId = categoryId,
+        titleEnglish = "Bismillah",
+        titleArabic = "بسم الله",
+        textArabic = "بِسْمِ ٱللَّهِ",
+        transliteration = "Bismillah",
+        translation = "In the name of God",
+        source = "Abu Dawud",
+        virtue = "Protection",
+        repeatCount = 3,
+        audioFile = null,
+        displayOrder = 1,
+    )
+
+    private fun mark(
+        targetId: Int,
+        bookmarked: Boolean = true,
+        favourite: Boolean = false,
+        note: String? = null,
+        contextId: Int? = 1,
+    ) = BookmarkEntity(
+        kind = BookmarkKind.DUA,
+        targetId = targetId,
+        bookmarked = bookmarked,
+        favourite = favourite,
+        note = note,
+        contextId = contextId,
+        createdAt = 1L,
+        updatedAt = 1L,
+    )
+
+    private fun progress(
+        targetId: Int,
+        date: Long,
+        completed: Int = 0,
+        total: Int? = 7,
+    ) = ProgressEntity(
+        kind = ProgressKind.DUA,
+        targetId = targetId,
+        date = date,
+        completed = completed,
+        total = total,
+        isCompleted = false,
+        createdAt = 1L,
+        updatedAt = 1L,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/FavouriteCataloguesTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/FavouriteCataloguesTest.kt
@@ -1,0 +1,338 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUlHusnaDao
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUnNabiDao
+import com.arshadshah.nimaz.data.local.database.dao.ProphetDao
+import com.arshadshah.nimaz.data.local.database.entity.AsmaUlHusnaEntity
+import com.arshadshah.nimaz.data.local.database.entity.AsmaUnNabiEntity
+import com.arshadshah.nimaz.data.local.database.entity.ProphetEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The three read-only catalogues a user can only *favourite*: the 99 names, the names of the
+ * Prophet ﷺ, and the 25 prophets.
+ *
+ * All three have the same shape and the same trap. Each used to have its own favourites table
+ * where the row's only meaning was "favourited", so a toggle was insert-or-delete. The
+ * consolidated row can *also* be bookmarked — so a toggle that still deletes the row destroys a
+ * bookmark the user made separately, with nothing on screen to say it happened. Three
+ * repositories, three copies of the same `when`, and this is the test that keeps them agreeing.
+ *
+ * The other shared trap is the JSON array columns. `quran_references`, `key_lessons`,
+ * `quran_mentions` and `miracles` are all comma-free JSON stored as text, and a corpus that
+ * ships a malformed one must give a detail screen with an empty list, not a crash.
+ */
+class FavouriteCataloguesTest {
+
+    private lateinit var bookmarkDao: BookmarkDao
+
+    private lateinit var asmaUlHusnaDao: AsmaUlHusnaDao
+    private lateinit var asmaUnNabiDao: AsmaUnNabiDao
+    private lateinit var prophetDao: ProphetDao
+
+    private lateinit var names: AsmaUlHusnaRepositoryImpl
+    private lateinit var nabiNames: AsmaUnNabiRepositoryImpl
+    private lateinit var prophets: ProphetRepositoryImpl
+
+    @Before
+    fun setUp() {
+        bookmarkDao = mockk(relaxed = true)
+        asmaUlHusnaDao = mockk(relaxed = true)
+        asmaUnNabiDao = mockk(relaxed = true)
+        prophetDao = mockk(relaxed = true)
+        every { bookmarkDao.favourites(any()) } returns flowOf(emptyList())
+        names = AsmaUlHusnaRepositoryImpl(asmaUlHusnaDao, bookmarkDao)
+        nabiNames = AsmaUnNabiRepositoryImpl(asmaUnNabiDao, bookmarkDao)
+        prophets = ProphetRepositoryImpl(prophetDao, bookmarkDao)
+    }
+
+    // ── the toggle, for each catalogue ────────────────────────────────────────
+
+    @Test
+    fun `favouriting a name with no mark creates a row that is not a bookmark`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns null
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        names.toggleFavorite(1)
+
+        assertThat(saved.single().favourite).isTrue()
+        // Favouriting is not bookmarking: the row must not claim a mark the user never made.
+        assertThat(saved.single().bookmarked).isFalse()
+    }
+
+    @Test
+    fun `un-favouriting a name that is also bookmarked clears the flag and keeps the row`() =
+        runTest {
+            coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns
+                mark(BookmarkKind.ASMA_UL_HUSNA, favourite = true, bookmarked = true)
+
+            names.toggleFavorite(1)
+
+            coVerify { bookmarkDao.clearFavourite(BookmarkKind.ASMA_UL_HUSNA, 1, any()) }
+            coVerify(exactly = 0) { bookmarkDao.delete(BookmarkKind.ASMA_UL_HUSNA, 1) }
+        }
+
+    @Test
+    fun `un-favouriting a name that is nothing else removes the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns
+            mark(BookmarkKind.ASMA_UL_HUSNA, favourite = true, bookmarked = false)
+
+        names.toggleFavorite(1)
+
+        coVerify { bookmarkDao.delete(BookmarkKind.ASMA_UL_HUSNA, 1) }
+    }
+
+    @Test
+    fun `favouriting a name that is already bookmarked sets the flag on the same row`() =
+        runTest {
+            coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns
+                mark(BookmarkKind.ASMA_UL_HUSNA, favourite = false, bookmarked = true)
+            val saved = mutableListOf<BookmarkEntity>()
+            coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+            names.toggleFavorite(1)
+
+            assertThat(saved.single().favourite).isTrue()
+            assertThat(saved.single().bookmarked).isTrue()
+        }
+
+    @Test
+    fun `the names of the Prophet follow the same four rules`() = runTest {
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UN_NABI, 2) } returns null
+        nabiNames.toggleFavorite(2)
+        assertThat(saved.single().favourite).isTrue()
+
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UN_NABI, 2) } returns
+            mark(BookmarkKind.ASMA_UN_NABI, favourite = true, bookmarked = true)
+        nabiNames.toggleFavorite(2)
+        coVerify { bookmarkDao.clearFavourite(BookmarkKind.ASMA_UN_NABI, 2, any()) }
+
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UN_NABI, 2) } returns
+            mark(BookmarkKind.ASMA_UN_NABI, favourite = true, bookmarked = false)
+        nabiNames.toggleFavorite(2)
+        coVerify { bookmarkDao.delete(BookmarkKind.ASMA_UN_NABI, 2) }
+
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UN_NABI, 2) } returns
+            mark(BookmarkKind.ASMA_UN_NABI, favourite = false, bookmarked = true)
+        nabiNames.toggleFavorite(2)
+        assertThat(saved.last().favourite).isTrue()
+        assertThat(saved.last().bookmarked).isTrue()
+    }
+
+    @Test
+    fun `the prophets follow the same four rules`() = runTest {
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 3) } returns null
+        prophets.toggleFavorite(3)
+        assertThat(saved.single().favourite).isTrue()
+
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 3) } returns
+            mark(BookmarkKind.PROPHET, favourite = true, bookmarked = true)
+        prophets.toggleFavorite(3)
+        coVerify { bookmarkDao.clearFavourite(BookmarkKind.PROPHET, 3, any()) }
+
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 3) } returns
+            mark(BookmarkKind.PROPHET, favourite = true, bookmarked = false)
+        prophets.toggleFavorite(3)
+        coVerify { bookmarkDao.delete(BookmarkKind.PROPHET, 3) }
+
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 3) } returns
+            mark(BookmarkKind.PROPHET, favourite = false, bookmarked = true)
+        prophets.toggleFavorite(3)
+        assertThat(saved.last().favourite).isTrue()
+        assertThat(saved.last().bookmarked).isTrue()
+    }
+
+    // ── "is it favourited" reads the flag, not the row's existence ────────────
+
+    @Test
+    fun `a bookmarked but un-favourited row does not count as a favourite`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns
+            mark(BookmarkKind.ASMA_UL_HUSNA, favourite = false, bookmarked = true)
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UN_NABI, 1) } returns
+            mark(BookmarkKind.ASMA_UN_NABI, favourite = false, bookmarked = true)
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 1) } returns
+            mark(BookmarkKind.PROPHET, favourite = false, bookmarked = true)
+
+        // The row exists; the flag does not. Testing existence is the old table's habit.
+        assertThat(names.isFavorite(1)).isFalse()
+        assertThat(nabiNames.isFavorite(1)).isFalse()
+        assertThat(prophets.isFavorite(1)).isFalse()
+    }
+
+    @Test
+    fun `a favourited row counts, and a missing row does not`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 1) } returns
+            mark(BookmarkKind.PROPHET, favourite = true, bookmarked = false)
+        coEvery { bookmarkDao.find(BookmarkKind.PROPHET, 2) } returns null
+
+        assertThat(prophets.isFavorite(1)).isTrue()
+        assertThat(prophets.isFavorite(2)).isFalse()
+    }
+
+    // ── the favourite flag on the way out ─────────────────────────────────────
+
+    @Test
+    fun `a listed name carries whether it is favourited`() = runTest {
+        every { asmaUlHusnaDao.getAllNames() } returns flowOf(listOf(name(1), name(2)))
+        every { bookmarkDao.favourites(BookmarkKind.ASMA_UL_HUSNA) } returns
+            flowOf(listOf(mark(BookmarkKind.ASMA_UL_HUSNA, targetId = 2, favourite = true)))
+
+        val listed = names.getAllNames().first()
+
+        assertThat(listed.single { it.id == 1 }.isFavorite).isFalse()
+        assertThat(listed.single { it.id == 2 }.isFavorite).isTrue()
+    }
+
+    @Test
+    fun `an id the corpus does not hold opens nothing`() = runTest {
+        coEvery { asmaUlHusnaDao.getNameById(99) } returns null
+        coEvery { asmaUnNabiDao.getNameById(99) } returns null
+        coEvery { prophetDao.getProphetById(99) } returns null
+
+        assertThat(names.getNameById(99)).isNull()
+        assertThat(nabiNames.getNameById(99)).isNull()
+        assertThat(prophets.getProphetById(99)).isNull()
+    }
+
+    @Test
+    fun `opening one name reads its favourite flag from the user's database`() = runTest {
+        coEvery { asmaUlHusnaDao.getNameById(1) } returns name(1)
+        coEvery { bookmarkDao.find(BookmarkKind.ASMA_UL_HUSNA, 1) } returns
+            mark(BookmarkKind.ASMA_UL_HUSNA, favourite = true)
+
+        assertThat(names.getNameById(1)!!.isFavorite).isTrue()
+    }
+
+    @Test
+    fun `a device with no favourites does not query the content database for them`() = runTest {
+        every { bookmarkDao.favourites(BookmarkKind.PROPHET) } returns flowOf(emptyList())
+
+        assertThat(prophets.getFavoriteProphets().first()).isEmpty()
+        // `WHERE id IN ()` is not a query worth making.
+        io.mockk.verify(exactly = 0) { prophetDao.getByIds(any()) }
+    }
+
+    @Test
+    fun `favourited ids come from the user's database and the rows from the content one`() =
+        runTest {
+            every { bookmarkDao.favourites(BookmarkKind.ASMA_UN_NABI) } returns
+                flowOf(listOf(mark(BookmarkKind.ASMA_UN_NABI, targetId = 4, favourite = true)))
+            every { asmaUnNabiDao.getByIds(listOf(4)) } returns flowOf(listOf(nabiName(4)))
+
+            val favourites = nabiNames.getFavoriteNames().first()
+
+            assertThat(favourites.single().id).isEqualTo(4)
+            assertThat(favourites.single().isFavorite).isTrue()
+        }
+
+    // ── the JSON array columns ────────────────────────────────────────────────
+
+    @Test
+    fun `a name's references are parsed out of its JSON column`() = runTest {
+        coEvery { asmaUlHusnaDao.getNameById(1) } returns
+            name(1, references = """["1:1","2:255"]""")
+
+        assertThat(names.getNameById(1)!!.quranReferences)
+            .containsExactly("1:1", "2:255").inOrder()
+    }
+
+    @Test
+    fun `a malformed references column gives an empty list, not a crash`() = runTest {
+        coEvery { asmaUlHusnaDao.getNameById(1) } returns name(1, references = "not json")
+
+        // A detail screen with no references beats a detail screen that will not open.
+        assertThat(names.getNameById(1)!!.quranReferences).isEmpty()
+    }
+
+    @Test
+    fun `a prophet's three JSON columns are each parsed`() = runTest {
+        coEvery { prophetDao.getProphetById(1) } returns prophet(
+            1,
+            keyLessons = """["patience"]""",
+            quranMentions = """["2:124"]""",
+            miracles = """["the staff","the sea"]""",
+        )
+
+        val read = prophets.getProphetById(1)!!
+
+        assertThat(read.keyLessons).containsExactly("patience")
+        assertThat(read.quranMentions).containsExactly("2:124")
+        assertThat(read.miracles).containsExactly("the staff", "the sea").inOrder()
+    }
+
+    @Test
+    fun `one malformed column does not take the other two down with it`() = runTest {
+        coEvery { prophetDao.getProphetById(1) } returns prophet(
+            1,
+            keyLessons = "{",
+            quranMentions = """["2:124"]""",
+            miracles = """["the staff"]""",
+        )
+
+        val read = prophets.getProphetById(1)!!
+
+        assertThat(read.keyLessons).isEmpty()
+        assertThat(read.quranMentions).containsExactly("2:124")
+        assertThat(read.miracles).containsExactly("the staff")
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun mark(
+        kind: String,
+        targetId: Int = 1,
+        favourite: Boolean = false,
+        bookmarked: Boolean = false,
+    ) = BookmarkEntity(
+        kind = kind,
+        targetId = targetId,
+        bookmarked = bookmarked,
+        favourite = favourite,
+        createdAt = 1L,
+        updatedAt = 1L,
+    )
+
+    private fun name(id: Int, references: String = "[]") = AsmaUlHusnaEntity(
+        id = id, number = id, nameArabic = "الرحمن", nameTransliteration = "Ar-Rahman",
+        nameEnglish = "The Most Merciful", meaning = "mercy", explanation = "e",
+        benefits = "b", quranReferences = references, usageInDua = "u", displayOrder = id,
+    )
+
+    private fun nabiName(id: Int) = AsmaUnNabiEntity(
+        id = id, number = id, nameArabic = "محمد", nameTransliteration = "Muhammad",
+        nameEnglish = "The Praised One", meaning = "praise", explanation = "e",
+        source = "s", displayOrder = id,
+    )
+
+    private fun prophet(
+        id: Int,
+        keyLessons: String = "[]",
+        quranMentions: String = "[]",
+        miracles: String = "[]",
+    ) = ProphetEntity(
+        id = id, number = id, nameArabic = "موسى", nameEnglish = "Moses",
+        nameTransliteration = "Musa", titleArabic = "كليم الله",
+        titleEnglish = "The one who spoke with God", storySummary = "s",
+        keyLessons = keyLessons, quranMentions = quranMentions, era = "e", lineage = "l",
+        yearsLived = "120", placeOfPreaching = "Egypt", miracles = miracles, displayOrder = id,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/HadithRepositoryImplIdsTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/HadithRepositoryImplIdsTest.kt
@@ -1,0 +1,558 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.HadithChapterCount
+import com.arshadshah.nimaz.data.local.database.dao.HadithDao
+import com.arshadshah.nimaz.data.local.database.entity.HadithBookEntity
+import com.arshadshah.nimaz.data.local.database.entity.HadithEntity
+import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
+import com.arshadshah.nimaz.data.local.search.SearchKind
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.domain.model.HadithBookmark
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The identifier seam between the hadith screens and the hadith tables.
+ *
+ * The domain model carries **strings** — `Hadith.id`, `HadithBook.id`, `HadithChapter.id` — and
+ * every table underneath is keyed by an **Int**. So every read in this repository parses, and
+ * every parse has a failure arm that a route argument can reach: a deep link, a restored
+ * back-stack entry, a bookmark to a book a later corpus renumbered.
+ *
+ * The two arms are deliberately different and the difference is the whole point:
+ *
+ *  - a lookup of *one specific thing* returns **null** — "no such hadith", which the screen
+ *    renders as an empty state;
+ *  - a *list* query falls back to **0** — an id no book has, so the flow is empty rather than
+ *    absent, and a `LazyColumn` gets a list to be empty of.
+ *
+ * Get either wrong and the failure is a crash on a deep link (`toInt()` on "bukhari") or, worse,
+ * book 0's hadiths silently rendered under another book's title.
+ *
+ * Chapters are the sharper case still: there is **no chapters table**. They are derived from
+ * `GROUP BY chapter_id`, their ids are composite (`"{bookId}_{chapterId}"`), and the stored id
+ * is 0-based while the number a reader sees is 1-based. An off-by-one here is not an error —
+ * it is every chapter heading in the app being wrong by one.
+ */
+class HadithRepositoryImplIdsTest {
+
+    private lateinit var hadithDao: HadithDao
+    private lateinit var bookmarkDao: BookmarkDao
+    private lateinit var searchIndex: ContentSearchIndex
+    private lateinit var repository: HadithRepositoryImpl
+
+    @Before
+    fun setUp() {
+        hadithDao = mockk(relaxed = true)
+        bookmarkDao = mockk(relaxed = true)
+        searchIndex = mockk(relaxed = true)
+        coEvery { searchIndex.isAvailable() } returns false
+        every { hadithDao.getAllBooks() } returns flowOf(listOf(book(1)))
+        repository = HadithRepositoryImpl(hadithDao, bookmarkDao, searchIndex)
+    }
+
+    // ── a single thing: an unparseable id means "no such thing" ───────────────
+
+    @Test
+    fun `a book id that is not a number is no book at all`() = runTest {
+        assertThat(repository.getBookById("bukhari")).isNull()
+
+        // Never `toInt()`: a deep link carrying a slug would crash the screen it opened.
+        coVerify(exactly = 0) { hadithDao.getBookById(any()) }
+    }
+
+    @Test
+    fun `a book id that is a number is looked up`() = runTest {
+        coEvery { hadithDao.getBookById(1) } returns book(1)
+
+        assertThat(repository.getBookById("1")!!.nameEnglish).isEqualTo("Sahih al-Bukhari")
+    }
+
+    @Test
+    fun `a hadith id that is not a number is no hadith at all`() = runTest {
+        assertThat(repository.getHadithById("first")).isNull()
+        assertThat(repository.getHadithByNumber("bukhari", 1)).isNull()
+
+        coVerify(exactly = 0) { hadithDao.getHadithById(any()) }
+        coVerify(exactly = 0) { hadithDao.getHadithByNumber(any(), any()) }
+    }
+
+    @Test
+    fun `a hadith is looked up by its number within a book`() = runTest {
+        coEvery { hadithDao.getHadithByNumber(1, 7) } returns hadith(id = 7)
+
+        assertThat(repository.getHadithByNumber("1", 7)!!.id).isEqualTo("7")
+    }
+
+    @Test
+    fun `a reference is a string all the way down and is not parsed`() = runTest {
+        coEvery { hadithDao.getHadithByReference("bukhari:1") } returns hadith(id = 1)
+
+        assertThat(repository.getHadithByReference("bukhari:1")!!.reference).isEqualTo("bukhari:1")
+    }
+
+    @Test
+    fun `asking for a list of ids drops the ones that are not numbers`() = runTest {
+        coEvery { hadithDao.getHadithsByIds(listOf(1, 3)) } returns listOf(hadith(1), hadith(3))
+
+        assertThat(repository.getHadithsByIds(listOf("1", "not-an-id", "3")).map { it.id })
+            .containsExactly("1", "3")
+    }
+
+    @Test
+    fun `a list of ids none of which are numbers queries nothing`() = runTest {
+        assertThat(repository.getHadithsByIds(listOf("a", "b"))).isEmpty()
+
+        coVerify(exactly = 0) { hadithDao.getHadithsByIds(any()) }
+    }
+
+    // ── a list: an unparseable id means "empty", not "absent" ─────────────────
+
+    @Test
+    fun `an unparseable book id lists no hadiths rather than every hadith`() = runTest {
+        every { hadithDao.getHadithsByBook(0) } returns flowOf(emptyList())
+
+        assertThat(repository.getHadithsByBook("bukhari").first()).isEmpty()
+        // Book 0 exists in no corpus, so the flow is empty — but it *is* a flow, which is what
+        // a LazyColumn needs in order to be empty of anything.
+        verifyBookQueried(0)
+    }
+
+    @Test
+    fun `a bookmark list for an unparseable book falls back the same way`() = runTest {
+        every { bookmarkDao.inContext(BookmarkKind.HADITH, 0) } returns flowOf(emptyList())
+
+        assertThat(repository.getBookmarksByBook("bukhari").first()).isEmpty()
+    }
+
+    @Test
+    fun `a bookmark flag for an unparseable hadith observes nothing rather than crashing`() =
+        runTest {
+            every { bookmarkDao.observeIsBookmarked(BookmarkKind.HADITH, 0) } returns flowOf(false)
+
+            assertThat(repository.isHadithBookmarked("first").first()).isFalse()
+        }
+
+    // ── chapters, which are not a table ───────────────────────────────────────
+
+    @Test
+    fun `a stored chapter id is zero based and the number shown is one based`() = runTest {
+        every { hadithDao.getChapterCountsForBook(1) } returns
+            flowOf(listOf(HadithChapterCount(chapterId = 0, hadithCount = 7)))
+
+        val chapter = repository.getChaptersByBook("1").first().single()
+
+        // The raw id keeps loading working; the number is what the reader sees.
+        assertThat(chapter.id).isEqualTo("1_0")
+        assertThat(chapter.chapterNumber).isEqualTo(1)
+        assertThat(chapter.nameEnglish).isEqualTo("Chapter 1")
+        assertThat(chapter.nameArabic).isEqualTo("الباب 1")
+        assertThat(chapter.hadithCount).isEqualTo(7)
+    }
+
+    @Test
+    fun `a chapter's count is the real one, not a placeholder`() = runTest {
+        every { hadithDao.getChapterCountsForBook(1) } returns flowOf(
+            listOf(
+                HadithChapterCount(chapterId = 0, hadithCount = 7),
+                HadithChapterCount(chapterId = 1, hadithCount = 53),
+            )
+        )
+
+        val counts = repository.getChaptersByBook("1").first().map { it.hadithCount }
+
+        assertThat(counts).containsExactly(7, 53).inOrder()
+    }
+
+    @Test
+    fun `a composite chapter id round trips back into its parts`() = runTest {
+        val chapter = repository.getChapterById("3_11")!!
+
+        assertThat(chapter.bookId).isEqualTo("3")
+        assertThat(chapter.chapterNumber).isEqualTo(12)
+        assertThat(chapter.id).isEqualTo("3_11")
+    }
+
+    @Test
+    fun `a chapter id that is not composite opens nothing`() = runTest {
+        assertThat(repository.getChapterById("11")).isNull()
+        assertThat(repository.getChapterById("1_2_3")).isNull()
+    }
+
+    @Test
+    fun `a composite chapter id whose chapter part is not a number opens nothing`() = runTest {
+        assertThat(repository.getChapterById("1_intro")).isNull()
+    }
+
+    @Test
+    fun `a chapter's hadiths are read by the raw chapter id, not the displayed number`() =
+        runTest {
+            every { hadithDao.getHadithsByChapter(11) } returns flowOf(listOf(hadith(1)))
+
+            assertThat(repository.getHadithsByChapter("3_11").first()).hasSize(1)
+        }
+
+    @Test
+    fun `a bare chapter id still resolves, for a caller that has only the number`() = runTest {
+        every { hadithDao.getHadithsByChapter(11) } returns flowOf(listOf(hadith(1)))
+
+        assertThat(repository.getHadithsByChapter("11").first()).hasSize(1)
+    }
+
+    @Test
+    fun `a chapter id that resolves to nothing reads chapter zero rather than crashing`() =
+        runTest {
+            every { hadithDao.getHadithsByChapter(0) } returns flowOf(emptyList())
+
+            assertThat(repository.getHadithsByChapter("intro").first()).isEmpty()
+            assertThat(repository.getHadithsByChapter("1_intro").first()).isEmpty()
+        }
+
+    @Test
+    fun `searching chapters matches the English name and the Arabic one`() = runTest {
+        every { hadithDao.getChapterCountsForBook(1) } returns flowOf(
+            listOf(
+                HadithChapterCount(chapterId = 0, hadithCount = 1),
+                HadithChapterCount(chapterId = 1, hadithCount = 1),
+            )
+        )
+
+        assertThat(repository.searchChapters("1", "chapter 2").first().map { it.id })
+            .containsExactly("1_1")
+        assertThat(repository.searchChapters("1", "الباب 1").first().map { it.id })
+            .containsExactly("1_0")
+        assertThat(repository.searchChapters("1", "nothing").first()).isEmpty()
+    }
+
+    // ── hadith of the day ─────────────────────────────────────────────────────
+
+    @Test
+    fun `an install with no hadith corpus has no hadith of the day`() = runTest {
+        coEvery { hadithDao.getHadithCount() } returns 0
+
+        assertThat(repository.getHadithOfTheDay()).isNull()
+        // The modulo would divide by zero; the guard is what stops the home screen crashing on
+        // an install whose content artifact has not landed yet.
+        coVerify(exactly = 0) { hadithDao.getHadithByOffset(any()) }
+    }
+
+    @Test
+    fun `the hadith of the day is picked deterministically from the day of the year`() = runTest {
+        coEvery { hadithDao.getHadithCount() } returns 34_532
+        val offset = java.time.LocalDate.now().dayOfYear % 34_532
+        coEvery { hadithDao.getHadithByOffset(offset) } returns hadith(id = 99)
+
+        assertThat(repository.getHadithOfTheDay()!!.id).isEqualTo("99")
+        // Twice in a day is the same hadith, or the home screen changes it on every scroll.
+        assertThat(repository.getHadithOfTheDay()!!.id).isEqualTo("99")
+    }
+
+    @Test
+    fun `a corpus smaller than the day of the year still resolves an offset in range`() =
+        runTest {
+            coEvery { hadithDao.getHadithCount() } returns 10
+            coEvery { hadithDao.getHadithByOffset(any()) } answers {
+                hadith(id = firstArg<Int>())
+            }
+
+            val id = repository.getHadithOfTheDay()!!.id.toInt()
+
+            assertThat(id).isAtLeast(0)
+            assertThat(id).isLessThan(10)
+        }
+
+    @Test
+    fun `an offset past the end of the corpus reports nothing`() = runTest {
+        coEvery { hadithDao.getHadithByOffset(999_999) } returns null
+
+        assertThat(repository.getHadithByOffset(999_999)).isNull()
+        assertThat(repository.getHadithCount()).isEqualTo(0)
+    }
+
+    // ── search ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `without an index the search scans, and names each book it found`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns false
+        every { hadithDao.searchHadiths("intention") } returns flowOf(listOf(hadith(1)))
+
+        val result = repository.searchHadiths("intention").first().single()
+
+        assertThat(result.bookName).isEqualTo("Sahih al-Bukhari")
+        assertThat(result.chapterName).isEqualTo("Chapter 1")
+        assertThat(result.matchedText).isEqualTo("Actions are by intentions")
+    }
+
+    @Test
+    fun `with an index the scan is not run at all`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("النية", SearchKind.HADITH, null, any()) } returns
+            listOf("1", "not-an-id")
+        coEvery { hadithDao.getHadithsByIds(listOf(1)) } returns listOf(hadith(1))
+
+        assertThat(repository.searchHadiths("النية").first()).hasSize(1)
+        // `text_arabic LIKE '%…%'` scans 36 MB and matches nothing for a vocalised matn.
+        verifyNoScan()
+    }
+
+    @Test
+    fun `a hadith whose book is not in the catalogue is labelled by its id`() = runTest {
+        every { hadithDao.getAllBooks() } returns flowOf(emptyList())
+        every { hadithDao.searchHadiths(any()) } returns flowOf(listOf(hadith(1, bookId = 42)))
+
+        assertThat(repository.searchHadiths("x").first().single().bookName).isEqualTo("Book 42")
+    }
+
+    @Test
+    fun `searching within a book scopes the query to that book`() = runTest {
+        every { hadithDao.searchHadithsInBook(1, "intention") } returns flowOf(listOf(hadith(1)))
+
+        assertThat(repository.searchHadithsInBook("1", "intention").first().single().bookName)
+            .isEqualTo("Sahih al-Bukhari")
+    }
+
+    @Test
+    fun `searching within an unparseable book searches book zero, which is empty`() = runTest {
+        every { hadithDao.searchHadithsInBook(0, "x") } returns flowOf(emptyList())
+
+        assertThat(repository.searchHadithsInBook("bukhari", "x").first()).isEmpty()
+    }
+
+    // ── grades ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every grade is queried by the lowercase value the corpus stores`() = runTest {
+        every { hadithDao.getHadithsByGrade(any()) } returns flowOf(emptyList())
+
+        HadithGrade.entries.forEach { repository.getHadithsByGrade(it).first() }
+
+        listOf("sahih", "hasan", "daif", "mawdu", "unknown").forEach {
+            verifyGradeQueried(it)
+        }
+    }
+
+    @Test
+    fun `a hadith with a blank chain of narration has no chain rather than an empty one`() =
+        runTest {
+            coEvery { hadithDao.getHadithById(1) } returns hadith(1).copy(narratorChain = "   ")
+
+            // The reader hides the section when there is no chain; an empty string would draw
+            // a heading over nothing, and a guessed chain is never shown.
+            assertThat(repository.getHadithById("1")!!.narratorChain).isNull()
+        }
+
+    @Test
+    fun `a hadith with a curated chain keeps it`() = runTest {
+        coEvery { hadithDao.getHadithById(1) } returns hadith(1).copy(narratorChain = "A > B")
+
+        assertThat(repository.getHadithById("1")!!.narratorChain).isEqualTo("A > B")
+    }
+
+    // ── bookmarks ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `bookmarking a hadith files it under its book and number`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.HADITH, 7) } returns null
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleBookmark(hadithId = "7", bookId = "1", hadithNumber = 12)
+
+        assertThat(saved.single().contextId).isEqualTo(1)
+        assertThat(saved.single().ordinal).isEqualTo(12)
+        assertThat(saved.single().bookmarked).isTrue()
+    }
+
+    @Test
+    fun `un-bookmarking a hadith that is not favourited deletes the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.HADITH, 7) } returns
+            mark(targetId = 7, bookmarked = true)
+
+        repository.toggleBookmark("7", "1", 12)
+
+        coVerify { bookmarkDao.delete(BookmarkKind.HADITH, 7) }
+    }
+
+    @Test
+    fun `bookmarking a hadith that is only favourited keeps the favourite`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.HADITH, 7) } returns
+            mark(targetId = 7, bookmarked = false, favourite = true, createdAt = 5L)
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleBookmark("7", "1", 12)
+
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().bookmarked).isTrue()
+        // One row, one history: the favourite's creation time is the row's.
+        assertThat(saved.single().createdAt).isEqualTo(5L)
+    }
+
+    @Test
+    fun `toggling a bookmark on an unparseable hadith writes nothing`() = runTest {
+        repository.toggleBookmark("first", "1", 1)
+        repository.deleteBookmark("first")
+
+        coVerify(exactly = 0) { bookmarkDao.upsert(any()) }
+        coVerify(exactly = 0) { bookmarkDao.delete(any(), any()) }
+    }
+
+    @Test
+    fun `a bookmark reads back with the book and number it was filed under`() = runTest {
+        every { bookmarkDao.bookmarks(BookmarkKind.HADITH) } returns
+            flowOf(listOf(mark(targetId = 7, contextId = 1, ordinal = 12, note = "n", colour = "c")))
+
+        val bookmark = repository.getAllBookmarks().first().single()
+
+        assertThat(bookmark.hadithId).isEqualTo("7")
+        assertThat(bookmark.bookId).isEqualTo("1")
+        assertThat(bookmark.hadithNumber).isEqualTo(12)
+        assertThat(bookmark.note).isEqualTo("n")
+        assertThat(bookmark.color).isEqualTo("c")
+    }
+
+    @Test
+    fun `a bookmark row with no context still reads back`() = runTest {
+        every { bookmarkDao.bookmarks(BookmarkKind.HADITH) } returns
+            flowOf(listOf(mark(targetId = 7, contextId = null, ordinal = null)))
+
+        val bookmark = repository.getAllBookmarks().first().single()
+
+        assertThat(bookmark.bookId).isEqualTo("0")
+        assertThat(bookmark.hadithNumber).isEqualTo(0)
+    }
+
+    @Test
+    fun `looking up a bookmark by an unparseable hadith id finds none`() = runTest {
+        assertThat(repository.getBookmarkByHadithId("first")).isNull()
+    }
+
+    @Test
+    fun `looking up a bookmark by hadith id reads the consolidated row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.HADITH, 7) } returns mark(targetId = 7)
+
+        assertThat(repository.getBookmarkByHadithId("7")!!.hadithId).isEqualTo("7")
+    }
+
+    @Test
+    fun `inserting and updating a bookmark both write one consolidated row`() = runTest {
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+        val bookmark = HadithBookmark(
+            id = 0, hadithId = "7", bookId = "1", hadithNumber = 12,
+            note = "n", color = "c", createdAt = 1L, updatedAt = 2L,
+        )
+
+        repository.insertBookmark(bookmark)
+        repository.updateBookmark(bookmark.copy(note = "edited"))
+
+        assertThat(saved).hasSize(2)
+        assertThat(saved.map { it.kind }.toSet()).containsExactly(BookmarkKind.HADITH)
+        assertThat(saved.map { it.targetId }.toSet()).containsExactly(7)
+        assertThat(saved.last().note).isEqualTo("edited")
+    }
+
+    @Test
+    fun `a bookmark whose hadith id is not a number writes against target zero`() = runTest {
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.insertBookmark(
+            HadithBookmark(
+                id = 0, hadithId = "first", bookId = "bukhari", hadithNumber = 1,
+                note = null, color = null, createdAt = 1L, updatedAt = 1L,
+            )
+        )
+
+        assertThat(saved.single().targetId).isEqualTo(0)
+        assertThat(saved.single().contextId).isNull()
+    }
+
+    @Test
+    fun `deleting a bookmark by a numeric id removes the row`() = runTest {
+        repository.deleteBookmark("7")
+
+        coVerify { bookmarkDao.delete(BookmarkKind.HADITH, 7) }
+    }
+
+    // ── initialisation ────────────────────────────────────────────────────────
+
+    @Test
+    fun `an artifact with books in it counts as initialised`() = runTest {
+        repository.initializeHadithData()
+
+        assertThat(repository.isDataInitialized()).isTrue()
+    }
+
+    @Test
+    fun `an artifact with no books counts as uninitialised`() = runTest {
+        every { hadithDao.getAllBooks() } returns flowOf(emptyList())
+
+        assertThat(repository.isDataInitialized()).isFalse()
+    }
+
+    @Test
+    fun `a book reads back with the counts the catalogue holds`() = runTest {
+        val catalogue = repository.getAllBooks().first().single()
+
+        assertThat(catalogue.id).isEqualTo("1")
+        assertThat(catalogue.totalHadiths).isEqualTo(7563)
+        assertThat(catalogue.authorName).isEqualTo("Al-Bukhari")
+        assertThat(catalogue.displayOrder).isEqualTo(1)
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun verifyBookQueried(id: Int) = verify { hadithDao.getHadithsByBook(id) }
+
+    private fun verifyGradeQueried(grade: String) = verify { hadithDao.getHadithsByGrade(grade) }
+
+    private fun verifyNoScan() = verify(exactly = 0) { hadithDao.searchHadiths(any()) }
+
+    private fun book(id: Int) = HadithBookEntity(
+        id = id, nameEnglish = "Sahih al-Bukhari", nameArabic = "البخاري",
+        author = "Al-Bukhari", hadithCount = 7563, description = "Authentic collection",
+        icon = "bukhari_icon",
+    )
+
+    private fun hadith(id: Int, bookId: Int = 1, chapterId: Int = 1) = HadithEntity(
+        id = id, bookId = bookId, chapterId = chapterId, numberInBook = id,
+        numberInChapter = id, textArabic = "إنما الأعمال بالنيات",
+        textEnglish = "Actions are by intentions", narrator = "Umar",
+        grade = "sahih", reference = "bukhari:1", narratorChain = null,
+    )
+
+    private fun mark(
+        targetId: Int,
+        bookmarked: Boolean = true,
+        favourite: Boolean = false,
+        note: String? = null,
+        colour: String? = null,
+        contextId: Int? = 1,
+        ordinal: Int? = 12,
+        createdAt: Long = 1L,
+    ) = BookmarkEntity(
+        kind = BookmarkKind.HADITH,
+        targetId = targetId,
+        bookmarked = bookmarked,
+        favourite = favourite,
+        note = note,
+        colour = colour,
+        contextId = contextId,
+        ordinal = ordinal,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/HelpRepositoryImplSearchTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/HelpRepositoryImplSearchTest.kt
@@ -1,0 +1,153 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.HelpDao
+import com.arshadshah.nimaz.data.local.database.entity.HelpItemEntity
+import com.arshadshah.nimaz.data.local.database.entity.HelpStringEntity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Help search, which is a *localised* search over a table that holds every language at once.
+ *
+ * Two queries run — the user's language and English — and the results are merged. The merge is
+ * where the failures are, and none of them looks like an error:
+ *
+ *  - **the localised hit must win.** English is the fallback, and the same help item exists in
+ *    both, so de-duplicating the wrong way round shows an English title to a user reading in
+ *    French;
+ *  - **only questions and titles are searched.** Answer and body rows are in the same table, and
+ *    letting them through returns a result whose "title" is a paragraph from the middle of a
+ *    guide;
+ *  - **a hit whose item the corpus has lost is dropped.** A stale string row would otherwise
+ *    produce a search result that opens nothing.
+ */
+class HelpRepositoryImplSearchTest {
+
+    private lateinit var dao: HelpDao
+    private lateinit var repository: HelpRepositoryImpl
+
+    @Before
+    fun setUp() {
+        dao = mockk(relaxed = true)
+        every { dao.getAllItems() } returns flowOf(listOf(item("q1"), item("g1", type = "GUIDE")))
+        every { dao.searchStrings(any(), any()) } returns flowOf(emptyList())
+        repository = HelpRepositoryImpl(dao)
+    }
+
+    @Test
+    fun `a blank query searches nothing at all`() = runTest {
+        assertThat(repository.search("   ", lang = "fr").first()).isEmpty()
+
+        // Two `LIKE '%%'` queries over every string in every language is not a search.
+        verify(exactly = 0) { dao.searchStrings(any(), any()) }
+    }
+
+    @Test
+    fun `a localised hit and its English twin collapse to the localised one`() = runTest {
+        every { dao.searchStrings("fr", "prayer") } returns
+            flowOf(listOf(string("q1", "question", "fr", "Comment ?")))
+        every { dao.searchStrings("en", "prayer") } returns
+            flowOf(listOf(string("q1", "question", "en", "How do I?")))
+
+        val results = repository.search("prayer", lang = "fr").first()
+
+        assertThat(results).hasSize(1)
+        assertThat(results.single().title).isEqualTo("Comment ?")
+    }
+
+    @Test
+    fun `an item with no localised string still surfaces in English`() = runTest {
+        every { dao.searchStrings("fr", "prayer") } returns flowOf(emptyList())
+        every { dao.searchStrings("en", "prayer") } returns
+            flowOf(listOf(string("q1", "question", "en", "How do I?")))
+
+        assertThat(repository.search("prayer", "fr").first().single().title)
+            .isEqualTo("How do I?")
+    }
+
+    @Test
+    fun `a body or answer match is not a search result`() = runTest {
+        every { dao.searchStrings("en", "prayer") } returns flowOf(
+            listOf(
+                string("q1", "answer", "en", "…a paragraph from the middle of the answer…"),
+                string("g1", "body", "en", "…a paragraph from the middle of a guide…"),
+            )
+        )
+
+        assertThat(repository.search("prayer", "en").first()).isEmpty()
+    }
+
+    @Test
+    fun `a guide is marked as one and a question is not`() = runTest {
+        every { dao.searchStrings("en", "prayer") } returns flowOf(
+            listOf(
+                string("q1", "question", "en", "How do I?"),
+                string("g1", "title", "en", "Setting up prayer times"),
+            )
+        )
+
+        val results = repository.search("prayer", "en").first()
+
+        assertThat(results.single { it.itemId == "q1" }.isGuide).isFalse()
+        assertThat(results.single { it.itemId == "g1" }.isGuide).isTrue()
+        assertThat(results.single { it.itemId == "g1" }.topicId).isEqualTo("topic")
+    }
+
+    @Test
+    fun `a string row whose help item no longer exists is dropped`() = runTest {
+        every { dao.searchStrings("en", "prayer") } returns
+            flowOf(listOf(string("removed", "question", "en", "orphan")))
+
+        // Otherwise the search offers a result that opens nothing.
+        assertThat(repository.search("prayer", "en").first()).isEmpty()
+    }
+
+    @Test
+    fun `a string that belongs to a topic rather than an item is not a result`() = runTest {
+        every { dao.searchStrings("en", "prayer") } returns
+            flowOf(listOf(string("q1", "title", "en", "Prayer", ownerType = "TOPIC")))
+
+        assertThat(repository.search("prayer", "en").first()).isEmpty()
+    }
+
+    @Test
+    fun `the search query is built at collection time, not when it is asked for`() = runTest {
+        every { dao.searchStrings("en", "prayer") } returns flowOf(emptyList())
+
+        val flow = repository.search("prayer", "en")
+
+        verify(exactly = 0) { dao.searchStrings(any(), any()) }
+        flow.first()
+        verify { dao.searchStrings("en", "prayer") }
+    }
+
+    private fun item(id: String, type: String = "QUESTION") = HelpItemEntity(
+        id = id,
+        topicId = "topic",
+        type = type,
+        displayOrder = 1,
+        iconKey = null,
+        estimatedMinutes = null,
+    )
+
+    private fun string(
+        ownerId: String,
+        fieldKey: String,
+        lang: String,
+        value: String,
+        ownerType: String = "ITEM",
+    ) = HelpStringEntity(
+        ownerType = ownerType,
+        ownerId = ownerId,
+        fieldKey = fieldKey,
+        langCode = lang,
+        value = value,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplMarksTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplMarksTest.kt
@@ -1,0 +1,360 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.AyahWithText
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
+import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
+import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
+import com.arshadshah.nimaz.data.local.search.SearchKind
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.domain.model.QuranTranslation
+import com.arshadshah.nimaz.domain.model.SearchType
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The remaining arms of the two things in [QuranRepositoryImpl] that write.
+ *
+ * `toggleBookmark` and the reading position are read-modify-write against a single row, and
+ * both have arms that only run for a user who has done two different things to the same verse
+ * — or who has been reading for months. Neither failure shows on screen:
+ *
+ *  - toggling a bookmark off on a verse that is *also* favourited must clear the flag, not the
+ *    row. Deleting it destroys a favourite the user made separately;
+ *  - `updateReadingPosition` rewrites the row, and the running totals (`totalAyahsRead`,
+ *    `currentKhatmaCount`) are not in its arguments. Reading them back off the existing row is
+ *    the only thing standing between a page turn and a khatma counter reset to zero.
+ *
+ * The search arms below are the *translation* half, which the Arabic-only tests never reach:
+ * both the index path and the `LIKE` path merge two result sets and de-duplicate, and a verse
+ * that matches in both must appear once.
+ */
+class QuranRepositoryImplMarksTest {
+
+    private lateinit var quranDao: QuranDao
+    private lateinit var bookmarkDao: BookmarkDao
+    private lateinit var readingProgressDao: ReadingProgressDao
+    private lateinit var searchIndex: ContentSearchIndex
+    private lateinit var repository: QuranRepositoryImpl
+
+    @Before
+    fun setUp() {
+        quranDao = mockk(relaxed = true)
+        bookmarkDao = mockk(relaxed = true)
+        readingProgressDao = mockk(relaxed = true)
+        searchIndex = mockk(relaxed = true)
+        coEvery { searchIndex.isAvailable() } returns false
+        every { quranDao.getAllSurahs() } returns flowOf(listOf(surah()))
+        repository = QuranRepositoryImpl(quranDao, bookmarkDao, readingProgressDao, searchIndex)
+    }
+
+    // ── the bookmark toggle ───────────────────────────────────────────────────
+
+    @Test
+    fun `toggling a bookmark on a verse with no row creates one`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns null
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleBookmark(262, surahNumber = 2, ayahNumber = 255)
+
+        assertThat(saved.single().bookmarked).isTrue()
+        assertThat(saved.single().favourite).isFalse()
+        assertThat(saved.single().contextId).isEqualTo(2)
+        assertThat(saved.single().ordinal).isEqualTo(255)
+    }
+
+    @Test
+    fun `toggling a bookmark off on a favourited verse keeps the favourite`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(262, bookmarked = true, favourite = true)
+
+        repository.toggleBookmark(262, 2, 255)
+
+        coVerify { bookmarkDao.clearBookmark(BookmarkKind.AYAH, 262, any()) }
+        coVerify(exactly = 0) { bookmarkDao.delete(BookmarkKind.AYAH, 262) }
+    }
+
+    @Test
+    fun `toggling a bookmark off on a verse that is nothing else removes the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(262, bookmarked = true, favourite = false)
+
+        repository.toggleBookmark(262, 2, 255)
+
+        coVerify { bookmarkDao.delete(BookmarkKind.AYAH, 262) }
+    }
+
+    @Test
+    fun `bookmarking a verse that is only favourited sets the flag on the same row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(262, bookmarked = false, favourite = true, createdAt = 7L)
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleBookmark(262, 2, 255)
+
+        assertThat(saved.single().bookmarked).isTrue()
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().createdAt).isEqualTo(7L)
+    }
+
+    @Test
+    fun `deleting a bookmark on a favourited verse clears the flag instead`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(262, bookmarked = true, favourite = true)
+
+        repository.deleteBookmark(262)
+
+        coVerify { bookmarkDao.clearBookmark(BookmarkKind.AYAH, 262, any()) }
+    }
+
+    @Test
+    fun `deleting a bookmark on a verse with no row writes nothing`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns null
+
+        repository.deleteBookmark(262)
+
+        coVerify(exactly = 0) { bookmarkDao.delete(any(), any()) }
+        coVerify(exactly = 0) { bookmarkDao.clearBookmark(any(), any(), any()) }
+    }
+
+    @Test
+    fun `un-favouriting a verse that is nothing else removes the row`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(262, bookmarked = false, favourite = true)
+
+        repository.toggleFavorite(262, 2, 255)
+
+        coVerify { bookmarkDao.delete(BookmarkKind.AYAH, 262) }
+    }
+
+    @Test
+    fun `favouriting a verse with no row creates one that is not a bookmark`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns null
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.toggleFavorite(262, 2, 255)
+
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().bookmarked).isFalse()
+    }
+
+    // ── the reading position ──────────────────────────────────────────────────
+
+    @Test
+    fun `moving the reading position keeps the running totals`() = runTest {
+        coEvery { readingProgressDao.get() } returns ReadingProgressEntity(
+            id = 1, lastReadSurah = 1, lastReadAyah = 1, lastReadPage = 1, lastReadJuz = 1,
+            totalAyahsRead = 4_000, currentKhatmaCount = 3, updatedAt = 1L,
+        )
+        val saved = mutableListOf<ReadingProgressEntity>()
+        coEvery { readingProgressDao.upsert(capture(saved)) } returns Unit
+
+        repository.updateReadingPosition(surah = 2, ayah = 255, page = 42, juz = 3)
+
+        // Neither total is an argument, so a blind write resets a counter the user has been
+        // accumulating for months.
+        assertThat(saved.single().totalAyahsRead).isEqualTo(4_000)
+        assertThat(saved.single().currentKhatmaCount).isEqualTo(3)
+        assertThat(saved.single().lastReadPage).isEqualTo(42)
+    }
+
+    @Test
+    fun `a first ever read starts both totals at zero rather than failing`() = runTest {
+        coEvery { readingProgressDao.get() } returns null
+        val saved = mutableListOf<ReadingProgressEntity>()
+        coEvery { readingProgressDao.upsert(capture(saved)) } returns Unit
+
+        repository.updateReadingPosition(1, 1, 1, 1)
+
+        assertThat(saved.single().totalAyahsRead).isEqualTo(0)
+        assertThat(saved.single().currentKhatmaCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `verses read are added to the running total, not written over it`() = runTest {
+        coEvery { readingProgressDao.get() } returns ReadingProgressEntity(
+            id = 1, lastReadSurah = 2, lastReadAyah = 255, lastReadPage = 42, lastReadJuz = 3,
+            totalAyahsRead = 900, currentKhatmaCount = 2, updatedAt = 1L,
+        )
+        val saved = mutableListOf<ReadingProgressEntity>()
+        coEvery { readingProgressDao.upsert(capture(saved)) } returns Unit
+
+        repository.incrementAyahsRead(7)
+
+        assertThat(saved.single().totalAyahsRead).isEqualTo(907)
+        // The position is untouched: counting verses is not moving the bookmark.
+        assertThat(saved.single().lastReadPage).isEqualTo(42)
+    }
+
+    @Test
+    fun `counting verses on a device with no progress row starts one`() = runTest {
+        coEvery { readingProgressDao.get() } returns null
+        val saved = mutableListOf<ReadingProgressEntity>()
+        coEvery { readingProgressDao.upsert(capture(saved)) } returns Unit
+
+        repository.incrementAyahsRead(7)
+
+        assertThat(saved.single().totalAyahsRead).isEqualTo(7)
+        assertThat(saved.single().lastReadSurah).isEqualTo(1)
+    }
+
+    // ── search, the translation half ──────────────────────────────────────────
+
+    @Test
+    fun `without an index a translation search adds to the Arabic results`() = runTest {
+        every { quranDao.searchAyahsWithText("mercy") } returns flowOf(listOf(ayah(1)))
+        every {
+            quranDao.searchTranslations("mercy", QuranTranslation.DEFAULT.id)
+        } returns flowOf(listOf(translation(2, "the Merciful")))
+        coEvery { quranDao.getAyahWithTextById(2) } returns ayah(2)
+
+        val results = repository.searchQuran("mercy", QuranTranslation.DEFAULT.id).first()
+
+        assertThat(results.map { it.ayah.id }).containsExactly(1, 2)
+        assertThat(results.map { it.searchType })
+            .containsExactly(SearchType.ARABIC, SearchType.TRANSLATION)
+        assertThat(results.single { it.ayah.id == 2 }.matchedText).isEqualTo("the Merciful")
+    }
+
+    @Test
+    fun `a verse matching in both Arabic and translation is listed once`() = runTest {
+        every { quranDao.searchAyahsWithText("mercy") } returns flowOf(listOf(ayah(1)))
+        every {
+            quranDao.searchTranslations("mercy", QuranTranslation.DEFAULT.id)
+        } returns flowOf(listOf(translation(1, "the Merciful")))
+        coEvery { quranDao.getAyahWithTextById(1) } returns ayah(1)
+
+        val results = repository.searchQuran("mercy", QuranTranslation.DEFAULT.id).first()
+
+        assertThat(results.map { it.ayah.id }).containsExactly(1)
+        // The Arabic hit wins, because it came first.
+        assertThat(results.single().searchType).isEqualTo(SearchType.ARABIC)
+    }
+
+    @Test
+    fun `a translation hit whose verse the corpus has lost is dropped, not rendered blank`() =
+        runTest {
+            every { quranDao.searchAyahsWithText(any()) } returns flowOf(emptyList())
+            every {
+                quranDao.searchTranslations("mercy", QuranTranslation.DEFAULT.id)
+            } returns flowOf(listOf(translation(9_999, "orphan")))
+            coEvery { quranDao.getAyahWithTextById(9_999) } returns null
+
+            assertThat(repository.searchQuran("mercy", QuranTranslation.DEFAULT.id).first())
+                .isEmpty()
+        }
+
+    @Test
+    fun `a verse whose surah is not in the list is labelled by its surah id`() = runTest {
+        every { quranDao.getAllSurahs() } returns flowOf(emptyList())
+        every { quranDao.searchAyahsWithText("x") } returns flowOf(listOf(ayah(1)))
+
+        assertThat(repository.searchQuran("x", null).first().single().surahName)
+            .isEqualTo("Surah 1")
+    }
+
+    @Test
+    fun `with an index the translation half is narrowed to the reader's own translation`() =
+        runTest {
+            coEvery { searchIndex.isAvailable() } returns true
+            coEvery { searchIndex.refs("mercy", SearchKind.QURAN, null, any()) } returns
+                listOf("1")
+            coEvery {
+                searchIndex.refs("mercy", SearchKind.TRANSLATION, QuranTranslation.DEFAULT.id, any())
+            } returns listOf("2")
+            coEvery { quranDao.getAyahsWithTextByIds(listOf(1)) } returns listOf(ayah(1))
+            coEvery { quranDao.getAyahsWithTextByIds(listOf(2)) } returns listOf(ayah(2))
+            coEvery {
+                quranDao.getTranslationsByAyahIds(listOf(2), QuranTranslation.DEFAULT.id)
+            } returns listOf(translation(2, "the Merciful"))
+
+            val results = repository.searchQuran("mercy", QuranTranslation.DEFAULT.id).first()
+
+            // A hit in the Bengali translation must not surface for a reader on Sahih
+            // International: the index query carries the source.
+            assertThat(results.map { it.ayah.id }).containsExactly(1, 2)
+            assertThat(results.single { it.ayah.id == 2 }.matchedText).isEqualTo("the Merciful")
+        }
+
+    @Test
+    fun `with an index and no translation selected only the Arabic half runs`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("mercy", SearchKind.QURAN, null, any()) } returns listOf("1")
+        coEvery { quranDao.getAyahsWithTextByIds(listOf(1)) } returns listOf(ayah(1))
+
+        assertThat(repository.searchQuran("mercy", null).first().map { it.ayah.id })
+            .containsExactly(1)
+        coVerify(exactly = 0) { quranDao.getTranslationsByAyahIds(any(), any()) }
+    }
+
+    @Test
+    fun `an indexed translation hit whose verse row is missing is dropped`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("mercy", SearchKind.QURAN, null, any()) } returns emptyList()
+        coEvery {
+            searchIndex.refs("mercy", SearchKind.TRANSLATION, QuranTranslation.DEFAULT.id, any())
+        } returns listOf("2")
+        coEvery { quranDao.getAyahsWithTextByIds(emptyList()) } returns emptyList()
+        coEvery { quranDao.getAyahsWithTextByIds(listOf(2)) } returns emptyList()
+        coEvery {
+            quranDao.getTranslationsByAyahIds(listOf(2), QuranTranslation.DEFAULT.id)
+        } returns listOf(translation(2, "orphan"))
+
+        assertThat(repository.searchQuran("mercy", QuranTranslation.DEFAULT.id).first()).isEmpty()
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun surah() = SurahEntity(
+        id = 1, number = 1, nameArabic = "الفاتحة", nameEnglish = "The Opening",
+        nameTransliteration = "Al-Fatihah", revelationType = "meccan", versesCount = 7,
+        orderRevealed = 5, startPage = 1,
+    )
+
+    private fun ayah(id: Int) = AyahWithText(
+        ayah = AyahEntity(
+            id = id, surahId = 1, numberInSurah = id, numberGlobal = id,
+            juz = 1, hizb = 1, page = 1,
+        ),
+        textUthmani = "بِسْمِ ٱللَّهِ",
+        textSimple = "bismillah",
+        sajdaKind = null,
+        sajdaSequence = null,
+    )
+
+    private fun translation(ayahId: Int, text: String) = TranslationEntity(
+        ayahId = ayahId, text = text, translatorId = QuranTranslation.DEFAULT.id,
+    )
+
+    private fun mark(
+        targetId: Int,
+        bookmarked: Boolean = true,
+        favourite: Boolean = false,
+        createdAt: Long = 1L,
+    ) = BookmarkEntity(
+        kind = BookmarkKind.AYAH,
+        targetId = targetId,
+        bookmarked = bookmarked,
+        favourite = favourite,
+        contextId = 2,
+        ordinal = 255,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplReadingTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplReadingTest.kt
@@ -1,0 +1,711 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.AyahWithText
+import com.arshadshah.nimaz.data.local.database.dao.MushafLayoutLineRow
+import com.arshadshah.nimaz.data.local.database.dao.PageAyahRangeRow
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.entity.AyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahInfoEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahStructureEntity
+import com.arshadshah.nimaz.data.local.database.entity.TranslationEntity
+import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.QuranTranslation
+import com.arshadshah.nimaz.domain.model.RevelationType
+import com.arshadshah.nimaz.domain.model.SajdaType
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The read paths of [QuranRepositoryImpl] — the ones a reader screen actually calls.
+ *
+ * These pin behaviour that a screen cannot report on its own:
+ *
+ *  - a **line-accurate** edition does not paginate by `ayahs.page`. It resolves the page's span
+ *    through its own layout table, and the failure mode when it does not is not an error: it is
+ *    the *Madani* page, silently, in an Indo-Pak reader (#325). An unknown span must emit an
+ *    empty page rather than the wrong one;
+ *  - the layout table is several hundred immutable rows consulted on every page turn, so it is
+ *    memoised per edition — and a memo that re-queries is invisible except as a slow reader;
+ *  - every verse read path stamps `isBookmarked` from the *user's* database, which lives in a
+ *    different file from the content. A path that forgets shows a reader with no bookmarks and
+ *    no error;
+ *  - a translator id is normalised against the catalogue, so a stale preference resolves to the
+ *    default rather than querying for rows that cannot exist;
+ *  - the division markers (ʿayn, ۞) are drawn on the verse that *begins* or *ends* a division,
+ *    not on every verse inside it, and the two conventions are opposite ways round.
+ */
+class QuranRepositoryImplReadingTest {
+
+    private lateinit var quranDao: QuranDao
+    private lateinit var bookmarkDao: BookmarkDao
+    private lateinit var readingProgressDao: ReadingProgressDao
+    private lateinit var searchIndex: ContentSearchIndex
+    private lateinit var repository: QuranRepositoryImpl
+
+    @Before
+    fun setUp() {
+        quranDao = mockk(relaxed = true)
+        bookmarkDao = mockk(relaxed = true)
+        readingProgressDao = mockk(relaxed = true)
+        searchIndex = mockk(relaxed = true)
+        coEvery { searchIndex.isAvailable() } returns false
+        coEvery { bookmarkDao.bookmarkedIds(BookmarkKind.AYAH) } returns emptyList()
+        every { quranDao.getAllSurahs() } returns flowOf(listOf(surahEntity()))
+        repository = QuranRepositoryImpl(quranDao, bookmarkDao, readingProgressDao, searchIndex)
+    }
+
+    // ── the surah list ────────────────────────────────────────────────────────
+
+    @Test
+    fun `a surah row becomes a surah with its revelation type resolved`() = runTest {
+        val surah = repository.getAllSurahs().first().single()
+
+        assertThat(surah.number).isEqualTo(1)
+        assertThat(surah.nameEnglish).isEqualTo("The Opening")
+        assertThat(surah.revelationType).isEqualTo(RevelationType.MECCAN)
+        assertThat(surah.ayahCount).isEqualTo(7)
+        assertThat(surah.startPage).isEqualTo(1)
+    }
+
+    @Test
+    fun `a surah number the corpus does not hold reports none`() = runTest {
+        coEvery { quranDao.getSurahByNumber(115) } returns null
+
+        assertThat(repository.getSurahByNumber(115)).isNull()
+    }
+
+    @Test
+    fun `a surah number the corpus holds comes back as a domain surah`() = runTest {
+        coEvery { quranDao.getSurahByNumber(1) } returns surahEntity()
+
+        assertThat(repository.getSurahByNumber(1)!!.nameTransliteration).isEqualTo("Al-Fatihah")
+    }
+
+    @Test
+    fun `the revelation filter is queried with the stored lowercase value`() = runTest {
+        every { quranDao.getSurahsByRevelationType("medinan") } returns
+            flowOf(listOf(surahEntity().copy(number = 2, revelationType = "medinan")))
+
+        val surahs = repository.getSurahsByRevelationType(RevelationType.MEDINAN).first()
+
+        // The enum name is uppercase and matches no row in the content database.
+        assertThat(surahs.single().revelationType).isEqualTo(RevelationType.MEDINAN)
+    }
+
+    // ── verses ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a surah's verses are fetched by its row id, not by its number`() = runTest {
+        // The surah's primary key and its printed number are not the same column.
+        every { quranDao.getAllSurahs() } returns
+            flowOf(listOf(surahEntity().copy(id = 42, number = 7)))
+        every { quranDao.getAyahsWithTextBySurah(42) } returns flowOf(listOf(ayah(id = 954)))
+
+        val ayahs = repository.getAyahsBySurah(7).first()
+
+        assertThat(ayahs.map { it.id }).containsExactly(954)
+    }
+
+    @Test
+    fun `a surah number with no row yields an empty reader rather than every verse`() = runTest {
+        every { quranDao.getAllSurahs() } returns flowOf(listOf(surahEntity()))
+
+        assertThat(repository.getAyahsBySurah(115).first()).isEmpty()
+        verifyNoAyahFetch()
+    }
+
+    @Test
+    fun `asking for no verse ids queries nothing`() = runTest {
+        assertThat(repository.getAyahsByIds(emptyList())).isEmpty()
+
+        coVerify(exactly = 0) { quranDao.getAyahsWithTextByIds(any()) }
+    }
+
+    @Test
+    fun `verse ids come back as verses`() = runTest {
+        coEvery { quranDao.getAyahsWithTextByIds(listOf(1, 2)) } returns
+            listOf(ayah(id = 1), ayah(id = 2))
+
+        assertThat(repository.getAyahsByIds(listOf(1, 2)).map { it.id }).containsExactly(1, 2)
+    }
+
+    @Test
+    fun `a verse id the corpus does not hold reports none`() = runTest {
+        coEvery { quranDao.getAyahWithTextById(99999) } returns null
+
+        assertThat(repository.getAyahById(99999)).isNull()
+    }
+
+    @Test
+    fun `a verse carries the Uthmani text and a genuinely different simple text`() = runTest {
+        coEvery { quranDao.getAyahWithTextById(1) } returns
+            ayah(id = 1).copy(textUthmani = "بِسۡمِ", textSimple = "bism")
+
+        val verse = repository.getAyahById(1)!!
+
+        // These were byte-identical in all 6,236 rows before schemaVersion 22: a reader who chose
+        // the plain script got the Uthmani one and could not tell.
+        assertThat(verse.textArabic).isEqualTo("بِسۡمِ")
+        assertThat(verse.textSimple).isEqualTo("bism")
+    }
+
+    @Test
+    fun `a verse with no simple text falls back to the Uthmani one rather than to blank`() =
+        runTest {
+            coEvery { quranDao.getAyahWithTextById(1) } returns
+                ayah(id = 1).copy(textUthmani = "بِسۡمِ", textSimple = null)
+
+            assertThat(repository.getAyahById(1)!!.textSimple).isEqualTo("بِسۡمِ")
+        }
+
+    @Test
+    fun `a division marker lands on the verse that closes a ruku and opens a quarter`() = runTest {
+        coEvery { quranDao.getAyahWithTextById(5) } returns ayah(id = 5).let {
+            it.copy(ayah = it.ayah.copy(rukuEndAyahId = 5, rubStartAyahId = 5, rubNumber = 3))
+        }
+        coEvery { quranDao.getAyahWithTextById(6) } returns ayah(id = 6).let {
+            // Verse 6 falls *inside* the same ruku and quarter but begins/ends neither.
+            it.copy(ayah = it.ayah.copy(rukuEndAyahId = 9, rubStartAyahId = 5, rubNumber = 3))
+        }
+
+        val marked = repository.getAyahById(5)!!
+        val inside = repository.getAyahById(6)!!
+
+        assertThat(marked.isRukuEnd).isTrue()
+        assertThat(marked.isRubStart).isTrue()
+        assertThat(inside.isRukuEnd).isFalse()
+        assertThat(inside.isRubStart).isFalse()
+        assertThat(inside.rubNumber).isEqualTo(3)
+    }
+
+    @Test
+    fun `a verse with no quarter recorded reports zero rather than crashing`() = runTest {
+        coEvery { quranDao.getAyahWithTextById(1) } returns ayah(id = 1)
+
+        assertThat(repository.getAyahById(1)!!.rubNumber).isEqualTo(0)
+    }
+
+    @Test
+    fun `a sajda verse carries its kind and its sequence`() = runTest {
+        every { quranDao.getSajdaAyahsWithText() } returns flowOf(
+            listOf(ayah(id = 1160).copy(sajdaKind = "recommended", sajdaSequence = 1))
+        )
+
+        val sajda = repository.getSajdaAyahs().first().single()
+
+        assertThat(sajda.sajdaType).isEqualTo(SajdaType.fromString("recommended"))
+        assertThat(sajda.sajdaNumber).isEqualTo(1)
+    }
+
+    // ── juz ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a juz read with no translator asks for no translations`() = runTest {
+        every { quranDao.getAyahsWithTextByJuz(1) } returns flowOf(listOf(ayah(id = 1)))
+
+        val verses = repository.getAyahsByJuz(1, translatorId = null).first()
+
+        assertThat(verses.single().translation).isNull()
+        coVerify(exactly = 0) { quranDao.getTranslationsForAyahs(any(), any()) }
+    }
+
+    @Test
+    fun `a juz read with a translator attaches the translation to each verse`() = runTest {
+        every { quranDao.getAyahsWithTextByJuz(1) } returns flowOf(listOf(ayah(id = 1)))
+        every { quranDao.getTranslationsForAyahs(listOf(1), QuranTranslation.DEFAULT.id) } returns
+            flowOf(listOf(translationRow(1, "In the name of God")))
+
+        assertThat(repository.getAyahsByJuz(1, QuranTranslation.DEFAULT.id).first().single().translation)
+            .isEqualTo("In the name of God")
+    }
+
+    @Test
+    fun `a stale translator preference reads the default rather than nothing`() = runTest {
+        every { quranDao.getAyahsWithTextByJuz(1) } returns flowOf(listOf(ayah(id = 1)))
+        every { quranDao.getTranslationsForAyahs(listOf(1), QuranTranslation.DEFAULT.id) } returns
+            flowOf(listOf(translationRow(1, "fallback")))
+
+        val verses = repository.getAyahsByJuz(1, "a-translation-that-was-removed").first()
+
+        assertThat(verses.single().translation).isEqualTo("fallback")
+    }
+
+    @Test
+    fun `an empty juz does not query translations for an empty id list`() = runTest {
+        every { quranDao.getAyahsWithTextByJuz(31) } returns flowOf(emptyList())
+
+        assertThat(repository.getAyahsByJuz(31, QuranTranslation.DEFAULT.id).first()).isEmpty()
+        coVerify(exactly = 0) { quranDao.getTranslationsForAyahs(any(), any()) }
+    }
+
+    @Test
+    fun `a bookmarked verse is marked bookmarked when read through a juz`() = runTest {
+        every { quranDao.getAyahsWithTextByJuz(1) } returns
+            flowOf(listOf(ayah(id = 1), ayah(id = 2)))
+        coEvery { bookmarkDao.bookmarkedIds(BookmarkKind.AYAH) } returns listOf(2)
+
+        val verses = repository.getAyahsByJuz(1, translatorId = null).first()
+
+        assertThat(verses.single { it.id == 1 }.isBookmarked).isFalse()
+        assertThat(verses.single { it.id == 2 }.isBookmarked).isTrue()
+    }
+
+    // ── pages ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a flowed edition paginates by the page column`() = runTest {
+        every { quranDao.getAyahsWithTextByPage(3) } returns flowOf(listOf(ayah(id = 20)))
+
+        val verses = repository.getAyahsByPage(3, null, MushafScript.MADANI).first()
+
+        assertThat(verses.map { it.id }).containsExactly(20)
+        coVerify(exactly = 0) { quranDao.getLayoutPageAyahRanges(any()) }
+    }
+
+    @Test
+    fun `a line accurate edition resolves the page through its own layout table`() = runTest {
+        coEvery { quranDao.getLayoutPageAyahRanges("INDOPAK_16") } returns
+            listOf(PageAyahRangeRow(page = 3, minAyahId = 30, maxAyahId = 40, ayahCount = 11))
+        every { quranDao.getAyahsWithTextByRange(30, 40) } returns flowOf(listOf(ayah(id = 30)))
+
+        val verses = repository.getAyahsByPage(3, null, MushafScript.INDOPAK_16).first()
+
+        assertThat(verses.map { it.id }).containsExactly(30)
+        // Never the `ayahs.page` column — that is the Madani pagination (#325).
+        coVerify(exactly = 0) { quranDao.getAyahsWithTextByPage(any()) }
+    }
+
+    @Test
+    fun `a page the layout table does not span comes back empty, not as the Madani page`() =
+        runTest {
+            coEvery { quranDao.getLayoutPageAyahRanges("INDOPAK_16") } returns
+                listOf(PageAyahRangeRow(page = 1, minAyahId = 1, maxAyahId = 7, ayahCount = 7))
+
+            assertThat(repository.getAyahsByPage(600, null, MushafScript.INDOPAK_16).first())
+                .isEmpty()
+            coVerify(exactly = 0) { quranDao.getAyahsWithTextByPage(any()) }
+        }
+
+    @Test
+    fun `the layout table is read once per edition however many pages are turned`() = runTest {
+        coEvery { quranDao.getLayoutPageAyahRanges("INDOPAK_16") } returns
+            listOf(
+                PageAyahRangeRow(page = 1, minAyahId = 1, maxAyahId = 7, ayahCount = 7),
+                PageAyahRangeRow(page = 2, minAyahId = 8, maxAyahId = 20, ayahCount = 13),
+            )
+        every { quranDao.getAyahsWithTextByRange(any(), any()) } returns flowOf(emptyList())
+
+        repository.getAyahsByPage(1, null, MushafScript.INDOPAK_16).first()
+        repository.getAyahsByPage(2, null, MushafScript.INDOPAK_16).first()
+        repository.getPageAyahRanges(MushafScript.INDOPAK_16)
+
+        coVerify(exactly = 1) { quranDao.getLayoutPageAyahRanges("INDOPAK_16") }
+    }
+
+    @Test
+    fun `each edition memoises its own layout rather than sharing one`() = runTest {
+        coEvery { quranDao.getLayoutPageAyahRanges("INDOPAK_16") } returns
+            listOf(PageAyahRangeRow(page = 1, minAyahId = 1, maxAyahId = 7, ayahCount = 7))
+        coEvery { quranDao.getLayoutPageAyahRanges("INDOPAK_15") } returns
+            listOf(PageAyahRangeRow(page = 1, minAyahId = 1, maxAyahId = 5, ayahCount = 5))
+
+        val sixteen = repository.getPageAyahRanges(MushafScript.INDOPAK_16).single()
+        val fifteen = repository.getPageAyahRanges(MushafScript.INDOPAK_15).single()
+
+        assertThat(sixteen.maxAyahId).isEqualTo(7)
+        assertThat(fifteen.maxAyahId).isEqualTo(5)
+    }
+
+    @Test
+    fun `a flowed edition's page ranges come from the verse table, not the layout table`() =
+        runTest {
+            coEvery { quranDao.getPageAyahRanges() } returns
+                listOf(PageAyahRangeRow(page = 1, minAyahId = 1, maxAyahId = 7, ayahCount = 7))
+
+            assertThat(repository.getPageAyahRanges(MushafScript.MADANI).single().ayahCount)
+                .isEqualTo(7)
+            coVerify(exactly = 0) { quranDao.getLayoutPageAyahRanges(any()) }
+        }
+
+    @Test
+    fun `an edition with no stored glyphs has no printed layout to render`() = runTest {
+        // MADANI has no textSource, so there is nothing to group into lines.
+        val layout = repository.getMushafPageLayout(1, MushafScript.MADANI)
+
+        assertThat(layout.page).isEqualTo(1)
+        assertThat(layout.lines).isEmpty()
+        coVerify(exactly = 0) { quranDao.getMushafLayoutByPage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a line accurate edition's page is grouped into printed lines`() = runTest {
+        coEvery { quranDao.getMushafLayoutByPage("INDOPAK_16", "INDOPAK", 2) } returns listOf(
+            layoutRow(line = 1, ayahId = 8, text = "الم ذلك", first = 0, last = 1),
+            layoutRow(line = 2, ayahId = 8, text = "الم ذلك", first = 1, last = 1),
+        )
+
+        val layout = repository.getMushafPageLayout(2, MushafScript.INDOPAK_16)
+
+        assertThat(layout.page).isEqualTo(2)
+        assertThat(layout.lines).hasSize(2)
+    }
+
+    // ── a surah and its verses together ───────────────────────────────────────
+
+    @Test
+    fun `a surah number with no row opens nothing rather than an empty surah`() = runTest {
+        assertThat(repository.getSurahWithAyahs(115, null).first()).isNull()
+    }
+
+    @Test
+    fun `a surah opens with its verses, translations and bookmarks in one read`() = runTest {
+        coEvery { quranDao.getSurahByNumber(1) } returns surahEntity()
+        every { quranDao.getAyahsWithTextBySurah(1) } returns
+            flowOf(listOf(ayah(id = 1), ayah(id = 2)))
+        every {
+            quranDao.getTranslationsForAyahs(listOf(1, 2), QuranTranslation.DEFAULT.id)
+        } returns flowOf(listOf(translationRow(1, "In the name of God")))
+        coEvery { bookmarkDao.bookmarkedIds(BookmarkKind.AYAH) } returns listOf(2)
+
+        val opened = repository.getSurahWithAyahs(1, QuranTranslation.DEFAULT.id).first()!!
+
+        assertThat(opened.surah.nameEnglish).isEqualTo("The Opening")
+        assertThat(opened.ayahs.single { it.id == 1 }.translation).isEqualTo("In the name of God")
+        // A verse the translation is missing for still renders — with no translation, not blank.
+        assertThat(opened.ayahs.single { it.id == 2 }.translation).isNull()
+        assertThat(opened.ayahs.single { it.id == 2 }.isBookmarked).isTrue()
+    }
+
+    @Test
+    fun `a surah listed but with no row of its own opens with no verses`() = runTest {
+        coEvery { quranDao.getSurahByNumber(1) } returns null
+
+        val opened = repository.getSurahWithAyahs(1, null).first()!!
+
+        assertThat(opened.ayahs).isEmpty()
+    }
+
+    // ── translations ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `the translator list is the catalogue, not whichever rows happen to be present`() =
+        runTest {
+            val translators = repository.getAvailableTranslators()
+
+            assertThat(translators).hasSize(QuranTranslation.entries.size)
+            assertThat(translators.map { it.id })
+                .containsExactlyElementsIn(QuranTranslation.entries.map { it.id })
+            // A DISTINCT over the table would have no display name or language to report.
+            assertThat(translators.first().name).isNotEmpty()
+            assertThat(translators.first().languageCode).isNotEmpty()
+            coVerify(exactly = 0) { quranDao.getAvailableTranslatorIds() }
+        }
+
+    @Test
+    fun `translations come back keyed by verse id`() = runTest {
+        every { quranDao.getTranslationsForAyahs(listOf(1, 2), QuranTranslation.DEFAULT.id) } returns
+            flowOf(listOf(translationRow(1, "one"), translationRow(2, "two")))
+
+        val byId = repository.getTranslationsForAyahs(listOf(1, 2), QuranTranslation.DEFAULT.id)
+            .first()
+
+        assertThat(byId).containsExactly(1, "one", 2, "two")
+    }
+
+    @Test
+    fun `an unknown translator id reads the default catalogue entry`() = runTest {
+        every { quranDao.getTranslationsForAyahs(listOf(1), QuranTranslation.DEFAULT.id) } returns
+            flowOf(listOf(translationRow(1, "default")))
+
+        assertThat(repository.getTranslationsForAyahs(listOf(1), "gone").first())
+            .containsExactly(1, "default")
+    }
+
+    // ── bookmarks and favourites, on the read side ────────────────────────────
+
+    @Test
+    fun `the bookmark list carries the surah and verse the row was filed under`() = runTest {
+        every { bookmarkDao.bookmarks(BookmarkKind.AYAH) } returns
+            flowOf(listOf(mark(targetId = 262, contextId = 2, ordinal = 255)))
+
+        val bookmark = repository.getAllBookmarks().first().single()
+
+        assertThat(bookmark.ayahId).isEqualTo(262)
+        assertThat(bookmark.surahNumber).isEqualTo(2)
+        assertThat(bookmark.ayahNumber).isEqualTo(255)
+    }
+
+    @Test
+    fun `a row with no context still reads back rather than being dropped`() = runTest {
+        every { bookmarkDao.bookmarks(BookmarkKind.AYAH) } returns
+            flowOf(listOf(mark(targetId = 1, contextId = null, ordinal = null)))
+
+        val bookmark = repository.getAllBookmarks().first().single()
+
+        assertThat(bookmark.surahNumber).isEqualTo(0)
+        assertThat(bookmark.ayahNumber).isEqualTo(0)
+    }
+
+    @Test
+    fun `a verse that is only favourited is not reported as bookmarked`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(targetId = 262, bookmarked = false, favourite = true)
+
+        // One row, two flags: asking for the bookmark must not answer with the favourite.
+        assertThat(repository.getBookmarkByAyahId(262)).isNull()
+    }
+
+    @Test
+    fun `a bookmarked verse reports its note and colour`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(targetId = 262, bookmarked = true, note = "memorise", colour = "#FF0000")
+
+        val bookmark = repository.getBookmarkByAyahId(262)!!
+
+        assertThat(bookmark.note).isEqualTo("memorise")
+        assertThat(bookmark.color).isEqualTo("#FF0000")
+    }
+
+    @Test
+    fun `a verse with no row at all reports no bookmark`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns null
+
+        assertThat(repository.getBookmarkByAyahId(262)).isNull()
+    }
+
+    @Test
+    fun `the bookmarked flag is observed rather than polled`() = runTest {
+        every { bookmarkDao.observeIsBookmarked(BookmarkKind.AYAH, 262) } returns flowOf(true)
+
+        assertThat(repository.isAyahBookmarked(262).first()).isTrue()
+    }
+
+    @Test
+    fun `the favourites list and the favourite ids read the same rows`() = runTest {
+        every { bookmarkDao.favourites(BookmarkKind.AYAH) } returns
+            flowOf(listOf(mark(targetId = 262, contextId = 2, ordinal = 255, favourite = true)))
+
+        assertThat(repository.getAllFavorites().first().single().ayahId).isEqualTo(262)
+        assertThat(repository.getFavoriteAyahIds().first()).containsExactly(262)
+    }
+
+    @Test
+    fun `updating a bookmark keeps a favourite on the same verse`() = runTest {
+        coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+            mark(targetId = 262, bookmarked = true, favourite = true)
+        val saved = mutableListOf<BookmarkEntity>()
+        coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+        repository.updateBookmark(
+            repository.getBookmarkByAyahId(262)!!.copy(note = "edited", color = "#00FF00")
+        )
+
+        assertThat(saved.single().favourite).isTrue()
+        assertThat(saved.single().bookmarked).isTrue()
+        assertThat(saved.single().note).isEqualTo("edited")
+        assertThat(saved.single().colour).isEqualTo("#00FF00")
+    }
+
+    @Test
+    fun `adding a bookmark to a verse that has none keeps the row's original creation time`() =
+        runTest {
+            coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns
+                mark(targetId = 262, bookmarked = false, favourite = true, createdAt = 111L)
+            val saved = mutableListOf<BookmarkEntity>()
+            coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+            repository.addBookmark(262, surahNumber = 2, ayahNumber = 255, note = null, color = null)
+
+            // The verse was favourited months ago; bookmarking it now must not re-date the row.
+            assertThat(saved.single().createdAt).isEqualTo(111L)
+            assertThat(saved.single().favourite).isTrue()
+            assertThat(saved.single().bookmarked).isTrue()
+        }
+
+    @Test
+    fun `adding a bookmark to a verse with no row files it under its surah and number`() =
+        runTest {
+            coEvery { bookmarkDao.find(BookmarkKind.AYAH, 262) } returns null
+            val saved = mutableListOf<BookmarkEntity>()
+            coEvery { bookmarkDao.upsert(capture(saved)) } returns Unit
+
+            repository.addBookmark(262, surahNumber = 2, ayahNumber = 255, note = "n", color = "c")
+
+            assertThat(saved.single().contextId).isEqualTo(2)
+            assertThat(saved.single().ordinal).isEqualTo(255)
+            assertThat(saved.single().favourite).isFalse()
+        }
+
+    // ── reading progress ──────────────────────────────────────────────────────
+
+    @Test
+    fun `no progress row reports no progress rather than a zeroed one`() = runTest {
+        every { readingProgressDao.observe() } returns flowOf(null)
+
+        assertThat(repository.getReadingProgress().first()).isNull()
+    }
+
+    @Test
+    fun `the progress row reads back as the position and the running totals`() = runTest {
+        every { readingProgressDao.observe() } returns flowOf(
+            com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity(
+                id = 1,
+                lastReadSurah = 2, lastReadAyah = 255, lastReadPage = 42, lastReadJuz = 3,
+                totalAyahsRead = 900, currentKhatmaCount = 2, updatedAt = 7L,
+            )
+        )
+
+        val progress = repository.getReadingProgress().first()!!
+
+        assertThat(progress.lastReadSurah).isEqualTo(2)
+        assertThat(progress.lastReadPage).isEqualTo(42)
+        assertThat(progress.totalAyahsRead).isEqualTo(900)
+        assertThat(progress.currentKhatmaCount).isEqualTo(2)
+    }
+
+    // ── surah info and structure ──────────────────────────────────────────────
+
+    @Test
+    fun `a surah's themes column is split into a list`() = runTest {
+        coEvery { quranDao.getSurahInfo(1) } returns SurahInfoEntity(
+            surahNumber = 1,
+            description = "The opening chapter.",
+            themes = "prayer, guidance ,mercy",
+        )
+
+        val info = repository.getSurahInfo(1)!!
+
+        assertThat(info.themes).containsExactly("prayer", "guidance", "mercy").inOrder()
+    }
+
+    @Test
+    fun `a surah with no info row reports none`() = runTest {
+        coEvery { quranDao.getSurahInfo(115) } returns null
+
+        assertThat(repository.getSurahInfo(115)).isNull()
+    }
+
+    @Test
+    fun `the ruku counts come back keyed by surah`() = runTest {
+        every { quranDao.getAllSurahStructure() } returns flowOf(
+            listOf(structure(surahId = 1, rukuCount = 1), structure(surahId = 2, rukuCount = 40))
+        )
+
+        assertThat(repository.getSurahRukuCounts().first()).containsExactly(1, 1, 2, 40)
+    }
+
+    // ── initialisation ────────────────────────────────────────────────────────
+
+    @Test
+    fun `an artifact with surahs in it counts as initialised`() = runTest {
+        repository.initializeQuranData()
+
+        assertThat(repository.isDataInitialized()).isTrue()
+    }
+
+    @Test
+    fun `an artifact with no surahs counts as uninitialised`() = runTest {
+        every { quranDao.getAllSurahs() } returns flowOf(emptyList())
+
+        assertThat(repository.isDataInitialized()).isFalse()
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun verifyNoAyahFetch() =
+        coVerify(exactly = 0) { quranDao.getAyahsWithTextBySurah(any()) }
+
+    private fun surahEntity() = SurahEntity(
+        id = 1,
+        number = 1,
+        nameArabic = "الفاتحة",
+        nameEnglish = "The Opening",
+        nameTransliteration = "Al-Fatihah",
+        revelationType = "meccan",
+        versesCount = 7,
+        orderRevealed = 5,
+        startPage = 1,
+    )
+
+    private fun ayah(id: Int) = AyahWithText(
+        ayah = AyahEntity(
+            id = id,
+            surahId = 1,
+            numberInSurah = id,
+            numberGlobal = id,
+            juz = 1,
+            hizb = 1,
+            page = 1,
+        ),
+        textUthmani = "بِسْمِ ٱللَّهِ",
+        textSimple = "bismillah",
+        sajdaKind = null,
+        sajdaSequence = null,
+    )
+
+    private fun translationRow(ayahId: Int, text: String) = TranslationEntity(
+        ayahId = ayahId,
+        text = text,
+        translatorId = QuranTranslation.DEFAULT.id,
+    )
+
+    private fun mark(
+        targetId: Int,
+        bookmarked: Boolean = true,
+        favourite: Boolean = false,
+        note: String? = null,
+        colour: String? = null,
+        contextId: Int? = 2,
+        ordinal: Int? = 255,
+        createdAt: Long = 1L,
+    ) = BookmarkEntity(
+        kind = BookmarkKind.AYAH,
+        targetId = targetId,
+        bookmarked = bookmarked,
+        favourite = favourite,
+        note = note,
+        colour = colour,
+        contextId = contextId,
+        ordinal = ordinal,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+    )
+
+    private fun structure(surahId: Int, rukuCount: Int) = SurahStructureEntity(
+        surahId = surahId,
+        rukuCount = rukuCount,
+        startAyahId = 1,
+        endAyahId = 7,
+        startPage = 1,
+        endPage = 1,
+        hasBasmalah = 1,
+        revelationOrder = 5,
+    )
+
+    private fun layoutRow(line: Int, ayahId: Int, text: String, first: Int, last: Int) =
+        MushafLayoutLineRow(
+            page = 2,
+            line = line,
+            lineType = "ayah",
+            surahId = 2,
+            ayahId = ayahId,
+            firstWordPosition = first,
+            lastWordPosition = last,
+            text = text,
+            ayahNumberInSurah = 1,
+        )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplThematicTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/QuranRepositoryImplThematicTest.kt
@@ -1,0 +1,545 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.entity.AyahThemeEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.QuranTopicEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewEntity
+import com.arshadshah.nimaz.data.local.database.entity.SurahOverviewSectionEntity
+import com.arshadshah.nimaz.data.local.database.entity.TopicWithSurahCount
+import com.arshadshah.nimaz.data.local.search.ContentSearchIndex
+import com.arshadshah.nimaz.data.local.search.SearchKind
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.domain.model.SurahOverviewGroup
+import com.arshadshah.nimaz.domain.model.TopicTree
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The thematic layer (schemaVersion 24) — the half of [QuranRepositoryImpl] that turns three
+ * overlapping topic hierarchies into something a screen can render.
+ *
+ * What is pinned here is the logic that fails *quietly*, not the mapping:
+ *
+ *  - a breadcrumb is a loop over parent columns that are **content**, regenerated per release
+ *    elsewhere. A cycle in them hangs a screen forever, and the two visited-set guards are the
+ *    only thing between the app and that. Neither is exercised by data that ships, which is
+ *    exactly why they need a test;
+ *  - `getTopicBreadcrumbs` picks the hierarchy *per topic*, not per call, because search spans
+ *    all three. Get that wrong and a result from the ontology comes back pathless while the
+ *    thematic tab is selected — a blank breadcrumb, no error;
+ *  - `getTopicDetail` cites the whole **subtree**, not the node. Asking only for a node's own
+ *    citations is what made "Doctrine" open on "0 verses";
+ *  - `searchTopics` re-sorts by index rank because `getTopics` does not preserve it, so a
+ *    relevance-ordered search that silently comes back in id order looks like it works;
+ *  - `hasThematicContent` is memoised, and a memo that re-queries is invisible except as a
+ *    slow screen.
+ */
+class QuranRepositoryImplThematicTest {
+
+    private lateinit var quranDao: QuranDao
+    private lateinit var bookmarkDao: BookmarkDao
+    private lateinit var readingProgressDao: ReadingProgressDao
+    private lateinit var searchIndex: ContentSearchIndex
+    private lateinit var repository: QuranRepositoryImpl
+
+    @Before
+    fun setUp() {
+        quranDao = mockk(relaxed = true)
+        bookmarkDao = mockk(relaxed = true)
+        readingProgressDao = mockk(relaxed = true)
+        searchIndex = mockk(relaxed = true)
+        coEvery { searchIndex.isAvailable() } returns false
+        repository = QuranRepositoryImpl(quranDao, bookmarkDao, readingProgressDao, searchIndex)
+    }
+
+    // ── the surah overview ────────────────────────────────────────────────────
+
+    @Test
+    fun `a surah with no overview row reports none rather than an empty one`() = runTest {
+        coEvery { quranDao.getSurahOverview(9) } returns null
+
+        assertThat(repository.getSurahOverview(9)).isNull()
+        // The sections query must not run for a surah that has no overview to hang them on.
+        coVerify(exactly = 0) { quranDao.getSurahOverviewSections(any()) }
+    }
+
+    @Test
+    fun `an overview carries its sections in the group each one declares`() = runTest {
+        coEvery { quranDao.getSurahOverview(2) } returns
+            SurahOverviewEntity(surahNumber = 2, summary = "The longest surah.")
+        coEvery { quranDao.getSurahOverviewSections(2) } returns listOf(
+            section(position = 1, heading = "Guidance", group = "name"),
+            section(position = 2, heading = "Law", group = "theme"),
+        )
+
+        val overview = repository.getSurahOverview(2)!!
+
+        assertThat(overview.summary).isEqualTo("The longest surah.")
+        assertThat(overview.sections.map { it.heading }).containsExactly("Guidance", "Law").inOrder()
+        assertThat(overview.sections.map { it.group })
+            .containsExactly(SurahOverviewGroup.NAME, SurahOverviewGroup.THEME)
+            .inOrder()
+    }
+
+    @Test
+    fun `a section whose group is not a known wire value still renders`() = runTest {
+        coEvery { quranDao.getSurahOverview(1) } returns
+            SurahOverviewEntity(surahNumber = 1, summary = "The Opening.")
+        coEvery { quranDao.getSurahOverviewSections(1) } returns
+            listOf(section(position = 1, heading = "Odd", group = "a-group-from-a-newer-corpus"))
+
+        val sections = repository.getSurahOverview(1)!!.sections
+
+        // A corpus that adds a group must not make an older build drop the section.
+        assertThat(sections).hasSize(1)
+        assertThat(sections.single().group).isEqualTo(SurahOverviewGroup.OTHER)
+    }
+
+    // ── themes ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a surah's themes come back as verse spans, not as single verses`() = runTest {
+        coEvery { quranDao.getThemesForSurah(12) } returns listOf(
+            AyahThemeEntity(
+                surahNumber = 12, ayahFrom = 4, ayahTo = 6,
+                theme = "The dream", keywords = "dream,stars", ayahCount = 3,
+            )
+        )
+
+        val theme = repository.getThemesForSurah(12).single()
+
+        assertThat(theme.ayahFrom).isEqualTo(4)
+        assertThat(theme.ayahTo).isEqualTo(6)
+        assertThat(theme.ayahCount).isEqualTo(3)
+        assertThat(theme.theme).isEqualTo("The dream")
+    }
+
+    @Test
+    fun `a verse outside every theme span reports no theme`() = runTest {
+        coEvery { quranDao.getThemeForAyah(12, 99) } returns null
+
+        assertThat(repository.getThemeForAyah(12, 99)).isNull()
+    }
+
+    @Test
+    fun `a verse inside a span reports the span's theme`() = runTest {
+        coEvery { quranDao.getThemeForAyah(12, 5) } returns AyahThemeEntity(
+            surahNumber = 12, ayahFrom = 4, ayahTo = 6,
+            theme = "The dream", keywords = "dream", ayahCount = 3,
+        )
+
+        assertThat(repository.getThemeForAyah(12, 5)!!.theme).isEqualTo("The dream")
+    }
+
+    // ── the three hierarchies ─────────────────────────────────────────────────
+
+    @Test
+    fun `each tree is queried by its own wire name, not by its enum name`() = runTest {
+        coEvery { quranDao.getRootTopics(any()) } returns emptyList()
+
+        repository.getTopicTreeRoots(TopicTree.ONTOLOGY)
+
+        // The wire value is what the corpus stores; the enum name is uppercase and matches nothing.
+        coVerify { quranDao.getRootTopics("ontology") }
+    }
+
+    @Test
+    fun `a topic's children are read from the tree being browsed`() = runTest {
+        coEvery { quranDao.getChildTopics("index", 7) } returns listOf(topic(id = 8, name = "Musa"))
+
+        val children = repository.getTopicChildren(topicId = 7, tree = TopicTree.INDEX)
+
+        assertThat(children.map { it.name }).containsExactly("Musa")
+    }
+
+    @Test
+    fun `the branch ids arrive as a set so a screen can test membership`() = runTest {
+        coEvery { quranDao.getBranchTopicIds("thematic") } returns listOf(1, 2, 2, 3)
+
+        assertThat(repository.getBranchTopicIds(TopicTree.THEMATIC)).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `a topic's comma separated related ids become a list of ints`() = runTest {
+        coEvery { quranDao.getAllTopics() } returns
+            listOf(topic(id = 1, relatedTopicIds = "4, 5 ,not-a-number,6"))
+
+        val related = repository.getAllTopics().single().relatedTopicIds
+
+        // Whitespace and a junk entry from a hand-edited corpus must not lose the real ids.
+        assertThat(related).containsExactly(4, 5, 6).inOrder()
+    }
+
+    @Test
+    fun `a topic with no related ids reports an empty list rather than a zero`() = runTest {
+        coEvery { quranDao.getAllTopics() } returns listOf(topic(id = 1, relatedTopicIds = ""))
+
+        assertThat(repository.getAllTopics().single().relatedTopicIds).isEmpty()
+    }
+
+    @Test
+    fun `the thematic and ontology flags are read as flags, not as counts`() = runTest {
+        coEvery { quranDao.getAllTopics() } returns
+            listOf(topic(id = 1, isThematic = 1, isOntology = 0))
+
+        val subject = repository.getAllTopics().single()
+
+        assertThat(subject.isThematic).isTrue()
+        assertThat(subject.isOntology).isFalse()
+    }
+
+    // ── breadcrumbs ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `asking for no breadcrumbs queries nothing`() = runTest {
+        assertThat(repository.getTopicBreadcrumbs(emptyList(), TopicTree.THEMATIC)).isEmpty()
+
+        coVerify(exactly = 0) { quranDao.getTopics(any()) }
+    }
+
+    @Test
+    fun `a breadcrumb climbs to the root and reads root first`() = runTest {
+        // 3 -> 2 -> 1 in the thematic tree.
+        val leaf = topic(id = 3, name = "Leaf", thematicParentId = 2, isThematic = 1)
+        val mid = topic(id = 2, name = "Mid", thematicParentId = 1, isThematic = 1)
+        val root = topic(id = 1, name = "Root", thematicParentId = null, isThematic = 1)
+        coEvery { quranDao.getTopics(listOf(3)) } returns listOf(leaf)
+        coEvery { quranDao.getTopics(listOf(2)) } returns listOf(mid)
+        coEvery { quranDao.getTopics(listOf(1)) } returns listOf(root)
+
+        val trail = repository.getTopicBreadcrumbs(listOf(3), TopicTree.THEMATIC).getValue(3)
+
+        assertThat(trail.map { it.name }).containsExactly("Root", "Mid").inOrder()
+    }
+
+    @Test
+    fun `a cycle in the corpus's parents terminates instead of hanging`() = runTest {
+        // 1 -> 2 -> 1. Content is validated acyclic at import; the next corpus might not be.
+        val a = topic(id = 1, name = "A", thematicParentId = 2, isThematic = 1)
+        val b = topic(id = 2, name = "B", thematicParentId = 1, isThematic = 1)
+        coEvery { quranDao.getTopics(listOf(1)) } returns listOf(a)
+        coEvery { quranDao.getTopics(listOf(2)) } returns listOf(b)
+
+        val trail = repository.getTopicBreadcrumbs(listOf(1), TopicTree.THEMATIC).getValue(1)
+
+        // B is reached once; the step back to A is refused by the visited set.
+        assertThat(trail.map { it.name }).containsExactly("B")
+    }
+
+    @Test
+    fun `an ontology topic keeps its path while the thematic tab is selected`() = runTest {
+        // Search spans all three trees, so a result the thematic outline does not place must
+        // still come back with the path the ontology gives it.
+        val leaf = topic(id = 5, name = "Camel", ontologyParentId = 4, isThematic = 0, isOntology = 1)
+        val parent = topic(id = 4, name = "Living Creation", isThematic = 0, isOntology = 1)
+        coEvery { quranDao.getTopics(listOf(5)) } returns listOf(leaf)
+        coEvery { quranDao.getTopics(listOf(4)) } returns listOf(parent)
+
+        val trail = repository.getTopicBreadcrumbs(listOf(5), TopicTree.THEMATIC).getValue(5)
+
+        assertThat(trail.map { it.name }).containsExactly("Living Creation")
+    }
+
+    @Test
+    fun `two topics at different depths each climb only as far as their own root`() = runTest {
+        val deep = topic(id = 3, name = "Deep", thematicParentId = 2, isThematic = 1)
+        val mid = topic(id = 2, name = "Mid", thematicParentId = 1, isThematic = 1)
+        val root = topic(id = 1, name = "Root", isThematic = 1)
+        val shallow = topic(id = 9, name = "Shallow", thematicParentId = 1, isThematic = 1)
+        coEvery { quranDao.getTopics(listOf(3, 9)) } returns listOf(deep, shallow)
+        coEvery { quranDao.getTopics(listOf(2, 1)) } returns listOf(mid, root)
+        coEvery { quranDao.getTopics(listOf(1)) } returns listOf(root)
+
+        val trails = repository.getTopicBreadcrumbs(listOf(3, 9), TopicTree.THEMATIC)
+
+        assertThat(trails.getValue(3).map { it.name }).containsExactly("Root", "Mid").inOrder()
+        assertThat(trails.getValue(9).map { it.name }).containsExactly("Root")
+    }
+
+    @Test
+    fun `an id the corpus does not know gets no trail rather than an empty one`() = runTest {
+        coEvery { quranDao.getTopics(listOf(404)) } returns emptyList()
+
+        assertThat(repository.getTopicBreadcrumbs(listOf(404), TopicTree.THEMATIC)).isEmpty()
+    }
+
+    @Test
+    fun `a parent the corpus points at but does not hold ends the trail`() = runTest {
+        val leaf = topic(id = 3, name = "Leaf", thematicParentId = 99, isThematic = 1)
+        coEvery { quranDao.getTopics(listOf(3)) } returns listOf(leaf)
+        coEvery { quranDao.getTopics(listOf(99)) } returns emptyList()
+
+        assertThat(repository.getTopicBreadcrumbs(listOf(3), TopicTree.THEMATIC).getValue(3))
+            .isEmpty()
+    }
+
+    // ── the detail screen ─────────────────────────────────────────────────────
+
+    @Test
+    fun `a topic id that does not exist opens nothing rather than an empty screen`() = runTest {
+        coEvery { quranDao.getTopic(1) } returns null
+
+        assertThat(repository.getTopicDetail(1, TopicTree.THEMATIC)).isNull()
+        coVerify(exactly = 0) { quranDao.getTopicAyahsIn(any()) }
+    }
+
+    @Test
+    fun `a branch cites the verses of its whole subtree, not just its own`() = runTest {
+        // "Doctrine" holds no citations itself; its children carry them all.
+        coEvery { quranDao.getTopic(1) } returns topic(id = 1, name = "Doctrine", isThematic = 1)
+        coEvery { quranDao.getChildTopics("thematic", 1) } returns
+            listOf(topic(id = 2, name = "Tawhid", thematicParentId = 1, isThematic = 1))
+        coEvery { quranDao.getChildTopics("thematic", 2) } returns
+            listOf(topic(id = 3, name = "Names", thematicParentId = 2, isThematic = 1))
+        coEvery { quranDao.getChildTopics("thematic", 3) } returns emptyList()
+        coEvery { quranDao.getTopicAyahsIn(listOf(1, 2, 3)) } returns listOf(
+            QuranTopicAyahEntity(topicId = 3, ayahId = 262, surahNumber = 2, ayahNumber = 255)
+        )
+
+        val detail = repository.getTopicDetail(1, TopicTree.THEMATIC)!!
+
+        assertThat(detail.citations.map { it.ayahId }).containsExactly(262)
+        assertThat(detail.children.map { it.name }).containsExactly("Tawhid")
+    }
+
+    @Test
+    fun `a cycle among children stops the subtree walk`() = runTest {
+        coEvery { quranDao.getTopic(1) } returns topic(id = 1, name = "A", isThematic = 1)
+        coEvery { quranDao.getChildTopics("thematic", 1) } returns listOf(topic(id = 2, name = "B"))
+        coEvery { quranDao.getChildTopics("thematic", 2) } returns listOf(topic(id = 1, name = "A"))
+        coEvery { quranDao.getTopicAyahsIn(any()) } returns emptyList()
+
+        val detail = repository.getTopicDetail(1, TopicTree.THEMATIC)!!
+
+        assertThat(detail.children.map { it.name }).containsExactly("B")
+        // The walk visits each id once, so it terminates: 2 points back at 1 and 1 is not
+        // re-expanded. Without the visited set this never returns.
+        coVerify { quranDao.getTopicAyahsIn(listOf(1, 2)) }
+    }
+
+    @Test
+    fun `a detail's breadcrumb walks upwards and stops at a cycle`() = runTest {
+        coEvery { quranDao.getTopic(3) } returns
+            topic(id = 3, name = "Leaf", thematicParentId = 2, isThematic = 1)
+        coEvery { quranDao.getTopic(2) } returns
+            topic(id = 2, name = "Mid", thematicParentId = 3, isThematic = 1)
+        coEvery { quranDao.getTopicAyahsIn(any()) } returns emptyList()
+
+        val detail = repository.getTopicDetail(3, TopicTree.THEMATIC)!!
+
+        assertThat(detail.breadcrumb.map { it.name }).containsExactly("Mid")
+    }
+
+    @Test
+    fun `a detail's breadcrumb ends where the corpus loses the parent`() = runTest {
+        coEvery { quranDao.getTopic(3) } returns
+            topic(id = 3, name = "Leaf", thematicParentId = 77, isThematic = 1)
+        coEvery { quranDao.getTopic(77) } returns null
+        coEvery { quranDao.getTopicAyahsIn(any()) } returns emptyList()
+
+        assertThat(repository.getTopicDetail(3, TopicTree.THEMATIC)!!.breadcrumb).isEmpty()
+    }
+
+    @Test
+    fun `related topics are fetched only when the topic declares some`() = runTest {
+        coEvery { quranDao.getTopic(1) } returns topic(id = 1, relatedTopicIds = "")
+        coEvery { quranDao.getTopicAyahsIn(any()) } returns emptyList()
+
+        val detail = repository.getTopicDetail(1, TopicTree.THEMATIC)!!
+
+        assertThat(detail.related).isEmpty()
+        coVerify(exactly = 0) { quranDao.getTopics(any()) }
+    }
+
+    @Test
+    fun `a topic that declares related ids resolves them to topics`() = runTest {
+        coEvery { quranDao.getTopic(1) } returns topic(id = 1, relatedTopicIds = "4,5")
+        coEvery { quranDao.getTopics(listOf(4, 5)) } returns
+            listOf(topic(id = 4, name = "Sabr"), topic(id = 5, name = "Shukr"))
+        coEvery { quranDao.getTopicAyahsIn(any()) } returns emptyList()
+
+        val detail = repository.getTopicDetail(1, TopicTree.THEMATIC)!!
+
+        assertThat(detail.related.map { it.name }).containsExactly("Sabr", "Shukr")
+        assertThat(detail.tree).isEqualTo(TopicTree.THEMATIC)
+    }
+
+    // ── a surah's subjects ────────────────────────────────────────────────────
+
+    @Test
+    fun `a surah's subjects carry the count of verses in this surah, not across the Quran`() =
+        runTest {
+            coEvery { quranDao.getTopicsForSurah(112) } returns listOf(
+                TopicWithSurahCount(topic = topic(id = 1, name = "Allah", ayahCount = 153), versesHere = 2)
+            )
+
+            val subject = repository.getTopicsForSurah(112).single()
+
+            // Ordering a surah's subjects by the Quran-wide count is what this projection exists
+            // to prevent; the domain model must expose the local count.
+            assertThat(subject.versesInSurah).isEqualTo(2)
+            assertThat(subject.topic.ayahCount).isEqualTo(153)
+        }
+
+    @Test
+    fun `a verse's subjects come back as topics`() = runTest {
+        coEvery { quranDao.getTopicsForAyah(262) } returns listOf(topic(id = 1, name = "Tawhid"))
+
+        assertThat(repository.getTopicsForAyah(262).map { it.name }).containsExactly("Tawhid")
+    }
+
+    @Test
+    fun `a surah's subject count is asked of the database, not derived from a list`() = runTest {
+        coEvery { quranDao.countTopicsForSurah(2) } returns 431
+
+        assertThat(repository.countTopicsForSurah(2)).isEqualTo(431)
+        coVerify(exactly = 0) { quranDao.getTopicsForSurah(any()) }
+    }
+
+    // ── topic search ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a blank query searches nothing`() = runTest {
+        assertThat(repository.searchTopics("   ", limit = 10)).isEmpty()
+
+        coVerify(exactly = 0) { quranDao.searchTopicsByName(any(), any()) }
+    }
+
+    @Test
+    fun `without an index the search falls back to the English name`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns false
+        coEvery { quranDao.searchTopicsByName("musa", 5) } returns listOf(topic(id = 1, name = "Musa"))
+
+        assertThat(repository.searchTopics("  musa  ", limit = 5).map { it.name })
+            .containsExactly("Musa")
+    }
+
+    @Test
+    fun `with an index the results keep relevance order, not id order`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("resurrection", SearchKind.TOPIC, null, any()) } returns listOf("9", "3", "7")
+        // getTopics does not preserve the order it was asked in.
+        coEvery { quranDao.getTopics(listOf(9, 3, 7)) } returns
+            listOf(topic(id = 3, name = "C"), topic(id = 7, name = "B"), topic(id = 9, name = "A"))
+
+        val names = repository.searchTopics("resurrection", limit = 10).map { it.name }
+
+        assertThat(names).containsExactly("A", "C", "B").inOrder()
+    }
+
+    @Test
+    fun `the index result is capped at the limit before the rows are fetched`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("a", SearchKind.TOPIC, null, any()) } returns listOf("1", "2", "3", "4")
+        coEvery { quranDao.getTopics(listOf(1, 2)) } returns
+            listOf(topic(id = 1), topic(id = 2))
+
+        assertThat(repository.searchTopics("a", limit = 2)).hasSize(2)
+        coVerify { quranDao.getTopics(listOf(1, 2)) }
+    }
+
+    @Test
+    fun `index refs that are not ids are dropped, and duplicates collapse`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("a", SearchKind.TOPIC, null, any()) } returns
+            listOf("1", "not-an-id", "1", "2")
+        coEvery { quranDao.getTopics(listOf(1, 2)) } returns listOf(topic(id = 1), topic(id = 2))
+
+        assertThat(repository.searchTopics("a", limit = 10)).hasSize(2)
+    }
+
+    @Test
+    fun `an index that matches nothing does not query for an empty id list`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("zzz", SearchKind.TOPIC, null, any()) } returns emptyList()
+
+        assertThat(repository.searchTopics("zzz", limit = 10)).isEmpty()
+        coVerify(exactly = 0) { quranDao.getTopics(any()) }
+    }
+
+    @Test
+    fun `a row the index knows but the table has lost sorts last rather than crashing`() = runTest {
+        coEvery { searchIndex.isAvailable() } returns true
+        coEvery { searchIndex.refs("a", SearchKind.TOPIC, null, any()) } returns listOf("1", "2")
+        // Row 2 is returned; row 1 is not — a stale index against a replaced content database.
+        coEvery { quranDao.getTopics(listOf(1, 2)) } returns listOf(topic(id = 2, name = "B"))
+
+        assertThat(repository.searchTopics("a", limit = 10).map { it.name }).containsExactly("B")
+    }
+
+    // ── the thematic-content probe ────────────────────────────────────────────
+
+    @Test
+    fun `an install whose artifact carries the thematic layer is asked once`() = runTest {
+        coEvery { quranDao.countThemes() } returns 1200
+        coEvery { quranDao.countTopics() } returns 2512
+
+        assertThat(repository.hasThematicContent()).isTrue()
+        assertThat(repository.hasThematicContent()).isTrue()
+
+        // The content database is replaced wholesale by a release, never written to at runtime,
+        // so two COUNT(*)s per screen would be two queries to learn a constant.
+        coVerify(exactly = 1) { quranDao.countThemes() }
+    }
+
+    @Test
+    fun `topics without themes does not count as thematic content`() = runTest {
+        coEvery { quranDao.countThemes() } returns 0
+        coEvery { quranDao.countTopics() } returns 2512
+
+        assertThat(repository.hasThematicContent()).isFalse()
+        // Short-circuits: no point counting topics when there are no themes.
+        coVerify(exactly = 0) { quranDao.countTopics() }
+    }
+
+    @Test
+    fun `themes without topics does not count as thematic content`() = runTest {
+        coEvery { quranDao.countThemes() } returns 1200
+        coEvery { quranDao.countTopics() } returns 0
+
+        assertThat(repository.hasThematicContent()).isFalse()
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun section(position: Int, heading: String, group: String) =
+        SurahOverviewSectionEntity(
+            surahNumber = 2,
+            position = position,
+            heading = heading,
+            group = group,
+            body = "body",
+        )
+
+    private fun topic(
+        id: Int,
+        name: String = "Topic $id",
+        parentId: Int? = null,
+        thematicParentId: Int? = null,
+        ontologyParentId: Int? = null,
+        isThematic: Int = 1,
+        isOntology: Int = 0,
+        ayahCount: Int = 0,
+        relatedTopicIds: String = "",
+    ) = QuranTopicEntity(
+        topicId = id,
+        name = name,
+        arabicName = "",
+        parentId = parentId,
+        thematicParentId = thematicParentId,
+        ontologyParentId = ontologyParentId,
+        description = "",
+        wikiLink = "",
+        isThematic = isThematic,
+        isOntology = isOntology,
+        ayahCount = ayahCount,
+        relatedTopicIds = relatedTopicIds,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/TasbihRepositoryImplStatsTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/repository/TasbihRepositoryImplStatsTest.kt
@@ -1,0 +1,235 @@
+package com.arshadshah.nimaz.data.repository
+
+import com.arshadshah.nimaz.data.local.database.dao.TasbihDao
+import com.arshadshah.nimaz.data.local.database.entity.TasbihPresetEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihSessionEntity
+import com.arshadshah.nimaz.data.local.user.PresetUsageWithSessions
+import com.arshadshah.nimaz.data.local.user.TasbihSessionDao
+import com.arshadshah.nimaz.domain.model.DefaultTasbihPresets
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tasbih statistics and the default-preset repair.
+ *
+ * The statistics are `SUM()` aggregates, and SQLite's answer to `SUM` over no rows is **NULL**,
+ * not 0. Every one of those nulls reaches a screen that renders a number, so a missing
+ * `?: 0` is a crash on the stats screen for a user who has not counted anything this week —
+ * exactly the user least likely to report it.
+ *
+ * `seedMissingDefaults` is the repair path for an install that lost a default preset (deleted,
+ * or a corpus that shipped without one). It has to insert with `id = 0` so Room assigns fresh
+ * ids: reusing the default's id would *replace* whatever custom preset happens to hold it.
+ */
+class TasbihRepositoryImplStatsTest {
+
+    private lateinit var tasbihDao: TasbihDao
+    private lateinit var sessionDao: TasbihSessionDao
+    private lateinit var repository: TasbihRepositoryImpl
+
+    @Before
+    fun setUp() {
+        tasbihDao = mockk(relaxed = true)
+        sessionDao = mockk(relaxed = true)
+        repository = TasbihRepositoryImpl(tasbihDao, sessionDao)
+    }
+
+    // ── aggregates over nothing ───────────────────────────────────────────────
+
+    @Test
+    fun `a week with no sessions reports zeroes rather than crashing the stats screen`() =
+        runTest {
+            // SUM() over no rows is NULL in SQLite, and the screen renders a number.
+            coEvery { sessionDao.getTotalCountInRange(0L, 1L) } returns null
+            coEvery { sessionDao.getTotalDurationInRange(0L, 1L) } returns null
+            coEvery { sessionDao.getCompletedSessionsInRange(0L, 1L) } returns 0
+            coEvery { sessionDao.getMostUsedPresetsWithSessions(any()) } returns emptyList()
+
+            val stats = repository.getTasbihStats(0L, 1L)
+
+            assertThat(stats.totalCount).isEqualTo(0)
+            assertThat(stats.totalDuration).isEqualTo(0L)
+            assertThat(stats.completedSessions).isEqualTo(0)
+            assertThat(stats.mostUsedPresets).isEmpty()
+            assertThat(stats.startDate).isEqualTo(0L)
+            assertThat(stats.endDate).isEqualTo(1L)
+        }
+
+    @Test
+    fun `a week with sessions reports the sums and the presets behind them`() = runTest {
+        coEvery { sessionDao.getTotalCountInRange(0L, 1L) } returns 330
+        coEvery { sessionDao.getTotalDurationInRange(0L, 1L) } returns 600_000L
+        coEvery { sessionDao.getCompletedSessionsInRange(0L, 1L) } returns 10
+        coEvery { sessionDao.getMostUsedPresetsWithSessions(5) } returns
+            listOf(PresetUsageWithSessions(presetId = 1, totalCount = 330, sessionsCount = 10))
+        coEvery { tasbihDao.getPresetById(1) } returns preset(1, "SubhanAllah")
+
+        val stats = repository.getTasbihStats(0L, 1L)
+
+        assertThat(stats.totalCount).isEqualTo(330)
+        assertThat(stats.totalDuration).isEqualTo(600_000L)
+        assertThat(stats.mostUsedPresets.single().presetName).isEqualTo("SubhanAllah")
+        assertThat(stats.mostUsedPresets.single().sessionsCount).isEqualTo(10)
+    }
+
+    @Test
+    fun `usage of a preset the user has since deleted is dropped, not shown nameless`() =
+        runTest {
+            coEvery { sessionDao.getMostUsedPresetsWithSessions(5) } returns
+                listOf(PresetUsageWithSessions(presetId = 99, totalCount = 5, sessionsCount = 1))
+            coEvery { tasbihDao.getPresetById(99) } returns null
+
+            assertThat(repository.getTasbihStats(0L, 1L).mostUsedPresets).isEmpty()
+        }
+
+    @Test
+    fun `the standalone total also survives a range with no sessions`() = runTest {
+        coEvery { sessionDao.getTotalCountInRange(0L, 1L) } returns null
+        coEvery { sessionDao.getCompletedSessionsInRange(0L, 1L) } returns 0
+
+        assertThat(repository.getTotalCountInRange(0L, 1L)).isEqualTo(0)
+        assertThat(repository.getCompletedSessionsInRange(0L, 1L)).isEqualTo(0)
+    }
+
+    // ── sessions ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a session id that no longer exists opens nothing`() = runTest {
+        coEvery { sessionDao.getSessionById(7) } returns null
+
+        assertThat(repository.getSessionById(7)).isNull()
+    }
+
+    @Test
+    fun `a session reads back with the counter it holds`() = runTest {
+        coEvery { sessionDao.getSessionById(7) } returns session(7)
+
+        val read = repository.getSessionById(7)!!
+
+        assertThat(read.currentCount).isEqualTo(33)
+        assertThat(read.totalLaps).isEqualTo(1)
+        assertThat(read.presetName).isEqualTo("SubhanAllah")
+    }
+
+    @Test
+    fun `a device with no counter open has no active session`() = runTest {
+        coEvery { sessionDao.getActiveSession() } returns null
+
+        assertThat(repository.getActiveSession()).isNull()
+    }
+
+    @Test
+    fun `an open counter is the active session`() = runTest {
+        coEvery { sessionDao.getActiveSession() } returns session(7).copy(isCompleted = false)
+
+        assertThat(repository.getActiveSession()!!.isCompleted).isFalse()
+    }
+
+    // ── the default presets ───────────────────────────────────────────────────
+
+    @Test
+    fun `an install that already has every default is left alone`() = runTest {
+        coEvery { tasbihDao.getAllPresetNames() } returns
+            DefaultTasbihPresets.allDefaults.map { it.name }
+
+        repository.seedMissingDefaults()
+
+        coVerify(exactly = 0) { tasbihDao.insertPresets(any()) }
+    }
+
+    @Test
+    fun `a missing default is re-inserted under a fresh id, never the default's own`() =
+        runTest {
+            val missingName = DefaultTasbihPresets.allDefaults.first().name
+            coEvery { tasbihDao.getAllPresetNames() } returns
+                DefaultTasbihPresets.allDefaults.drop(1).map { it.name }
+            val inserted = mutableListOf<List<TasbihPresetEntity>>()
+            coEvery { tasbihDao.insertPresets(capture(inserted)) } returns Unit
+
+            repository.seedMissingDefaults()
+
+            assertThat(inserted.single().map { it.name }).containsExactly(missingName)
+            // Reusing the default's id would REPLACE whatever custom preset holds it.
+            assertThat(inserted.single().map { it.id }.toSet()).containsExactly(0L)
+        }
+
+    @Test
+    fun `a fresh install gets every default seeded`() = runTest {
+        val inserted = mutableListOf<List<TasbihPresetEntity>>()
+        coEvery { tasbihDao.insertPresets(capture(inserted)) } returns Unit
+
+        repository.initializeDefaultPresets()
+
+        assertThat(inserted.single()).hasSize(DefaultTasbihPresets.allDefaults.size)
+        assertThat(inserted.single().first().isCustom).isEqualTo(0)
+    }
+
+    @Test
+    fun `an install with no default presets reports so`() = runTest {
+        every { tasbihDao.getDefaultPresets() } returns flowOf(emptyList())
+        assertThat(repository.hasDefaultPresets()).isFalse()
+
+        every { tasbihDao.getDefaultPresets() } returns flowOf(listOf(preset(1, "SubhanAllah")))
+        assertThat(repository.hasDefaultPresets()).isTrue()
+    }
+
+    @Test
+    fun `a preset with no optional text writes empty strings rather than nulls`() = runTest {
+        val inserted = mutableListOf<TasbihPresetEntity>()
+        coEvery { tasbihDao.insertPreset(capture(inserted)) } returns 1L
+
+        repository.insertPreset(
+            DefaultTasbihPresets.allDefaults.first().copy(
+                id = 0,
+                arabicText = null,
+                transliteration = null,
+                translation = null,
+                category = null,
+                isDefault = false,
+            )
+        )
+
+        // The columns are NOT NULL; a screen renders "" as nothing, which is the intent.
+        assertThat(inserted.single().arabic).isEmpty()
+        assertThat(inserted.single().transliteration).isEmpty()
+        assertThat(inserted.single().translation).isEmpty()
+        assertThat(inserted.single().category).isNull()
+        // Custom, because the user made it.
+        assertThat(inserted.single().isCustom).isEqualTo(1)
+    }
+
+    @Test
+    fun `a preset's category is stored in the lowercase form the table uses`() = runTest {
+        val inserted = mutableListOf<TasbihPresetEntity>()
+        coEvery { tasbihDao.insertPreset(capture(inserted)) } returns 1L
+
+        repository.insertPreset(
+            DefaultTasbihPresets.allDefaults.first()
+                .copy(id = 0, category = TasbihCategory.AFTER_PRAYER)
+        )
+
+        assertThat(inserted.single().category).isEqualTo("after_prayer")
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private fun preset(id: Long, name: String) = TasbihPresetEntity(
+        id = id, name = name, arabic = "سبحان الله", transliteration = name,
+        translation = "Glory be to Allah", targetCount = 33, isCustom = 0, displayOrder = 1,
+        updatedAt = 1L,
+    )
+
+    private fun session(id: Long) = TasbihSessionEntity(
+        id = id, presetId = 1, presetName = "SubhanAllah", date = 1L, currentCount = 33,
+        targetCount = 33, totalLaps = 1, isCompleted = true, duration = 60_000L,
+        startedAt = 1L, completedAt = 2L, note = null, updatedAt = 2L,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/NearbyConnectionsManagerTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/NearbyConnectionsManagerTest.kt
@@ -1,0 +1,755 @@
+package com.arshadshah.nimaz.data.sync
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.common.api.Status
+import com.google.android.gms.nearby.Nearby
+import com.google.android.gms.nearby.connection.AdvertisingOptions
+import com.google.android.gms.nearby.connection.ConnectionInfo
+import com.google.android.gms.nearby.connection.ConnectionLifecycleCallback
+import com.google.android.gms.nearby.connection.ConnectionResolution
+import com.google.android.gms.nearby.connection.ConnectionsClient
+import com.google.android.gms.nearby.connection.ConnectionsStatusCodes
+import com.google.android.gms.nearby.connection.DiscoveredEndpointInfo
+import com.google.android.gms.nearby.connection.DiscoveryOptions
+import com.google.android.gms.nearby.connection.EndpointDiscoveryCallback
+import com.google.android.gms.nearby.connection.Payload
+import com.google.android.gms.nearby.connection.PayloadCallback
+import com.google.android.gms.nearby.connection.PayloadTransferUpdate
+import com.google.android.gms.tasks.Tasks
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Device-to-device transfer, driven through a mocked `ConnectionsClient`.
+ *
+ * The two callbacks that carry all the logic — the connection lifecycle and the payload
+ * callback — are private fields, but they are *handed to* the client, so capturing the
+ * arguments of `startAdvertising` and `acceptConnection` gets a real reference to each and lets
+ * the whole protocol be replayed without radios.
+ *
+ * Everything here is a defect that produces no error message:
+ *
+ *  - **a payload arriving on the wrong branch.** Signals, data and file transfers share one
+ *    BYTES/FILE channel, and the only thing that tells data from a signal is the leading
+ *    `0x1F`. Route a signal into the importer and it tries to import "cancel"; route data into
+ *    the signal decoder and the transfer completes having imported nothing;
+ *  - **transfer updates for a signal moving the progress bar.** Each signal generates its own
+ *    IN_PROGRESS/SUCCESS pair, so without the id filter the bar jumps to 100% and the screen
+ *    reports the transfer done while the real payload is still in flight;
+ *  - **a disconnect overwriting a finished state.** The partner always disconnects at the end,
+ *    so an unguarded `onDisconnected` rewrites a successful sync as "connection lost";
+ *  - **the `@Singleton` holding a dead ViewModel.** The data callback captures a
+ *    `SyncViewModel`, so without a way to clear it the destroyed ViewModel and its cancelled
+ *    scope stay reachable for the life of the process.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NearbyConnectionsManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var client: ConnectionsClient
+    private lateinit var manager: NearbyConnectionsManager
+
+    private val lifecycle = slot<ConnectionLifecycleCallback>()
+    private val discovery = slot<EndpointDiscoveryCallback>()
+    private val payloads = slot<PayloadCallback>()
+    private val sent = mutableListOf<Payload>()
+
+    private val received = mutableListOf<ByteArray>()
+    private val signals = mutableListOf<SyncSignal>()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        client = mockk(relaxed = true)
+        mockkStatic(Nearby::class)
+        every { Nearby.getConnectionsClient(any<Context>()) } returns client
+
+        every {
+            client.startAdvertising(any<String>(), any(), capture(lifecycle), any<AdvertisingOptions>())
+        } returns Tasks.forResult(null)
+        every {
+            client.startDiscovery(any(), capture(discovery), any<DiscoveryOptions>())
+        } returns Tasks.forResult(null)
+        every { client.acceptConnection(any(), capture(payloads)) } returns Tasks.forResult(null)
+        every { client.sendPayload(any<String>(), capture(sent)) } returns Tasks.forResult(null)
+
+        manager = NearbyConnectionsManager(context)
+        manager.setOnDataReceived { received += it }
+        manager.setOnSignalReceived { signals += it }
+    }
+
+    @After
+    fun tearDown() = unmockkStatic(Nearby::class)
+
+    // ── the connection handshake ──────────────────────────────────────────────
+
+    @Test
+    fun `a device starts idle and advertises when asked`() {
+        assertThat(NearbyConnectionsManager(context).connectionState.value)
+            .isEqualTo(ConnectionState.Idle)
+
+        manager.startAdvertising("Pixel")
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Advertising)
+        verify { client.startAdvertising("Pixel", any(), any(), any<AdvertisingOptions>()) }
+    }
+
+    @Test
+    fun `an advertising failure is reported rather than leaving the screen advertising`() {
+        every {
+            client.startAdvertising(any<String>(), any(), any(), any<AdvertisingOptions>())
+        } returns Tasks.forException(IllegalStateException("no wifi"))
+
+        manager.startAdvertising("Pixel")
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(manager.connectionState.value).isInstanceOf(ConnectionState.Error::class.java)
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("no wifi")
+    }
+
+    @Test
+    fun `discovery requests a connection to the first endpoint it finds`() {
+        manager.startDiscovery("Pixel")
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Discovering)
+        discovery.captured.onEndpointFound("E1", mockk<DiscoveredEndpointInfo>(relaxed = true))
+        discovery.captured.onEndpointLost("E1")
+
+        verify { client.requestConnection("Pixel", "E1", any()) }
+    }
+
+    @Test
+    fun `a discovery failure is reported`() {
+        every {
+            client.startDiscovery(any(), any(), any<DiscoveryOptions>())
+        } returns Tasks.forException(IllegalStateException("no permission"))
+
+        manager.startDiscovery("Pixel")
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        assertThat(manager.connectionState.value).isInstanceOf(ConnectionState.Error::class.java)
+    }
+
+    @Test
+    fun `an incoming connection surfaces the digits the two users compare`() {
+        manager.startAdvertising("Pixel")
+
+        lifecycle.captured.onConnectionInitiated("E1", connectionInfo("Galaxy", "1234"))
+
+        val state = manager.connectionState.value as ConnectionState.Connecting
+        assertThat(state.endpointName).isEqualTo("Galaxy")
+        // The digits are the only thing standing between this and a stranger's phone.
+        assertThat(state.authToken).isEqualTo("1234")
+    }
+
+    @Test
+    fun `accepting waits for the partner rather than claiming to be connected`() {
+        connectTo("Galaxy")
+        manager.acceptConnection("E1")
+
+        // Nearby needs *both* sides to accept; showing Connected here is a screen that lies.
+        val state = manager.connectionState.value as ConnectionState.WaitingForPartnerAccept
+        assertThat(state.endpointName).isEqualTo("Galaxy")
+        verify { client.acceptConnection("E1", any()) }
+    }
+
+    @Test
+    fun `the partner's name survives from the invitation into the connection`() {
+        connectTo("Galaxy")
+        manager.acceptConnection("E1")
+        lifecycle.captured.onConnectionResult("E1", resolution(ConnectionsStatusCodes.STATUS_OK))
+
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `connecting without ever seeing an invitation still connects, namelessly`() {
+        manager.startAdvertising("Pixel")
+
+        lifecycle.captured.onConnectionResult("E1", resolution(ConnectionsStatusCodes.STATUS_OK))
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", ""))
+    }
+
+    @Test
+    fun `a rejected connection says it was rejected, not that it failed`() {
+        connectTo("Galaxy")
+
+        lifecycle.captured.onConnectionResult(
+            "E1", resolution(ConnectionsStatusCodes.STATUS_CONNECTION_REJECTED)
+        )
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .isEqualTo("Connection rejected")
+    }
+
+    @Test
+    fun `any other status is reported with the message the framework gave`() {
+        connectTo("Galaxy")
+
+        lifecycle.captured.onConnectionResult("E1", resolution(13, "radio off"))
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("radio off")
+    }
+
+    @Test
+    fun `rejecting an invitation returns to idle`() {
+        connectTo("Galaxy")
+
+        manager.rejectConnection("E1")
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Idle)
+        verify { client.rejectConnection("E1") }
+    }
+
+    // ── disconnects ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `a disconnect mid transfer is reported as a lost connection`() {
+        connectAndAccept()
+
+        lifecycle.captured.onDisconnected("E1")
+
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.Cancelled(CancelReason.CONNECTION_LOST))
+    }
+
+    @Test
+    fun `a disconnect after a completed transfer does not rewrite the result`() {
+        connectAndAccept()
+        payloads.captured.onPayloadTransferUpdate("E1", update(id = 9, status = SUCCESS, transferred = 4_096))
+        val completed = manager.connectionState.value
+
+        lifecycle.captured.onDisconnected("E1")
+
+        // The partner always disconnects at the end; an unguarded handler turns every
+        // successful sync into "connection lost".
+        assertThat(completed).isEqualTo(ConnectionState.Completed(4_096))
+        assertThat(manager.connectionState.value).isEqualTo(completed)
+    }
+
+    @Test
+    fun `a disconnect after a cancellation does not rewrite the reason`() {
+        connectAndAccept()
+        manager.cancelWithSignal()
+
+        lifecycle.captured.onDisconnected("E1")
+
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.Cancelled(CancelReason.BY_USER))
+    }
+
+    @Test
+    fun `a disconnect after an error keeps the error`() {
+        connectAndAccept()
+        payloads.captured.onPayloadTransferUpdate("E1", update(id = 9, status = FAILURE))
+
+        lifecycle.captured.onDisconnected("E1")
+
+        assertThat(manager.connectionState.value).isInstanceOf(ConnectionState.Error::class.java)
+    }
+
+    // ── sending ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `nothing is sent before a connection exists`() {
+        manager.sendData("payload".toByteArray())
+        manager.sendSignal(SyncSignal.Ready)
+
+        assertThat(sent).isEmpty()
+    }
+
+    @Test
+    fun `a small export travels as a gzipped BYTES payload behind its marker byte`() {
+        connectAndAccept()
+
+        manager.sendData("""{"bookmarks":[]}""".toByteArray())
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Transferring(0f))
+        val bytes = sent.single().asBytes()!!
+        assertThat(bytes[0]).isEqualTo(0x1F.toByte())
+        assertThat(String(gunzip(bytes.copyOfRange(1, bytes.size))))
+            .isEqualTo("""{"bookmarks":[]}""")
+    }
+
+    @Test
+    fun `an export too large for a BYTES payload falls back to a file`() {
+        connectAndAccept()
+        manager.sendData(incompressible())
+
+        assertThat(sent.single().type).isEqualTo(Payload.Type.FILE)
+        assertThat(File(context.cacheDir, "sync_export.gz").exists()).isTrue()
+    }
+
+    @Test
+    fun `the temp send file is deleted once the transfer completes`() {
+        connectAndAccept()
+        manager.sendData(incompressible())
+        val temp = File(context.cacheDir, "sync_export.gz")
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(id = 5, status = SUCCESS, transferred = 100))
+
+        assertThat(temp.exists()).isFalse()
+    }
+
+    @Test
+    fun `a signal is sent and its own transfer updates are ignored`() {
+        connectAndAccept()
+
+        manager.sendSignal(SyncSignal.ImportStarted)
+        val signalId = sent.single().id
+        payloads.captured.onPayloadTransferUpdate("E1", update(signalId, IN_PROGRESS, 10, 100))
+        payloads.captured.onPayloadTransferUpdate("E1", update(signalId, SUCCESS, 100, 100))
+
+        // Without the id filter each signal drives the bar to 100% and the screen calls the
+        // transfer finished while the real payload is still in flight.
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `cancelling tells the partner, drops the link and records who cancelled`() {
+        connectAndAccept()
+
+        manager.cancelWithSignal()
+
+        assertThat(SyncSignal.decode(sent.single().asBytes()!!)).isEqualTo(SyncSignal.Cancel)
+        verify { client.disconnectFromEndpoint("E1") }
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.Cancelled(CancelReason.BY_USER))
+    }
+
+    // ── receiving ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a gzipped BYTES payload reaches the data handler decompressed`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived(
+            "E1", Payload.fromBytes(byteArrayOf(0x1F) + gzip("""{"khatams":[]}""".toByteArray()))
+        )
+
+        assertThat(String(received.single())).isEqualTo("""{"khatams":[]}""")
+        assertThat(signals).isEmpty()
+    }
+
+    @Test
+    fun `a corrupt gzipped payload is reported rather than handed on half read`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived(
+            "E1", Payload.fromBytes(byteArrayOf(0x1F, 0x8B.toByte(), 0x08, 0x00, 0x00))
+        )
+
+        assertThat(received).isEmpty()
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("decompress")
+    }
+
+    @Test
+    fun `data arriving with no handler registered is reported, not dropped silently`() {
+        connectAndAccept()
+        manager.setOnDataReceived(null)
+
+        payloads.captured.onPayloadReceived(
+            "E1", Payload.fromBytes(byteArrayOf(0x1F) + gzip("{}".toByteArray()))
+        )
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("No data handler")
+    }
+
+    @Test
+    fun `a signal payload reaches the signal handler and not the data handler`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived(
+            "E1", Payload.fromBytes(SyncSignal.encode(SyncSignal.ImportProgress(2, 11, "Prayer")))
+        )
+
+        assertThat(signals.single()).isEqualTo(SyncSignal.ImportProgress(2, 11, "Prayer"))
+        // Routing a signal into the importer means trying to import the word "cancel".
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `a BYTES payload that is neither data nor a signal is ignored`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived("E1", Payload.fromBytes("garbage".toByteArray()))
+
+        assertThat(received).isEmpty()
+        assertThat(signals).isEmpty()
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `a signal arriving with no handler registered does not break the connection`() {
+        connectAndAccept()
+        manager.setOnSignalReceived(null)
+
+        payloads.captured.onPayloadReceived("E1", Payload.fromBytes(SyncSignal.encode(SyncSignal.Ack)))
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `an incoming file is read and handed on only once its transfer succeeds`() {
+        connectAndAccept()
+        val file = File(context.cacheDir, "incoming.gz").apply { writeBytes("the export".toByteArray()) }
+        val payload = filePayload(id = 77, uri = Uri.fromFile(file))
+
+        payloads.captured.onPayloadReceived("E1", payload)
+        assertThat(received).isEmpty()
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(77, IN_PROGRESS, 50, 100))
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Transferring(0.5f))
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(77, SUCCESS, 100, 100))
+        assertThat(String(received.single())).isEqualTo("the export")
+    }
+
+    @Test
+    fun `an incoming file that reads back empty is reported`() {
+        connectAndAccept()
+        val file = File(context.cacheDir, "empty.gz").apply { writeBytes(ByteArray(0)) }
+
+        payloads.captured.onPayloadReceived("E1", filePayload(id = 78, uri = Uri.fromFile(file)))
+        payloads.captured.onPayloadTransferUpdate("E1", update(78, SUCCESS, 0, 0))
+
+        assertThat(received).isEmpty()
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("empty")
+    }
+
+    @Test
+    fun `a file payload the framework cannot resolve reads as nothing rather than crashing`() {
+        connectAndAccept()
+        val payload = mockk<Payload>(relaxed = true) {
+            every { id } returns 79
+            every { type } returns Payload.Type.FILE
+            every { asFile() } returns null
+        }
+
+        payloads.captured.onPayloadReceived("E1", payload)
+        payloads.captured.onPayloadTransferUpdate("E1", update(79, SUCCESS, 0, 0))
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("empty")
+    }
+
+    @Test
+    fun `a file whose uri never materialises reads as nothing rather than crashing`() {
+        connectAndAccept()
+        val payload = mockk<Payload>(relaxed = true) {
+            every { id } returns 80
+            every { type } returns Payload.Type.FILE
+            every { asFile() } returns mockk(relaxed = true) { every { asUri() } returns null }
+        }
+
+        payloads.captured.onPayloadReceived("E1", payload)
+        payloads.captured.onPayloadTransferUpdate("E1", update(80, SUCCESS, 0, 0))
+
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `an unknown payload type is ignored rather than treated as data`() {
+        connectAndAccept()
+        val payload = mockk<Payload>(relaxed = true) {
+            every { id } returns 81
+            every { type } returns 99
+        }
+
+        payloads.captured.onPayloadReceived("E1", payload)
+
+        assertThat(received).isEmpty()
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `a failed transfer is reported and its pending payload dropped`() {
+        connectAndAccept()
+        val file = File(context.cacheDir, "half.gz").apply { writeBytes("half".toByteArray()) }
+        payloads.captured.onPayloadReceived("E1", filePayload(id = 82, uri = Uri.fromFile(file)))
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(82, FAILURE))
+        payloads.captured.onPayloadTransferUpdate("E1", update(82, SUCCESS, 4, 4))
+
+        // The dropped payload matters: a SUCCESS arriving afterwards must not import a file
+        // whose transfer already failed.
+        assertThat(received).isEmpty()
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Completed(4))
+    }
+
+    @Test
+    fun `a cancelled transfer is reported as cancelled`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(83, CANCELED))
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("canceled")
+    }
+
+    @Test
+    fun `a transfer of unknown length reports no progress rather than dividing by zero`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(84, IN_PROGRESS, 10, 0))
+
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Transferring(0f))
+    }
+
+    // ── teardown ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `stopping clears the handlers so a destroyed ViewModel is not held`() {
+        connectAndAccept()
+        manager.sendData(incompressible())
+
+        manager.stopAll()
+
+        verify { client.stopAdvertising() }
+        verify { client.stopDiscovery() }
+        verify { client.stopAllEndpoints() }
+        assertThat(File(context.cacheDir, "sync_export.gz").exists()).isFalse()
+
+        // The manager is a @Singleton and the callback captures the ViewModel: without this
+        // the ViewModel and its cancelled scope outlive the screen for the process's life.
+        payloads.captured.onPayloadReceived(
+            "E1", Payload.fromBytes(byteArrayOf(0x1F) + gzip("{}".toByteArray()))
+        )
+        assertThat(received).isEmpty()
+        // And nothing is sent afterwards, because the endpoint is forgotten too.
+        sent.clear()
+        manager.sendSignal(SyncSignal.Ack)
+        assertThat(sent).isEmpty()
+    }
+
+    @Test
+    fun `disconnecting twice is safe`() {
+        connectAndAccept()
+
+        manager.disconnect()
+        manager.disconnect()
+
+        verify(exactly = 1) { client.disconnectFromEndpoint("E1") }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun connectTo(name: String) {
+        manager.startAdvertising("Pixel")
+        lifecycle.captured.onConnectionInitiated("E1", connectionInfo(name, "1234"))
+    }
+
+    private fun connectAndAccept() {
+        connectTo("Galaxy")
+        manager.acceptConnection("E1")
+        lifecycle.captured.onConnectionResult("E1", resolution(ConnectionsStatusCodes.STATUS_OK))
+        sent.clear()
+    }
+
+    private fun connectionInfo(name: String, digits: String) =
+        mockk<ConnectionInfo>(relaxed = true) {
+            every { endpointName } returns name
+            every { authenticationDigits } returns digits
+        }
+
+    private fun resolution(code: Int, message: String? = null) =
+        mockk<ConnectionResolution>(relaxed = true) {
+            every { status } returns Status(code, message)
+        }
+
+    private fun filePayload(id: Long, uri: Uri): Payload {
+        val payloadId = id
+        return mockk(relaxed = true) {
+            every { this@mockk.id } returns payloadId
+            every { type } returns Payload.Type.FILE
+            every { asFile() } returns mockk(relaxed = true) { every { asUri() } returns uri }
+        }
+    }
+
+    /** A STREAM payload whose bytes the manager reads on its own background thread. */
+    private fun streamPayload(id: Long, data: ByteArray): Payload {
+        val payloadId = id
+        return mockk(relaxed = true) {
+            every { this@mockk.id } returns payloadId
+            every { type } returns Payload.Type.STREAM
+            every { asStream() } returns mockk(relaxed = true) {
+                every { asInputStream() } returns data.inputStream()
+            }
+        }
+    }
+
+    /** The stream is read off the main thread, so the assertion has to wait for it. */
+    private fun awaitUntil(condition: () -> Boolean) {
+        val deadline = System.nanoTime() + 5_000_000_000L
+        while (!condition() && System.nanoTime() < deadline) Thread.sleep(5)
+        assertThat(condition()).isTrue()
+    }
+
+    private fun update(
+        id: Long,
+        status: Int,
+        transferred: Long = 0,
+        total: Long = 0,
+    ): PayloadTransferUpdate = PayloadTransferUpdate.Builder()
+        .setPayloadId(id)
+        .setStatus(status)
+        .setBytesTransferred(transferred)
+        .setTotalBytes(total)
+        .build()
+
+    /** Bigger than the 31 KB BYTES ceiling *after* gzip, which needs real entropy. */
+    private fun incompressible(): ByteArray =
+        ByteArray(400_000).also { java.util.Random(42).nextBytes(it) }
+
+    private fun gzip(data: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        GZIPOutputStream(out).use { it.write(data) }
+        return out.toByteArray()
+    }
+
+    private fun gunzip(data: ByteArray): ByteArray =
+        GZIPInputStream(data.inputStream()).use { it.readBytes() }
+
+    private companion object {
+        const val IN_PROGRESS = PayloadTransferUpdate.Status.IN_PROGRESS
+        const val SUCCESS = PayloadTransferUpdate.Status.SUCCESS
+        const val FAILURE = PayloadTransferUpdate.Status.FAILURE
+        const val CANCELED = PayloadTransferUpdate.Status.CANCELED
+    }
+
+    @Test
+    fun `a partner that accepts before this device does still connects by name`() {
+        connectTo("Galaxy")
+
+        // The other side accepted first, so the result arrives while this device is still
+        // showing the confirmation digits.
+        lifecycle.captured.onConnectionResult("E1", resolution(ConnectionsStatusCodes.STATUS_OK))
+
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `accepting a connection this device never saw an invitation for is nameless`() {
+        manager.startAdvertising("Pixel")
+
+        manager.acceptConnection("E1")
+
+        assertThat(manager.connectionState.value)
+            .isEqualTo(ConnectionState.WaitingForPartnerAccept("E1", ""))
+    }
+
+    // ── the stream transport ──────────────────────────────────────────────────
+
+    @Test
+    fun `a streamed export is read off the wire and handed to the importer`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived("E1", streamPayload(90, "the export".toByteArray()))
+
+        // Read on a background thread, so the transfer update below is not what delivers it.
+        awaitUntil { received.isNotEmpty() }
+        assertThat(String(received.single())).isEqualTo("the export")
+    }
+
+    @Test
+    fun `a stream that carries nothing is reported rather than imported as empty`() {
+        connectAndAccept()
+
+        payloads.captured.onPayloadReceived("E1", streamPayload(91, ByteArray(0)))
+
+        awaitUntil { manager.connectionState.value is ConnectionState.Error }
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("empty")
+        assertThat(received).isEmpty()
+    }
+
+    @Test
+    fun `a stream with no readable input is reported rather than silently dropped`() {
+        connectAndAccept()
+        val payload = mockk<Payload>(relaxed = true) {
+            every { id } returns 92
+            every { type } returns Payload.Type.STREAM
+            every { asStream() } returns null
+        }
+
+        payloads.captured.onPayloadReceived("E1", payload)
+
+        awaitUntil { manager.connectionState.value is ConnectionState.Error }
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("Failed to read data")
+    }
+
+    @Test
+    fun `a stream arriving with no handler registered is reported`() {
+        connectAndAccept()
+        manager.setOnDataReceived(null)
+
+        payloads.captured.onPayloadReceived("E1", streamPayload(93, "x".toByteArray()))
+
+        awaitUntil { manager.connectionState.value is ConnectionState.Error }
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("No data handler")
+    }
+
+    @Test
+    fun `a stream's transfer updates do not drive the progress bar`() {
+        connectAndAccept()
+        payloads.captured.onPayloadReceived("E1", streamPayload(94, "the export".toByteArray()))
+        awaitUntil { received.isNotEmpty() }
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(94, IN_PROGRESS, 50, 100))
+        payloads.captured.onPayloadTransferUpdate("E1", update(94, SUCCESS, 100, 100))
+
+        // The reading thread owns completion; a Completed here would end the sync before the
+        // data had been imported.
+        assertThat(manager.connectionState.value).isEqualTo(ConnectionState.Connected("E1", "Galaxy"))
+    }
+
+    @Test
+    fun `a stream whose transfer fails is reported`() {
+        connectAndAccept()
+        payloads.captured.onPayloadReceived("E1", streamPayload(95, "x".toByteArray()))
+        awaitUntil { received.isNotEmpty() }
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(95, FAILURE))
+
+        assertThat((manager.connectionState.value as ConnectionState.Error).message)
+            .contains("Transfer failed")
+    }
+
+    @Test
+    fun `a stream whose transfer is cancelled is reported`() {
+        connectAndAccept()
+        payloads.captured.onPayloadReceived("E1", streamPayload(96, "x".toByteArray()))
+        awaitUntil { received.isNotEmpty() }
+
+        payloads.captured.onPayloadTransferUpdate("E1", update(96, CANCELED))
+
+        assertThat(manager.connectionState.value).isInstanceOf(ConnectionState.Error::class.java)
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncDataExporterTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncDataExporterTest.kt
@@ -1,0 +1,363 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.arshadshah.nimaz.core.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUlHusnaDao
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUnNabiDao
+import com.arshadshah.nimaz.data.local.database.dao.DuaDao
+import com.arshadshah.nimaz.data.local.database.dao.FastingDao
+import com.arshadshah.nimaz.data.local.database.dao.HadithDao
+import com.arshadshah.nimaz.data.local.database.dao.KhatamDao
+import com.arshadshah.nimaz.data.local.database.dao.LocationDao
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.data.local.database.dao.ProphetDao
+import com.arshadshah.nimaz.data.local.database.dao.QaidaDao
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.dao.TafseerDao
+import com.arshadshah.nimaz.data.local.database.dao.TasbihDao
+import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ProgressDao
+import com.arshadshah.nimaz.data.local.user.ProgressKind
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.data.local.user.TafseerUserDao
+import com.arshadshah.nimaz.data.local.user.TasbihSessionDao
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What actually leaves the device when the user taps Send.
+ *
+ * Every field here reaches another phone's database and there is no undo, so the failure mode
+ * of an export is not an error — it is a record that quietly never arrives, or arrives stripped
+ * of half its columns. Three things in particular are only visible from this side:
+ *
+ *  - the payload keeps the **old seven-table wire format** on purpose, because a phone on this
+ *    version has to sync with one that still has seven bookmark tables. So the consolidated
+ *    `bookmarks` row is *fanned back out* by kind and by flag, and a verse that is both
+ *    bookmarked and favourited has to appear in **both** lists — as it did when it was a row in
+ *    each table. A filter that reads `bookmarked` where it means `favourite` silently drops one;
+ *  - progress rows are one table too (`ProgressKind`), so dua counts, qaida lessons and qaida
+ *    cells all come out of `progressDao.all()` and are told apart by nothing but the kind;
+ *  - **only favourite locations travel, and the current-location flag never does** — importing
+ *    one that carried it would move the receiving device's prayer times to another city.
+ */
+class SyncDataExporterTest {
+
+    private val quranDao: QuranDao = mockk(relaxed = true)
+    private val prayerDao: PrayerDao = mockk(relaxed = true)
+    private val fastingDao: FastingDao = mockk(relaxed = true)
+    private val tasbihDao: TasbihDao = mockk(relaxed = true)
+    private val sessionDao: TasbihSessionDao = mockk(relaxed = true)
+    private val khatamDao: KhatamDao = mockk(relaxed = true)
+    private val tafseerDao: TafseerDao = mockk(relaxed = true)
+    private val tafseerUserDao: TafseerUserDao = mockk(relaxed = true)
+    private val zakatDao: ZakatDao = mockk(relaxed = true)
+    private val asmaUlHusnaDao: AsmaUlHusnaDao = mockk(relaxed = true)
+    private val asmaUnNabiDao: AsmaUnNabiDao = mockk(relaxed = true)
+    private val prophetDao: ProphetDao = mockk(relaxed = true)
+    private val hadithDao: HadithDao = mockk(relaxed = true)
+    private val bookmarkDao: BookmarkDao = mockk(relaxed = true)
+    private val progressDao: ProgressDao = mockk(relaxed = true)
+    private val readingProgressDao: ReadingProgressDao = mockk(relaxed = true)
+    private val duaDao: DuaDao = mockk(relaxed = true)
+    private val qaidaDao: QaidaDao = mockk(relaxed = true)
+    private val locationDao: LocationDao = mockk(relaxed = true)
+    private val preferences: PreferencesDataStore = mockk(relaxed = true)
+
+    private val exporter by lazy {
+        SyncDataExporter(
+            quranDao, prayerDao, fastingDao, tasbihDao, sessionDao, khatamDao, tafseerDao,
+            tafseerUserDao, zakatDao, asmaUlHusnaDao, asmaUnNabiDao, prophetDao, hadithDao,
+            bookmarkDao, progressDao, readingProgressDao, duaDao, qaidaDao, locationDao,
+            preferences,
+        )
+    }
+
+    @Before
+    fun setUp() = SyncFixtures.populate(
+        prayerDao = prayerDao,
+        fastingDao = fastingDao,
+        tasbihDao = tasbihDao,
+        sessionDao = sessionDao,
+        khatamDao = khatamDao,
+        tafseerUserDao = tafseerUserDao,
+        zakatDao = zakatDao,
+        bookmarkDao = bookmarkDao,
+        progressDao = progressDao,
+        readingProgressDao = readingProgressDao,
+        locationDao = locationDao,
+        preferences = preferences,
+    )
+
+    // ── the consolidated bookmark row, fanned back out ────────────────────────
+
+    @Test
+    fun `a verse that is both bookmarked and favourited travels in both lists`() = runTest {
+        val payload = exporter.export()
+
+        // One row, two flags — and the wire format still has two tables.
+        assertThat(payload.bookmarks.map { it.ayahId }).contains(SyncFixtures.BOTH_AYAH)
+        assertThat(payload.favorites.map { it.ayahId }).contains(SyncFixtures.BOTH_AYAH)
+    }
+
+    @Test
+    fun `a verse that is only favourited does not travel as a bookmark`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.favorites.map { it.ayahId }).contains(SyncFixtures.FAVOURITE_ONLY_AYAH)
+        assertThat(payload.bookmarks.map { it.ayahId })
+            .doesNotContain(SyncFixtures.FAVOURITE_ONLY_AYAH)
+    }
+
+    @Test
+    fun `a bookmark carries the surah and verse it was filed under`() = runTest {
+        val bookmark = exporter.export().bookmarks.single { it.ayahId == SyncFixtures.BOTH_AYAH }
+
+        assertThat(bookmark.surahNumber).isEqualTo(2)
+        assertThat(bookmark.ayahNumber).isEqualTo(255)
+        assertThat(bookmark.note).isEqualTo("memorise")
+        assertThat(bookmark.color).isEqualTo("#FF0000")
+    }
+
+    @Test
+    fun `marks of other kinds do not leak into the Quran lists`() = runTest {
+        val payload = exporter.export()
+
+        // Hadith, dua and the three name kinds share the table with ayah marks.
+        assertThat(payload.bookmarks.map { it.ayahId })
+            .containsNoneOf(SyncFixtures.HADITH_ID, SyncFixtures.DUA_ID)
+        assertThat(payload.hadithBookmarks.map { it.hadithId })
+            .containsExactly(SyncFixtures.HADITH_ID)
+        assertThat(payload.duaBookmarks.map { it.duaId }).containsExactly(SyncFixtures.DUA_ID)
+    }
+
+    @Test
+    fun `each name kind exports into its own list`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.asmaUlHusnaBookmarks.map { it.refId }).containsExactly(7)
+        assertThat(payload.asmaUnNabiBookmarks.map { it.refId }).containsExactly(8)
+        assertThat(payload.prophetBookmarks.map { it.refId }).containsExactly(9)
+    }
+
+    // ── the shared progress table, told apart by kind ─────────────────────────
+
+    @Test
+    fun `dua, qaida lesson and qaida cell progress separate by kind`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.duaProgress.map { it.duaId }).containsExactly(SyncFixtures.DUA_ID)
+        assertThat(payload.qaidaLessonProgress.map { it.lessonId }).containsExactly(3)
+        assertThat(payload.qaidaCellProgress.map { it.cellId }).containsExactly(11)
+    }
+
+    @Test
+    fun `a qaida lesson exports its state, stars and resume point`() = runTest {
+        val lesson = exporter.export().qaidaLessonProgress.single()
+
+        assertThat(lesson.status).isEqualTo("COMPLETED")
+        assertThat(lesson.stars).isEqualTo(3)
+        assertThat(lesson.lastCellId).isEqualTo(11)
+        assertThat(lesson.completedCells).isEqualTo(12)
+        assertThat(lesson.totalCells).isEqualTo(12)
+    }
+
+    @Test
+    fun `a qaida cell exports the lesson it belongs to`() = runTest {
+        val cell = exporter.export().qaidaCellProgress.single()
+
+        assertThat(cell.lessonId).isEqualTo(3)
+        assertThat(cell.heardCount).isEqualTo(4)
+        assertThat(cell.isCompleted).isTrue()
+    }
+
+    @Test
+    fun `a lesson with no recorded total exports zero rather than dropping the row`() = runTest {
+        coEvery { progressDao.all() } returns listOf(
+            SyncFixtures.progress(ProgressKind.QAIDA_LESSON, targetId = 4, total = null)
+        )
+
+        val lesson = exporter.export().qaidaLessonProgress.single()
+
+        assertThat(lesson.totalCells).isEqualTo(0)
+        assertThat(lesson.status).isEmpty()
+    }
+
+    // ── the parent-child tables ───────────────────────────────────────────────
+
+    @Test
+    fun `every khatam's ayahs and daily logs are gathered, not just the active one's`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.khatams.map { it.id }).containsExactly(1L, 2L)
+        assertThat(payload.khatamAyahs.map { it.khatamId }).containsExactly(1L, 2L)
+        assertThat(payload.khatamDailyLogs.map { it.khatamId }).containsExactly(1L, 2L)
+    }
+
+    @Test
+    fun `a khatam exports the fields the receiving device needs to reschedule its reminder`() =
+        runTest {
+            val khatam = exporter.export().khatams.first { it.id == 1L }
+
+            assertThat(khatam.reminderEnabled).isTrue()
+            assertThat(khatam.reminderTime).isEqualTo("06:30")
+            assertThat(khatam.dailyTarget).isEqualTo(20)
+            assertThat(khatam.isActive).isTrue()
+        }
+
+    // ── everything else that has to arrive whole ──────────────────────────────
+
+    @Test
+    fun `prayer, fast and makeup records carry their timestamps`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.prayerRecords.single().prayerName).isEqualTo("fajr")
+        assertThat(payload.prayerRecords.single().isJamaah).isTrue()
+        assertThat(payload.fastRecords.single().fastType).isEqualTo("ramadan")
+        assertThat(payload.fastRecords.single().hijriMonth).isEqualTo(9)
+        assertThat(payload.makeupFasts.single().fidyaAmount).isEqualTo(5.0)
+    }
+
+    @Test
+    fun `tasbih presets and sessions travel with the counts they hold`() = runTest {
+        val payload = exporter.export()
+
+        assertThat(payload.tasbihPresets.single().name).isEqualTo("SubhanAllah")
+        assertThat(payload.tasbihPresets.single().targetCount).isEqualTo(33)
+        assertThat(payload.tasbihSessions.single().currentCount).isEqualTo(33)
+        assertThat(payload.tasbihSessions.single().totalLaps).isEqualTo(1)
+    }
+
+    @Test
+    fun `tafseer highlights carry the span they cover, which is what identifies them`() = runTest {
+        val highlight = exporter.export().tafseerHighlights.single()
+
+        // The row id cannot identify a highlight: it is autoGenerate, so both phones hand out 1.
+        assertThat(highlight.ayahId).isEqualTo(262)
+        assertThat(highlight.tafseerId).isEqualTo("ibn-kathir")
+        assertThat(highlight.startOffset).isEqualTo(10)
+        assertThat(highlight.endOffset).isEqualTo(40)
+        assertThat(exporter.export().tafseerNotes.single().text).isEqualTo("note text")
+    }
+
+    @Test
+    fun `a zakat calculation exports what it was worked out from`() = runTest {
+        val history = exporter.export().zakatHistory.single()
+
+        assertThat(history.netWorth).isEqualTo(4000.0)
+        assertThat(history.zakatDue).isEqualTo(100.0)
+        assertThat(history.nisabType).isEqualTo("silver")
+        assertThat(history.isPaid).isTrue()
+    }
+
+    @Test
+    fun `only favourite locations are exported and none of them carries a current flag`() =
+        runTest {
+            val payload = exporter.export()
+
+            // `getFavoriteLocationsSync` is the query; the payload type has no field for
+            // `isCurrentLocation` at all, which is what stops a sync moving the other phone's
+            // prayer times to this city.
+            assertThat(payload.favoriteLocations.map { it.city }).containsExactly("Dublin")
+            assertThat(payload.favoriteLocations.single().calculationMethod).isEqualTo("MWL")
+            assertThat(payload.favoriteLocations.single().fajrAngle).isEqualTo(18.0)
+        }
+
+    @Test
+    fun `reading progress travels as the running totals, not just the position`() = runTest {
+        val progress = exporter.export().readingProgress!!
+
+        assertThat(progress.lastReadSurah).isEqualTo(2)
+        assertThat(progress.totalAyahsRead).isEqualTo(900)
+        assertThat(progress.currentKhatmaCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `a device that has never opened the Quran exports no reading progress`() = runTest {
+        coEvery { readingProgressDao.get() } returns null
+
+        assertThat(exporter.export().readingProgress).isNull()
+    }
+
+    @Test
+    fun `preferences are exported as the datastore reports them`() = runTest {
+        assertThat(exporter.export().preferences).containsExactly("theme", "dark")
+    }
+
+    @Test
+    fun `an empty device still produces a well formed payload`() = runTest {
+        SyncFixtures.empty(
+            prayerDao, fastingDao, tasbihDao, sessionDao, khatamDao, tafseerUserDao, zakatDao,
+            bookmarkDao, progressDao, readingProgressDao, locationDao, preferences,
+        )
+
+        val payload = exporter.export()
+
+        // Every category reports zero rather than the export failing part-way.
+        assertThat(payload.categories().map { it.count }.toSet()).containsExactly(0)
+        assertThat(payload.appVersion).isEqualTo(11)
+        assertThat(payload.exportedAt).isGreaterThan(0L)
+    }
+
+    @Test
+    fun `the progress labels name what is being exported at each step`() = runTest {
+        val labels = mutableListOf<String>()
+
+        exporter.export { _, _, label -> labels += label }
+
+        assertThat(labels).hasSize(SyncDataExporter.STEP_COUNT)
+        assertThat(labels.toSet()).hasSize(SyncDataExporter.STEP_COUNT)
+        assertThat(labels.first()).contains("Quran")
+        assertThat(labels.last()).contains("preferences")
+    }
+
+    @Test
+    fun `a mark filed under nothing exports as zero rather than being dropped`() = runTest {
+        coEvery { bookmarkDao.all() } returns listOf(
+            com.arshadshah.nimaz.data.local.user.BookmarkEntity(
+                kind = BookmarkKind.AYAH, targetId = 262, bookmarked = true, favourite = true,
+                contextId = null, ordinal = null, createdAt = 1L, updatedAt = 2L,
+            ),
+            com.arshadshah.nimaz.data.local.user.BookmarkEntity(
+                kind = BookmarkKind.HADITH, targetId = 5001, bookmarked = true,
+                contextId = null, ordinal = null, createdAt = 1L, updatedAt = 2L,
+            ),
+            com.arshadshah.nimaz.data.local.user.BookmarkEntity(
+                kind = BookmarkKind.DUA, targetId = 42, bookmarked = true,
+                contextId = null, createdAt = 1L, updatedAt = 2L,
+            ),
+        )
+
+        val payload = exporter.export()
+
+        // The wire format has no nullable context, and dropping the row would lose the mark.
+        assertThat(payload.bookmarks.single().surahNumber).isEqualTo(0)
+        assertThat(payload.bookmarks.single().ayahNumber).isEqualTo(0)
+        assertThat(payload.favorites.single().surahNumber).isEqualTo(0)
+        assertThat(payload.hadithBookmarks.single().bookId).isEqualTo(0)
+        assertThat(payload.duaBookmarks.single().categoryId).isEqualTo(0)
+    }
+
+    @Test
+    fun `a qaida cell with no lesson recorded exports as lesson zero`() = runTest {
+        coEvery { progressDao.all() } returns listOf(
+            SyncFixtures.progress(ProgressKind.QAIDA_CELL, targetId = 11, total = null)
+        )
+
+        assertThat(exporter.export().qaidaCellProgress.single().lessonId).isEqualTo(0)
+    }
+
+    @Test
+    fun `a dua count with no target recorded exports as zero`() = runTest {
+        coEvery { progressDao.all() } returns listOf(
+            SyncFixtures.progress(ProgressKind.DUA, targetId = 42, total = null)
+        )
+
+        assertThat(exporter.export().duaProgress.single().targetCount).isEqualTo(0)
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncFixtures.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncFixtures.kt
@@ -1,0 +1,239 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.arshadshah.nimaz.core.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.data.local.database.dao.FastingDao
+import com.arshadshah.nimaz.data.local.database.dao.KhatamDao
+import com.arshadshah.nimaz.data.local.database.dao.LocationDao
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.data.local.database.dao.TasbihDao
+import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
+import com.arshadshah.nimaz.data.local.database.entity.FastRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamDailyLogEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamEntity
+import com.arshadshah.nimaz.data.local.database.entity.LocationEntity
+import com.arshadshah.nimaz.data.local.database.entity.MakeupFastEntity
+import com.arshadshah.nimaz.data.local.database.entity.PrayerRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerHighlightEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerNoteEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihPresetEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihSessionEntity
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ProgressDao
+import com.arshadshah.nimaz.data.local.user.ProgressEntity
+import com.arshadshah.nimaz.data.local.user.ProgressKind
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.data.local.user.TafseerUserDao
+import com.arshadshah.nimaz.data.local.user.TasbihSessionDao
+import io.mockk.coEvery
+
+/**
+ * A device with one of everything on it, and the same device with nothing on it.
+ *
+ * Both the exporter and the importer tests need a populated set of DAOs, and the two halves
+ * only prove a round trip if they agree on the rows — so the rows live here once.
+ */
+internal object SyncFixtures {
+
+    /** A verse that is bookmarked *and* favourited: one row, two flags, two wire lists. */
+    const val BOTH_AYAH = 262
+
+    /** A verse that is only favourited — it must not travel as a bookmark. */
+    const val FAVOURITE_ONLY_AYAH = 300
+
+    const val HADITH_ID = 5001
+    const val DUA_ID = 42
+
+    fun populate(
+        prayerDao: PrayerDao,
+        fastingDao: FastingDao,
+        tasbihDao: TasbihDao,
+        sessionDao: TasbihSessionDao,
+        khatamDao: KhatamDao,
+        tafseerUserDao: TafseerUserDao,
+        zakatDao: ZakatDao,
+        bookmarkDao: BookmarkDao,
+        progressDao: ProgressDao,
+        readingProgressDao: ReadingProgressDao,
+        locationDao: LocationDao,
+        preferences: PreferencesDataStore,
+    ) {
+        coEvery { bookmarkDao.all() } returns marks()
+        coEvery { progressDao.all() } returns progressRows()
+        coEvery { readingProgressDao.get() } returns ReadingProgressEntity(
+            id = 1,
+            lastReadSurah = 2, lastReadAyah = 255, lastReadPage = 42, lastReadJuz = 3,
+            totalAyahsRead = 900, currentKhatmaCount = 2, updatedAt = 1_000L,
+        )
+        coEvery { prayerDao.getAllPrayerRecords() } returns listOf(prayerRecord())
+        coEvery { fastingDao.getAllFastRecords() } returns listOf(fastRecord())
+        coEvery { fastingDao.getAllMakeupFastsSync() } returns listOf(makeupFast())
+        coEvery { tasbihDao.getAllPresetsSync() } returns listOf(preset())
+        coEvery { sessionDao.getAllSessionsSync() } returns listOf(session())
+        coEvery { khatamDao.getAllKhatamsSync() } returns listOf(khatam(1L), khatam(2L))
+        coEvery { khatamDao.getKhatamAyahsSync(1L) } returns
+            listOf(KhatamAyahEntity(khatamId = 1L, ayahId = 1, readAt = 10L, updatedAt = 10L))
+        coEvery { khatamDao.getKhatamAyahsSync(2L) } returns
+            listOf(KhatamAyahEntity(khatamId = 2L, ayahId = 2, readAt = 20L, updatedAt = 20L))
+        coEvery { khatamDao.getDailyLogsSync(1L) } returns
+            listOf(KhatamDailyLogEntity(khatamId = 1L, date = 1L, ayahsRead = 20, updatedAt = 10L))
+        coEvery { khatamDao.getDailyLogsSync(2L) } returns
+            listOf(KhatamDailyLogEntity(khatamId = 2L, date = 2L, ayahsRead = 30, updatedAt = 20L))
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns listOf(highlight())
+        coEvery { tafseerUserDao.getAllNotesSync() } returns listOf(note())
+        coEvery { zakatDao.getAllHistorySync() } returns listOf(zakat())
+        coEvery { locationDao.getFavoriteLocationsSync() } returns listOf(location())
+        coEvery { preferences.exportAllPreferences() } returns mapOf("theme" to "dark")
+    }
+
+    fun empty(
+        prayerDao: PrayerDao,
+        fastingDao: FastingDao,
+        tasbihDao: TasbihDao,
+        sessionDao: TasbihSessionDao,
+        khatamDao: KhatamDao,
+        tafseerUserDao: TafseerUserDao,
+        zakatDao: ZakatDao,
+        bookmarkDao: BookmarkDao,
+        progressDao: ProgressDao,
+        readingProgressDao: ReadingProgressDao,
+        locationDao: LocationDao,
+        preferences: PreferencesDataStore,
+    ) {
+        coEvery { bookmarkDao.all() } returns emptyList()
+        coEvery { progressDao.all() } returns emptyList()
+        coEvery { readingProgressDao.get() } returns null
+        coEvery { prayerDao.getAllPrayerRecords() } returns emptyList()
+        coEvery { fastingDao.getAllFastRecords() } returns emptyList()
+        coEvery { fastingDao.getAllMakeupFastsSync() } returns emptyList()
+        coEvery { tasbihDao.getAllPresetsSync() } returns emptyList()
+        coEvery { sessionDao.getAllSessionsSync() } returns emptyList()
+        coEvery { khatamDao.getAllKhatamsSync() } returns emptyList()
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns emptyList()
+        coEvery { tafseerUserDao.getAllNotesSync() } returns emptyList()
+        coEvery { zakatDao.getAllHistorySync() } returns emptyList()
+        coEvery { locationDao.getAllLocationsSync() } returns emptyList()
+        coEvery { locationDao.getFavoriteLocationsSync() } returns emptyList()
+        coEvery { preferences.exportAllPreferences() } returns emptyMap()
+    }
+
+    fun marks() = listOf(
+        BookmarkEntity(
+            kind = BookmarkKind.AYAH, targetId = BOTH_AYAH, bookmarked = true, favourite = true,
+            note = "memorise", colour = "#FF0000", contextId = 2, ordinal = 255,
+            createdAt = 100L, updatedAt = 200L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.AYAH, targetId = FAVOURITE_ONLY_AYAH,
+            bookmarked = false, favourite = true, contextId = 3, ordinal = 1,
+            createdAt = 110L, updatedAt = 210L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.HADITH, targetId = HADITH_ID, bookmarked = true,
+            note = "hadith note", colour = "#00FF00", contextId = 1, ordinal = 12,
+            createdAt = 120L, updatedAt = 220L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.DUA, targetId = DUA_ID, bookmarked = true, favourite = true,
+            note = "dua note", contextId = 4, createdAt = 130L, updatedAt = 230L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.ASMA_UL_HUSNA, targetId = 7, favourite = true,
+            createdAt = 140L, updatedAt = 240L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.ASMA_UN_NABI, targetId = 8, favourite = true,
+            createdAt = 150L, updatedAt = 250L,
+        ),
+        BookmarkEntity(
+            kind = BookmarkKind.PROPHET, targetId = 9, favourite = true,
+            createdAt = 160L, updatedAt = 260L,
+        ),
+    )
+
+    fun progressRows() = listOf(
+        ProgressEntity(
+            kind = ProgressKind.DUA, targetId = DUA_ID, date = 500L, completed = 3, total = 7,
+            isCompleted = false, createdAt = 300L, updatedAt = 300L,
+        ),
+        ProgressEntity(
+            kind = ProgressKind.QAIDA_LESSON, targetId = 3, completed = 12, total = 12,
+            isCompleted = true, state = "COMPLETED", score = 3, resumeId = 11,
+            createdAt = 310L, updatedAt = 310L,
+        ),
+        ProgressEntity(
+            kind = ProgressKind.QAIDA_CELL, targetId = 11, contextId = 3, completed = 4,
+            isCompleted = true, createdAt = 320L, updatedAt = 320L,
+        ),
+    )
+
+    fun progress(kind: String, targetId: Int, total: Int?) = ProgressEntity(
+        kind = kind, targetId = targetId, total = total, createdAt = 1L, updatedAt = 1L,
+    )
+
+    fun prayerRecord() = PrayerRecordEntity(
+        id = 1, date = 1_000L, prayerName = "fajr", status = "prayed", prayedAt = 1_100L,
+        scheduledTime = 1_050L, isJamaah = true, isQadaFor = null, note = "n",
+        createdAt = 1_000L, updatedAt = 1_200L,
+    )
+
+    fun fastRecord() = FastRecordEntity(
+        id = 1, date = 2_000L, hijriDate = "1/9/1446", hijriMonth = 9, hijriYear = 1446,
+        fastType = "ramadan", status = "fasted", exemptionReason = null,
+        suhoorTime = 1_900L, iftarTime = 2_500L, note = null,
+        createdAt = 2_000L, updatedAt = 2_200L,
+    )
+
+    fun makeupFast() = MakeupFastEntity(
+        id = 1, originalDate = 3_000L, originalHijriDate = "2/9/1446", reason = "travel",
+        status = "pending", completedDate = null, fidyaAmount = 5.0, note = null,
+        createdAt = 3_000L, updatedAt = 3_200L,
+    )
+
+    fun preset() = TasbihPresetEntity(
+        id = 1, name = "SubhanAllah", arabic = "سبحان الله", transliteration = "SubhanAllah",
+        translation = "Glory be to God", targetCount = 33, isCustom = 0, displayOrder = 1,
+        updatedAt = 4_000L,
+    )
+
+    fun session() = TasbihSessionEntity(
+        id = 1, presetId = 1, presetName = "SubhanAllah", date = 5_000L, currentCount = 33,
+        targetCount = 33, totalLaps = 1, isCompleted = true, duration = 60_000L,
+        startedAt = 5_000L, completedAt = 5_060L, note = null, updatedAt = 5_100L,
+    )
+
+    fun khatam(id: Long) = KhatamEntity(
+        id = id, name = "Khatam $id", notes = null, status = "active", isActive = id == 1L,
+        dailyTarget = 20, deadline = null, reminderEnabled = true, reminderTime = "06:30",
+        totalAyahsRead = 100, createdAt = 6_000L + id, startedAt = 6_000L + id,
+        completedAt = null, updatedAt = 6_100L + id,
+    )
+
+    fun highlight() = TafseerHighlightEntity(
+        id = 1, ayahId = 262, tafseerId = "ibn-kathir", startOffset = 10, endOffset = 40,
+        color = "#FFFF00", note = "why", createdAt = 7_000L, updatedAt = 7_100L,
+    )
+
+    fun note() = TafseerNoteEntity(
+        id = 1, ayahId = 262, tafseerId = "ibn-kathir", text = "note text",
+        createdAt = 8_000L, updatedAt = 8_100L,
+    )
+
+    fun zakat() = ZakatHistoryEntity(
+        id = 1, calculatedAt = 9_000L, totalAssets = 5_000.0, totalLiabilities = 1_000.0,
+        netWorth = 4_000.0, zakatDue = 100.0, nisabType = "silver", nisabValue = 600.0,
+        isPaid = true, paidAt = 9_100L, notes = "paid", updatedAt = 9_200L,
+    )
+
+    fun location() = LocationEntity(
+        id = 1, name = "Dublin", latitude = 53.35, longitude = -6.26, timezone = "Europe/Dublin",
+        country = "Ireland", city = "Dublin", isCurrentLocation = true, isFavorite = true,
+        calculationMethod = "MWL", asrCalculation = "standard",
+        highLatitudeRule = "middle_of_night", fajrAngle = 18.0, ishaAngle = 17.0,
+        createdAt = 10_000L, updatedAt = 10_100L,
+    )
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncRoundTripTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncRoundTripTest.kt
@@ -1,0 +1,673 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.arshadshah.nimaz.core.datastore.PreferencesDataStore
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUlHusnaDao
+import com.arshadshah.nimaz.data.local.database.dao.AsmaUnNabiDao
+import com.arshadshah.nimaz.data.local.database.dao.DuaDao
+import com.arshadshah.nimaz.data.local.database.dao.FastingDao
+import com.arshadshah.nimaz.data.local.database.dao.HadithDao
+import com.arshadshah.nimaz.data.local.database.dao.KhatamDao
+import com.arshadshah.nimaz.data.local.database.dao.LocationDao
+import com.arshadshah.nimaz.data.local.database.dao.PrayerDao
+import com.arshadshah.nimaz.data.local.database.dao.ProphetDao
+import com.arshadshah.nimaz.data.local.database.dao.QaidaDao
+import com.arshadshah.nimaz.data.local.database.dao.QuranDao
+import com.arshadshah.nimaz.data.local.database.dao.TafseerDao
+import com.arshadshah.nimaz.data.local.database.dao.TasbihDao
+import com.arshadshah.nimaz.data.local.database.dao.ZakatDao
+import com.arshadshah.nimaz.data.local.database.NimazDatabase
+import com.arshadshah.nimaz.data.local.database.entity.FastRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamAyahEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamDailyLogEntity
+import com.arshadshah.nimaz.data.local.database.entity.KhatamEntity
+import com.arshadshah.nimaz.data.local.database.entity.LocationEntity
+import com.arshadshah.nimaz.data.local.database.entity.MakeupFastEntity
+import com.arshadshah.nimaz.data.local.database.entity.PrayerRecordEntity
+import com.arshadshah.nimaz.data.local.database.entity.ReadingProgressEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerHighlightEntity
+import com.arshadshah.nimaz.data.local.database.entity.TafseerNoteEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihPresetEntity
+import com.arshadshah.nimaz.data.local.database.entity.TasbihSessionEntity
+import com.arshadshah.nimaz.data.local.database.entity.ZakatHistoryEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkDao
+import com.arshadshah.nimaz.data.local.user.BookmarkEntity
+import com.arshadshah.nimaz.data.local.user.BookmarkKind
+import com.arshadshah.nimaz.data.local.user.ProgressDao
+import com.arshadshah.nimaz.data.local.user.ProgressEntity
+import com.arshadshah.nimaz.data.local.user.ProgressKind
+import com.arshadshah.nimaz.data.local.user.ReadingProgressDao
+import com.arshadshah.nimaz.data.local.user.TafseerUserDao
+import com.arshadshah.nimaz.data.local.user.TasbihSessionDao
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Export from a populated phone, import into an empty one, and assert the second phone now
+ * holds what the first did.
+ *
+ * A wrong import silently overwrites another device's records and there is no undo, so the two
+ * halves are only worth anything together: an exporter that drops a column and an importer that
+ * never reads it agree perfectly, and the user loses the data with nothing to see.
+ *
+ * The properties pinned here are the ones a single-sided test cannot state:
+ *
+ *  - **row ids never travel.** `id` is `autoGenerate` on both phones, so both have handed out
+ *    1, 2, 3… Khatams merge on `createdAt`, prayers on `date`+`prayerName`, fasts on `date`,
+ *    presets on `name`, sessions on `startedAt`, highlights on the span they cover, locations
+ *    on coordinates. Merging on the id meant an incoming record overwrote an unrelated local
+ *    one that happened to hold it;
+ *  - **a khatam's children are re-parented** through the sender-id → local-id map the parent
+ *    import returns. Without it another device's read verses attached to whichever local khatam
+ *    held that id and inflated its progress;
+ *  - **the merge is additive, because the payload carries no tombstones.** It lists what the
+ *    sending device *has*, so a flag set on either side stays set and nothing is deleted for
+ *    being absent.
+ */
+class SyncRoundTripTest {
+
+    // The sending phone.
+    private val srcPrayerDao: PrayerDao = mockk(relaxed = true)
+    private val srcFastingDao: FastingDao = mockk(relaxed = true)
+    private val srcTasbihDao: TasbihDao = mockk(relaxed = true)
+    private val srcSessionDao: TasbihSessionDao = mockk(relaxed = true)
+    private val srcKhatamDao: KhatamDao = mockk(relaxed = true)
+    private val srcTafseerUserDao: TafseerUserDao = mockk(relaxed = true)
+    private val srcZakatDao: ZakatDao = mockk(relaxed = true)
+    private val srcBookmarkDao: BookmarkDao = mockk(relaxed = true)
+    private val srcProgressDao: ProgressDao = mockk(relaxed = true)
+    private val srcReadingProgressDao: ReadingProgressDao = mockk(relaxed = true)
+    private val srcLocationDao: LocationDao = mockk(relaxed = true)
+    private val srcPreferences: PreferencesDataStore = mockk(relaxed = true)
+
+    // The receiving phone.
+    private val prayerDao: PrayerDao = mockk(relaxed = true)
+    private val fastingDao: FastingDao = mockk(relaxed = true)
+    private val tasbihDao: TasbihDao = mockk(relaxed = true)
+    private val sessionDao: TasbihSessionDao = mockk(relaxed = true)
+    private val khatamDao: KhatamDao = mockk(relaxed = true)
+    private val tafseerUserDao: TafseerUserDao = mockk(relaxed = true)
+    private val zakatDao: ZakatDao = mockk(relaxed = true)
+    private val bookmarkDao: BookmarkDao = mockk(relaxed = true)
+    private val progressDao: ProgressDao = mockk(relaxed = true)
+    private val readingProgressDao: ReadingProgressDao = mockk(relaxed = true)
+    private val locationDao: LocationDao = mockk(relaxed = true)
+    private val preferences: PreferencesDataStore = mockk(relaxed = true)
+
+    private val exporter by lazy {
+        SyncDataExporter(
+            mockk<QuranDao>(relaxed = true), srcPrayerDao, srcFastingDao, srcTasbihDao,
+            srcSessionDao, srcKhatamDao, mockk<TafseerDao>(relaxed = true), srcTafseerUserDao,
+            srcZakatDao, mockk<AsmaUlHusnaDao>(relaxed = true), mockk<AsmaUnNabiDao>(relaxed = true),
+            mockk<ProphetDao>(relaxed = true), mockk<HadithDao>(relaxed = true), srcBookmarkDao,
+            srcProgressDao, srcReadingProgressDao, mockk<DuaDao>(relaxed = true),
+            mockk<QaidaDao>(relaxed = true), srcLocationDao, srcPreferences,
+        )
+    }
+
+    private val importer by lazy {
+        SyncDataImporter(
+            database = mockk<NimazDatabase>(relaxed = true),
+            quranDao = mockk(relaxed = true),
+            prayerDao = prayerDao,
+            fastingDao = fastingDao,
+            tasbihDao = tasbihDao,
+            sessionDao = sessionDao,
+            khatamDao = khatamDao,
+            tafseerDao = mockk(relaxed = true),
+            tafseerUserDao = tafseerUserDao,
+            zakatDao = zakatDao,
+            asmaUlHusnaDao = mockk(relaxed = true),
+            asmaUnNabiDao = mockk(relaxed = true),
+            prophetDao = mockk(relaxed = true),
+            hadithDao = mockk(relaxed = true),
+            bookmarkDao = bookmarkDao,
+            progressDao = progressDao,
+            readingProgressDao = readingProgressDao,
+            duaDao = mockk(relaxed = true),
+            qaidaDao = mockk(relaxed = true),
+            locationDao = locationDao,
+            preferencesDataStore = preferences,
+        )
+    }
+
+    /**
+     * The receiving phone's `bookmarks` table, which has to be a **real** store rather than a
+     * stub: `importBookmarks` and `importFavorites` both read it and both write it, and the
+     * whole point of the merge is that the second one sees what the first wrote.
+     */
+    private val markStore = mutableListOf<BookmarkEntity>()
+
+    /** Every upsert, in order — the merge is asserted on what was written, not on what is left. */
+    private val marks = mutableListOf<BookmarkEntity>()
+    private val progressRows = mutableListOf<ProgressEntity>()
+    private val locations = mutableListOf<LocationEntity>()
+    private val prayerRecords = mutableListOf<List<PrayerRecordEntity>>()
+    private val fastRecords = mutableListOf<List<FastRecordEntity>>()
+    private val makeupFasts = mutableListOf<MakeupFastEntity>()
+    private val presets = mutableListOf<TasbihPresetEntity>()
+    private val sessions = mutableListOf<TasbihSessionEntity>()
+    private val khatamsInserted = mutableListOf<KhatamEntity>()
+    private val khatamsUpdated = mutableListOf<KhatamEntity>()
+    private val khatamAyahs = mutableListOf<List<KhatamAyahEntity>>()
+    private val dailyLogs = mutableListOf<KhatamDailyLogEntity>()
+    private val highlights = mutableListOf<List<TafseerHighlightEntity>>()
+    private val notes = mutableListOf<List<TafseerNoteEntity>>()
+    private val zakats = mutableListOf<List<ZakatHistoryEntity>>()
+    private val readingProgress = mutableListOf<ReadingProgressEntity>()
+    private val importedPreferences = mutableListOf<Map<String, String>>()
+
+    @Before
+    fun setUp() {
+        SyncFixtures.populate(
+            prayerDao = srcPrayerDao,
+            fastingDao = srcFastingDao,
+            tasbihDao = srcTasbihDao,
+            sessionDao = srcSessionDao,
+            khatamDao = srcKhatamDao,
+            tafseerUserDao = srcTafseerUserDao,
+            zakatDao = srcZakatDao,
+            bookmarkDao = srcBookmarkDao,
+            progressDao = srcProgressDao,
+            readingProgressDao = srcReadingProgressDao,
+            locationDao = srcLocationDao,
+            preferences = srcPreferences,
+        )
+        emptyReceiver()
+        recordReceiverWrites()
+    }
+
+    /** The receiving phone starts with nothing; individual tests override a table. */
+    private fun emptyReceiver() {
+        coEvery { bookmarkDao.all() } answers { markStore.toList() }
+        coEvery { progressDao.all() } returns emptyList()
+        coEvery { readingProgressDao.get() } returns null
+        coEvery { prayerDao.getAllPrayerRecords() } returns emptyList()
+        coEvery { fastingDao.getAllFastRecords() } returns emptyList()
+        coEvery { fastingDao.getAllMakeupFastsSync() } returns emptyList()
+        coEvery { tasbihDao.getAllPresetsSync() } returns emptyList()
+        coEvery { sessionDao.getAllSessionsSync() } returns emptyList()
+        coEvery { khatamDao.getAllKhatamsSync() } returns emptyList()
+        coEvery { khatamDao.getDailyLog(any(), any()) } returns null
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns emptyList()
+        coEvery { tafseerUserDao.getAllNotesSync() } returns emptyList()
+        coEvery { zakatDao.getAllHistorySync() } returns emptyList()
+        coEvery { locationDao.getAllLocationsSync() } returns emptyList()
+    }
+
+    private fun recordReceiverWrites() {
+        coEvery { bookmarkDao.upsert(any()) } answers {
+            val row = firstArg<BookmarkEntity>()
+            markStore.removeAll { it.kind == row.kind && it.targetId == row.targetId }
+            markStore += row
+            marks += row
+        }
+        coEvery { progressDao.upsert(capture(progressRows)) } returns Unit
+        coEvery { locationDao.insertLocation(capture(locations)) } returns 1L
+        coEvery { prayerDao.insertPrayerRecords(capture(prayerRecords)) } returns Unit
+        coEvery { fastingDao.insertFastRecords(capture(fastRecords)) } returns Unit
+        coEvery { fastingDao.insertMakeupFast(capture(makeupFasts)) } returns Unit
+        coEvery { tasbihDao.insertPreset(capture(presets)) } returns 1L
+        coEvery { sessionDao.insertSession(capture(sessions)) } returns 1L
+        // Room hands out fresh local ids; the sender's are never reused.
+        coEvery { khatamDao.insertKhatam(capture(khatamsInserted)) } answers
+            { 100L + khatamsInserted.size }
+        coEvery { khatamDao.updateKhatam(capture(khatamsUpdated)) } returns Unit
+        coEvery { khatamDao.insertAyahs(capture(khatamAyahs)) } returns Unit
+        coEvery { khatamDao.upsertDailyLog(capture(dailyLogs)) } returns Unit
+        coEvery { tafseerUserDao.insertHighlights(capture(highlights)) } returns Unit
+        coEvery { tafseerUserDao.insertNotes(capture(notes)) } returns Unit
+        coEvery { zakatDao.insertCalculations(capture(zakats)) } returns Unit
+        coEvery { readingProgressDao.upsert(capture(readingProgress)) } returns Unit
+        coEvery { preferences.importPreferences(capture(importedPreferences)) } returns Unit
+    }
+
+    private suspend fun roundTrip() = importer.import(exporter.export())
+
+    // ── every category survives the trip ──────────────────────────────────────
+
+    @Test
+    fun `an empty phone ends up holding what the sending phone had`() = runTest {
+        roundTrip()
+
+        assertThat(marks.filter { it.kind == BookmarkKind.AYAH }.map { it.targetId })
+            .containsAtLeast(SyncFixtures.BOTH_AYAH, SyncFixtures.FAVOURITE_ONLY_AYAH)
+        assertThat(prayerRecords.flatten().map { it.prayerName }).containsExactly("fajr")
+        assertThat(fastRecords.flatten().map { it.fastType }).containsExactly("ramadan")
+        assertThat(makeupFasts.map { it.reason }).containsExactly("travel")
+        assertThat(presets.map { it.name }).containsExactly("SubhanAllah")
+        assertThat(sessions.map { it.startedAt }).containsExactly(5_000L)
+        assertThat(khatamsInserted.map { it.name }).containsExactly("Khatam 1", "Khatam 2")
+        assertThat(highlights.flatten().map { it.tafseerId }).containsExactly("ibn-kathir")
+        assertThat(notes.flatten().map { it.text }).containsExactly("note text")
+        assertThat(zakats.flatten().map { it.zakatDue }).containsExactly(100.0)
+        assertThat(locations.map { it.city }).containsExactly("Dublin")
+        assertThat(readingProgress.single().totalAyahsRead).isEqualTo(900)
+        assertThat(importedPreferences.single()).containsExactly("theme", "dark")
+    }
+
+    @Test
+    fun `a verse bookmarked and favourited arrives with both flags set`() = runTest {
+        roundTrip()
+
+        val row = marks.last { it.kind == BookmarkKind.AYAH && it.targetId == SyncFixtures.BOTH_AYAH }
+        assertThat(row.bookmarked).isTrue()
+        assertThat(row.favourite).isTrue()
+        assertThat(row.note).isEqualTo("memorise")
+    }
+
+    @Test
+    fun `a verse that was only favourited does not arrive bookmarked`() = runTest {
+        roundTrip()
+
+        val row = marks.last {
+            it.kind == BookmarkKind.AYAH && it.targetId == SyncFixtures.FAVOURITE_ONLY_AYAH
+        }
+        assertThat(row.favourite).isTrue()
+        assertThat(row.bookmarked).isFalse()
+    }
+
+    @Test
+    fun `the three progress kinds arrive under their own kinds`() = runTest {
+        roundTrip()
+
+        assertThat(progressRows.map { it.kind })
+            .containsAtLeast(ProgressKind.DUA, ProgressKind.QAIDA_LESSON, ProgressKind.QAIDA_CELL)
+        val cell = progressRows.last { it.kind == ProgressKind.QAIDA_CELL }
+        assertThat(cell.contextId).isEqualTo(3)
+        assertThat(cell.completed).isEqualTo(4)
+    }
+
+    @Test
+    fun `a qaida lesson's completed flag is derived from its state, not carried`() = runTest {
+        roundTrip()
+
+        val lesson = progressRows.last { it.kind == ProgressKind.QAIDA_LESSON }
+        assertThat(lesson.state).isEqualTo("COMPLETED")
+        assertThat(lesson.isCompleted).isTrue()
+        assertThat(lesson.score).isEqualTo(3)
+        assertThat(lesson.resumeId).isEqualTo(11)
+    }
+
+    // ── ids never travel ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a khatam's verses attach to the local khatam, not to the sender's id`() = runTest {
+        roundTrip()
+
+        // The sender's khatams are 1 and 2; Room handed out 101 and 102 here. A child that
+        // kept the sender's id would inflate whichever local khatam happens to hold it.
+        assertThat(khatamAyahs.flatten().map { it.khatamId }).containsExactly(101L, 102L)
+        assertThat(dailyLogs.map { it.khatamId }).containsExactly(101L, 102L)
+    }
+
+    @Test
+    fun `an inserted khatam does not carry the sender's row id`() = runTest {
+        roundTrip()
+
+        assertThat(khatamsInserted.map { it.id }).containsExactly(0L, 0L)
+        // createdAt is what identifies a khatam across devices, so it must survive intact.
+        assertThat(khatamsInserted.map { it.createdAt }).containsExactly(6_001L, 6_002L)
+    }
+
+    @Test
+    fun `a khatam already here is updated in place rather than duplicated`() = runTest {
+        coEvery { khatamDao.getAllKhatamsSync() } returns
+            listOf(SyncFixtures.khatam(1L).copy(id = 77L, name = "stale", updatedAt = 0L))
+
+        roundTrip()
+
+        // Matched on createdAt, updated under the *local* id, and its children re-parented to it.
+        assertThat(khatamsUpdated.map { it.id }).containsExactly(77L)
+        assertThat(khatamsUpdated.single().name).isEqualTo("Khatam 1")
+        assertThat(khatamAyahs.flatten().map { it.khatamId }).contains(77L)
+    }
+
+    @Test
+    fun `a khatam that is newer here keeps its local row but still adopts the children`() =
+        runTest {
+            coEvery { khatamDao.getAllKhatamsSync() } returns
+                listOf(SyncFixtures.khatam(1L).copy(id = 88L, name = "mine", updatedAt = 999_999L))
+
+            roundTrip()
+
+            assertThat(khatamsUpdated).isEmpty()
+            assertThat(khatamsInserted.map { it.name }).containsExactly("Khatam 2")
+            // The id is still mapped, or this khatam's verses would have nowhere to land.
+            assertThat(khatamAyahs.flatten().map { it.khatamId }).contains(88L)
+        }
+
+    @Test
+    fun `a child whose parent is not in the payload is dropped rather than misfiled`() = runTest {
+        importer.importKhatamData(SyncPayload(khatamAyahs = listOf(
+            SyncKhatamAyah(khatamId = 404L, ayahId = 1, readAt = 1L, updatedAt = 1L)
+        )))
+
+        assertThat(khatamAyahs).isEmpty()
+        assertThat(dailyLogs).isEmpty()
+    }
+
+    @Test
+    fun `a prayer record matched on date and prayer keeps the local row id`() = runTest {
+        coEvery { prayerDao.getAllPrayerRecords() } returns listOf(
+            SyncFixtures.prayerRecord().copy(id = 55L, status = "missed", updatedAt = 0L)
+        )
+
+        roundTrip()
+
+        assertThat(prayerRecords.flatten().single().id).isEqualTo(55L)
+        assertThat(prayerRecords.flatten().single().status).isEqualTo("prayed")
+    }
+
+    @Test
+    fun `a location already saved here is matched on its coordinates`() = runTest {
+        coEvery { locationDao.getAllLocationsSync() } returns listOf(
+            SyncFixtures.location().copy(id = 66L, name = "old name", updatedAt = 0L)
+        )
+
+        roundTrip()
+
+        assertThat(locations.single().id).isEqualTo(66L)
+        assertThat(locations.single().name).isEqualTo("Dublin")
+    }
+
+    @Test
+    fun `an imported location never becomes this device's current location`() = runTest {
+        roundTrip()
+
+        // Moving the receiving phone's prayer times to another city is the failure this prevents.
+        assertThat(locations.single().isCurrentLocation).isFalse()
+        assertThat(locations.single().isFavorite).isTrue()
+    }
+
+    @Test
+    fun `a location that is current here stays current after the sync`() = runTest {
+        coEvery { locationDao.getAllLocationsSync() } returns listOf(
+            SyncFixtures.location().copy(id = 66L, isCurrentLocation = true, updatedAt = 0L)
+        )
+
+        roundTrip()
+
+        assertThat(locations.single().isCurrentLocation).isTrue()
+    }
+
+    @Test
+    fun `a highlight is matched on the span it covers, not on its row id`() = runTest {
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns listOf(
+            SyncFixtures.highlight().copy(id = 99L, color = "#000000", updatedAt = 0L)
+        )
+
+        roundTrip()
+
+        assertThat(highlights.flatten().single().id).isEqualTo(99L)
+        assertThat(highlights.flatten().single().color).isEqualTo("#FFFF00")
+    }
+
+    @Test
+    fun `a highlight over a different span is a different highlight`() = runTest {
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns listOf(
+            SyncFixtures.highlight().copy(id = 99L, startOffset = 0, endOffset = 5)
+        )
+
+        roundTrip()
+
+        assertThat(highlights.flatten().single().id).isEqualTo(0L)
+    }
+
+    // ── the older side never wins ─────────────────────────────────────────────
+
+    @Test
+    fun `records that are older than the local ones are not written at all`() = runTest {
+        val future = 9_999_999L
+        coEvery { prayerDao.getAllPrayerRecords() } returns
+            listOf(SyncFixtures.prayerRecord().copy(updatedAt = future))
+        coEvery { fastingDao.getAllFastRecords() } returns
+            listOf(SyncFixtures.fastRecord().copy(updatedAt = future))
+        coEvery { fastingDao.getAllMakeupFastsSync() } returns
+            listOf(SyncFixtures.makeupFast().copy(updatedAt = future))
+        coEvery { tasbihDao.getAllPresetsSync() } returns
+            listOf(SyncFixtures.preset().copy(updatedAt = future))
+        coEvery { sessionDao.getAllSessionsSync() } returns
+            listOf(SyncFixtures.session().copy(updatedAt = future))
+        coEvery { zakatDao.getAllHistorySync() } returns
+            listOf(SyncFixtures.zakat().copy(updatedAt = future))
+        coEvery { tafseerUserDao.getAllNotesSync() } returns
+            listOf(SyncFixtures.note().copy(updatedAt = future))
+        coEvery { readingProgressDao.get() } returns ReadingProgressEntity(
+            id = 1, lastReadSurah = 9, lastReadAyah = 9, lastReadPage = 9, lastReadJuz = 9,
+            totalAyahsRead = 5_000, currentKhatmaCount = 9, updatedAt = future,
+        )
+        coEvery { locationDao.getAllLocationsSync() } returns
+            listOf(SyncFixtures.location().copy(updatedAt = future))
+
+        roundTrip()
+
+        // The empty-list guard matters: an empty INSERT is a write the DAO should never see.
+        assertThat(prayerRecords).isEmpty()
+        assertThat(fastRecords).isEmpty()
+        assertThat(makeupFasts).isEmpty()
+        assertThat(presets).isEmpty()
+        assertThat(sessions).isEmpty()
+        assertThat(zakats).isEmpty()
+        assertThat(notes).isEmpty()
+        assertThat(readingProgress).isEmpty()
+        assertThat(locations).isEmpty()
+    }
+
+    @Test
+    fun `an incoming hadith mark does not clear a favourite this device set`() = runTest {
+        markStore += BookmarkEntity(
+            kind = BookmarkKind.HADITH, targetId = SyncFixtures.HADITH_ID,
+            bookmarked = true, favourite = true, createdAt = 1L, updatedAt = 1L,
+        )
+
+        roundTrip()
+
+        // The wire format has no field for it, so writing the row blind would silently lose it.
+        val row = marks.last { it.kind == BookmarkKind.HADITH }
+        assertThat(row.favourite).isTrue()
+    }
+
+    @Test
+    fun `an incoming name favourite unions with the local one rather than replacing it`() =
+        runTest {
+            markStore += BookmarkEntity(
+                kind = BookmarkKind.PROPHET, targetId = 9, bookmarked = true,
+                favourite = false, note = "mine", createdAt = 1L, updatedAt = 5L,
+            )
+
+            roundTrip()
+
+            // SyncNameBookmark carries no updatedAt, so there is no timestamp to arbitrate with:
+            // a flag set on either side stays set, and the local note survives.
+            val row = marks.last { it.kind == BookmarkKind.PROPHET }
+            assertThat(row.favourite).isTrue()
+            assertThat(row.note).isEqualTo("mine")
+            assertThat(row.createdAt).isEqualTo(1L)
+        }
+
+    @Test
+    fun `an incoming name row can never clear a local favourite`() = runTest {
+        markStore += BookmarkEntity(
+            kind = BookmarkKind.ASMA_UL_HUSNA, targetId = 7, bookmarked = true,
+            favourite = true, createdAt = 1L, updatedAt = 1L,
+        )
+
+        importer.importNamesData(
+            SyncPayload(asmaUlHusnaBookmarks = listOf(
+                SyncNameBookmark(id = 0, refId = 7, isFavorite = false, createdAt = 2L)
+            ))
+        )
+
+        assertThat(marks.single().favourite).isTrue()
+    }
+
+    @Test
+    fun `an older incoming bookmark keeps the local note and colour but merges the timestamps`() =
+        runTest {
+            markStore += BookmarkEntity(
+                kind = BookmarkKind.AYAH, targetId = SyncFixtures.BOTH_AYAH,
+                bookmarked = true, favourite = false, note = "local note", colour = "#0000FF",
+                createdAt = 50L, updatedAt = 9_999L,
+            )
+
+            roundTrip()
+
+            val row = marks.first {
+                it.kind == BookmarkKind.AYAH && it.targetId == SyncFixtures.BOTH_AYAH
+            }
+            assertThat(row.note).isEqualTo("local note")
+            assertThat(row.colour).isEqualTo("#0000FF")
+            // The row's history spans both devices: earliest creation, latest change.
+            assertThat(row.createdAt).isEqualTo(50L)
+            assertThat(row.updatedAt).isEqualTo(9_999L)
+        }
+
+    @Test
+    fun `an arriving favourite does not clear the bookmark or its note`() = runTest {
+        markStore += BookmarkEntity(
+            kind = BookmarkKind.AYAH, targetId = SyncFixtures.FAVOURITE_ONLY_AYAH,
+            bookmarked = true, favourite = false, note = "keep me", colour = "#123456",
+            createdAt = 1L, updatedAt = 1L,
+        )
+
+        roundTrip()
+
+        val row = marks.last {
+            it.kind == BookmarkKind.AYAH && it.targetId == SyncFixtures.FAVOURITE_ONLY_AYAH
+        }
+        assertThat(row.bookmarked).isTrue()
+        assertThat(row.favourite).isTrue()
+        assertThat(row.note).isEqualTo("keep me")
+    }
+
+    // ── nothing to do is not an error ─────────────────────────────────────────
+
+    @Test
+    fun `importing an empty payload writes nothing anywhere`() = runTest {
+        importer.import(SyncPayload())
+
+        assertThat(marks).isEmpty()
+        assertThat(progressRows).isEmpty()
+        assertThat(prayerRecords).isEmpty()
+        assertThat(khatamsInserted).isEmpty()
+        assertThat(locations).isEmpty()
+        assertThat(readingProgress).isEmpty()
+        // An empty preference map must not reach the datastore — that would be a write for nothing.
+        assertThat(importedPreferences).isEmpty()
+    }
+
+    @Test
+    fun `a payload from a device with no reading history leaves the local position alone`() =
+        runTest {
+            coEvery { srcReadingProgressDao.get() } returns null
+
+            roundTrip()
+
+            assertThat(readingProgress).isEmpty()
+        }
+
+    @Test
+    fun `the categories list counts what the payload actually holds`() = runTest {
+        val payload = exporter.export()
+
+        val counts = payload.categories().associate { it.key to it.count }
+        assertThat(counts["bookmarks"]).isEqualTo(1)
+        assertThat(counts["favorites"]).isEqualTo(2)
+        assertThat(counts["khatams"]).isEqualTo(2)
+        assertThat(counts["khatamAyahs"]).isEqualTo(2)
+        assertThat(counts["readingProgress"]).isEqualTo(1)
+        assertThat(payload.categories().single { it.key == "readingProgress" }.isFlag).isTrue()
+    }
+
+    @Test
+    fun `every remaining table also refuses a record older than the local one`() = runTest {
+        val future = 9_999_999L
+        markStore += listOf(
+            BookmarkEntity(
+                kind = BookmarkKind.HADITH, targetId = SyncFixtures.HADITH_ID,
+                bookmarked = true, favourite = false, note = "mine",
+                createdAt = 1L, updatedAt = future,
+            ),
+            BookmarkEntity(
+                kind = BookmarkKind.DUA, targetId = SyncFixtures.DUA_ID,
+                bookmarked = true, favourite = false, note = "mine",
+                createdAt = 1L, updatedAt = future,
+            ),
+        )
+        coEvery { progressDao.all() } returns listOf(
+            ProgressEntity(
+                kind = ProgressKind.DUA, targetId = SyncFixtures.DUA_ID, date = 500L,
+                completed = 9, createdAt = 1L, updatedAt = future,
+            ),
+            ProgressEntity(
+                kind = ProgressKind.QAIDA_LESSON, targetId = 3, completed = 9,
+                createdAt = 1L, updatedAt = future,
+            ),
+            ProgressEntity(
+                kind = ProgressKind.QAIDA_CELL, targetId = 11, completed = 9,
+                createdAt = 1L, updatedAt = future,
+            ),
+        )
+        coEvery { tafseerUserDao.getAllHighlightsSync() } returns
+            listOf(SyncFixtures.highlight().copy(updatedAt = future))
+        coEvery { khatamDao.getAllKhatamsSync() } returns
+            listOf(SyncFixtures.khatam(1L).copy(id = 77L, updatedAt = future))
+        coEvery { khatamDao.getDailyLog(77L, 1L) } returns
+            KhatamDailyLogEntity(khatamId = 77L, date = 1L, ayahsRead = 99, updatedAt = future)
+
+        roundTrip()
+
+        // Each of these is a `local == null || incoming.updatedAt > local.updatedAt`, and each
+        // one getting it backwards overwrites a record the user made more recently on *this*
+        // phone with a stale copy from the other.
+        assertThat(marks.none { it.kind == BookmarkKind.HADITH }).isTrue()
+        assertThat(marks.none { it.kind == BookmarkKind.DUA }).isTrue()
+        assertThat(progressRows).isEmpty()
+        assertThat(highlights).isEmpty()
+        assertThat(dailyLogs.none { it.khatamId == 77L && it.date == 1L }).isTrue()
+    }
+
+    @Test
+    fun `a khatam already here keeps the local id for a log that is newer on the wire`() =
+        runTest {
+            coEvery { khatamDao.getAllKhatamsSync() } returns
+                listOf(SyncFixtures.khatam(1L).copy(id = 77L, updatedAt = 0L))
+            coEvery { khatamDao.getDailyLog(77L, 1L) } returns
+                KhatamDailyLogEntity(khatamId = 77L, date = 1L, ayahsRead = 1, updatedAt = 0L)
+
+            roundTrip()
+
+            val log = dailyLogs.single { it.khatamId == 77L }
+            assertThat(log.ayahsRead).isEqualTo(20)
+        }
+
+    @Test
+    fun `a name favourite this device never set is adopted from the wire`() = runTest {
+        // The union runs the other way too: local false, incoming true.
+        roundTrip()
+
+        assertThat(marks.single { it.kind == BookmarkKind.ASMA_UL_HUSNA }.favourite).isTrue()
+        assertThat(marks.single { it.kind == BookmarkKind.ASMA_UN_NABI }.favourite).isTrue()
+    }
+
+    @Test
+    fun `a name neither side favourited stays un-favourited`() = runTest {
+        markStore += BookmarkEntity(
+            kind = BookmarkKind.PROPHET, targetId = 9, bookmarked = true, favourite = false,
+            createdAt = 1L, updatedAt = 1L,
+        )
+
+        importer.importNamesData(
+            SyncPayload(prophetBookmarks = listOf(
+                SyncNameBookmark(id = 0, refId = 9, isFavorite = false, createdAt = 2L)
+            ))
+        )
+
+        assertThat(marks.single().favourite).isFalse()
+        assertThat(marks.single().bookmarked).isTrue()
+    }
+}

--- a/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncSignalTest.kt
+++ b/core/data/src/test/kotlin/com/arshadshah/nimaz/data/sync/SyncSignalTest.kt
@@ -1,0 +1,77 @@
+package com.arshadshah.nimaz.data.sync
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The wire protocol the two phones coordinate with.
+ *
+ * Signals travel over the *same* BYTES channel as the payload itself, so both ends have to be
+ * able to tell one from the other and neither side can ask. Two properties matter:
+ *
+ *  - a signal must **decode back to itself**. `ImportProgress` is the only one with fields, and
+ *    it drives the sender's progress bar while the receiver imports — decode it wrong and the
+ *    sender watches a bar that never moves while the transfer is in fact working;
+ *  - **anything that is not a signal must decode to null, not throw.** `onPayloadReceived` tries
+ *    `decode` on every BYTES payload that is not gzip-prefixed, so a stray or truncated message
+ *    reaching an exception would take the whole transfer down.
+ */
+class SyncSignalTest {
+
+    private val all = listOf(
+        SyncSignal.Ready,
+        SyncSignal.Cancel,
+        SyncSignal.ImportStarted,
+        SyncSignal.ImportComplete,
+        SyncSignal.Ack,
+        SyncSignal.ImportProgress(step = 3, total = 11, label = "Importing khatam data..."),
+    )
+
+    @Test
+    fun `every signal survives a round trip through the wire`() {
+        all.forEach { signal ->
+            assertThat(SyncSignal.decode(SyncSignal.encode(signal))).isEqualTo(signal)
+        }
+    }
+
+    @Test
+    fun `progress carries the numbers the sender's bar is drawn from`() {
+        val decoded = SyncSignal.decode(
+            SyncSignal.encode(SyncSignal.ImportProgress(3, 11, "Importing khatam data..."))
+        ) as SyncSignal.ImportProgress
+
+        assertThat(decoded.step).isEqualTo(3)
+        assertThat(decoded.total).isEqualTo(11)
+        assertThat(decoded.label).isEqualTo("Importing khatam data...")
+    }
+
+    @Test
+    fun `no two signals encode to the same bytes`() {
+        // Two signals that look alike on the wire would have one silently acted on as the other.
+        assertThat(all.map { String(SyncSignal.encode(it)) }).containsNoDuplicates()
+    }
+
+    @Test
+    fun `a payload that is not a signal decodes to nothing rather than throwing`() {
+        // `onPayloadReceived` runs this on every non-gzip BYTES payload it sees.
+        assertThat(SyncSignal.decode("not json at all".toByteArray())).isNull()
+        assertThat(SyncSignal.decode(byteArrayOf())).isNull()
+        assertThat(SyncSignal.decode(byteArrayOf(0x1F, 0x8B.toByte(), 0x08, 0x00))).isNull()
+    }
+
+    @Test
+    fun `a signal from a newer app version decodes rather than being rejected`() {
+        val fromTheFuture =
+            """{"type":"import_progress","step":1,"total":2,"label":"x","eta":42}"""
+
+        val decoded = SyncSignal.decode(fromTheFuture.toByteArray())
+
+        // A phone on this version has to keep syncing with one on the next.
+        assertThat(decoded).isEqualTo(SyncSignal.ImportProgress(1, 2, "x"))
+    }
+
+    @Test
+    fun `a signal this version does not know decodes to nothing rather than throwing`() {
+        assertThat(SyncSignal.decode("""{"type":"a_signal_from_2027"}""".toByteArray())).isNull()
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -48,6 +48,7 @@ Two on-device/JVM test surfaces exist:
   - [The six widgets, composed for real (`:feature:widget/src/test`)](#the-six-widgets-composed-for-real-featurewidgetsrctest)
   - [Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)](#prayer-times-the-month-table-and-the-qibla-featureprayersrctest-and-srctestdebug)
   - [About, Help and the More menu (`:feature:about/src/test`)](#about-help-and-the-more-menu-featureaboutsrctest)
+  - [The repositories, the sync and the adhan store (`:core:data/src/test`)](#the-repositories-the-sync-and-the-adhan-store-coredatasrctest)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -168,7 +169,7 @@ floor is a ratchet — raised when a module is brought up to it, never lowered t
 green. The branch floor is set per module, at 80% where branches are reachable and lower where
 the Compose compiler's `$dirty` checks make them not (see
 [Where each module stands](#where-each-module-stands)). `:core:database` is the first module
-locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:prayer` and `:feature:about`.
+locked (#597); then `:feature:quran`, `:core:domain`, `:core:navigation`, `:core:common`, `:feature:calendar`, `:core:datastore`, `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:prayer`, `:feature:about` and `:core:data`.
 
 ### What is not counted, and why
 
@@ -261,8 +262,8 @@ module-by-module pass; a module is **locked** once it clears the 80% line floor 
 floors in its own `build.gradle.kts`.
 
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
-`:core:navigation`, `:core:common` and `:core:datastore` are locked at 80/80 — none of them draws
-anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
+`:core:navigation`, `:core:common`, `:core:datastore` and `:core:data` are locked at 80/80 — none of
+them draws anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
 `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget` and `:feature:about`, which *are* Compose modules: the
 unreachable branch below is emitted **per parameter of every restartable composable**, so its
 weight scales with how many composables a module has, and six files — or eight, or the two screens
@@ -304,8 +305,8 @@ split, and should say so where it sets its floors.
 | `:feature:widget` | 97.6% | 89.3% | **locked** at 80/80 (#608) |
 | `:feature:prayer` | 84.1% | 70.5% | **locked** at 80 line / 60 branch (#609) |
 | `:feature:about` | 94.1% | 83.8% | **locked** at 80/80 (#610) |
+| `:core:data` | 88.1% | 84.6% | **locked** at 80/80 (#611) |
 | `:core:ui` | 50.3% | 47.8% | |
-| `:core:data` | 39.0% | 31.2% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
 | `:feature:content` | 28.8% | 19.5% | |
 | `:feature:settings` | 11.3% | 14.9% | |
@@ -927,6 +928,106 @@ them. The rest is `LicenceCatalogueTest`'s subject staying in `:app` (the AboutL
 reads the *applying* project's classpath, so this module renders a catalogue it cannot produce),
 the `hiltViewModel()` default arguments, and a handful of `when`-merge lines the compiler emits
 with no statement of their own. No `COVERAGE_EXCLUSIONS` entry was added or widened.
+
+
+### The repositories, the sync and the adhan store (`:core:data/src/test`)
+
+The fourteenth module locked: **39.0% lines to 88.1%**, from 1,666 covered lines to 3,762, and
+31.2% to **84.6%** branches. 431 tests added across twenty new classes, taking the module's suite
+from 266 to 697. Five files were at **0%** between them — `AdhanAudioManager` (256 lines),
+`NearbyConnectionsManager` and its two callbacks (334), `IntegrityTokenProvider` (39),
+`AnnouncementBootstrap` (30) and `AdhanSound` (37) — 696 of the 2,602 missing lines.
+
+**Nothing is softened, and nothing was excluded.** There is no Compose here, so the `$dirty`
+bitmask that buys `:feature:quran` and `:feature:prayer` their 60% branch floor does not exist in
+this module: every branch is one somebody wrote.
+
+**Playbook step 1 found nothing owed to this module, which took checking.** `:app/src/test` holds
+`LibraryMappingTest`, `LibraryRepositoryImplTest` and `DeviceStateCorpusTest`, and #611 flagged all
+three as candidates to move. None of them belongs here: `LibraryRepositoryImpl` lives in `:app`
+(the AboutLibraries plugin reads the *applying* project's classpath), and `DeviceStateCorpusTest`
+builds a `NimazDatabase` — a `:core:database` type — and reaches no `:core:data` class at all.
+`NextSurahToPlayTest`, `QuranAudioManagerDownloadTest` and `QuranReciterCdnMapTest` all exercise
+`QuranAudioManager`, which stays in `:app` because `MainActivity` holds one. Every line of the rise
+above is new tests.
+
+**Four things here are worth knowing before adding a test to this module.**
+
+- **The two halves of sync are only worth testing together.** An exporter that drops a column and
+  an importer that never reads it agree perfectly, and the user loses the data with nothing on
+  screen. `SyncRoundTripTest` exports from a populated set of DAOs and imports into an empty one,
+  so a column that goes missing anywhere along the way fails an assertion about the *receiving*
+  device. `SyncFixtures` holds the rows both halves use, once.
+- **A DAO mock that does not persist breaks the bookmark merge.** `importBookmarks` and
+  `importFavorites` both read `bookmarkDao.all()` and both write it, and the whole point of the
+  merge is that the second sees what the first wrote. `SyncRoundTripTest` therefore keeps a real
+  `markStore` list behind the mock rather than a fixed `returns`; with a static stub the round trip
+  "loses" the bookmark half and the test fails for a reason that is not in the production code.
+- **`NearbyConnectionsManager`'s callbacks are private fields, but they are *handed to* the
+  client.** Mock `Nearby.getConnectionsClient` and capture the arguments of `startAdvertising`,
+  `startDiscovery` and `acceptConnection`, and the whole protocol replays without radios. Two
+  further notes: a GMS `Task`'s listeners post to the **main looper**, which under Robolectric is
+  the thread the test is suspended on, so tests that await a result stub a `Task` whose listeners
+  fire inline (the same trick `AndroidDeviceLocationRepositoryTest` and
+  `IntegrityTokenProviderTest` use); and the STREAM branch reads on a background `Thread`, so its
+  assertions poll rather than following the call.
+- **A `Geocoder` constructed inside a private function is unreachable through Robolectric's own
+  shadow**, because `ShadowGeocoder` keeps its answers on the *instance*.
+  `device/StubGeocoder.kt` is a `@Config(shadows = …)` replacement that keeps them statically and
+  implements the blocking overloads as well as the listener ones, so both sides of the API-33
+  split in `AndroidDeviceLocationRepository.geocode` are reachable.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| Export and import agree | `SyncRoundTripTest` | a populated phone's records arrive on an empty one, category by category. Row **ids never travel** — khatams merge on `createdAt`, prayers on `date`+`prayerName`, fasts on `date`, presets on `name`, sessions on `startedAt`, highlights on the span they cover, locations on coordinates — because `id` is `autoGenerate` and both phones have handed out 1, 2, 3… |
+| A khatam's children | same | re-parented through the sender-id → local-id map the parent import returns. Without it another device's read verses attach to whichever local khatam holds that id and inflate its progress, which no screen can show as wrong |
+| The older side never wins | same | every `local == null \|\| incoming.updatedAt > local.updatedAt` has both arms taken, on all eleven tables. Getting one backwards overwrites a record the user made more recently on *this* phone with a stale copy from the other, and there is no undo |
+| The merge is additive | same | the payload lists what the sending device **has** — there are no tombstones — so a flag set on either side stays set and nothing is deleted for being absent. A name favourite unions both ways; an arriving hadith mark cannot clear a local favourite the wire format has no field for |
+| The current location never travels | same, and `SyncDataExporterTest` | only favourites are exported, the payload type has no `isCurrentLocation` field, and an imported location is never made current. The failure is a sync that moves the receiving phone's prayer times to another city |
+| The seven-table wire format | `SyncDataExporterTest` | one consolidated `bookmarks` row is fanned back out by kind and by flag, because a phone on this version has to sync with one that still has seven tables. A verse that is both bookmarked and favourited appears in **both** lists; a filter reading `bookmarked` where it means `favourite` silently drops one |
+| The shared `progress` table | same | dua counts, qaida lessons and qaida cells all come out of one `progressDao.all()` and are told apart by nothing but `kind` |
+| The progress bar's arithmetic | same, and `SyncDataExporterStepsTest` | eleven callbacks, eleven distinct labels, monotonic and never past the total — the defect that filled the bar to 120%, captioned it "Step 11 of 10" and rewound it to 80% |
+| The signal protocol | `SyncSignalTest` | every signal round-trips, no two encode alike, and **anything that is not a signal decodes to null rather than throwing** — `onPayloadReceived` runs `decode` on every non-gzip BYTES payload, so an exception there takes the transfer down |
+| Which branch a payload takes | `NearbyConnectionsManagerTest` | signals, data and files share one channel and only the leading `0x1F` separates them. A signal routed into the importer tries to import the word "cancel"; data routed into the signal decoder completes the sync having imported nothing |
+| A signal's own transfer updates | same | skipped by payload id. Each signal generates its own IN_PROGRESS/SUCCESS pair, so without the filter the bar jumps to 100% and the screen calls the transfer done while the real payload is still in flight |
+| A disconnect at the end | same | the partner always disconnects when it is finished, so an unguarded `onDisconnected` rewrites every successful sync as "connection lost". Completed, Error and Cancelled all survive it |
+| The `@Singleton`'s handler | same | `stopAll` clears the data and signal callbacks. They capture the `SyncViewModel`, so without this a destroyed ViewModel and its cancelled scope stay reachable for the life of the process |
+| An HTML error page saved as `.mp3` | `AdhanAudioManagerTest` | rejected by magic bytes **and deleted**, so the next attempt re-downloads rather than trusting a file that exists, is named right and plays nothing. ID3, bare MPEG sync and RIFF all count as audio; a bare sync word is common and rejecting it would re-download forever |
+| Repairing an install whose URLs changed | same | the version stamp beside the files, and a bump deleting the recordings. This is the undo for Mishary's *regular* URL serving the Fajr recording — every install that had already downloaded it kept playing the wrong adhan. The generated beep survives, because a URL change cannot have staled a file with no URL |
+| The generated chime | same | `SIMPLE_BEEP` has no URL and is synthesised into a WAV on the device. The round trip is the point: a wrong header means `isDownloaded` rejects the manager's own output and the beep can never finish downloading. Also asserted: real RIFF/WAVE/data chunks whose declared sizes match the file, 44.1 kHz, and samples that are not silence |
+| Deleting one variant of a pair | same | regular and Fajr are separate files, so removing one must not reset the pair's state while the other is on disk |
+| The Fajr flag | `AdhanSoundTest` | every sound resolves a different file and URL for Fajr, no two sounds share a file name, and a stored preference naming a sound that no longer exists falls back rather than crashing |
+| The attestation token | `IntegrityTokenProviderTest` | the provider is prepared **once** and reused — the classic API throttled per app-instance, so a few asks worked and then every fetch failed — and a stale provider is re-prepared once and retried. A debug build that cannot attest sends `"debug-skip"`; a release build sends `""`, because sending the skip token from a release build would be an attestation bypass shipped to users |
+| The announcements channel | `AnnouncementBootstrapTest` | its own low-importance channel, kept apart from the prayer and adhan ones, under the id the manifest hands the OS — a mismatch drops every background announcement with no error anywhere. A build with no `google-services.json` must not reach for messaging, and a messaging call that throws must not take the launch down |
+| An empty console text box | `AnnouncementPayloadExtrasTest` | sends `""`, not nothing. Every optional field is trimmed and emptied to null, or a `cta_label` of `""` draws a button with no words and a `proof_ref` of `""` a citation card citing nothing. Extras and payload map to the same announcement, so a cold start and a running app agree |
+| The three overlapping topic hierarchies | `QuranRepositoryImplThematicTest` | a breadcrumb picks its tree **per topic**, because search spans all three — an ontology result must not come back pathless while the thematic tab is selected. Both cycle guards terminate: the parent columns are content, regenerated per release elsewhere, and a cycle in them hangs a screen rather than erroring |
+| A branch topic's verses | same | the whole **subtree**, not the node. Asking only for a node's own citations is what made "Doctrine" open on "0 verses" |
+| Topic search order | same | index order is relevance order and `getTopics` does not preserve it, so a relevance search that silently comes back in id order looks like it works |
+| A line-accurate mushaf page | `QuranRepositoryImplReadingTest` | resolved through the edition's own layout table, memoised per edition, and an unknown span emits an **empty** page — not the unrelated Madani page, which is the actual failure mode (#325) |
+| Every verse read path | same | stamps `isBookmarked` from the *user's* database, which is a different file from the content. A path that forgets shows a reader with no bookmarks and no error. A stale translator preference resolves to the default rather than querying for rows that cannot exist |
+| One row, two flags | `QuranRepositoryImplMarksTest`, `DuaRepositoryImplMarksTest`, `FavouriteCataloguesTest` | bookmarking and favouriting share a row, so turning one off clears the *flag* when the other is set and removes the row only when nothing is. Three catalogues, three repositories and three copies of the same `when`; this is what keeps them agreeing |
+| The running totals | `QuranRepositoryImplMarksTest` | `updateReadingPosition` rewrites the row and neither `totalAyahsRead` nor `currentKhatmaCount` is an argument. Reading them back off the existing row is the only thing between a page turn and a khatma counter reset to zero |
+| String ids over Int tables | `HadithRepositoryImplIdsTest`, `DuaRepositoryImplMarksTest` | the domain carries strings and every table is keyed by an Int, so every read parses. A lookup of one thing returns **null**; a list query falls back to **0** — an id no book has, so a `LazyColumn` gets a list to be empty of. Getting either wrong is a crash on a deep link, or book 0's hadiths under another book's title. A *write* against an unparseable id must do nothing at all |
+| Chapters, which are not a table | `HadithRepositoryImplIdsTest` | derived from `GROUP BY chapter_id`, keyed `"{bookId}_{chapterId}"`, and the stored id is 0-based while the number a reader sees is 1-based. An off-by-one is every chapter heading in the app being wrong by one |
+| Hadith of the day | same | deterministic from the day of the year, and an install whose content artifact has not landed yet has **none** — the modulo would divide by zero on the home screen |
+| Localised help search | `HelpRepositoryImplSearchTest` | two queries merged, and the localised hit must win: de-duplicating the other way shows an English title to a reader in French. Only questions and titles are searched, or a result's "title" is a paragraph from the middle of a guide |
+| `SUM()` over no rows | `TasbihRepositoryImplStatsTest` | is NULL in SQLite, and every one of those nulls reaches a screen that renders a number. A missing `?: 0` crashes the stats screen for a user who has not counted anything this week |
+| Repairing a lost default preset | same | inserted with `id = 0` so Room assigns a fresh one. Reusing the default's id would **replace** whatever custom preset happens to hold it |
+| The qibla needle's input | `AndroidCompassSensorsTest` | the filter is **seeded** on the first sample — a 0.97 low-pass started from zero needs ~100 samples to converge, which is what made the screen say "ready" and then sweep the needle in from a meaningless heading. Nothing is published until both sensors have reported, accuracy comes from the magnetometer only, and the listener is unregistered when collection ends |
+| The geocoder's fallback chain | `AndroidDeviceLocationRepositoryTest` | locality, then county, then state, then feature name. Reverse-geocoding a point in open country returns an address with no locality, and without the chain the prayer-times header showed nothing. A geocoder that throws on a flaky connection returns empty rather than crashing the search box |
+| What counts as location permission | same | fine **or** coarse. Requiring fine tells a user who granted approximate location that they granted nothing. Notification permission is a runtime grant only from Tiramisu; asking below that returns denied on every device and the app nags forever |
+| The tasbih tick | `AndroidCounterFeedbackTest` | vibration and sound are independent settings, and crossing them buzzes a phone in a mosque. `release()` twice is safe, and a tick after it is a no-op rather than a use-after-free |
+
+**What stays uncovered, and why.** The largest single gap is `AdhanAudioManager.downloadFile` and
+the retry loop above it — about 75 lines and 50 branches. It opens a `HttpURLConnection` against
+the CDN URL baked into `AdhanSound`, and there is no seam: exercising it would need either a real
+network request from a unit test or a JVM-wide `URLStreamHandlerFactory`, which is global,
+one-shot per process, and would make every other Robolectric class in the module order-dependent
+in the way #620 documents. Everything the manager does *around* the transfer is covered.
+`MediaPlayer` playback is the same shape at smaller scale. The rest is spread thinly over
+`PrayerRepositoryImpl`, `TafseerRepositoryImpl` and `KhatamRepositoryImpl`, which were already
+past the floor. **No `COVERAGE_EXCLUSIONS` entry was added or widened** — the list is shared with
+every locked module, so widening it would move their numbers too.
 
 
 ## Conventions


### PR DESCRIPTION
Closes #611. Part of #604 — the fourteenth module locked.

## Before / after

| | Before | After | Floor |
|---|---|---|---|
| Line | 39.0% (1,666 / 4,268) | **88.1%** (3,762 / 4,268) | 0.80 |
| Branch | 31.2% | **84.6%** (1,151 / 1,360) | 0.80 |
| Tests | 266 in 27 classes | **697 in 47 classes** | |

431 tests added across twenty new classes. Five files were at **0%** between them and account for
most of the rise: `AdhanAudioManager` (256 lines), `NearbyConnectionsManager` and its two callbacks
(334), `IntegrityTokenProvider` (39), `AnnouncementBootstrap` (30) and `AdhanSound` (37) — 696 of
the 2,602 missing lines.

**Nothing is softened and nothing was excluded.** There is no Compose in this module, so the
`$dirty` bitmask that buys `:feature:quran` and `:feature:prayer` their 60% branch floor does not
exist here: every branch is one somebody wrote.

**Playbook step 1 found nothing owed to this module**, which took checking — #611 flagged three
`:app/src/test` classes as candidates to move. None of them belongs here: `LibraryRepositoryImpl`
lives in `:app` (the AboutLibraries plugin reads the *applying* project's classpath),
`DeviceStateCorpusTest` builds a `NimazDatabase` and reaches no `:core:data` class at all, and the
three audio tests exercise `QuranAudioManager`, which stays in `:app` because `MainActivity` holds
one. Every point of the rise above is new tests.

## What the new tests pin, and the failure each catches

**Sync — the highest-stakes part, and the reason it is worth a round trip.** An exporter that drops
a column and an importer that never reads it agree perfectly, and the user loses the data with
nothing on screen. `SyncRoundTripTest` exports from a populated set of DAOs and imports into an
empty one, so a column lost anywhere fails an assertion about the *receiving* device.

- **Row ids never travel.** `id` is `autoGenerate` on both phones, so both have handed out 1, 2, 3…
  Khatams merge on `createdAt`, prayers on `date`+`prayerName`, fasts on `date`, presets on `name`,
  sessions on `startedAt`, highlights on the span they cover, locations on coordinates. Merging on
  the id meant an incoming record overwrote an unrelated local one that happened to hold it.
- **A khatam's children are re-parented** through the sender-id → local-id map. Without it another
  device's read verses attach to whichever local khatam holds that id and inflate its progress.
- **The older side never wins** — every `local == null || incoming.updatedAt > local.updatedAt` has
  both arms taken, on all eleven tables. There is no undo for getting one backwards.
- **The merge stays additive**, because the payload has no tombstones: a flag set on either side
  stays set, and an arriving hadith mark cannot clear a local favourite the wire format has no
  field for.
- **The current location never travels.** Only favourites are exported and an imported location is
  never made current — the failure is a sync that moves the receiving phone's prayer times to
  another city.

**Nearby Connections**, replayed through a mocked `ConnectionsClient` (the callbacks are private
fields, but they are *handed to* the client, so capturing the arguments of `startAdvertising` /
`startDiscovery` / `acceptConnection` gets a real reference to each):

- **Which branch a payload takes.** Signals, data and files share one channel and only the leading
  `0x1F` separates them. A signal routed into the importer tries to import the word "cancel"; data
  routed into the signal decoder completes the sync having imported nothing.
- **A signal's own transfer updates are skipped by id.** Each signal generates its own
  IN_PROGRESS/SUCCESS pair, so without the filter the bar jumps to 100% and the screen calls the
  transfer done while the real payload is still in flight.
- **A disconnect at the end does not rewrite the result.** The partner always disconnects when it
  is finished, so an unguarded `onDisconnected` turns every successful sync into "connection lost".
- **`stopAll` clears the data and signal handlers** — they capture the `SyncViewModel`, and this is
  a `@Singleton`.

**`AdhanAudioManager` — the file store that decides whether the phone makes a sound at prayer time.**
An HTML error page saved as `.mp3` is rejected by magic bytes *and deleted*, so the next attempt
re-downloads rather than trusting a file that exists, is named right and plays nothing. The
URL-version stamp is the undo for Mishary's *regular* URL serving the Fajr recording — every
install that had already downloaded it kept playing the wrong adhan. And the generated chime
round-trips through the manager's own validation: a wrong WAV header means `isDownloaded` rejects
its own output and the beep can never finish downloading.

**The repositories** — one row with two flags (bookmark vs favourite) across Quran, Dua and the
three favourite-only catalogues, where turning one off must clear the *flag* and not the row; the
string-id-over-Int-table seam in Hadith and Dua, where a single lookup returns **null** and a list
query falls back to **0**, and a *write* against an unparseable id must do nothing; the reading
position's running totals surviving a page turn; and the three overlapping topic hierarchies with
both their cycle guards.

**The platform adapters** — the compass filter being *seeded* on its first sample (a 0.97 low-pass
started from zero needs ~100 samples to converge, which is what made the screen say "ready" and
then sweep the needle in from a meaningless heading), the geocoder's four-step display-name
fallback, fine-**or**-coarse counting as location permission, and the tasbih tick's two independent
settings.

## The gate bites

Floor temporarily set to `0.99`:

```
> :core:data:coverageFloor: line coverage 88.1% is below the floor this module is locked at (99.0%), covering 3762/4268 (88.1%).
  :core:data:coverageFloor: branch coverage 84.6% is below the floor this module is locked at (99.0%), covering 1151/1360 (84.6%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to it is not meant to come back down.
```

Restored to `0.80` / `0.80`, and `:core:data:coverageFloor` passes.

## What stays uncovered, and why

`AdhanAudioManager.downloadFile` and the retry loop above it — about 75 lines and 50 branches. It
opens a `HttpURLConnection` against the CDN URL baked into `AdhanSound`, and there is no seam:
exercising it would need either a real network request from a unit test or a JVM-wide
`URLStreamHandlerFactory`, which is global, one-shot per process, and would make every other
Robolectric class in the module order-dependent in the way #620 documents. Everything the manager
does *around* the transfer is covered. **`COVERAGE_EXCLUSIONS` was not added to or widened** — the
list is shared with every locked module — and the reason is written into both the build file and
`docs/TESTING.md`.

## Verification

Run locally, real output:

- `./gradlew :core:data:testDebugUnitTest` — **BUILD SUCCESSFUL**, 697 tests, 0 failures
- `./gradlew :core:data:check` — **BUILD SUCCESSFUL** (includes `moduleBoundary`,
  `PublicApiHasNoPersistenceTypesTest` and `coverageFloor`)
- `./gradlew :core:data:lintDebug` — **BUILD SUCCESSFUL**
- `./gradlew coverageFloor` — **BUILD SUCCESSFUL**, all 18 modules, no locked module regressed
- `python3 scripts/check_docs.py` — **All 23 documentation checks passed**

`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` for the private content
artifact and **could not be run here** — CI is the check for those. No `androidTest` source was
touched, so nothing needs an emulator.

## Docs

`docs/TESTING.md`: snapshot-table row, `:core:data` added to the 80/80 list and to the locked
sequence, contents entry, and a full audit section — four notes worth knowing before adding a test
to this module (why the two halves of sync are only worth testing together, why the bookmark DAO
mock has to persist, how the Nearby callbacks are reached, and why `device/StubGeocoder.kt` exists),
a table of what each new class pins, and the uncovered-and-why paragraph.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qYneNKoWYTxJWNW6x4GWK)_