### PR TITLE
Coverage: bring :feature:content's hadith and dua screens to 61.6% (1 of 2)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -49,6 +49,7 @@ Two on-device/JVM test surfaces exist:
   - [Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)](#prayer-times-the-month-table-and-the-qibla-featureprayersrctest-and-srctestdebug)
   - [About, Help and the More menu (`:feature:about/src/test`)](#about-help-and-the-more-menu-featureaboutsrctest)
   - [The repositories, the sync and the adhan store (`:core:data/src/test`)](#the-repositories-the-sync-and-the-adhan-store-coredatasrctest)
+  - [The hadith and dua corpora, rendered (`:feature:content/src/test`)](#the-hadith-and-dua-corpora-rendered-featurecontentsrctest)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -308,7 +309,7 @@ split, and should say so where it sets its floors.
 | `:core:data` | 88.1% | 84.6% | **locked** at 80/80 (#611) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
-| `:feature:content` | 28.8% | 19.5% | |
+| `:feature:content` | 61.6% | 49.6% | hadith + dua done (#624); not locked yet |
 | `:feature:settings` | 11.3% | 14.9% | |
 
 `:app` is absent because its own suite needs the private content artifact and cannot be measured
@@ -1028,6 +1029,74 @@ in the way #620 documents. Everything the manager does *around* the transfer is 
 `PrayerRepositoryImpl`, `TafseerRepositoryImpl` and `KhatamRepositoryImpl`, which were already
 past the floor. **No `COVERAGE_EXCLUSIONS` entry was added or widened** — the list is shared with
 every locked module, so widening it would move their numbers too.
+
+
+### The hadith and dua corpora, rendered (`:feature:content/src/test`)
+
+The fifteenth module, taken in two passes because 2,448 lines is more than one review should
+carry. **This is the first pass: hadith and dua.** It moves the module from **28.8% lines to
+61.6%** — 1,380 covered lines to 2,949 — and from 19.5% to **49.6%** branches, with 108 tests in
+ten new classes. The module is **not locked yet**; the second pass takes the prophets, the names,
+qaida, the catalog and `contentGraph`, and declares the floors.
+
+Seven screens were at **0%** between them — `HadithReaderScreen` (302 lines),
+`DuasCollectionScreen` (259), `HadithCollectionScreen` (251), `DuaReaderScreen` (216),
+`DuaCategoryScreen` (183), `HadithChaptersScreen` (160) and `DuaOccasionScreen` (58) — plus the
+two adaptive wrappers over them (96). Nothing had ever composed one.
+
+**What makes this module worth testing is that its failures are silent.** Every screen here
+renders *shipped* content — narrations and supplications this build did not write, arriving as a
+fetched artifact from `arshad-shah/nimaz-data` — and the way that goes wrong is never a crash. A
+field the artifact does not carry renders as a blank line; an optional grade or reference
+vanishes; a load failure reports itself as "no chapters found" and tells a reader to give up on a
+collection that is fine. The `when` ordering that separates *loading*, *failed* and *genuinely
+empty* is load-bearing on five of these screens, and `chapters.isEmpty()` is true in all three
+states.
+
+**The display settings were pinned at the persistence layer and nowhere else.**
+`hadithShowArabic`, `hadithShowChain`, `duaShowTransliteration` and the rest were covered by
+`:core:datastore` (#603) — that they round-trip. What no test asserted is that the screens
+*honour* them: that turning the chain off actually removes the chain. Each is a separate `if` in
+a reader, and a reader who hides the Arabic and gets it anyway can only report "the setting does
+nothing".
+
+**Two things here are worth knowing before adding a test to this module.**
+
+- **`hiltViewModel()` does not need Hilt on the adaptive screens.** `AdaptiveHadithScreen` and
+  `AdaptiveDuaScreen` hand their inner screens no ViewModel, so the default argument runs — and
+  per #604's playbook item 8, an owner whose `ViewModelStore` already holds the mock answers
+  before any factory is consulted. Both classes seed one. This is what makes the phone-vs-tablet
+  branch reachable at all.
+- **A `LazyColumn` at 2,200dp is not always tall enough.** The dua category-icon test renders
+  forty-five rows to cover the emoji→icon lookup and runs at `w411dp-h6000dp`; the rest of the
+  class stays at the usual height.
+
+| Area | Covered by | What it pins |
+|---|---|---|
+| The four ways into the hadith reader | `HadithReaderScreenTest` | one `LaunchedEffect` turns four route shapes into four different loads, and their guards overlap by construction — `bookId` is empty for a search hit *and* for a grade shelf. The order is what keeps a **bookmark** from being looked up as a primary key, which lands the reader on a real narration from an arbitrary book rather than crashing |
+| Each display toggle removing its own element | same, and `DuaReaderScreenTest` | Arabic, translation, grade and chain in the hadith reader; Arabic, transliteration and translation in the dua reader. The transliteration is guarded **twice** — the setting, and whether the artifact carries one — so "off" and "absent" have to produce the same page |
+| A narration with no grade, narrator or reference | `HadithReaderScreenTest` | renders none of the three badges rather than three empty pills. The chain of whitespace is not offered at all |
+| The isnād, expanded | same | collapsed by default; expanding splits the chain on its four separators and lists the narrators. A chain the separators do not match is shown **whole** instead of as a one-dot timeline |
+| "Narrated by" not said twice | same | the dataset carries the prefix inline for some collections and a bare name for others. Prefixing unconditionally yields "Narrated by Narrated by Abu Huraira" |
+| Failure vs emptiness, on five screens | `HadithChaptersScreenTest`, `HadithReaderScreenTest`, `HadithCollectionScreenTest`, `DuaOccasionScreenTest`, `DuaReaderScreenTest` | the error branch sits **before** the empty branch on every one of them, because the list is empty in both cases. Getting it back to front tells a reader their collection is empty when the database could not be read |
+| Retry re-issuing the right load | same five | `HadithEvent.Retry` re-runs only the failing surface; the dua screens re-issue the **route's** id, not whatever the ViewModel loaded last |
+| The hadith of the day's two lives | `HadithCollectionScreenTest` | `getHadithOfTheDay` is best-effort, so `hadithOfTheDay` is null on a healthy screen and the card shows shipped fallback text. Nothing distinguishes the two at a glance, and bookmarking while the fallback is up must dispatch **nothing** rather than the fallback's imaginary id |
+| Which grades are browsable | same | exactly Sahih, Hasan and Ḍaʿīf. Mawḍūʿ (fabricated) is a warning label on a narration, not a shelf to invite anyone onto, and the list it is absent from is a private `val` no compiler check guards |
+| Every collection getting its own cover | same | the six Kutub al-Sittah ids plus the default arm, all seven resolved while the card composes |
+| A bookmark citing the number a reader sees | same | the card dispatches `hadithNumberInBook`, not `hadithNumber`. The two differ wherever numbering restarts per volume, and a bookmark saved under the wrong one reopens on a different narration |
+| The chapter search being derived | `HadithChaptersScreenTest` | rows come from `filteredChapters`, which recomputes from `searchQuery` on every read. Rendering `chapters` instead passes every test that does not search — and the header still renders when the search matches nothing, so a typo does not blank the screen |
+| A chapter opened under its own book | same | `onNavigateToChapter(bookId, chapter.id)` carries both, because the reader keys on the composite `bookId_chapterId`; the id alone resolves the chapter header to null |
+| The dua library's two layouts | `DuasCollectionScreenTest` | curated order splits into a four-card grid and a list below it; alphabetical collapses both into one A–Z list. `take(4)`/`drop(4)` are a partition only while both branches run, and nine categories all have to survive the split |
+| Every category emoji resolving to an icon | same | forty-three mapped keys plus an unknown emoji and a category with none. An emoji the artifact starts using turns silently into a mosque, and they all look alike |
+| The sort control naming where it goes | same | the content description inverts with the state rather than describing it — the only thing a screen-reader user has to go on |
+| The shared dua row, in both of its forms | `DuaCategoryScreenTest`, `DuaOccasionScreenTest` | given `onOccasionClick` the occasion is a badge into that occasion's whole list; without it, plain text. The occasion screen passes nothing, because a chip navigating to the list you are on is a dead end |
+| The occasion label being localised | `DuaCategoryScreenTest`, `DuaOccasionLabelsTest` | `DuaOccasion.displayName()` is hardcoded English — right for a log line, wrong on a chip. All seventeen occasions map to distinct resources, and the mosque and home pairs are opposite rather than interchangeable |
+| A repeat count of zero | `DuaCategoryScreenTest`, `DuaReaderScreenTest` | the artifact stores `0` for "no prescribed count", and an unguarded badge reads "0x" |
+| The occasion screen not borrowing a header | `DuaOccasionScreenTest` | it renders from `categoryState`, the surface `LoadCategory` also fills, so a stale `category` left in it would put another collection's name above these duas |
+| Adding a dua to the tasbih | `DuaReaderScreenTest` | goes through this feature's own ViewModel, not a `hiltViewModel<TasbihViewModel>()` reach across the module boundary — and the toast is the reader's only feedback that it happened |
+| Favouriting citing the category too | same | a `DuaBookmark` is keyed on both ids; the dua's alone files the favourite under no collection |
+| Phone push vs tablet pane | `AdaptiveHadithScreenTest`, `AdaptiveDuaScreenTest` | the same tap must push a route on a phone and move the scaffold's detail pane on a tablet. Backwards, a tablet stacks a full-screen list over a layout built to show both, and a phone's rows do nothing — neither crashes, and the inner screens' own tests cannot see it because the lambda they assert on is the wrapper's choice |
+| The detail pane's second decision | same two | chapters or reader, dua list or dua, from whether the pane's args carry the second id — which the list pane built two taps earlier |
 
 
 ## Conventions

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveDuaScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveDuaScreenTest.kt
@@ -1,0 +1,205 @@
+package com.arshadshah.nimaz.presentation.screens.adaptive
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaCategoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaCollectionUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaFavoritesUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaReaderUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The dua library on a phone and on a tablet.
+ *
+ * Same shape as `AdaptiveHadithScreenTest`, and worth asserting separately because the wiring is
+ * hand-written per feature rather than shared: opening a category pushes `Route.DuaCategory` on
+ * a phone and moves the scaffold's detail pane on a tablet, and the detail pane then renders
+ * either the category or the reader depending on whether its args carry a dua.
+ *
+ * The one difference from hadith is the **args carry the category forward**: opening a dua from
+ * the detail pane rebuilds `DuaDetailArgs` with both ids, so going back from the reader lands on
+ * the category it came from rather than on an empty pane. Dropping `categoryId` there compiles
+ * and looks right until someone navigates back.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdaptiveDuaScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val collectionState = MutableStateFlow(
+        DuaCollectionUiState(
+            categories = listOf(morning, evening),
+            filteredCategories = listOf(morning, evening),
+            isLoading = false,
+        )
+    )
+    private val categoryState = MutableStateFlow(
+        DuaCategoryUiState(category = morning, duas = listOf(wakingDua), isLoading = false)
+    )
+    private val readerState = MutableStateFlow(
+        DuaReaderUiState(duas = listOf(wakingDua), isLoading = false)
+    )
+    private val events = mutableListOf<DuaEvent>()
+
+    private val viewModel: DuaViewModel = mockk(relaxed = true) {
+        every { this@mockk.collectionState } returns this@AdaptiveDuaScreenTest.collectionState
+        every { this@mockk.categoryState } returns this@AdaptiveDuaScreenTest.categoryState
+        every { this@mockk.readerState } returns this@AdaptiveDuaScreenTest.readerState
+        every { favoritesState } returns MutableStateFlow(DuaFavoritesUiState(isLoading = false))
+        every { onEvent(any()) } answers { events += firstArg<DuaEvent>() }
+        every { isDuaFavorite(any()) } returns flowOf(false)
+    }
+
+    private val navigated = mutableListOf<Route>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            CompositionLocalProvider(LocalViewModelStoreOwner provides seededOwner()) {
+                AdaptiveDuaScreen(
+                    onNavigate = { navigated += it },
+                    onNavigateBack = {},
+                    onNavigateToBookmarks = {},
+                    onNavigateToSearch = {},
+                )
+            }
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone the collection is the whole screen`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertExists()
+        composeRule.onNodeWithText("Morning Adhkar").assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone opening a category pushes its own destination`() {
+        setContent()
+
+        composeRule.onNodeWithText("Evening Adhkar").performClick()
+
+        assertThat(navigated).containsExactly(Route.DuaCategory("evening"))
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet opening a category moves the detail pane instead of navigating`() {
+        setContent()
+
+        composeRule.onNodeWithText("Morning Adhkar").performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+        // The category's own duas, in the pane beside the still-visible list.
+        composeRule.onNodeWithText("Upon waking").assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet the detail pane shows the reader once a dua is chosen`() {
+        setContent()
+
+        composeRule.onNodeWithText("Morning Adhkar").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Upon waking").performClick()
+        composeRule.waitForIdle()
+
+        // The reader's own body, which the category list only ever shows two lines of.
+        composeRule.onNodeWithText("Praise be to Allah who gave us life").assertExists()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet nothing is in the detail pane until something is chosen`() {
+        setContent()
+
+        composeRule.onNodeWithText("Upon waking").assertDoesNotExist()
+    }
+
+    private fun seededOwner(): ViewModelStoreOwner {
+        val store = ViewModelStore()
+        seed(store, DuaViewModel::class.java, viewModel)
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    private fun <VM : ViewModel> seed(store: ViewModelStore, type: Class<VM>, instance: VM) {
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                instance as T
+        }
+        ViewModelProvider.create(store, factory)[type]
+    }
+
+    private companion object {
+        val morning = DuaCategory(
+            id = "morning",
+            nameArabic = "أذكار الصباح",
+            nameEnglish = "Morning Adhkar",
+            description = "Supplications for the morning",
+            iconName = "🌅",
+            displayOrder = 1,
+            duaCount = 12,
+        )
+        val evening = morning.copy(
+            id = "evening",
+            nameEnglish = "Evening Adhkar",
+            nameArabic = "أذكار المساء",
+            iconName = "🌙",
+        )
+        val wakingDua = Dua(
+            id = "dua_1",
+            categoryId = "morning",
+            titleArabic = "دعاء",
+            titleEnglish = "Upon waking",
+            textArabic = "الحمد لله الذي أحيانا",
+            textTransliteration = "Alhamdulillahilladhi ahyana",
+            textEnglish = "Praise be to Allah who gave us life",
+            reference = "Sahih al-Bukhari 6312",
+            occasion = DuaOccasion.WAKING_UP,
+            benefits = null,
+            repeatCount = null,
+            audioUrl = null,
+            displayOrder = 1,
+        )
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveHadithScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveHadithScreenTest.kt
@@ -1,0 +1,244 @@
+package com.arshadshah.nimaz.presentation.screens.adaptive
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithBook
+import com.arshadshah.nimaz.domain.model.HadithChapter
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithBookmarksUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithChaptersUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithCollectionUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithReaderUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The hadith library on a phone and on a tablet — the same three screens, wired two ways.
+ *
+ * On a phone, opening a collection is a **route push**; on a tablet the identical tap must not
+ * navigate at all, because the chapters belong in the scaffold's detail pane beside the list
+ * that is still on screen. Get it backwards and a tablet stacks a full-screen chapter list over
+ * a layout built to show both, while a phone's rows do nothing. Neither failure crashes, and
+ * `HadithCollectionScreen`'s own tests cannot see either: the lambda they assert on is the one
+ * this file chooses.
+ *
+ * The detail pane also carries a **second** decision — chapters or reader, from whether the
+ * pane's args have a chapter — so one pane renders two different screens, and the argument that
+ * decides is built by the list pane two taps earlier.
+ *
+ * The screens inside resolve their ViewModel through `hiltViewModel()`, and none of them is
+ * handed one from here. Per #604's playbook item 8 that does not need Hilt: an owner whose
+ * `ViewModelStore` already holds the mock answers before any factory is consulted, which is
+ * what [seededOwner] is for.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdaptiveHadithScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val collectionState = MutableStateFlow(
+        HadithCollectionUiState(
+            books = listOf(bukhari, muslim),
+            isLoading = false,
+        )
+    )
+    private val chaptersState = MutableStateFlow(
+        HadithChaptersUiState(
+            book = bukhari,
+            chapters = listOf(revelation),
+            isLoading = false,
+        )
+    )
+    private val readerState = MutableStateFlow(
+        HadithReaderUiState(
+            chapter = revelation,
+            hadiths = listOf(firstHadith),
+            isLoading = false,
+        )
+    )
+    private val events = mutableListOf<HadithEvent>()
+
+    private val viewModel: HadithViewModel = mockk(relaxed = true) {
+        every { this@mockk.collectionState } returns this@AdaptiveHadithScreenTest.collectionState
+        every { this@mockk.chaptersState } returns this@AdaptiveHadithScreenTest.chaptersState
+        every { this@mockk.readerState } returns this@AdaptiveHadithScreenTest.readerState
+        every { bookmarksState } returns MutableStateFlow(HadithBookmarksUiState(isLoading = false))
+        every { onEvent(any()) } answers { events += firstArg<HadithEvent>() }
+        every { isHadithBookmarked(any()) } returns flowOf(false)
+    }
+
+    private val navigated = mutableListOf<Route>()
+    private val openedGrades = mutableListOf<HadithGrade>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            CompositionLocalProvider(LocalViewModelStoreOwner provides seededOwner()) {
+                AdaptiveHadithScreen(
+                    onNavigate = { navigated += it },
+                    onNavigateBack = {},
+                    onNavigateToSearch = {},
+                    onNavigateToBookmarks = {},
+                    onNavigateToGrade = { openedGrades += it },
+                )
+            }
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone the collection is the whole screen`() {
+        setContent()
+
+        composeRule.onNodeWithText("Sahih al-Bukhari").assertExists()
+        composeRule.onNodeWithText(string(R.string.kutub_al_sittah)).assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone opening a collection pushes its own destination`() {
+        setContent()
+
+        composeRule.onNodeWithText("Sahih Muslim").performClick()
+
+        assertThat(navigated).containsExactly(Route.HadithBook("muslim"))
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet opening a collection moves the detail pane instead of navigating`() {
+        // The list stays on screen; a push here would cover it.
+        setContent()
+
+        composeRule.onNodeWithText("Sahih al-Bukhari").performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+        composeRule.onNodeWithText("Revelation").assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet the detail pane shows the reader once a chapter is chosen`() {
+        // Two taps, and the second is what puts a chapter id into the pane's args — the only
+        // thing separating "show the chapters" from "show the hadith".
+        setContent()
+
+        composeRule.onNodeWithText("Sahih al-Bukhari").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Revelation").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Actions are but by intention").assertExists()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet the detail pane is empty until something is chosen`() {
+        setContent()
+
+        composeRule.onNodeWithText("Actions are but by intention").assertDoesNotExist()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `browsing a grade is handed straight out on either size`() {
+        // Grade browsing is not a pane: it replaces the reader's whole list, so it navigates
+        // from both branches rather than opening beside the collection.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).performClick()
+
+        assertThat(openedGrades).containsExactly(HadithGrade.SAHIH)
+    }
+
+    private fun seededOwner(): ViewModelStoreOwner {
+        val store = ViewModelStore()
+        seed(store, HadithViewModel::class.java, viewModel)
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    private fun <VM : ViewModel> seed(store: ViewModelStore, type: Class<VM>, instance: VM) {
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                instance as T
+        }
+        ViewModelProvider.create(store, factory)[type]
+    }
+
+    private companion object {
+        val bukhari = HadithBook(
+            id = "bukhari",
+            nameArabic = "صحيح البخاري",
+            nameEnglish = "Sahih al-Bukhari",
+            authorName = "Imam al-Bukhari",
+            authorArabic = "البخاري",
+            totalHadiths = 7563,
+            totalChapters = 97,
+            description = null,
+            displayOrder = 1,
+        )
+        val muslim = bukhari.copy(
+            id = "muslim",
+            nameEnglish = "Sahih Muslim",
+            authorName = "Imam Muslim",
+        )
+        val revelation = HadithChapter(
+            id = "bukhari_1",
+            bookId = "bukhari",
+            chapterNumber = 1,
+            nameArabic = "بدء الوحي",
+            nameEnglish = "Revelation",
+            hadithCount = 7,
+            hadithStartNumber = 1,
+            hadithEndNumber = 7,
+        )
+        val firstHadith = Hadith(
+            id = "bukhari_1_1",
+            bookId = "bukhari",
+            chapterId = "1",
+            hadithNumber = 1,
+            hadithNumberInBook = 1,
+            textArabic = "إنما الأعمال بالنيات",
+            textEnglish = "Actions are but by intention",
+            narratorChain = null,
+            narratorName = "Umar ibn al-Khattab",
+            grade = HadithGrade.SAHIH,
+            gradeArabic = null,
+            reference = "Sahih al-Bukhari 1",
+        )
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaCategoryScreenTest.kt
@@ -1,0 +1,267 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaCategoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * One category's duas, and the row component the occasion screen shares with it.
+ *
+ * **`DuaListItem` is the same row in two screens with one difference**: given an
+ * `onOccasionClick` the occasion under the title becomes a tappable badge into that occasion's
+ * whole list; without one it is plain text. Both branches ship — the category screen passes the
+ * lambda, the occasion screen does not, because a chip that navigates to the list you are
+ * already looking at is a dead end. Nothing but a rendering test can tell the two apart.
+ *
+ * **The occasion label must come from the resources, not from the domain model.**
+ * `DuaOccasion.displayName()` returns hardcoded English, which is right for a log line and
+ * wrong on a chip a German reader is looking at; `duaOccasionLabelRes` is the presentation-layer
+ * mapping that exists for it. A row rendering the enum's own name would look correct in every
+ * English test.
+ *
+ * **The repeat badge is guarded twice** — null, and zero. The content artifact carries `0` for
+ * duas with no prescribed count, and an unguarded badge reads "0x".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class DuaCategoryScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val categoryState = MutableStateFlow(DuaCategoryUiState())
+    private val events = mutableListOf<DuaEvent>()
+
+    private val viewModel: DuaViewModel = mockk(relaxed = true) {
+        every { this@mockk.categoryState } returns this@DuaCategoryScreenTest.categoryState
+        every { onEvent(any()) } answers { events += firstArg<DuaEvent>() }
+    }
+
+    private val openedDuas = mutableListOf<String>()
+    private val openedOccasions = mutableListOf<DuaOccasion>()
+
+    private fun setContent(categoryId: String = "morning") {
+        composeRule.setThemedContent {
+            DuaCategoryScreen(
+                categoryId = categoryId,
+                onNavigateBack = {},
+                onNavigateToDua = { openedDuas += it },
+                onNavigateToOccasion = { openedOccasions += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `opening the screen asks for the category named in the route`() {
+        categoryState.value = DuaCategoryUiState(isLoading = false)
+
+        setContent(categoryId = "before_sleep")
+
+        assertThat(events).containsExactly(DuaEvent.LoadCategory("before_sleep"))
+    }
+
+    @Test
+    fun `each dua renders its number, title, Arabic and translation`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(
+                dua(
+                    id = "d1",
+                    displayOrder = 1,
+                    titleEnglish = "Upon waking",
+                    textArabic = "الحمد لله",
+                    textEnglish = "Praise be to Allah",
+                ),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Upon waking").assertIsDisplayed()
+        composeRule.onNodeWithText("الحمد لله").assertExists()
+        composeRule.onNodeWithText("Praise be to Allah").assertExists()
+        composeRule.onNodeWithText("1").assertExists()
+    }
+
+    @Test
+    fun `the header card carries the category's Arabic name and description`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(
+                nameArabic = "أذكار الصباح",
+                description = "Said between dawn and sunrise",
+            ),
+            duas = listOf(dua()),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("أذكار الصباح").assertExists()
+        composeRule.onNodeWithText("Said between dawn and sunrise").assertExists()
+    }
+
+    @Test
+    fun `a category with no description renders its header without one`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(nameArabic = "أدعية", description = null),
+            duas = listOf(dua()),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("أدعية").assertExists()
+    }
+
+    @Test
+    fun `tapping a dua opens that dua`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(
+                dua(id = "d1", titleEnglish = "Upon waking"),
+                dua(id = "d2", titleEnglish = "Upon leaving home"),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithText("Upon leaving home").performClick()
+
+        assertThat(openedDuas).containsExactly("d2")
+    }
+
+    @Test
+    fun `the occasion under a title is a way into that occasion's whole list`() {
+        // Only this screen passes `onOccasionClick`, and the badge it turns the label into is
+        // the sole route to `DuaOccasionScreen`.
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(dua(id = "d1", occasion = DuaOccasion.TRAVELING)),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithText(string(R.string.dua_occasion_traveling)).performClick()
+
+        assertThat(openedOccasions).containsExactly(DuaOccasion.TRAVELING)
+        // Tapping the occasion is not tapping the row.
+        assertThat(openedDuas).isEmpty()
+    }
+
+    @Test
+    fun `the occasion label is the localised one, not the domain model's English`() {
+        // `DuaOccasion.BEFORE_SLEEP.displayName()` and the resource differ in wording; rendering
+        // the model's own string would pass unnoticed in English and ship untranslated
+        // everywhere else.
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(dua(id = "d1", occasion = DuaOccasion.BEFORE_SLEEP)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_occasion_before_sleep)).assertExists()
+    }
+
+    @Test
+    fun `a dua filed under no occasion renders no occasion line`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(dua(id = "d1", titleEnglish = "Unfiled", occasion = null)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Unfiled").assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.dua_occasion_general)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a prescribed repeat count is shown, and a count of zero is not`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(),
+            duas = listOf(
+                dua(id = "d1", titleEnglish = "Thrice", repeatCount = 3),
+                dua(id = "d2", titleEnglish = "Unprescribed", repeatCount = 0),
+                dua(id = "d3", titleEnglish = "Unknown", repeatCount = null),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_repeat_count_format, 3)).assertExists()
+        composeRule.onNodeWithText(string(R.string.dua_repeat_count_format, 0)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the app bar counts the category's duas`() {
+        categoryState.value = DuaCategoryUiState(
+            category = category(nameEnglish = "Morning Adhkar", duaCount = 12),
+            duas = listOf(dua()),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Morning Adhkar").assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.duas_count_format, 12, 12)
+        ).assertExists()
+    }
+
+    @Test
+    fun `a failed load is reported, and retrying reloads the same category`() {
+        categoryState.value = DuaCategoryUiState(
+            isLoading = false,
+            error = UiError(message = R.string.dua_category_load_failed, details = "disk I/O"),
+        )
+
+        setContent(categoryId = "evening")
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.dua_category_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        // The route's id, not whatever the ViewModel happened to load last.
+        assertThat(events).containsExactly(DuaEvent.LoadCategory("evening"))
+    }
+
+    @Test
+    fun `the app bar falls back to a generic title until the category is known`() {
+        composeRule.mainClock.autoAdvance = false
+        categoryState.value = DuaCategoryUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.duas)).assertExists()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaFixtures.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaFixtures.kt
@@ -1,0 +1,69 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaBookmark
+import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+
+/**
+ * Content the dua screens render.
+ *
+ * Every optional field the screens branch on — transliteration, benefits, reference, repeat
+ * count, occasion, description — is a named parameter, so a test that is about one of them
+ * names only that one.
+ */
+internal fun category(
+    id: String = "morning",
+    nameEnglish: String = "Morning Adhkar",
+    nameArabic: String = "أذكار الصباح",
+    description: String? = "Supplications for the morning",
+    iconName: String? = "🌅",
+    duaCount: Int = 12,
+    displayOrder: Int = 1,
+) = DuaCategory(
+    id = id,
+    nameArabic = nameArabic,
+    nameEnglish = nameEnglish,
+    description = description,
+    iconName = iconName,
+    displayOrder = displayOrder,
+    duaCount = duaCount,
+)
+
+internal fun dua(
+    id: String = "dua_1",
+    categoryId: String = "morning",
+    titleEnglish: String = "Upon waking",
+    textArabic: String = "الحمد لله الذي أحيانا",
+    textTransliteration: String? = "Alhamdulillahilladhi ahyana",
+    textEnglish: String = "Praise be to Allah who gave us life",
+    reference: String? = "Sahih al-Bukhari 6312",
+    occasion: DuaOccasion? = DuaOccasion.WAKING_UP,
+    benefits: String? = null,
+    repeatCount: Int? = null,
+    displayOrder: Int = 1,
+) = Dua(
+    id = id,
+    categoryId = categoryId,
+    titleArabic = "دعاء",
+    titleEnglish = titleEnglish,
+    textArabic = textArabic,
+    textTransliteration = textTransliteration,
+    textEnglish = textEnglish,
+    reference = reference,
+    occasion = occasion,
+    benefits = benefits,
+    repeatCount = repeatCount,
+    audioUrl = null,
+    displayOrder = displayOrder,
+)
+
+internal fun favourite(id: Long, duaId: String = "dua_$id") = DuaBookmark(
+    id = id,
+    duaId = duaId,
+    categoryId = "morning",
+    note = null,
+    isFavorite = true,
+    createdAt = 0L,
+    updatedAt = 0L,
+)

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionLabelsTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionLabelsTest.kt
@@ -1,0 +1,62 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The occasion→resource mapping, asserted exhaustively.
+ *
+ * `DuaOccasion.displayName()` on the domain model returns hardcoded English; this mapping is
+ * the presentation-layer replacement, and it is a seventeen-arm `when` written by hand. Two
+ * arms pointing at the same resource is the failure it catches — "Entering the mosque" and
+ * "Leaving the mosque" are one character apart in the source and opposite in meaning, and a
+ * reader who sees the wrong one has no way to tell it is wrong.
+ *
+ * Exhaustive by construction: the assertion iterates `entries`, so an eighteenth occasion added
+ * to the domain model without an arm here fails to compile in the mapping and fails here if it
+ * is given a duplicate.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DuaOccasionLabelsTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `every occasion has a label, and no two share one`() {
+        val labels = DuaOccasion.entries.associateWith { context.getString(duaOccasionLabelRes(it)) }
+
+        assertThat(labels).hasSize(DuaOccasion.entries.size)
+        labels.forEach { (occasion, label) ->
+            assertThat(label).isNotEmpty()
+            // A label that is still the enum constant means the arm was never written.
+            assertThat(label).isNotEqualTo(occasion.name)
+        }
+        assertThat(labels.values.toSet()).hasSize(DuaOccasion.entries.size)
+    }
+
+    @Test
+    fun `the two mosque occasions are opposite, not interchangeable`() {
+        // One character apart in the source; opposite on screen.
+        val entering = context.getString(duaOccasionLabelRes(DuaOccasion.ENTERING_MOSQUE))
+        val leaving = context.getString(duaOccasionLabelRes(DuaOccasion.LEAVING_MOSQUE))
+
+        assertThat(entering).isNotEqualTo(leaving)
+        assertThat(entering).ignoringCase().contains("enter")
+        assertThat(leaving).ignoringCase().contains("leav")
+    }
+
+    @Test
+    fun `the two home occasions are opposite, not interchangeable`() {
+        val entering = context.getString(duaOccasionLabelRes(DuaOccasion.ENTERING_HOME))
+        val leaving = context.getString(duaOccasionLabelRes(DuaOccasion.LEAVING_HOME))
+
+        assertThat(entering).isNotEqualTo(leaving)
+        assertThat(entering).ignoringCase().contains("enter")
+        assertThat(leaving).ignoringCase().contains("leav")
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaOccasionScreenTest.kt
@@ -1,0 +1,183 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaCategoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Every dua for one occasion, gathered across the curated categories.
+ *
+ * The cross-cut shipped in the database, the repository and the event before anything could
+ * dispatch it — so this screen is the only thing that makes `LoadDuasByOccasion` reachable, and
+ * a regression here returns the feature to existing everywhere except where a reader can get to
+ * it.
+ *
+ * It renders from `categoryState`, the same surface `LoadCategory` fills, so **the header card
+ * must not appear**: `state.category` is null in this mode by construction, and a screen that
+ * rendered the card unconditionally would show the last category the reader visited above an
+ * unrelated occasion's duas. The row here also passes no `onOccasionClick` — a chip navigating
+ * to the list you are already on is a dead end.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class DuaOccasionScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val categoryState = MutableStateFlow(DuaCategoryUiState())
+    private val events = mutableListOf<DuaEvent>()
+
+    private val viewModel: DuaViewModel = mockk(relaxed = true) {
+        every { this@mockk.categoryState } returns this@DuaOccasionScreenTest.categoryState
+        every { onEvent(any()) } answers { events += firstArg<DuaEvent>() }
+    }
+
+    private val openedDuas = mutableListOf<String>()
+
+    private fun setContent(occasion: DuaOccasion = DuaOccasion.MORNING) {
+        composeRule.setThemedContent {
+            DuaOccasionScreen(
+                occasion = occasion,
+                onNavigateBack = {},
+                onNavigateToDua = { openedDuas += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `opening the screen asks for that occasion's duas`() {
+        categoryState.value = DuaCategoryUiState(isLoading = false)
+
+        setContent(occasion = DuaOccasion.DISTRESS)
+
+        assertThat(events).containsExactly(
+            DuaEvent.LoadDuasByOccasion(DuaOccasion.DISTRESS)
+        )
+    }
+
+    @Test
+    fun `the occasion's own name titles the screen and the count follows it`() {
+        categoryState.value = DuaCategoryUiState(
+            duas = listOf(dua(id = "d1"), dua(id = "d2")),
+            isLoading = false,
+        )
+
+        setContent(occasion = DuaOccasion.FORGIVENESS)
+
+        composeRule.onNodeWithText(string(R.string.dua_occasion_forgiveness)).assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.duas_count_format, 2, 2)
+        ).assertExists()
+    }
+
+    @Test
+    fun `the duas gathered for the occasion are listed`() {
+        categoryState.value = DuaCategoryUiState(
+            duas = listOf(
+                dua(id = "d1", titleEnglish = "On leaving the house"),
+                dua(id = "d2", titleEnglish = "On boarding a mount"),
+            ),
+            isLoading = false,
+        )
+
+        setContent(occasion = DuaOccasion.TRAVELING)
+
+        composeRule.onNodeWithText("On leaving the house").assertIsDisplayed()
+        composeRule.onNodeWithText("On boarding a mount").assertIsDisplayed()
+    }
+
+    @Test
+    fun `no category header is rendered over an occasion's list`() {
+        // `categoryState` is shared with the category screen, and a stale `category` left in it
+        // would put another collection's Arabic name and description above these duas.
+        categoryState.value = DuaCategoryUiState(
+            category = category(nameArabic = "أذكار الصباح", description = "Morning adhkar"),
+            duas = listOf(dua(id = "d1", titleEnglish = "Travel dua")),
+            isLoading = false,
+        )
+
+        setContent(occasion = DuaOccasion.TRAVELING)
+
+        composeRule.onNodeWithText("Travel dua").assertIsDisplayed()
+        composeRule.onNodeWithText("Morning adhkar").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the occasion label under a row is text here, not a way back to this screen`() {
+        // No `onOccasionClick` is passed, so the badge branch of `DuaListItem` must not run.
+        categoryState.value = DuaCategoryUiState(
+            duas = listOf(dua(id = "d1", occasion = DuaOccasion.RAIN)),
+            isLoading = false,
+        )
+
+        setContent(occasion = DuaOccasion.RAIN)
+
+        composeRule.onNodeWithText("Travel dua").assertDoesNotExist()
+        composeRule.onNodeWithText(dua().titleEnglish).performClick()
+        assertThat(openedDuas).containsExactly("d1")
+    }
+
+    @Test
+    fun `an occasion nothing is filed under says so rather than looking broken`() {
+        categoryState.value = DuaCategoryUiState(duas = emptyList(), isLoading = false)
+
+        setContent(occasion = DuaOccasion.GRATITUDE)
+
+        composeRule.onNodeWithText(string(R.string.dua_occasion_empty)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed load is reported as a failure, and retrying re-asks for the occasion`() {
+        categoryState.value = DuaCategoryUiState(
+            duas = emptyList(),
+            isLoading = false,
+            error = UiError(message = R.string.dua_category_load_failed, details = "disk I/O"),
+        )
+
+        setContent(occasion = DuaOccasion.EATING)
+        events.clear()
+
+        composeRule.onNodeWithText(string(R.string.dua_category_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.dua_occasion_empty)).assertDoesNotExist()
+
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+        assertThat(events).containsExactly(DuaEvent.LoadDuasByOccasion(DuaOccasion.EATING))
+    }
+
+    @Test
+    fun `while loading, neither the list nor the empty message is on screen`() {
+        composeRule.mainClock.autoAdvance = false
+        categoryState.value = DuaCategoryUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_occasion_empty)).assertDoesNotExist()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreenTest.kt
@@ -1,0 +1,346 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaReaderUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+/**
+ * The dua reader: one supplication per page, with three display toggles over it.
+ *
+ * **The three toggles are what `:core:datastore` (#603) persists and nothing asserted.**
+ * `duaShowTransliteration` off must actually remove the transliteration — and the
+ * transliteration is doubly guarded, because the content artifact does not carry one for every
+ * dua, so "the setting is on but the field is empty" and "the setting is off" have to produce
+ * the same page without either being mistaken for the other.
+ *
+ * **Every optional field below the text is guarded, and the guards interact.** The meta row
+ * appears when there is a reference *or* a positive repeat count, and each chip inside it is
+ * guarded again; the virtue card appears only for a dua that ships benefits. Ungated, a dua
+ * with none of them renders an empty card and two empty pills under a supplication.
+ *
+ * **"Not found" and "failed to load" reach the same branch.** `duas.isEmpty()` is true for both,
+ * and the state's `error` is what separates them: a missing dua keeps the not-found wording, a
+ * failure says what failed. They looked identical before the error carried a kind.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class DuaReaderScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val readerState = MutableStateFlow(DuaReaderUiState())
+    private val events = mutableListOf<DuaEvent>()
+
+    private val viewModel: DuaViewModel = mockk(relaxed = true) {
+        every { this@mockk.readerState } returns this@DuaReaderScreenTest.readerState
+        every { onEvent(any()) } answers { events += firstArg<DuaEvent>() }
+        every { isDuaFavorite(any()) } returns flowOf(false)
+    }
+
+    private var settingsOpened = 0
+
+    private fun setContent(duaId: String = "dua_1") {
+        composeRule.setThemedContent {
+            DuaReaderScreen(
+                duaId = duaId,
+                onNavigateBack = {},
+                onNavigateToSettings = { settingsOpened++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun loaded(
+        vararg duas: com.arshadshah.nimaz.domain.model.Dua,
+        showArabic: Boolean = true,
+        showTransliteration: Boolean = true,
+        showTranslation: Boolean = true,
+    ) {
+        readerState.value = DuaReaderUiState(
+            duas = duas.toList(),
+            isLoading = false,
+            showArabic = showArabic,
+            showTransliteration = showTransliteration,
+            showTranslation = showTranslation,
+        )
+    }
+
+    @Test
+    fun `opening the reader asks for the dua named in the route`() {
+        readerState.value = DuaReaderUiState(isLoading = false)
+
+        setContent(duaId = "dua_42")
+
+        assertThat(events).containsExactly(DuaEvent.LoadDua("dua_42"))
+    }
+
+    @Test
+    fun `a dua renders its Arabic, transliteration and translation together`() {
+        loaded(
+            dua(
+                textArabic = "بسم الله",
+                textTransliteration = "Bismillah",
+                textEnglish = "In the name of Allah",
+            )
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("بسم الله").assertExists()
+        composeRule.onNodeWithText("Bismillah").assertExists()
+        composeRule.onNodeWithText("In the name of Allah").assertExists()
+    }
+
+    @Test
+    fun `hiding the Arabic removes the Arabic`() {
+        loaded(
+            dua(textArabic = "بسم الله", textEnglish = "In the name of Allah"),
+            showArabic = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("بسم الله").assertDoesNotExist()
+        composeRule.onNodeWithText("In the name of Allah").assertExists()
+    }
+
+    @Test
+    fun `hiding the transliteration removes the transliteration`() {
+        loaded(
+            dua(textTransliteration = "Bismillah", textEnglish = "In the name of Allah"),
+            showTransliteration = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Bismillah").assertDoesNotExist()
+        composeRule.onNodeWithText("In the name of Allah").assertExists()
+    }
+
+    @Test
+    fun `a dua that ships no transliteration renders as if the setting were off`() {
+        // The second half of the guard. Without it the divider and the spacing appear over an
+        // empty line, which reads as a missing translation rather than as absent data.
+        loaded(dua(textTransliteration = null, textEnglish = "In the name of Allah"))
+
+        setContent()
+
+        composeRule.onNodeWithText("In the name of Allah").assertExists()
+    }
+
+    @Test
+    fun `hiding the translation removes the translation`() {
+        loaded(
+            dua(textArabic = "بسم الله", textEnglish = "In the name of Allah"),
+            showTranslation = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("In the name of Allah").assertDoesNotExist()
+        composeRule.onNodeWithText("بسم الله").assertExists()
+    }
+
+    @Test
+    fun `a reference and a recitation count are shown as their own chips`() {
+        loaded(dua(reference = "Sahih Muslim 2723", repeatCount = 3))
+
+        setContent()
+
+        composeRule.onNodeWithText("Sahih Muslim 2723").assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.dua_reader_recite_count, 3, 3)
+        ).assertExists()
+    }
+
+    @Test
+    fun `a dua with neither a reference nor a count shows no meta row at all`() {
+        loaded(dua(reference = null, repeatCount = null, textEnglish = "Bare supplication"))
+
+        setContent()
+
+        composeRule.onNodeWithText("Bare supplication").assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.dua_reader_recite_count, 1, 1)
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a repeat count of zero is not a chip saying zero`() {
+        // The content artifact stores 0 for "no prescribed count", and `repeatCount > 0` is what
+        // keeps that out of the reader.
+        loaded(dua(reference = "Sunan Abi Dawud 5090", repeatCount = 0))
+
+        setContent()
+
+        composeRule.onNodeWithText("Sunan Abi Dawud 5090").assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.dua_reader_recite_count, 0, 0)
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a dua that ships a virtue shows the virtue card`() {
+        loaded(dua(benefits = "Whoever says this is protected until evening"))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_reader_virtue)).assertExists()
+        composeRule.onNodeWithText("Whoever says this is protected until evening").assertExists()
+    }
+
+    @Test
+    fun `a dua with no recorded virtue shows no empty virtue card`() {
+        loaded(dua(benefits = null))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_reader_virtue)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the occasion badge is localised, and absent when the dua has no occasion`() {
+        loaded(dua(occasion = DuaOccasion.RAIN))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_occasion_rain)).assertExists()
+    }
+
+    @Test
+    fun `the app bar carries the open dua's title`() {
+        loaded(dua(titleEnglish = "Dua for rain"))
+
+        setContent()
+
+        composeRule.onNodeWithText("Dua for rain").assertExists()
+    }
+
+    @Test
+    fun `favouriting the open dua cites its id and its category`() {
+        // The category id travels with the write because a `DuaBookmark` is keyed on both;
+        // sending the dua's id alone files the favourite under no collection.
+        loaded(dua(id = "dua_7", categoryId = "evening"))
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_favorite))
+            .performClick()
+
+        assertThat(events).contains(DuaEvent.ToggleFavorite("dua_7", "evening"))
+    }
+
+    @Test
+    fun `adding to tasbih writes through this feature's own ViewModel and says it did`() {
+        // The screen used to reach `TasbihViewModel` through a `hiltViewModel()` of its own —
+        // a cross-feature edge `moduleBoundary` now forbids, and one that never held the tasbih
+        // screen's instance anyway. The toast is the only feedback the reader gets.
+        val target = dua(id = "dua_9", titleEnglish = "Tasbih-able")
+        loaded(target)
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_add_tasbih))
+            .performClick()
+
+        assertThat(events).contains(DuaEvent.AddToTasbih(target))
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo(string(R.string.dua_reader_added_tasbih))
+    }
+
+    @Test
+    fun `a single-dua collection offers no page arrows`() {
+        loaded(dua())
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_prev))
+            .assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_share)).assertExists()
+    }
+
+    @Test
+    fun `a multi-dua collection offers arrows, and the first page cannot go back`() {
+        loaded(dua(id = "d1"), dua(id = "d2"), dua(id = "d3"))
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_prev))
+            .assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription(string(R.string.dua_reader_next))
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun `a dua id that resolves to nothing says not found`() {
+        readerState.value = DuaReaderUiState(duas = emptyList(), isLoading = false)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_reader_not_found)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a load that failed says what failed rather than not found`() {
+        readerState.value = DuaReaderUiState(
+            duas = emptyList(),
+            isLoading = false,
+            error = UiError(message = R.string.dua_category_load_failed, details = "disk I/O"),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_category_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.dua_reader_not_found)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the reader shows a spinner before it has anything to read`() {
+        composeRule.mainClock.autoAdvance = false
+        readerState.value = DuaReaderUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_reader_loading)).assertExists()
+        composeRule.onNodeWithText(string(R.string.dua_reader_not_found)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `dua settings are reachable from the reader`() {
+        loaded(dua())
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.dua_settings)).performClick()
+
+        assertThat(settingsOpened).isEqualTo(1)
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreenTest.kt
@@ -1,0 +1,326 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaCollectionUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaFavoritesUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.DuaViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The dua library, which is really two libraries behind one toggle.
+ *
+ * **The sort toggle changes the shape of the screen, not just the order.** In curated order the
+ * categories split into a four-card grid of "Daily Adhkar" and a list of "Situational Duas"
+ * below it; alphabetical collapses both into one flat A–Z list, because the curated split is
+ * meaningless once reordered. Two layouts from one boolean is exactly where a category can fall
+ * out of the screen entirely — `take(4)` and `drop(4)` are a partition only as long as both
+ * branches run.
+ *
+ * **The icon a category shows is looked up from the emoji the content artifact ships.**
+ * `getCategoryIcon` maps forty-odd emoji to Material icons and everything else to a mosque.
+ * The mapping is a private `when` in this file, so an emoji the artifact starts using is a
+ * silent fallback — every unknown category quietly becomes a mosque, and they all look alike.
+ *
+ * **A failed collection load used to leave the spinner up for good.** It is now a state with a
+ * retry, and the branch order — loading, then error, then content — is what keeps the failure
+ * from reading as an empty library.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class DuasCollectionScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val collectionState = MutableStateFlow(DuaCollectionUiState())
+    private val favoritesState = MutableStateFlow(DuaFavoritesUiState())
+    private val events = mutableListOf<DuaEvent>()
+
+    private val viewModel: DuaViewModel = mockk(relaxed = true) {
+        every { this@mockk.collectionState } returns this@DuasCollectionScreenTest.collectionState
+        every { this@mockk.favoritesState } returns this@DuasCollectionScreenTest.favoritesState
+        every { onEvent(any()) } answers { events += firstArg<DuaEvent>() }
+    }
+
+    private val opened = mutableListOf<String>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            DuasCollectionScreen(
+                onNavigateBack = { opened += "back" },
+                onNavigateToCategory = { opened += "category:$it" },
+                onNavigateToBookmarks = { opened += "bookmarks" },
+                onNavigateToSearch = { opened += "search" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun loaded(vararg categories: com.arshadshah.nimaz.domain.model.DuaCategory) {
+        collectionState.value = DuaCollectionUiState(
+            categories = categories.toList(),
+            filteredCategories = categories.toList(),
+            isLoading = false,
+        )
+    }
+
+    private fun categories(count: Int) = List(count) {
+        category(id = "c$it", nameEnglish = "Category $it", duaCount = it + 1)
+    }.toTypedArray()
+
+    @Test
+    fun `opening the library asks for the favourites and today's progress`() {
+        // Neither is part of the categories load, and both feed sections of this screen; a
+        // screen that never asks shows an empty favourites row on a device that has some.
+        collectionState.value = DuaCollectionUiState(isLoading = false)
+
+        setContent()
+
+        assertThat(events).containsExactly(DuaEvent.LoadFavorites, DuaEvent.LoadTodayProgress)
+            .inOrder()
+    }
+
+    @Test
+    fun `the curated order shows the first four as a grid and the rest as a list`() {
+        loaded(*categories(6))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertExists()
+        composeRule.onNodeWithText(string(R.string.situational_duas)).assertExists()
+        composeRule.onNodeWithText("Category 0").assertExists()
+        composeRule.onNodeWithText("Category 5").assertExists()
+    }
+
+    @Test
+    fun `a library of four or fewer has no situational section to show`() {
+        // `size > 4` guards the whole second section; without the guard a library of exactly
+        // four renders an empty "Situational Duas" heading over nothing.
+        loaded(*categories(4))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertExists()
+        composeRule.onNodeWithText(string(R.string.situational_duas)).assertDoesNotExist()
+        composeRule.onNodeWithText("Category 3").assertExists()
+    }
+
+    @Test
+    fun `no category is lost between the grid and the list below it`() {
+        // `take(4)` and `drop(4)` partition the list. Getting either bound wrong drops or
+        // duplicates a category, and both look like a plausible screen.
+        loaded(*categories(9))
+
+        setContent()
+
+        repeat(9) { index ->
+            composeRule.onNodeWithText("Category $index").assertExists()
+        }
+    }
+
+    @Test
+    fun `alphabetical order replaces both sections with one flat list`() {
+        collectionState.value = DuaCollectionUiState(
+            categories = categories(6).toList(),
+            filteredCategories = categories(6).toList(),
+            sortAlphabetical = true,
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.all_categories_az)).assertExists()
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.situational_duas)).assertDoesNotExist()
+        composeRule.onNodeWithText("Category 5").assertExists()
+    }
+
+    @Test
+    fun `the sort control dispatches the toggle and names the state it would move to`() {
+        // The content description is the only thing that tells a screen-reader user which way
+        // the toggle goes, and it inverts with the state rather than describing it.
+        loaded(*categories(5))
+
+        setContent()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.sort_categories_alphabetically)
+        ).performClick()
+
+        assertThat(events).contains(DuaEvent.ToggleCategoriesSort)
+    }
+
+    @Test
+    fun `once sorted the control offers the way back to the curated order`() {
+        collectionState.value = DuaCollectionUiState(
+            filteredCategories = categories(5).toList(),
+            sortAlphabetical = true,
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.sort_categories_default))
+            .assertExists()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.sort_categories_alphabetically)
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping a category opens that category, from either layout`() {
+        loaded(*categories(6))
+
+        setContent()
+        composeRule.onNodeWithText("Category 1").performClick()   // grid card
+        composeRule.onNodeWithText("Category 5").performClick()   // list row
+
+        assertThat(opened).containsExactly("category:c1", "category:c5").inOrder()
+    }
+
+    @Test
+    fun `a category with no description renders without a blank subtitle line`() {
+        collectionState.value = DuaCollectionUiState(
+            filteredCategories = listOf(
+                category(id = "c0", nameEnglish = "First"),
+                category(id = "c1", nameEnglish = "Second"),
+                category(id = "c2", nameEnglish = "Third"),
+                category(id = "c3", nameEnglish = "Fourth"),
+                category(
+                    id = "c4",
+                    nameEnglish = "Undescribed",
+                    description = null,
+                    duaCount = 3,
+                ),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Undescribed").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.duas_count_format, 3, 3)
+        ).assertExists()
+    }
+
+    @Test
+    // Forty-five rows do not fit even a 2,200dp viewport: a `LazyColumn` composes a screenful,
+    // so the last of them is never reached at the class's own height.
+    @Config(qualifiers = "w411dp-h6000dp")
+    fun `every emoji the content artifact ships resolves to an icon of its own`() {
+        // The mapping is a private `when` over forty-odd emoji plus a null case and a fallback.
+        // Rendering one category per key is what proves the lookup runs for each of them rather
+        // than silently collapsing to the mosque default.
+        val emoji = listOf(
+            "🌅", "🌙", "🤲", "☀️", "😴", "🏠", "🚪", "🕌", "🕋", "🍽️", "✨", "✈️", "🌧️",
+            "💚", "🙏", "🚿", "🚻", "📣", "👕", "🌟", "🤧", "📖", "💰", "💊", "🕊️", "😤",
+            "💳", "📜", "🌿", "👨‍👩‍👧", "💍", "🐫", "🌹", "🛡️", "🧎", "🌃", "🪦", "🌛",
+            "⚔️", "🌬️", "🤍", "📿", "🤝",
+        )
+        val withUnknownAndMissing = emoji + listOf("🧿", null)
+
+        collectionState.value = DuaCollectionUiState(
+            filteredCategories = withUnknownAndMissing.mapIndexed { index, icon ->
+                category(id = "c$index", nameEnglish = "Cat $index", iconName = icon)
+            },
+            sortAlphabetical = true,
+            isLoading = false,
+        )
+
+        setContent()
+
+        // The two fallbacks are the point: an unknown emoji and a category with none at all
+        // both still render a row rather than throwing or vanishing.
+        composeRule.onNodeWithText("Cat ${emoji.size}").assertExists()
+        composeRule.onNodeWithText("Cat ${emoji.size + 1}").assertExists()
+    }
+
+    @Test
+    fun `the favourites heading appears only when there are favourites`() {
+        loaded(*categories(5))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.favorites)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `saved favourites announce themselves above the categories`() {
+        loaded(*categories(5))
+        favoritesState.value = DuaFavoritesUiState(
+            favorites = listOf(favourite(1), favourite(2)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.favorites)).assertExists()
+    }
+
+    @Test
+    fun `a failed load says so and offers to load the categories again`() {
+        collectionState.value = DuaCollectionUiState(
+            isLoading = false,
+            error = UiError(
+                message = R.string.dua_collection_load_failed,
+                details = "no such table: duas",
+            ),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_collection_load_failed)).assertExists()
+        // The SQLite message goes to the crash report, never to the reader as the headline.
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertDoesNotExist()
+
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+        assertThat(events).containsExactly(DuaEvent.LoadAllCategories)
+    }
+
+    @Test
+    fun `while loading, neither the library nor the failure is on screen`() {
+        composeRule.mainClock.autoAdvance = false
+        collectionState.value = DuaCollectionUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.daily_adhkar)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.try_again)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `search and bookmarks are reachable from the app bar`() {
+        loaded(*categories(5))
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.search_title)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.bookmarks)).performClick()
+
+        assertThat(opened).containsExactly("search", "bookmarks").inOrder()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithChaptersScreenTest.kt
@@ -1,0 +1,275 @@
+package com.arshadshah.nimaz.presentation.screens.hadith
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithChaptersUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * One collection's chapters — the step between the library and the reader.
+ *
+ * **Three empty-looking states are three different things here**, and the screen's `when`
+ * ordering is the whole of what keeps them apart: still loading, failed to load, and a
+ * collection that genuinely lists no chapters. `chapters.isEmpty()` is true in all three. The
+ * comment in the source says the error branch sits before the empty branch *because* a failure
+ * once reported itself as "No chapters found" — a message that tells the reader to give up on
+ * a collection that is fine.
+ *
+ * **The search filter is derived, never stored.** `filteredChapters` recomputes from
+ * `searchQuery`, which is what lets a Room re-emission — a content refresh, a bookmark write —
+ * repaint the list without wiping what the reader typed. The screen is where that shows: the
+ * rows it renders come from `filteredChapters`, and rendering `chapters` instead would look
+ * correct until the moment someone searched.
+ *
+ * **A chapter is opened by book *and* chapter.** `onNavigateToChapter(bookId, chapter.id)`
+ * carries both because the reader keys on the composite `bookId_chapterId`; passing the
+ * chapter's own id alone resolves the header to null, which is the defect
+ * `Hadith.chapterKey` exists to prevent.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HadithChaptersScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val chaptersState = MutableStateFlow(HadithChaptersUiState())
+    private val events = mutableListOf<HadithEvent>()
+
+    private val viewModel: HadithViewModel = mockk(relaxed = true) {
+        every { this@mockk.chaptersState } returns this@HadithChaptersScreenTest.chaptersState
+        every { onEvent(any()) } answers { events += firstArg<HadithEvent>() }
+    }
+
+    private val openedChapters = mutableListOf<Pair<String, String>>()
+    private var backs = 0
+
+    private fun setContent(bookId: String = "bukhari") {
+        composeRule.setThemedContent {
+            HadithChaptersScreen(
+                bookId = bookId,
+                onNavigateBack = { backs++ },
+                onNavigateToChapter = { book, chapter -> openedChapters += book to chapter },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `opening the screen asks for the book named in the route`() {
+        // The screen owns no id of its own: everything below depends on this dispatch carrying
+        // the route's `bookId` rather than whatever the ViewModel last loaded.
+        chaptersState.value = HadithChaptersUiState(isLoading = false)
+
+        setContent(bookId = "tirmidhi")
+
+        assertThat(events).containsExactly(HadithEvent.LoadBook("tirmidhi"))
+    }
+
+    @Test
+    fun `the chapters render with their number, name and hadith count`() {
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = listOf(
+                chapter(id = "bukhari_1", chapterNumber = 1, nameEnglish = "Revelation", hadithCount = 7),
+                chapter(id = "bukhari_2", chapterNumber = 2, nameEnglish = "Belief", hadithCount = 51),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Revelation").assertIsDisplayed()
+        composeRule.onNodeWithText("Belief").assertIsDisplayed()
+        composeRule.onNodeWithText("51").assertExists()
+    }
+
+    @Test
+    fun `a chapter with no Arabic name renders without a blank second line`() {
+        // `nameArabic.isNotBlank()` guards the Arabic line. The content artifact does not carry
+        // one for every chapter of every collection.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = listOf(chapter(nameEnglish = "Ablution", nameArabic = "")),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Ablution").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping a chapter opens it under its own book`() {
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = listOf(
+                chapter(id = "bukhari_1", nameEnglish = "Revelation"),
+                chapter(id = "bukhari_2", nameEnglish = "Belief"),
+            ),
+            isLoading = false,
+        )
+
+        setContent(bookId = "bukhari")
+        composeRule.onNodeWithText("Belief").performClick()
+
+        assertThat(openedChapters).containsExactly("bukhari" to "bukhari_2")
+    }
+
+    @Test
+    fun `the header card reports the chapters actually loaded, not the book's own total`() {
+        // `totalChapters` is what the collection claims; `chapters.size` is what arrived. A
+        // partial content artifact makes the two disagree, and the count under the title is the
+        // only place a reader would ever see that.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(totalChapters = 97, totalHadiths = 7563),
+            chapters = List(3) { chapter(id = "bukhari_$it", chapterNumber = it + 1) },
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.hadith_chapters_count_format, 3, 3)
+        ).assertExists()
+        composeRule.onNodeWithText(string(R.string.hadith_count_format, "7563")).assertExists()
+    }
+
+    @Test
+    fun `a search narrows the list without touching the chapters underneath`() {
+        // `filteredChapters` is derived from `searchQuery` on every read. Rendering `chapters`
+        // instead would pass every test that does not set a query.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = listOf(
+                chapter(id = "bukhari_1", nameEnglish = "Revelation"),
+                chapter(id = "bukhari_2", nameEnglish = "Belief"),
+                chapter(id = "bukhari_3", nameEnglish = "Knowledge"),
+            ),
+            searchQuery = "bel",
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Belief").assertIsDisplayed()
+        composeRule.onNodeWithText("Revelation").assertDoesNotExist()
+        composeRule.onNodeWithText("Knowledge").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a search that matches nothing still shows the book's header`() {
+        // The header comes from `chapters`, the rows from `filteredChapters`. Driving both off
+        // the filtered list would blank the whole screen on a typo.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(nameEnglish = "Sahih al-Bukhari"),
+            chapters = listOf(chapter(nameEnglish = "Revelation")),
+            searchQuery = "zzzz",
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Imam al-Bukhari").assertExists()
+        composeRule.onNodeWithText("Revelation").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a collection that lists no chapters says so`() {
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = emptyList(),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.no_chapters_found)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed load is reported as a failure, not as an empty collection`() {
+        // The ordering this pins is the fix: `chapters.isEmpty()` is true here too, and the
+        // empty branch used to win.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(),
+            chapters = emptyList(),
+            isLoading = false,
+            error = UiError(
+                message = R.string.hadith_chapters_load_failed,
+                details = "disk I/O error",
+            ),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_chapters_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.no_chapters_found)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `retrying a failed chapter list re-issues the load`() {
+        chaptersState.value = HadithChaptersUiState(
+            isLoading = false,
+            error = UiError(message = R.string.hadith_chapters_load_failed),
+        )
+
+        setContent()
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).containsExactly(HadithEvent.Retry)
+    }
+
+    @Test
+    fun `the app bar falls back to a generic title until the book is known`() {
+        // `state.book` is null for the whole first frame of every navigation. Showing "Chapters"
+        // rather than an empty bar is what stops the screen from looking broken while it loads.
+        composeRule.mainClock.autoAdvance = false
+        chaptersState.value = HadithChaptersUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_chapters_title)).assertExists()
+    }
+
+    @Test
+    fun `once the book is known the app bar carries its name`() {
+        // Asserted on an empty collection deliberately: with chapters present the header card
+        // renders the same name a second time, and "found 2 nodes" would pass for the wrong
+        // reason — the generic title could still be sitting in the bar.
+        chaptersState.value = HadithChaptersUiState(
+            book = book(nameEnglish = "Sunan an-Nasa'i"),
+            chapters = emptyList(),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Sunan an-Nasa'i").assertExists()
+        composeRule.onNodeWithText(string(R.string.hadith_chapters_title)).assertDoesNotExist()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithCollectionScreenTest.kt
@@ -1,0 +1,352 @@
+package com.arshadshah.nimaz.presentation.screens.hadith
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.HadithBookmark
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.presentation.components.molecules.NimazErrorKind
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithBookmarksUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithCollectionUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The hadith library's front door: six collections, three grade shelves, and one card of
+ * content the app chose for today.
+ *
+ * Three properties are worth pinning and nothing else in the repository asserts any of them.
+ *
+ * **The hadith-of-the-day card has two lives.** `getHadithOfTheDay` is best-effort — the
+ * ViewModel drops its failure rather than replacing the book list over one card — so
+ * `hadithOfTheDay` is null on a perfectly healthy screen, and the card renders shipped
+ * fallback text instead. Nothing tells the two apart at a glance, which is what makes it worth
+ * an assertion: a card that shows Bukhari 6018 when the real selection failed to load is a
+ * silent substitution of one narration for another.
+ *
+ * **Only three grades are browsable.** Mawḍūʿ (fabricated) is deliberately absent — it is a
+ * warning label on an individual narration, not a shelf to invite anyone onto — and the list it
+ * is absent from is a private `val` no compiler check guards. A fourth pill arriving is exactly
+ * the kind of change that looks like a completion and is not.
+ *
+ * **The failure branch and the empty branch are distinguishable.** `books.isEmpty()` is true in
+ * both, so the ordering of the `when` is the whole of what separates "the library could not be
+ * read" from "the library is empty", and the retry that reaches `HadithEvent.Retry` is the only
+ * way out of the first.
+ *
+ * Rendered tall so the whole `LazyColumn` composes — the book grid is the last of five items.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HadithCollectionScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val collectionState = MutableStateFlow(HadithCollectionUiState())
+    private val bookmarksState = MutableStateFlow(HadithBookmarksUiState())
+    private val events = mutableListOf<HadithEvent>()
+
+    private val viewModel: HadithViewModel = mockk(relaxed = true) {
+        every { this@mockk.collectionState } returns this@HadithCollectionScreenTest.collectionState
+        every { this@mockk.bookmarksState } returns this@HadithCollectionScreenTest.bookmarksState
+        every { onEvent(any()) } answers { events += firstArg<HadithEvent>() }
+    }
+
+    private val opened = mutableListOf<String>()
+    private val openedGrades = mutableListOf<HadithGrade>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            HadithCollectionScreen(
+                onNavigateBack = { opened += "back" },
+                onNavigateToBook = { opened += "book:$it" },
+                onNavigateToBookmarks = { opened += "bookmarks" },
+                onNavigateToSearch = { opened += "search" },
+                onNavigateToGrade = { openedGrades += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the six collections each render with their author and hadith count`() {
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(
+                book(id = "bukhari", nameEnglish = "Sahih al-Bukhari", totalHadiths = 7563),
+                book(id = "muslim", nameEnglish = "Sahih Muslim", authorName = "Imam Muslim"),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Sahih al-Bukhari").assertIsDisplayed()
+        composeRule.onNodeWithText("Imam al-Bukhari").assertIsDisplayed()
+        composeRule.onNodeWithText("Sahih Muslim").assertIsDisplayed()
+        composeRule.onNodeWithText("Imam Muslim").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a book that ships no author renders without an empty line where the name goes`() {
+        // `authorName.isNotBlank()` guards the second line. Unguarded, a collection whose
+        // author field the content artifact does not carry renders a blank row and shifts the
+        // count line down — which reads as a layout bug, not as missing data.
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(book(nameEnglish = "Anonymous Collection", authorName = "")),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Anonymous Collection").assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_count_format, "7,563")).assertExists()
+    }
+
+    @Test
+    fun `tapping a collection opens that collection, by its own id`() {
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(
+                book(id = "bukhari", nameEnglish = "Sahih al-Bukhari"),
+                book(id = "ibnmajah", nameEnglish = "Sunan Ibn Majah"),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithText("Sunan Ibn Majah").performClick()
+
+        assertThat(opened).containsExactly("book:ibnmajah")
+    }
+
+    @Test
+    fun `every collection gets its own cover, and an unknown one still gets a cover`() {
+        // `getBookGradient` maps the six Kutub al-Sittah ids to their own palettes and
+        // everything else to a default. It is looked up while the card composes, so a book id
+        // the map does not know throws here rather than rendering plainly — which is what a
+        // seventh collection arriving from the content artifact would do.
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(
+                book(id = "bukhari", nameEnglish = "Bukhari"),
+                book(id = "muslim", nameEnglish = "Muslim"),
+                book(id = "tirmidhi", nameEnglish = "Tirmidhi"),
+                book(id = "nasai", nameEnglish = "Nasai"),
+                book(id = "abudawud", nameEnglish = "Abu Dawud"),
+                book(id = "ibnmajah", nameEnglish = "Ibn Majah"),
+                book(id = "malik", nameEnglish = "Muwatta Malik"),
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Muwatta Malik").assertIsDisplayed()
+        composeRule.onNodeWithText("Ibn Majah").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the bookmarked tile counts the bookmarks, not the books`() {
+        collectionState.value = HadithCollectionUiState(books = listOf(book()), isLoading = false)
+        bookmarksState.value = HadithBookmarksUiState(
+            bookmarks = listOf(bookmark(1), bookmark(2), bookmark(3)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.bookmarked)).assertExists()
+        composeRule.onNodeWithText("3").assertExists()
+    }
+
+    @Test
+    fun `the hadith of the day shows the selection when there is one`() {
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(book()),
+            hadithOfTheDay = hadith(
+                textEnglish = "The believer is the mirror of the believer",
+                reference = "Sunan Abi Dawud 4918",
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("The believer is the mirror of the believer").assertExists()
+        composeRule.onNodeWithText("Sunan Abi Dawud 4918").assertExists()
+        // The fallback narration must not be on screen at the same time as a real one.
+        composeRule.onNodeWithText(string(R.string.hadith_fallback_source)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a hadith of the day that never loaded falls back to the shipped narration`() {
+        // Best-effort: `loadHadithOfTheDay` reports its failure and drops it, so this state is
+        // reached both by "not loaded yet" and by "the content database could not be read".
+        collectionState.value = HadithCollectionUiState(books = listOf(book()), isLoading = false)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_fallback_english)).assertExists()
+        composeRule.onNodeWithText(string(R.string.hadith_fallback_source)).assertExists()
+    }
+
+    @Test
+    fun `bookmarking the hadith of the day cites the hadith's own book and number`() {
+        // The card is the only place that dispatches `ToggleBookmark` with
+        // `hadithNumberInBook` rather than `hadithNumber`; the two differ for every collection
+        // whose numbering restarts per volume, and a bookmark saved under the wrong one
+        // reopens on a different narration.
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(book()),
+            hadithOfTheDay = hadith(
+                id = "muslim_2_9",
+                bookId = "muslim",
+                hadithNumber = 9,
+                hadithNumberInBook = 2564,
+            ),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.bookmark)).performClick()
+
+        assertThat(events).containsExactly(
+            HadithEvent.ToggleBookmark(
+                hadithId = "muslim_2_9",
+                bookId = "muslim",
+                hadithNumber = 2564,
+            )
+        )
+    }
+
+    @Test
+    fun `bookmarking does nothing at all while the card is showing the fallback`() {
+        // There is no hadith to bookmark, and the card's tap handler is a no-op rather than a
+        // dispatch of the fallback's imaginary id.
+        collectionState.value = HadithCollectionUiState(books = listOf(book()), isLoading = false)
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.bookmark)).performClick()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `exactly the three browsable grades are offered, and each opens its own shelf`() {
+        collectionState.value = HadithCollectionUiState(books = listOf(book()), isLoading = false)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).performClick()
+        composeRule.onNodeWithText(string(R.string.hadith_grade_hasan)).performClick()
+        composeRule.onNodeWithText(string(R.string.hadith_grade_daif)).performClick()
+
+        assertThat(openedGrades).containsExactly(
+            HadithGrade.SAHIH,
+            HadithGrade.HASAN,
+            HadithGrade.DAIF,
+        ).inOrder()
+        // Fabricated is a warning on a narration, never a shelf.
+        composeRule.onNodeWithText(string(R.string.hadith_grade_mawdu)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a failed load says the library could not be read, and retry re-issues it`() {
+        collectionState.value = HadithCollectionUiState(
+            books = emptyList(),
+            isLoading = false,
+            error = UiError(message = R.string.hadith_books_load_failed, details = "no such table"),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_books_load_failed)).assertExists()
+        // Not "no collections" — the list being empty is a consequence of the failure.
+        composeRule.onNodeWithText(string(R.string.kutub_al_sittah)).assertDoesNotExist()
+
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+        assertThat(events).containsExactly(HadithEvent.Retry)
+    }
+
+    @Test
+    fun `a not-found error keeps its own kind rather than reading as a crash`() {
+        collectionState.value = HadithCollectionUiState(
+            isLoading = false,
+            error = UiError(
+                message = R.string.hadith_not_found,
+                kind = NimazErrorKind.NOT_FOUND,
+            ),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_not_found)).assertExists()
+    }
+
+    @Test
+    fun `the spinner shows only while there is nothing to show yet`() {
+        // `isLoading && books.isEmpty()`: a refresh that re-emits over a populated list must
+        // not replace the library with a spinner.
+        composeRule.mainClock.autoAdvance = false
+        collectionState.value = HadithCollectionUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.kutub_al_sittah)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a reload over a populated library leaves the library on screen`() {
+        collectionState.value = HadithCollectionUiState(
+            books = listOf(book(nameEnglish = "Sahih al-Bukhari")),
+            isLoading = true,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Sahih al-Bukhari").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search and bookmarks are reachable from the app bar`() {
+        collectionState.value = HadithCollectionUiState(books = listOf(book()), isLoading = false)
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.search)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.bookmarks)).performClick()
+
+        assertThat(opened).containsExactly("search", "bookmarks").inOrder()
+    }
+
+    private fun bookmark(id: Long) = HadithBookmark(
+        id = id,
+        hadithId = "bukhari_1_$id",
+        bookId = "bukhari",
+        hadithNumber = id.toInt(),
+        note = null,
+        color = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithFixtures.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithFixtures.kt
@@ -1,0 +1,79 @@
+package com.arshadshah.nimaz.presentation.screens.hadith
+
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithBook
+import com.arshadshah.nimaz.domain.model.HadithChapter
+import com.arshadshah.nimaz.domain.model.HadithGrade
+
+/**
+ * Content the hadith screens render, built here rather than in each test class.
+ *
+ * Every field the screens branch on is a parameter with a realistic default, so a test names
+ * only the field it is about — `hadith(grade = null)` reads as "a hadith with no grade", which
+ * is the case the assertion is making.
+ */
+internal fun book(
+    id: String = "bukhari",
+    nameEnglish: String = "Sahih al-Bukhari",
+    nameArabic: String = "صحيح البخاري",
+    authorName: String = "Imam al-Bukhari",
+    totalHadiths: Int = 7563,
+    totalChapters: Int = 97,
+) = HadithBook(
+    id = id,
+    nameArabic = nameArabic,
+    nameEnglish = nameEnglish,
+    authorName = authorName,
+    authorArabic = "البخاري",
+    totalHadiths = totalHadiths,
+    totalChapters = totalChapters,
+    description = null,
+    displayOrder = 1,
+)
+
+internal fun chapter(
+    id: String = "bukhari_1",
+    bookId: String = "bukhari",
+    chapterNumber: Int = 1,
+    nameEnglish: String = "Revelation",
+    nameArabic: String = "بدء الوحي",
+    hadithCount: Int = 7,
+) = HadithChapter(
+    id = id,
+    bookId = bookId,
+    chapterNumber = chapterNumber,
+    nameArabic = nameArabic,
+    nameEnglish = nameEnglish,
+    hadithCount = hadithCount,
+    hadithStartNumber = 1,
+    hadithEndNumber = hadithCount,
+)
+
+internal fun hadith(
+    id: String = "bukhari_1_1",
+    bookId: String = "bukhari",
+    chapterId: String = "1",
+    hadithNumber: Int = 1,
+    hadithNumberInBook: Int = 1,
+    textArabic: String = "إنما الأعمال بالنيات",
+    textEnglish: String = "Actions are but by intention",
+    narratorChain: String? = null,
+    narratorName: String? = "Umar ibn al-Khattab",
+    grade: HadithGrade? = HadithGrade.SAHIH,
+    reference: String? = "Sahih al-Bukhari 1",
+    isBookmarked: Boolean = false,
+) = Hadith(
+    id = id,
+    bookId = bookId,
+    chapterId = chapterId,
+    hadithNumber = hadithNumber,
+    hadithNumberInBook = hadithNumberInBook,
+    textArabic = textArabic,
+    textEnglish = textEnglish,
+    narratorChain = narratorChain,
+    narratorName = narratorName,
+    grade = grade,
+    gradeArabic = null,
+    reference = reference,
+    isBookmarked = isBookmarked,
+)

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreenTest.kt
@@ -1,0 +1,459 @@
+package com.arshadshah.nimaz.presentation.screens.hadith
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithReaderUiState
+import com.arshadshah.nimaz.presentation.viewmodel.content.HadithViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The hadith reader — and the four ways a reader arrives at one.
+ *
+ * **The entry-point `when` is the highest-value thing on this screen.** One `LaunchedEffect`
+ * turns four route shapes into four different loads, and every one of them is reachable from
+ * the UI: a chapter from the chapter list, a *number* from a bookmark, an *id* from search, and
+ * a *grade* from the collection screen's pills. Their guards overlap by construction —
+ * `bookId` is empty in the search case *and* in the grade case, `chapterId` carries a hadith id
+ * in one and a composite key in another — so the ordering is load-bearing, and the failure it
+ * prevents is a bookmark opening a stranger's narration rather than crashing. `HadithViewModel`
+ * cannot see any of this: it receives whichever event the screen chose.
+ *
+ * **The four display toggles each remove their own element.** `:core:datastore` (#603) pinned
+ * that the preferences persist; what was never asserted is that turning the chain off actually
+ * removes the chain. Each is a separate `if`, and a reader who has hidden the Arabic and gets
+ * it anyway has no way to report it beyond "the setting does nothing".
+ *
+ * **A hadith that ships without an optional field must not leave a hole.** The grade chip, the
+ * narrator badge, the reference badge and the isnād are each guarded; unguarded, a narration the
+ * content artifact carries no grade for renders an empty pill.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HadithReaderScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val readerState = MutableStateFlow(HadithReaderUiState())
+    private val events = mutableListOf<HadithEvent>()
+
+    private val viewModel: HadithViewModel = mockk(relaxed = true) {
+        every { this@mockk.readerState } returns this@HadithReaderScreenTest.readerState
+        every { onEvent(any()) } answers { events += firstArg<HadithEvent>() }
+        every { isHadithBookmarked(any()) } returns flowOf(false)
+    }
+
+    private var backs = 0
+    private var settingsOpened = 0
+
+    private fun setContent(
+        bookId: String = "bukhari",
+        chapterId: String = "bukhari_1",
+        hadithNumber: Int? = null,
+        grade: HadithGrade? = null,
+    ) {
+        composeRule.setThemedContent {
+            HadithReaderScreen(
+                bookId = bookId,
+                chapterId = chapterId,
+                onNavigateBack = { backs++ },
+                onNavigateToSettings = { settingsOpened++ },
+                hadithNumber = hadithNumber,
+                grade = grade,
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun loaded(vararg hadiths: com.arshadshah.nimaz.domain.model.Hadith) {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = hadiths.toList(),
+            isLoading = false,
+        )
+    }
+
+    // ---- the four ways in -------------------------------------------------------------
+
+    @Test
+    fun `a chapter route loads that chapter`() {
+        readerState.value = HadithReaderUiState(isLoading = false)
+
+        setContent(bookId = "bukhari", chapterId = "bukhari_2")
+
+        assertThat(events).containsExactly(HadithEvent.LoadChapter("bukhari_2"))
+    }
+
+    @Test
+    fun `a bookmark's book-and-number opens that number, not that primary key`() {
+        // A `HadithBookmark` stores the number printed in the reader, never the database id.
+        // Passing the number through the id path looks up a real hadith from an arbitrary book,
+        // so the reader lands somewhere plausible and wrong.
+        readerState.value = HadithReaderUiState(isLoading = false)
+
+        setContent(bookId = "muslim", chapterId = "", hadithNumber = 2564)
+
+        assertThat(events).containsExactly(
+            HadithEvent.LoadHadithByNumber(bookId = "muslim", hadithNumber = 2564)
+        )
+    }
+
+    @Test
+    fun `a bare hadith id from search is loaded as an id`() {
+        // No book, and no `book_chapter` composite in the second argument — the only shape that
+        // means "this is a hadith id".
+        readerState.value = HadithReaderUiState(isLoading = false)
+
+        setContent(bookId = "", chapterId = "bukhari-1-1")
+
+        assertThat(events).containsExactly(HadithEvent.LoadHadithById("bukhari-1-1"))
+    }
+
+    @Test
+    fun `browsing a grade wins over every other reading of the arguments`() {
+        // Grade browsing arrives with an empty book and an empty chapter — exactly the shape
+        // the search branch matches — so the guard order is what keeps "read every sahih
+        // narration" from resolving to "open the hadith whose id is the empty string".
+        readerState.value = HadithReaderUiState(isLoading = false)
+
+        setContent(bookId = "", chapterId = "", grade = HadithGrade.SAHIH)
+
+        assertThat(events).containsExactly(HadithEvent.FilterByGrade(HadithGrade.SAHIH))
+    }
+
+    @Test
+    fun `a grade shelf titles itself with the grade and counts what it found`() {
+        // There is no chapter in this mode, so the app bar would otherwise sit on "Loading…"
+        // for the whole session.
+        readerState.value = HadithReaderUiState(
+            chapter = null,
+            hadiths = listOf(hadith(), hadith(id = "b2"), hadith(id = "b3")),
+            isLoading = false,
+        )
+
+        setContent(bookId = "", chapterId = "", grade = HadithGrade.HASAN)
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_hasan)).assertExists()
+        composeRule.onNodeWithText(string(R.string.hadith_count_format, "3")).assertExists()
+    }
+
+    // ---- what a page renders ----------------------------------------------------------
+
+    @Test
+    fun `a hadith renders its Arabic, its translation and its reference`() {
+        loaded(
+            hadith(
+                textArabic = "إنما الأعمال بالنيات",
+                textEnglish = "Actions are but by intention",
+                reference = "Sahih al-Bukhari 1",
+            )
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("إنما الأعمال بالنيات").assertExists()
+        composeRule.onNodeWithText("Actions are but by intention").assertExists()
+        composeRule.onNodeWithText("Sahih al-Bukhari 1").assertExists()
+    }
+
+    @Test
+    fun `the chapter's name and number title the reader`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(chapterNumber = 2, nameEnglish = "Belief"),
+            hadiths = listOf(hadith()),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Belief").assertExists()
+        composeRule.onNodeWithText(string(R.string.hadith_chapter_format, 2)).assertExists()
+    }
+
+    @Test
+    fun `hiding the Arabic removes the Arabic`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(textArabic = "نص عربي", textEnglish = "English body")),
+            isLoading = false,
+            showArabic = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("نص عربي").assertDoesNotExist()
+        composeRule.onNodeWithText("English body").assertExists()
+    }
+
+    @Test
+    fun `hiding the translation removes the translation`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(textArabic = "نص عربي", textEnglish = "English body")),
+            isLoading = false,
+            showTranslation = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("English body").assertDoesNotExist()
+        composeRule.onNodeWithText("نص عربي").assertExists()
+    }
+
+    @Test
+    fun `hiding the grade removes the grade chip`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(grade = HadithGrade.SAHIH)),
+            isLoading = false,
+            showGrade = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `hiding the chain removes the chain`() {
+        // The setting `:core:datastore` persists, asserted where it has an effect.
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(narratorChain = "Malik -> Nafi -> Ibn Umar")),
+            isLoading = false,
+            showChain = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_isnad)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `showing the chain offers it collapsed, and expanding lists the narrators`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(narratorChain = "Malik -> Nafi -> Ibn Umar")),
+            isLoading = false,
+            showChain = true,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Malik").assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.hadith_isnad)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Malik").assertExists()
+        composeRule.onNodeWithText("Nafi").assertExists()
+        composeRule.onNodeWithText("Ibn Umar").assertExists()
+    }
+
+    @Test
+    fun `a single-narrator chain is shown whole rather than as a one-dot timeline`() {
+        // The timeline is drawn only when the chain actually splits; a chain the separators do
+        // not match would otherwise render as one lonely dot instead of the text it is.
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(narratorChain = "حدثنا عبد الله بن يوسف")),
+            isLoading = false,
+            showChain = true,
+        )
+
+        setContent()
+        composeRule.onNodeWithText(string(R.string.hadith_isnad)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("حدثنا عبد الله بن يوسف").assertExists()
+    }
+
+    @Test
+    fun `a chain of nothing but whitespace is not offered at all`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = listOf(hadith(narratorChain = "   ")),
+            isLoading = false,
+            showChain = true,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_isnad)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a narrator field that already says who narrated is not prefixed twice`() {
+        // The dataset carries "Narrated by …" inline for some collections and a bare name for
+        // others. Prefixing unconditionally produces "Narrated by Narrated by Abu Huraira".
+        loaded(hadith(narratorName = "Narrated by Abu Huraira"))
+
+        setContent()
+
+        composeRule.onNodeWithText("Narrated by Abu Huraira").assertExists()
+    }
+
+    @Test
+    fun `a bare narrator name is given the prefix`() {
+        loaded(hadith(narratorName = "Abu Huraira"))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_narrated_by_format, "Abu Huraira"))
+            .assertExists()
+    }
+
+    @Test
+    fun `a hadith with no grade and no narrator renders neither badge`() {
+        loaded(hadith(grade = null, narratorName = null, reference = null))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).assertDoesNotExist()
+        composeRule.onNodeWithText("Actions are but by intention").assertExists()
+    }
+
+    // ---- the bottom bar ---------------------------------------------------------------
+
+    @Test
+    fun `bookmarking the open hadith cites the hadith the reader is on`() {
+        loaded(hadith(id = "bukhari_1_1", bookId = "bukhari", hadithNumber = 1))
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_bookmark)).performClick()
+
+        assertThat(events).contains(
+            HadithEvent.ToggleBookmark(
+                hadithId = "bukhari_1_1",
+                bookId = "bukhari",
+                hadithNumber = 1,
+            )
+        )
+    }
+
+    @Test
+    fun `the bookmark control reflects the persisted flag, not the row that was loaded`() {
+        // `isHadithBookmarked` is a live flow; the loaded row's `isBookmarked` is only the seed.
+        // Reading the seed alone leaves the star stale the moment the bookmark is toggled from
+        // anywhere else.
+        every { viewModel.isHadithBookmarked("bukhari_1_1") } returns flowOf(true)
+        loaded(hadith(id = "bukhari_1_1", isBookmarked = false))
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_bookmark)).assertExists()
+    }
+
+    @Test
+    fun `a single-hadith chapter offers no page arrows`() {
+        // `NimazReaderBottomBar` hides both chevrons when there is nowhere to go — the actions
+        // stay, so this is not "the bar is missing".
+        loaded(hadith())
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.previous)).assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(string(R.string.next)).assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_copy)).assertExists()
+    }
+
+    @Test
+    fun `a multi-hadith chapter offers arrows, and the first page cannot go back`() {
+        loaded(hadith(id = "h1"), hadith(id = "h2"), hadith(id = "h3"))
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.previous)).assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription(string(R.string.next)).assertIsEnabled()
+    }
+
+    // ---- the states that are not a hadith ---------------------------------------------
+
+    @Test
+    fun `a load failure is reported as a failure rather than as an empty chapter`() {
+        readerState.value = HadithReaderUiState(
+            hadiths = emptyList(),
+            isLoading = false,
+            error = UiError(message = R.string.hadith_load_failed, details = "disk I/O error"),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_load_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.no_hadith_found)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `retrying a failed chapter re-issues the load`() {
+        readerState.value = HadithReaderUiState(
+            isLoading = false,
+            error = UiError(message = R.string.hadith_load_failed),
+        )
+
+        setContent()
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).containsExactly(HadithEvent.Retry)
+    }
+
+    @Test
+    fun `a chapter that really is empty says so`() {
+        readerState.value = HadithReaderUiState(
+            chapter = chapter(),
+            hadiths = emptyList(),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.no_hadith_found)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `hadith settings are reachable from the reader`() {
+        loaded(hadith())
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.hadith_settings)).performClick()
+
+        assertThat(settingsOpened).isEqualTo(1)
+    }
+
+    @Test
+    fun `the reader shows a spinner rather than a title it does not have yet`() {
+        composeRule.mainClock.autoAdvance = false
+        readerState.value = HadithReaderUiState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.loading)).assertExists()
+        composeRule.onNodeWithText(string(R.string.no_hadith_found)).assertDoesNotExist()
+    }
+}

--- a/feature/content/src/test/resources/robolectric.properties
+++ b/feature/content/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application


### PR DESCRIPTION
Part of #612 — **the first of two passes.** 2,448 lines is more than one review should carry, so this takes the hadith and dua corpora and a follow-up takes the prophets, the names, qaida, the catalog and `contentGraph` and declares `nimazCoverage {}`. **This PR does not lock the module.**

## Before / after

| | Before | After |
|---|---|---|
| Line | **28.8%** (1,380 / 4,785) | **61.6%** (2,949 / 4,785) |
| Branch | **19.5%** (253 / 1,298) | **49.6%** (644 / 1,298) |

1,569 lines and 391 branches, from **108 tests in ten new classes**. No production code changed. **No `COVERAGE_EXCLUSIONS` entry was added or widened.**

Nine files were at **0%** and are now covered: `HadithReaderScreen` (302 lines), `DuasCollectionScreen` (259), `HadithCollectionScreen` (251), `DuaReaderScreen` (216), `DuaCategoryScreen` (183), `HadithChaptersScreen` (160), `DuaOccasionScreen` (58), `AdaptiveHadithScreen` (50) and `AdaptiveDuaScreen` (46). Nothing in the repository had ever composed one of them.

## What the new tests pin — and the failure each catches

**The hadith reader's four entry points** (`HadithReaderScreenTest`). One `LaunchedEffect` turns four route shapes into four different loads, and every one is reachable from the UI: a chapter from the chapter list, a *number* from a bookmark, an *id* from search, a *grade* from the collection screen's pills. Their guards overlap by construction — `bookId` is empty for a search hit **and** for a grade shelf — so the ordering is load-bearing. Get it wrong and a bookmark's book-and-number is looked up as a primary key: the reader lands on a real narration from an arbitrary book rather than crashing. `HadithViewModel` cannot see any of this; it receives whichever event the screen chose.

**Each display toggle removing its own element** (`HadithReaderScreenTest`, `DuaReaderScreenTest`). `:core:datastore` (#603) pinned that `hadithShowArabic`, `hadithShowChain`, `duaShowTransliteration` and the rest round-trip. Nothing asserted that the screens *honour* them — that turning the chain off actually removes the chain. The transliteration is guarded twice (the setting, and whether the artifact carries one), so "off" and "absent" have to produce the same page without either being mistaken for the other.

**Failure told apart from emptiness, on five screens.** The list is empty when the load failed *and* when there is genuinely nothing, so the `when` ordering is the whole of what separates them — the source comment on `HadithChaptersScreen` records that a failure once reported itself as "No chapters found", which tells a reader to give up on a collection that is fine.

**Optional content that is absent rendering as absent, not as a hole.** A narration with no grade, a collection with no author, a chapter with no Arabic name, a category with no description, a dua with no transliteration, a repeat count of `0` (which the artifact stores for "no prescribed count", and which an unguarded badge renders as "0x").

**The hadith-of-the-day card's two lives** (`HadithCollectionScreenTest`). `getHadithOfTheDay` is best-effort, so `hadithOfTheDay` is null on a perfectly healthy screen and the card renders shipped fallback text. Nothing tells the two apart at a glance — and bookmarking while the fallback is up must dispatch **nothing** rather than the fallback's imaginary id.

**Which grades are browsable.** Exactly Sahih, Hasan and Ḍaʿīf; Mawḍūʿ (fabricated) is a warning label on a narration, not a shelf to invite anyone onto. The list it is absent from is a private `val` no compiler check guards.

**Phone push vs tablet detail pane** (`AdaptiveHadithScreenTest`, `AdaptiveDuaScreenTest`). The same tap must push a route on a phone and move the scaffold's detail pane on a tablet. Backwards, a tablet stacks a full-screen list over a layout built to show both, and a phone's rows do nothing. Neither crashes, and the inner screens' own tests cannot see it — the lambda they assert on is the wrapper's choice.

**The chapter search being derived** (`HadithChaptersScreenTest`). Rows come from `filteredChapters`, which recomputes from `searchQuery` on every read; rendering `chapters` instead passes every test that does not search.

**The dua library's two layouts** (`DuasCollectionScreenTest`). `take(4)`/`drop(4)` are a partition only while both branches run, so nine categories all have to survive the grid/list split. The emoji→icon lookup is covered across all forty-three mapped keys plus an unknown emoji and a category with none — an emoji the content artifact starts using turns silently into a mosque, and they all look alike.

**The occasion cross-cut** (`DuaOccasionScreenTest`, `DuaOccasionLabelsTest`). `LoadDuasByOccasion` shipped in the database, the repository and the event before anything could dispatch it, so this screen is the only thing that makes it reachable. It renders from `categoryState` — the surface `LoadCategory` also fills — so a stale `category` left in it would put another collection's name above these duas. All seventeen occasions map to distinct resources, and the two mosque and two home occasions are opposite rather than interchangeable.

## Notes for the reviewer

- **`hiltViewModel()` did not need Hilt.** The adaptive wrappers hand their inner screens no ViewModel, so the default argument runs. Per #604's playbook item 8, an owner whose `ViewModelStore` already holds the mock answers before any factory is consulted; both adaptive test classes seed one. That is what makes the phone-vs-tablet branch reachable at all.
- **A `LazyColumn` at 2,200dp is not always tall enough.** The category-icon test renders forty-five rows and runs at `w411dp-h6000dp`; the rest of its class stays at the usual height.
- `feature/content/src/test/resources/robolectric.properties` is new — the module had one only under `src/testDebug`, and a properties file is a resource of its own source set.

## Verification

```
./gradlew :feature:content:testDebugUnitTest   BUILD SUCCESSFUL
./gradlew :feature:content:check               BUILD SUCCESSFUL
./gradlew :feature:content:lintDebug           BUILD SUCCESSFUL
python3 scripts/check_docs.py                  All 23 documentation checks passed
```

`:app:testDebugUnitTest` and `:app:lintDebug` need `NIMAZ_DATA_TOKEN` for the private content artifact and **were not run here** — CI's lane covers them.

`docs/TESTING.md` carries the interim snapshot row and a new audit section; the follow-up updates both to the locked numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fa3T4hCpq7QU4Zb4PWR9xu)_