### PR TITLE
Coverage: bring :feature:content to 85.1% and lock it at 80/80 (2 of 2)

### DIFF
--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -58,12 +58,19 @@ eleven feature modules at once. PR 12 of #551 split it; the file is now 281 line
 
 | graph | destinations |  | graph | destinations |
 |---|---:|---|---|---:|
-| `quranGraph` | 21 | | `aboutGraph` | 7 |
-| `contentGraph` | 21 | | `searchGraph` | 4 |
-| `settingsGraph` | 16 | | `toolsGraph` | 2 |
-| `trackerGraph` | 11 | | `calendarGraph` | 2 |
-| `prayerGraph` | 8 | | `onboardingGraph` | 1 |
+| `quranGraph` | 19 | | `aboutGraph` | 7 |
+| `contentGraph` | 19 | | `searchGraph` | 4 |
+| `settingsGraph` | 20 | | `toolsGraph` | 2 |
+| `trackerGraph` | 14 | | `calendarGraph` | 2 |
+| `prayerGraph` | 5 | | `onboardingGraph` | 1 |
 | | | | `homeGraph` | 1 |
+
+> Five of these rows were wrong until #625 — `quranGraph` and `contentGraph` were listed as 21,
+> `settingsGraph` as 16, `trackerGraph` as 11 and `prayerGraph` as 8. The **total** was right, which
+> is exactly why nothing caught it: NAV-03 checks the 94 against `Routes.kt`, not the split. They
+> were corrected by counting `taggedComposable<Route.` per file with `check_docs.py`'s own
+> comment-stripping helper, after `ContentGraphTest` asserted 19 destinations against a graph
+> documented as holding 21. Recount the same way before editing a row here.
 
 Each takes a `NavController` — not the `onNavigate: (Route) -> Unit` lambda the issue sketched,
 because 11 of the 158 `navigate` calls in those blocks pass a `NavOptionsBuilder` (`popUpTo`,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -49,7 +49,7 @@ Two on-device/JVM test surfaces exist:
   - [Prayer times, the month table and the qibla (`:feature:prayer/src/test` and `src/testDebug`)](#prayer-times-the-month-table-and-the-qibla-featureprayersrctest-and-srctestdebug)
   - [About, Help and the More menu (`:feature:about/src/test`)](#about-help-and-the-more-menu-featureaboutsrctest)
   - [The repositories, the sync and the adhan store (`:core:data/src/test`)](#the-repositories-the-sync-and-the-adhan-store-coredatasrctest)
-  - [The hadith and dua corpora, rendered (`:feature:content/src/test`)](#the-hadith-and-dua-corpora-rendered-featurecontentsrctest)
+  - [The library, rendered (`:feature:content/src/test`)](#the-library-rendered-featurecontentsrctest)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -265,7 +265,8 @@ floors in its own `build.gradle.kts`.
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common`, `:core:datastore` and `:core:data` are locked at 80/80 — none of
 them draws anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
-`:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget` and `:feature:about`, which *are* Compose modules: the
+`:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:about` and
+`:feature:content`, which *are* Compose modules: the
 unreachable branch below is emitted **per parameter of every restartable composable**, so its
 weight scales with how many composables a module has, and six files — or eight, or the two screens
 in `:feature:tools`, or the one screen and four cards in `:feature:search`, or the seven screens in
@@ -273,6 +274,12 @@ in `:feature:tools`, or the one screen and four cards in `:feature:search`, or t
 `:feature:widget` is Compose of a different kind — six **Glance** widgets — and holds **89.3%**
 branches, which settles the question for the widget surface too.
 `:feature:onboarding` reports **90.3%** branches, the highest of any Compose module here.
+`:feature:content` is the **lowest** to hold the standard, and the closest any module has come to
+missing it: **80.4%**, four branches above the gate. It is also the largest Compose surface locked
+so far — nineteen screens across five corpora — which is the point: even there, the `$dirty`
+branches below never accumulate enough to force the softened floor. What they do is eat the
+margin, and a module that reports 80.4% is one unrelated refactor from a red gate. That is the
+ratchet working, not a reason to soften it.
 
 **Two modules are softened to 80 line / 60 branch, and for two different reasons.**
 `:feature:prayer` is the second, and its reason is arithmetic rather than Compose:
@@ -309,7 +316,7 @@ split, and should say so where it sets its floors.
 | `:core:data` | 88.1% | 84.6% | **locked** at 80/80 (#611) |
 | `:core:ui` | 50.3% | 47.8% | |
 | `:feature:tracker` | 30.4% | 24.4% | |
-| `:feature:content` | 61.6% | 49.6% | hadith + dua done (#624); not locked yet |
+| `:feature:content` | 85.1% | 80.4% | **locked** at 80/80 (#612) |
 | `:feature:settings` | 11.3% | 14.9% | |
 
 `:app` is absent because its own suite needs the private content artifact and cannot be measured
@@ -872,7 +879,7 @@ largest of them: seven screens, a bottom sheet and two renderer files. The `$dir
 branches are here as everywhere, and at this size they still do not add up to enough to move the
 number.
 
-**Two things here are worth knowing before adding a test to this module.**
+**Four things here are worth knowing before adding a test to this module.**
 
 - **`hiltViewModel()` does not always need Hilt, and that is how `AdaptiveMoreScreen` got
   covered.** `:feature:quran` (#598) and `:feature:search` (#607) both left their adaptive screens
@@ -1031,18 +1038,19 @@ past the floor. **No `COVERAGE_EXCLUSIONS` entry was added or widened** — the 
 every locked module, so widening it would move their numbers too.
 
 
-### The hadith and dua corpora, rendered (`:feature:content/src/test`)
+### The library, rendered (`:feature:content/src/test`)
 
-The fifteenth module, taken in two passes because 2,448 lines is more than one review should
-carry. **This is the first pass: hadith and dua.** It moves the module from **28.8% lines to
-61.6%** — 1,380 covered lines to 2,949 — and from 19.5% to **49.6%** branches, with 108 tests in
-ten new classes. The module is **not locked yet**; the second pass takes the prophets, the names,
-qaida, the catalog and `contentGraph`, and declares the floors.
+The fifteenth module locked: **28.8% lines to 85.1%**, from 1,380 covered lines to 4,072, and
+19.5% to **80.4%** branches. Taken in **two passes** because 2,448 lines is more than one review
+should carry — #624 took the hadith and dua corpora, #625 took the prophets, the names, qaida, the
+catalog and `contentGraph`, and declared the floors.
 
-Seven screens were at **0%** between them — `HadithReaderScreen` (302 lines),
-`DuasCollectionScreen` (259), `HadithCollectionScreen` (251), `DuaReaderScreen` (216),
-`DuaCategoryScreen` (183), `HadithChaptersScreen` (160) and `DuaOccasionScreen` (58) — plus the
-two adaptive wrappers over them (96). Nothing had ever composed one.
+**Nineteen files were at 0%**, which is every screen the module owns: the seven hadith and dua
+screens (1,429 lines), `ProphetDetailScreen` (193), `ContentGraph` (154), `NamesScreen` (133),
+`QaidaReaderScreen` (117), `FavouritesScreen` (96), `AsmaUlHusnaDetailScreen` (76),
+`QaidaHomeScreen` (65), `QaidaAudioManager` (83 across two classes), the three adaptive wrappers
+(137), `AsmaUnNabiDetailScreen` (39), `QaidaLettersScreen` (34) and the two catalog shells (68).
+Nothing in the repository had ever composed one of them.
 
 **What makes this module worth testing is that its failures are silent.** Every screen here
 renders *shipped* content — narrations and supplications this build did not write, arriving as a
@@ -1060,7 +1068,7 @@ states.
 a reader, and a reader who hides the Arabic and gets it anyway can only report "the setting does
 nothing".
 
-**Two things here are worth knowing before adding a test to this module.**
+**Four things here are worth knowing before adding a test to this module.**
 
 - **`hiltViewModel()` does not need Hilt on the adaptive screens.** `AdaptiveHadithScreen` and
   `AdaptiveDuaScreen` hand their inner screens no ViewModel, so the default argument runs — and
@@ -1070,6 +1078,13 @@ nothing".
 - **A `LazyColumn` at 2,200dp is not always tall enough.** The dua category-icon test renders
   forty-five rows to cover the emoji→icon lookup and runs at `w411dp-h6000dp`; the rest of the
   class stays at the usual height.
+- **A `WhileSubscribed` flow's `.value` is null until something collects it**, and three of
+  `QaidaReaderViewModel`'s moves read exactly that. A walk asserted without a subscriber passes
+  for the *wrong reason* — the move is refused rather than performed — so `QaidaCourseWalkTest`
+  has a named `subscribedViewModel()` helper and one test that deliberately does **not** use it.
+- **The Qaida course map is drawn art.** `QaidaCoursePath`'s medallions carry no text, only a
+  content description per lesson — which is the better contract anyway: it carries the number,
+  the title *and* whether the lesson is locked, and that phrase is all a screen-reader user gets.
 
 | Area | Covered by | What it pins |
 |---|---|---|
@@ -1097,7 +1112,43 @@ nothing".
 | Favouriting citing the category too | same | a `DuaBookmark` is keyed on both ids; the dua's alone files the favourite under no collection |
 | Phone push vs tablet pane | `AdaptiveHadithScreenTest`, `AdaptiveDuaScreenTest` | the same tap must push a route on a phone and move the scaffold's detail pane on a tablet. Backwards, a tablet stacks a full-screen list over a layout built to show both, and a phone's rows do nothing — neither crashes, and the inner screens' own tests cannot see it because the lambda they assert on is the wrapper's choice |
 | The detail pane's second decision | same two | chapters or reader, dua list or dua, from whether the pane's args carry the second id — which the list pane built two taps earlier |
+| Nineteen graph destinations, eleven of them argument-carrying | `ContentGraphTest` | the largest graph in the app. An unregistered destination throws only when a **user taps the row** — not at build time, and in none of the four gates `CLAUDE.md` lists. Four hadith routes are the same screen reached four ways, so losing one breaks exactly one entry point and nothing else. **This test is also what caught `docs/NAVIGATION.md` claiming 21** |
+| Which fields each catalogue searches | `CatalogueSearchFieldsTest` | `CatalogViewModel` is generic and `CatalogViewModelTest` drives it with a synthetic source, so the three **real** sources were at 0%. The prophets' search also covers the **title** and the **era** — how you look for a prophet whose name you cannot spell — and dropping an arm quietly returns fewer results with no crash and no empty state |
+| A slower detail read losing to a newer one | same | `requestedItemId` is set synchronously and checked *after* the suspension point, because a coroutine cancelled after its last suspension still runs to the end of its block. All three catalogue screens share one ViewModel per back-stack entry, so this is one fast back-and-forward away |
+| Every optional prophet section | `ProphetDetailScreenTest` | lessons, cited verses and miracles are each guarded; the timeline's four label/value pairs are the shape where two get swapped and the page still reads as a well-formed timeline. The only header in the app rendered with `number = null` |
+| The shared catalogue shell's two guards | `CatalogDetailScreensTest` | the FAB appears only when there is an item, and `isLoading || item == null` is **one** branch — a stale deep link leaves `isLoading = false` with no item, and without the second half the screen renders a header of nulls |
+| Three catalogues behind one search box | `NamesScreenTest` | one query reaches all three ViewModels, which is what makes the per-tab match counts mean anything; a dispatch reaching only the visible tab looks identical from the tab you are on. Clearing sends `ClearSearch`, not `Search("")` — they leave the same list, and only one keeps an empty query out of the debounced analytics flow |
+| A favourites section that is empty rendering nothing | `FavouritesScreenTest` | the check lives in `favouriteSection`, so a fourth kind of favourite cannot forget it. The whole-screen empty state is the screen's, not a section's: a reader with two starred prophets and no starred names must see the prophets |
+| The Qaida course walk, and its guards | `QaidaCourseWalkTest` | next refuses a **locked** lesson — the gate the whole progression rests on, duplicated from the screen where it is only cosmetic — previous stops at the start, and resume falls back to lesson 1 once `nextLessonId` is null. Re-selecting the open lesson is a no-op because `selectLesson` stops audio, and a `LaunchedEffect` re-fires on every recomposition |
+| Which cell is highlighted | same | resolved from the audio key against the **open** lesson's cells. Audio outlives the screen, so a clip still sounding after a lesson change must light nothing rather than a foreign tile |
+| A lesson finished during this visit, once | `QaidaReaderScreenTest` | `openedComplete` is captured from the first non-null status, so re-opening a finished lesson to practise does not put confetti in front of it — and finishing one while reading still celebrates |
+| Where a letter is made | `QaidaLettersScreenTest` | `makhrajLabel` and `makhrajEmoji` are two `when`s over the same five-value enum, and the sheet is the only place either runs. This line is the whole of what the sheet teaches |
+| A clip resolving to the right file | `QaidaAudioManagerTest` | a drop-in under `filesDir/qaida_audio/` beats the bundled asset — the entire on-demand delivery mode, one `if`, reachable through no setting. A **truncated** download is a zero-length file that exists, and trusting `exists()` alone plays silence forever with nothing on screen to say why |
+| A tap that should do nothing | same | a cell whose `audio_key` the artifact does not carry is refused rather than queued: queuing `""` asks for `qaida/audio/.mp3`, which fails asynchronously and surfaces as a *playback error* on a tap that should simply have been ignored. A line filters the same way, and one that filters down to a single clip is played as a tap |
+| The dua collection's sort | `DuaCollectionSortTest` | curated `displayOrder` or A–Z by **lowercased** English name — sorting without lowercasing puts every capitalised name before every lowercase one, which reads as no order at all. The toggle persists the state it is moving *to* |
+| The reader's paging window | same | opening a dua loads its whole category so the pager can page; a dua missing from its own category list opens at the top rather than at index **-1**, and one whose category comes back empty opens alone rather than resolving and then claiming "not found" |
+| The hadith reader's anchor | `HadithReaderAnchorTest` | held **by id, not by index**, so a content refresh that inserts a row above the reader keeps them on the hadith they were reading. An index-based anchor passes "a refresh does not reset the reader" and still moves them. A refresh that removes the anchored hadith falls back to the top rather than indexing at -1 |
+| A retry re-running only what failed | same | a retry tapped in the reader must not also re-fetch the book list behind it, and nothing on screen would say whether it did |
+| What the copy button puts on the clipboard | `HadithReaderScreenTest` | built by a local function nothing else calls, and it is what a reader pastes into a message. Narrator and reference are guarded separately from the page's own guards, so a hadith can render perfectly and paste with "Narrated by " and a trailing blank line |
+| An id with an underscore | same | `bookId.isEmpty() && !chapterId.contains("_")` is the whole classifier, and hadith ids in this dataset **do** contain underscores (`bukhari_1_1`) — the two shapes are one character apart and the rule is a convention, not a proof |
 
+
+**What stays uncovered, and why.** 125 of the 255 missing branches are the Compose compiler's
+`$dirty` bitmask — one per parameter of every restartable composable, on the signature line and
+its closing paren, neither side reachable because which one runs depends on what the *caller*
+changed between recompositions. Discount those and the module stands at **89.4% branches**. Of the
+rest, three pockets account for half: `QaidaAudioManager`'s `Player.Listener` (12 branches —
+Robolectric has no media pipeline, so the player never leaves `STATE_IDLE` and no callback fires;
+reaching them would mean reflecting into ExoPlayer's private listener set, and its *consumer* is
+covered instead); `DuaViewModel.filterAndSortCategories`'s search arms (10 — **genuinely dead**,
+because `searchQuery` is only ever written as `""` and the collection's search action navigates to
+`:feature:search`'s screen instead); and `QaidaPlayLineButton` (4 — behind
+`QAIDA_AUDIO_UI_ENABLED`, `false` while the recordings are regenerated, with the *absence* of the
+control asserted so the test is inverted rather than deleted when the flag flips). Sharing the
+hadith of the day is also uncovered: `shareBranded` hops to `Dispatchers.Default` to render a card
+before it shares anything, and that hop does not complete under the Compose test clock.
+**No `COVERAGE_EXCLUSIONS` entry was added or widened** — the list is shared with every locked
+module, so widening it would move their numbers too.
 
 ## Conventions
 

--- a/feature/content/build.gradle.kts
+++ b/feature/content/build.gradle.kts
@@ -19,6 +19,40 @@ android {
     }
 }
 
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
+// **80/80, and the branch number was not free.** This is the seventh Compose module to hold the
+// standard branch floor, and the closest any of them has come to missing it: the module reports
+// **80.4% branches**, four above the gate. That margin is thin on purpose rather than by
+// accident — the alternative was the softened 0.60 floor, and the arithmetic does not justify it
+// here. Of the 255 branches still missing, **125 are the Compose compiler's `$dirty` bitmask**:
+// one per parameter of every restartable composable, on the signature line and its closing
+// paren, and neither side reachable from a test because which side runs depends on what the
+// *caller* changed between recompositions. Discount those and the module stands at 89.4%. The
+// remaining 130 are spread thinly, and three pockets account for half of them:
+//
+//   - **`QaidaAudioManager`'s `Player.Listener`** (12) — `STATE_ENDED`, the error arm, and the
+//     `MEDIA_ITEM_TRANSITION_REASON_AUTO` branch that decides which key was *heard*. Robolectric
+//     has no media pipeline, so the player never leaves `STATE_IDLE` and no callback ever fires.
+//     Reaching them would mean reflecting into ExoPlayer's private listener set, which breaks on
+//     a media3 bump and fails far from its cause. The consumer is covered instead:
+//     `QaidaReaderViewModel` credits a cell from `completions` and from nowhere else.
+//   - **`DuaViewModel.filterAndSortCategories`'s search arms** (10) — genuinely dead today.
+//     `DuaCollectionUiState.searchQuery` is only ever written as `""`; no event sets it to
+//     anything else, because `DuasCollectionScreen`'s search action navigates to
+//     `Route.DuaSearch`, which is `:feature:search`'s screen against a different ViewModel.
+//     `DuaCollectionSortTest` says so in place of a test that would have to reach past the
+//     public surface to pretend otherwise. Wiring a query in is a change to make deliberately.
+//   - **`QaidaPlayLineButton`** (4) — behind `QAIDA_AUDIO_UI_ENABLED`, which is `false` while the
+//     recordings are regenerated. `QaidaLettersScreenTest` asserts the control is absent, and
+//     that assertion is the thing to invert rather than delete when the flag flips.
+//
+// **Nothing was excluded to reach these numbers** — no `COVERAGE_EXCLUSIONS` entry was added or
+// widened, and the list is shared with every locked module, so widening it would move theirs too.
+
 // The library: duas, hadith, qaida, the ninety-nine names, the names of the Prophet, the prophets,
 // and the catalog shell they share. Eight `screens/` packages in one module.
 //

--- a/feature/content/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/content/ContentGraph.kt
+++ b/feature/content/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/content/ContentGraph.kt
@@ -27,7 +27,7 @@ import com.arshadshah.nimaz.presentation.screens.qaida.QaidaLettersScreen
 import com.arshadshah.nimaz.presentation.screens.qaida.QaidaReaderScreen
 
 /**
- * The 21 Content destinations — dua, hadith, qaida, the name catalogues and the prophets.
+ * The 19 Content destinations — dua, hadith, qaida, the name catalogues and the prophets.
  *
  * Split out of `NavGraph.kt` in PR 12 of #551. That file registered all 94 destinations and
  * imported 69 screen composables, which meant every screen in the app was reachable from one

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/data/audio/QaidaAudioManagerTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/data/audio/QaidaAudioManagerTest.kt
@@ -1,0 +1,249 @@
+package com.arshadshah.nimaz.data.audio
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * The tap-to-hear engine behind the Qaida reader — its transport and its source resolution.
+ *
+ * **Source resolution is the part that decides whether a child hears anything.** A key resolves
+ * to a bundled `android_asset` clip by default, but a drop-in file under
+ * `filesDir/qaida_audio/` wins — that is the whole of the on-demand delivery mode, implemented
+ * as one `if` and reachable through no setting. Two ways for it to be wrong and neither is
+ * visible: ignore the override and every downloaded clip is dead weight; trust `exists()` alone
+ * and a **truncated download** (a zero-length file that exists) plays silence forever, with no
+ * way for the learner to recover and nothing on screen to say why.
+ *
+ * **The transport's guards are the rest.** A cell whose `audio_key` the content artifact does
+ * not carry must be refused rather than queued — queuing `""` asks the data source for
+ * `qaida/audio/.mp3`, which fails asynchronously and surfaces as a *playback error* on a tap
+ * that should simply have done nothing. A line filters the same way, and a line that filters
+ * down to one clip is played as a single tap rather than as a one-item playlist, because the
+ * two report completions differently.
+ *
+ * **What is not covered here, and why.** The `Player.Listener` — `STATE_ENDED`, the
+ * `MEDIA_ITEM_TRANSITION_REASON_AUTO` arm that decides which key was *heard*, and the error
+ * arm — needs the player to actually decode something, and Robolectric has no media pipeline:
+ * nothing ever leaves `STATE_IDLE`, so no callback fires. Reaching those bodies would mean
+ * reflecting into `ExoPlayer`'s private listener set, which is a shape that breaks on a media3
+ * bump and fails far from its cause. Its *consumer* is covered instead — `QaidaReaderViewModel`
+ * credits a cell from `completions` and from nowhere else, and
+ * `QaidaReaderViewModelTest` drives that flow directly with a fake manager.
+ */
+@UnstableApi
+@RunWith(RobolectricTestRunner::class)
+class QaidaAudioManagerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var manager: QaidaAudioManager
+
+    @Before
+    fun setUp() {
+        manager = QaidaAudioManager(context)
+    }
+
+    @After
+    fun tearDown() {
+        manager.release()
+    }
+
+    /**
+     * The player the manager built, read back off its own private field.
+     *
+     * The queue is the only place the resolved URI is observable — `resolveUri` and
+     * `mediaItemFor` are private and nothing else exposes what a key resolved to. This reaches
+     * one field of one class in this module rather than into `ExoPlayer`'s internals, so a
+     * media3 bump cannot break it.
+     */
+    private fun player(): ExoPlayer {
+        val field = QaidaAudioManager::class.java.getDeclaredField("player")
+        field.isAccessible = true
+        return field.get(manager) as ExoPlayer
+    }
+
+    private fun queuedUri(index: Int = 0): String =
+        player().getMediaItemAt(index).localConfiguration?.uri.toString()
+
+    // ---- source resolution ------------------------------------------------------------
+
+    @Test
+    fun `a key with no downloaded clip resolves to the bundled asset`() {
+        manager.play("l1_alif")
+
+        assertThat(queuedUri()).isEqualTo("file:///android_asset/qaida/audio/l1_alif.mp3")
+    }
+
+    @Test
+    fun `a downloaded clip wins over the bundled one`() {
+        val dir = File(context.filesDir, "qaida_audio").apply { mkdirs() }
+        File(dir, "l1_downloaded.mp3").writeBytes(ByteArray(64) { 1 })
+
+        manager.play("l1_downloaded")
+
+        assertThat(queuedUri()).contains("qaida_audio")
+        assertThat(queuedUri()).doesNotContain("android_asset")
+    }
+
+    @Test
+    fun `a truncated download is ignored in favour of the asset`() {
+        // A zero-length file that exists. Trusting `exists()` alone plays silence forever.
+        val dir = File(context.filesDir, "qaida_audio").apply { mkdirs() }
+        File(dir, "l1_truncated.mp3").writeBytes(ByteArray(0))
+
+        manager.play("l1_truncated")
+
+        assertThat(queuedUri()).isEqualTo("file:///android_asset/qaida/audio/l1_truncated.mp3")
+    }
+
+    @Test
+    fun `a replayed key reuses the resolved item rather than rebuilding it`() {
+        // Instant replay is the whole point of the engine; the cache is what delivers it.
+        manager.play("l1_alif")
+        val first = player().getMediaItemAt(0)
+        manager.play("l1_baa")
+        manager.play("l1_alif")
+
+        assertThat(player().getMediaItemAt(0)).isSameInstanceAs(first)
+    }
+
+    @Test
+    fun `releasing drops the cache as well as the player`() {
+        manager.play("l1_alif")
+        val before = player().getMediaItemAt(0)
+
+        manager.release()
+        manager.play("l1_alif")
+
+        assertThat(player().getMediaItemAt(0)).isNotSameInstanceAs(before)
+        assertThat(queuedUri()).isEqualTo("file:///android_asset/qaida/audio/l1_alif.mp3")
+    }
+
+    // ---- the transport ----------------------------------------------------------------
+
+    @Test
+    fun `playing a token makes it the current key and marks it loading`() {
+        manager.play("l1_alif")
+
+        assertThat(manager.state.value.currentKey).isEqualTo("l1_alif")
+        assertThat(manager.state.value.isLoading).isTrue()
+        assertThat(manager.state.value.error).isNull()
+    }
+
+    @Test
+    fun `a blank key is refused rather than queued`() {
+        manager.play("")
+
+        assertThat(manager.state.value.currentKey).isNull()
+        assertThat(manager.state.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a later tap replaces the earlier one`() {
+        manager.play("l1_alif")
+        manager.play("l1_baa")
+
+        assertThat(manager.state.value.currentKey).isEqualTo("l1_baa")
+        assertThat(player().mediaItemCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a whole line queues every clip and starts on the first`() {
+        manager.playSequence(listOf("l1_alif", "l1_baa", "l1_taa"))
+
+        assertThat(manager.state.value.currentKey).isEqualTo("l1_alif")
+        assertThat(player().mediaItemCount).isEqualTo(3)
+        assertThat(queuedUri(2)).endsWith("l1_taa.mp3")
+    }
+
+    @Test
+    fun `a line of one clip is played as a single tap`() {
+        // It delegates to `play`, which matters beyond tidiness: a one-item playlist reports
+        // its end through a different arm of the listener than a single item does.
+        manager.playSequence(listOf("only"))
+
+        assertThat(manager.state.value.currentKey).isEqualTo("only")
+        assertThat(player().mediaItemCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a line of nothing never builds a player`() {
+        manager.playSequence(emptyList())
+
+        assertThat(manager.state.value.currentKey).isNull()
+    }
+
+    @Test
+    fun `blank keys are dropped from a line rather than queued as silence`() {
+        manager.playSequence(listOf("l1_alif", "", "l1_taa"))
+
+        assertThat(player().mediaItemCount).isEqualTo(2)
+        assertThat(manager.state.value.currentKey).isEqualTo("l1_alif")
+        assertThat(queuedUri(1)).endsWith("l1_taa.mp3")
+    }
+
+    @Test
+    fun `a line whose keys are all blank is refused outright`() {
+        manager.playSequence(listOf("", "   "))
+
+        assertThat(manager.state.value.currentKey).isNull()
+    }
+
+    @Test
+    fun `a line that filters down to one clip is still played`() {
+        // The filter runs before the size check, so `["", "one"]` is a single tap and not a
+        // refusal — the arm an early `size` check on the raw list would get wrong.
+        manager.playSequence(listOf("", "one"))
+
+        assertThat(manager.state.value.currentKey).isEqualTo("one")
+        assertThat(player().mediaItemCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `stopping returns to idle and clears the queue`() {
+        manager.playSequence(listOf("l1_alif", "l1_baa"))
+
+        manager.stop()
+
+        assertThat(manager.state.value).isEqualTo(QaidaAudioState())
+        assertThat(player().mediaItemCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `stopping before anything played is safe`() {
+        // `QaidaReaderViewModel.selectLesson` stops audio on every lesson change, including
+        // the first — when there is no player at all.
+        manager.stop()
+
+        assertThat(manager.state.value).isEqualTo(QaidaAudioState())
+    }
+
+    @Test
+    fun `releasing twice is safe`() {
+        manager.play("l1_alif")
+
+        manager.release()
+        manager.release()
+
+        assertThat(manager.state.value).isEqualTo(QaidaAudioState())
+    }
+
+    @Test
+    fun `playing again after a release builds a fresh player`() {
+        manager.play("l1_alif")
+        manager.release()
+
+        manager.play("l1_baa")
+
+        assertThat(manager.state.value.currentKey).isEqualTo("l1_baa")
+        assertThat(player().mediaItemCount).isEqualTo(1)
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveNamesScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveNamesScreenTest.kt
@@ -1,0 +1,222 @@
+package com.arshadshah.nimaz.presentation.screens.adaptive
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.NamesTab
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.domain.model.Prophet
+import com.arshadshah.nimaz.presentation.screens.names.divineName
+import com.arshadshah.nimaz.presentation.screens.names.prophet
+import com.arshadshah.nimaz.presentation.screens.names.prophetName
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogDetailState
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogListState
+import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Names on a phone and on a tablet — the one adaptive wrapper serving **three** catalogues.
+ *
+ * It replaced `AdaptiveAsmaUlHusnaScreen`, `AdaptiveAsmaUnNabiScreen` and
+ * `AdaptiveProphetsScreen`, which differed only in which list and which detail they named. One
+ * scaffold serves all three because the pane is keyed by `NameDetailArgs`, which carries the
+ * **catalogue** as well as the id — and that is exactly what is worth pinning: the ids overlap
+ * completely (there is a name 1, a name of the Prophet 1 and a prophet 1), so a pane that
+ * dropped the catalogue would open a plausible, wrong page every time rather than failing.
+ *
+ * As with the dua and hadith wrappers, the phone branch must **navigate** and the tablet branch
+ * must not; here the phone branch also `return`s early rather than falling through, so the
+ * scaffold below it never composes on a phone.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdaptiveNamesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val allahList = MutableStateFlow(
+        CatalogListState(
+            items = listOf(divineName(1, nameTransliteration = "Ar-Rahman")),
+            filteredItems = listOf(divineName(1, nameTransliteration = "Ar-Rahman")),
+            isLoading = false,
+        )
+    )
+    private val prophetNameList = MutableStateFlow(
+        CatalogListState(
+            items = listOf(prophetName(1, nameTransliteration = "Muhammad")),
+            filteredItems = listOf(prophetName(1, nameTransliteration = "Muhammad")),
+            isLoading = false,
+        )
+    )
+    private val prophetList = MutableStateFlow(
+        CatalogListState(
+            items = listOf(prophet(1, nameEnglish = "Abraham")),
+            filteredItems = listOf(prophet(1, nameEnglish = "Abraham")),
+            isLoading = false,
+        )
+    )
+
+    private val allahDetail = MutableStateFlow(
+        CatalogDetailState(
+            isLoading = false,
+            item = divineName(1, nameTransliteration = "Ar-Rahman", meaning = "Mercy for all"),
+        )
+    )
+    private val prophetNameDetail = MutableStateFlow(
+        CatalogDetailState(
+            isLoading = false,
+            item = prophetName(1, nameTransliteration = "Muhammad", meaning = "Much praised"),
+        )
+    )
+    private val prophetDetail = MutableStateFlow(
+        CatalogDetailState(
+            isLoading = false,
+            item = prophet(1, nameEnglish = "Abraham", storySummary = "Left the idols of his people"),
+        )
+    )
+
+    private val allahViewModel: AsmaUlHusnaViewModel = mockk(relaxed = true) {
+        every { listState } returns allahList
+        every { detailState } returns allahDetail
+    }
+    private val prophetNameViewModel: AsmaUnNabiViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetNameList
+        every { detailState } returns prophetNameDetail
+    }
+    private val prophetViewModel: ProphetViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetList
+        every { detailState } returns prophetDetail
+    }
+
+    private val navigated = mutableListOf<Route>()
+
+    private fun setContent(initialTab: NamesTab = NamesTab.ASMA_UL_HUSNA) {
+        composeRule.setThemedContent {
+            CompositionLocalProvider(LocalViewModelStoreOwner provides seededOwner()) {
+                AdaptiveNamesScreen(
+                    onNavigate = { navigated += it },
+                    initialTab = initialTab,
+                    onNavigateBack = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone the tabbed list is the whole screen`() {
+        setContent()
+
+        composeRule.onNodeWithText("Ar-Rahman").assertExists()
+        // No detail pane on a phone: the branch returns before the scaffold.
+        composeRule.onNodeWithText("Mercy for all").assertDoesNotExist()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h2200dp")
+    fun `on a phone opening a name pushes its own detail route`() {
+        setContent()
+
+        composeRule.onNodeWithText("Ar-Rahman").performClick()
+
+        assertThat(navigated).containsExactly(Route.AsmaUlHusnaDetail(1))
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet a name opens beside the list rather than over it`() {
+        setContent()
+
+        composeRule.onNodeWithText("Ar-Rahman").performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+        composeRule.onNodeWithText("Mercy for all").assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the pane opens the catalogue that was asked for, not the id alone`() {
+        // Every catalogue has an item 1. `NameDetailArgs` carries the catalogue for exactly
+        // this reason — without it the pane opens a plausible, wrong page and never fails.
+        setContent(initialTab = NamesTab.PROPHETS)
+
+        composeRule.onNodeWithText("Abraham").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Left the idols of his people").assertExists()
+        composeRule.onNodeWithText("Mercy for all").assertDoesNotExist()
+        composeRule.onNodeWithText("Much praised").assertDoesNotExist()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `a name of the Prophet opens its own pane too`() {
+        setContent(initialTab = NamesTab.ASMA_UN_NABI)
+
+        composeRule.onNodeWithText("Muhammad").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Much praised").assertExists()
+        composeRule.onNodeWithText("Left the idols of his people").assertDoesNotExist()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `favourites navigates from the tablet branch as well`() {
+        // Favourites is a destination in its own right, not a pane — it spans all three
+        // catalogues, so it has nowhere to sit beside one of them.
+        setContent()
+
+        composeRule.onNodeWithContentDescription(
+            context.getString(R.string.cd_open_favourites)
+        ).performClick()
+
+        assertThat(navigated).containsExactly(Route.Favourites)
+    }
+
+    private fun seededOwner(): ViewModelStoreOwner {
+        val store = ViewModelStore()
+        seed(store, AsmaUlHusnaViewModel::class.java, allahViewModel)
+        seed(store, AsmaUnNabiViewModel::class.java, prophetNameViewModel)
+        seed(store, ProphetViewModel::class.java, prophetViewModel)
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    private fun <VM : ViewModel> seed(store: ViewModelStore, type: Class<VM>, instance: VM) {
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                instance as T
+        }
+        ViewModelProvider.create(store, factory)[type]
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/catalog/CatalogDetailScreensTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/catalog/CatalogDetailScreensTest.kt
@@ -1,0 +1,274 @@
+package com.arshadshah.nimaz.presentation.screens.catalog
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.presentation.screens.asma.AsmaUlHusnaDetailScreen
+import com.arshadshah.nimaz.presentation.screens.asmaunnabi.AsmaUnNabiDetailScreen
+import com.arshadshah.nimaz.presentation.screens.names.divineName
+import com.arshadshah.nimaz.presentation.screens.names.prophetName
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogDetailState
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The two catalogue detail screens that share `CatalogDetailScreen`, and the shared shell itself.
+ *
+ * The shell was written twice before it was extracted — scaffold, back bar titled by the item,
+ * favourite FAB, loading branch, `LazyColumn`, header — and the **sections** are the only genuinely
+ * per-catalogue part. So the properties worth pinning are the ones the shell decides for both:
+ *
+ * - **The FAB shows only when there is an item.** It reads `state.item?.let`, and a FAB rendered
+ *   over the loading state would toggle a favourite on nothing.
+ * - **`isLoading || item == null` is one branch, not two.** A detail read that resolves to null —
+ *   an id from a stale deep link, a name the content artifact no longer ships — leaves
+ *   `isLoading = false` and no item, and without the second half of that guard the screen
+ *   renders a header full of nulls.
+ * - **The bar falls back to a generic title.** Every navigation spends its first frame with no
+ *   item, and an empty app bar reads as a broken screen.
+ *
+ * And the one thing each screen owns: which sections it draws, and that a `LaunchedEffect` asks
+ * for the id in the *route* rather than trusting whatever the shared ViewModel last loaded — the
+ * three catalogue screens reuse one ViewModel instance per back-stack entry.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class CatalogDetailScreensTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val allahDetail = MutableStateFlow(CatalogDetailState<AsmaUlHusna>())
+    private val prophetNameDetail = MutableStateFlow(CatalogDetailState<AsmaUnNabi>())
+
+    private val allahEvents = mutableListOf<CatalogEvent>()
+    private val prophetNameEvents = mutableListOf<CatalogEvent>()
+
+    private val allahViewModel: AsmaUlHusnaViewModel = mockk(relaxed = true) {
+        every { detailState } returns allahDetail
+        every { onEvent(any()) } answers { allahEvents += firstArg<CatalogEvent>() }
+    }
+    private val prophetNameViewModel: AsmaUnNabiViewModel = mockk(relaxed = true) {
+        every { detailState } returns prophetNameDetail
+        every { onEvent(any()) } answers { prophetNameEvents += firstArg<CatalogEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun setAllahContent(nameId: Int = 1) {
+        composeRule.setThemedContent {
+            AsmaUlHusnaDetailScreen(
+                nameId = nameId,
+                onNavigateBack = { backs++ },
+                viewModel = allahViewModel,
+            )
+        }
+    }
+
+    private fun setProphetNameContent(nameId: Int = 1) {
+        composeRule.setThemedContent {
+            AsmaUnNabiDetailScreen(
+                nameId = nameId,
+                onNavigateBack = { backs++ },
+                viewModel = prophetNameViewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    // ---- one of the ninety-nine ------------------------------------------------------
+
+    @Test
+    fun `opening a name asks for the id the route carried`() {
+        // All three catalogue screens share one ViewModel instance per back-stack entry, so
+        // "whatever it last loaded" is a real and wrong answer here.
+        allahDetail.value = CatalogDetailState(isLoading = false, item = divineName(1))
+
+        setAllahContent(nameId = 42)
+
+        assertThat(allahEvents).containsExactly(CatalogEvent.LoadDetail(42))
+    }
+
+    @Test
+    fun `a name renders all five of its sections`() {
+        allahDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = divineName(
+                id = 1,
+                nameArabic = "الرحمن",
+                nameTransliteration = "Ar-Rahman",
+                meaning = "The One whose mercy encompasses all",
+                explanation = "Mercy that reaches everyone",
+                benefits = "Reciting it softens the heart",
+                usageInDua = "Ya Rahman, have mercy on me",
+            ),
+        )
+
+        setAllahContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_meaning)).assertExists()
+        composeRule.onNodeWithText("The One whose mercy encompasses all").assertExists()
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_explanation)).assertExists()
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_benefits)).assertExists()
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_usage_in_dua)).assertExists()
+        composeRule.onNodeWithText("Ya Rahman, have mercy on me").assertExists()
+    }
+
+    @Test
+    fun `the Quran references are chips, and absent when there are none`() {
+        // They are the reason the shared shell takes a `LazyListScope` slot rather than a list
+        // of (title, body) pairs — a `FlowRow` of chips is not prose.
+        allahDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = divineName(quranReferences = listOf("1:1", "55:1")),
+        )
+
+        setAllahContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_quran_references)).assertExists()
+        composeRule.onNodeWithText("1:1").assertExists()
+        composeRule.onNodeWithText("55:1").assertExists()
+    }
+
+    @Test
+    fun `a name the artifact cites no verses for shows no references card`() {
+        allahDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = divineName(quranReferences = emptyList()),
+        )
+
+        setAllahContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_quran_references))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_meaning)).assertExists()
+    }
+
+    @Test
+    fun `the favourite button toggles this name and reflects its state`() {
+        allahDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = divineName(id = 7, isFavorite = false),
+        )
+
+        setAllahContent(nameId = 7)
+        allahEvents.clear()
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites)).performClick()
+
+        assertThat(allahEvents).containsExactly(CatalogEvent.ToggleFavorite(7))
+    }
+
+    @Test
+    fun `an already-starred name offers to remove rather than to add`() {
+        allahDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = divineName(id = 7, isFavorite = true),
+        )
+
+        setAllahContent(nameId = 7)
+
+        composeRule.onNodeWithContentDescription(string(R.string.remove_from_favorites))
+            .assertExists()
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the bar carries a generic title until the name arrives`() {
+        composeRule.mainClock.autoAdvance = false
+        allahDetail.value = CatalogDetailState(isLoading = true)
+
+        setAllahContent()
+
+        composeRule.onNodeWithText(string(R.string.name_detail)).assertExists()
+        // Nothing to favourite yet, so nothing offers to.
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `an id that resolves to nothing keeps the loading shell rather than a header of nulls`() {
+        // `isLoading` is false and `item` is null — the second half of the shell's guard, and
+        // the state a stale deep link or a retired name lands in.
+        composeRule.mainClock.autoAdvance = false
+        allahDetail.value = CatalogDetailState(isLoading = false, item = null)
+
+        setAllahContent(nameId = 999)
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_meaning)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.name_detail)).assertExists()
+    }
+
+    // ---- one of the names of the Prophet ﷺ -------------------------------------------
+
+    @Test
+    fun `a name of the Prophet renders its three sections and its own source`() {
+        prophetNameDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = prophetName(
+                nameTransliteration = "Al-Mustafa",
+                meaning = "The chosen one",
+                explanation = "Chosen above all creation",
+                source = "Sahih Muslim 2278",
+            ),
+        )
+
+        setProphetNameContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_meaning)).assertExists()
+        composeRule.onNodeWithText("The chosen one").assertExists()
+        composeRule.onNodeWithText(string(R.string.asma_un_nabi_source)).assertExists()
+        composeRule.onNodeWithText("Sahih Muslim 2278").assertExists()
+        // It has no benefits or duʿāʾ-usage section — those belong to the other catalogue.
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_benefits)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `opening a name of the Prophet asks for the route's id and can be starred`() {
+        prophetNameDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = prophetName(id = 12, isFavorite = false),
+        )
+
+        setProphetNameContent(nameId = 12)
+
+        assertThat(prophetNameEvents).containsExactly(CatalogEvent.LoadDetail(12))
+
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites)).performClick()
+        assertThat(prophetNameEvents).contains(CatalogEvent.ToggleFavorite(12))
+    }
+
+    @Test
+    fun `the header names the item the reader opened`() {
+        prophetNameDetail.value = CatalogDetailState(
+            isLoading = false,
+            item = prophetName(nameArabic = "المصطفى", nameTransliteration = "Al-Mustafa"),
+        )
+
+        setProphetNameContent()
+
+        composeRule.onNodeWithText("المصطفى").assertIsDisplayed()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/content/ContentGraphTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/content/ContentGraphTest.kt
@@ -1,0 +1,147 @@
+package com.arshadshah.nimaz.presentation.screens.content
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.NamesTab
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Content feature's slice of the route graph — the largest single graph in the app.
+ *
+ * Nineteen destinations across five surfaces (qaida, hadith, dua, the name catalogues, the
+ * prophets), and **eleven of them carry arguments**, which is what makes a graph test worth
+ * more here than in most modules: an unregistered destination throws
+ * `IllegalArgumentException: navigation destination … is not a direct child of this NavGraph`
+ * at the moment a **user taps the row** — not at build time, and not in any of the four gates
+ * `CLAUDE.md` lists.
+ *
+ * Four of the hadith destinations are the *same screen* reached four ways — chapter, hadith id,
+ * hadith number, grade — and they exist as separate routes precisely so the reader can tell
+ * which it was asked for (see `HadithReaderScreenTest`). Losing one of them does not break the
+ * others, so the count is asserted as well as the membership.
+ *
+ * The graph is built without a `NavHost`, so nothing composes and none of these screens' Hilt
+ * ViewModels is constructed. This asserts registration only; the screen tests beside it assert
+ * what each destination renders.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ContentGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.DuaHome) {
+            contentGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all nineteen content destinations are registered`() {
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(19)
+        listOf(
+            Route.QaidaHome::class,
+            Route.QaidaReader::class,
+            Route.QaidaLetters::class,
+            Route.HadithHome::class,
+            Route.HadithBook::class,
+            Route.HadithChapter::class,
+            Route.HadithReader::class,
+            Route.HadithByNumber::class,
+            Route.HadithByGrade::class,
+            Route.DuaHome::class,
+            Route.DuaCategory::class,
+            Route.DuaOccasion::class,
+            Route.DuaReader::class,
+            Route.DuaFavorites::class,
+            Route.Names::class,
+            Route.Favourites::class,
+            Route.AsmaUlHusnaDetail::class,
+            Route.AsmaUnNabiDetail::class,
+            Route.ProphetDetail::class,
+        ).forEach { route ->
+            assertThat(routes.any { it.contains(route.qualifiedName!!) }).isTrue()
+        }
+    }
+
+    @Test
+    fun `the three qaida destinations resolve in their own right`() {
+        // The course map is opened from the More menu, the letter explorer from the map's app
+        // bar, and a lesson from either the trail or the map's "continue" button.
+        assertStartDestination(Route.QaidaHome)
+        assertStartDestination(Route.QaidaLetters)
+        assertStartDestination(Route.QaidaReader(lessonId = 3))
+    }
+
+    @Test
+    fun `every way into the hadith reader resolves`() {
+        // Four routes onto one screen. Each is reached from somewhere different — the chapter
+        // list, search, a bookmark, and the collection screen's grade pills — so losing one
+        // breaks exactly one of those and none of the others.
+        assertStartDestination(Route.HadithChapter(bookId = "bukhari", chapterId = "bukhari_1"))
+        assertStartDestination(Route.HadithReader(hadithId = "bukhari-1-1"))
+        assertStartDestination(Route.HadithByNumber(bookId = "muslim", hadithNumber = 2564))
+        assertStartDestination(Route.HadithByGrade(grade = HadithGrade.SAHIH.name))
+    }
+
+    @Test
+    fun `the hadith library and one collection resolve`() {
+        assertStartDestination(Route.HadithHome)
+        assertStartDestination(Route.HadithBook(bookId = "bukhari"))
+    }
+
+    @Test
+    fun `the dua library, a category, an occasion and one dua resolve`() {
+        // `DuaOccasion` is the cross-cut that shipped in the database and the repository before
+        // anything could reach it; its registration here is what makes the badge on a dua row
+        // do something.
+        assertStartDestination(Route.DuaHome)
+        assertStartDestination(Route.DuaCategory(categoryId = "morning"))
+        assertStartDestination(Route.DuaOccasion(occasion = DuaOccasion.TRAVELING.name))
+        assertStartDestination(Route.DuaReader(duaId = "dua_1"))
+        assertStartDestination(Route.DuaFavorites)
+    }
+
+    @Test
+    fun `the names tabs and the consolidated favourites resolve`() {
+        // `Route.Names` carries the tab ordinal, so all three tabs are one destination and a
+        // deep link naming any of them lands here.
+        assertStartDestination(Route.Names(tab = NamesTab.ASMA_UL_HUSNA.ordinal))
+        assertStartDestination(Route.Names(tab = NamesTab.PROPHETS.ordinal))
+        assertStartDestination(Route.Favourites)
+    }
+
+    @Test
+    fun `all three catalogue detail routes resolve`() {
+        assertStartDestination(Route.AsmaUlHusnaDetail(nameId = 1))
+        assertStartDestination(Route.AsmaUnNabiDetail(nameId = 1))
+        assertStartDestination(Route.ProphetDetail(prophetId = 1))
+    }
+
+    private fun assertStartDestination(route: Route) {
+        // `createGraph` throws here if the route it is handed is not among the destinations the
+        // builder registered — the same failure the app would hit on the first tap.
+        val graph = navController.createGraph(startDestination = route) {
+            contentGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaReaderScreenTest.kt
@@ -211,6 +211,45 @@ class DuaReaderScreenTest {
     }
 
     @Test
+    fun `a reference with no recitation count still gets its own chip`() {
+        // The meta row appears when there is a reference **or** a count, and each chip inside
+        // it is guarded again. Collapsing the two guards into one renders an empty second pill
+        // beside the reference.
+        loaded(dua(reference = "Sahih Muslim 2723", repeatCount = null))
+
+        setContent()
+
+        composeRule.onNodeWithText("Sahih Muslim 2723").assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.dua_reader_recite_count, 3, 3)
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a recitation count with no reference still gets its own chip`() {
+        // The other half, and the one the content artifact produces more often: a prescribed
+        // count with no citation recorded.
+        loaded(dua(reference = null, repeatCount = 3))
+
+        setContent()
+
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.dua_reader_recite_count, 3, 3)
+        ).assertExists()
+    }
+
+    @Test
+    fun `an empty reference string counts as no reference`() {
+        // `isNullOrEmpty`, not `== null`: the artifact stores `""` as readily as null, and an
+        // empty chip is a pill with nothing in it.
+        loaded(dua(reference = "", repeatCount = null, textEnglish = "Bare supplication"))
+
+        setContent()
+
+        composeRule.onNodeWithText("Bare supplication").assertExists()
+    }
+
+    @Test
     fun `a dua that ships a virtue shows the virtue card`() {
         loaded(dua(benefits = "Whoever says this is protected until evening"))
 

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuasCollectionScreenTest.kt
@@ -260,6 +260,32 @@ class DuasCollectionScreenTest {
     }
 
     @Test
+    @Config(qualifiers = "w411dp-h6000dp")
+    fun `every colour bucket a category id can hash into resolves to a colour`() {
+        // `getCategoryColor` switches on `categoryId.hashCode() % 8` — and Kotlin's `%` keeps
+        // the sign of the dividend, so a category id with a **negative** hash lands on a
+        // negative remainder and falls through to the `else`. The ids here are chosen to hit
+        // all eight buckets plus that one: without the `else`, the first category whose id
+        // happens to hash negative throws `NoWhenBranchException` while the list composes, and
+        // the whole library goes blank. Which ids hash negative is a property of the shipped
+        // content, not of this app.
+        val bucketIds = listOf("h", "a", "b", "c", "d", "e", "f", "g", "aaaaab")
+
+        collectionState.value = DuaCollectionUiState(
+            filteredCategories = bucketIds.mapIndexed { index, id ->
+                category(id = id, nameEnglish = "Bucket $index")
+            },
+            isLoading = false,
+        )
+
+        setContent()
+
+        bucketIds.indices.forEach { index ->
+            composeRule.onNodeWithText("Bucket $index").assertExists()
+        }
+    }
+
+    @Test
     fun `the favourites heading appears only when there are favourites`() {
         loaded(*categories(5))
 

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithReaderScreenTest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
 
 /**
  * The hadith reader — and the four ways a reader arrives at one.
@@ -92,6 +93,12 @@ class HadithReaderScreenTest {
     private fun string(@StringRes res: Int, vararg args: Any): String =
         context.getString(res, *args)
 
+    /** What the system clipboard holds, as the reader would paste it. */
+    private fun clipboardText(): String {
+        val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
+        return clipboard.primaryClip?.getItemAt(0)?.text?.toString().orEmpty()
+    }
+
     private fun loaded(vararg hadiths: com.arshadshah.nimaz.domain.model.Hadith) {
         readerState.value = HadithReaderUiState(
             chapter = chapter(),
@@ -134,6 +141,22 @@ class HadithReaderScreenTest {
         setContent(bookId = "", chapterId = "bukhari-1-1")
 
         assertThat(events).containsExactly(HadithEvent.LoadHadithById("bukhari-1-1"))
+    }
+
+    @Test
+    fun `an id carrying an underscore is read as a chapter, not as a hadith id`() {
+        // The guard is `bookId.isEmpty() && !chapterId.contains("_")`, and the underscore is
+        // the *whole* signal: a composite `book_chapter` key has one, a hadith id from search
+        // is assumed not to. This asserts the boundary the app actually relies on — with no
+        // book and an underscore present, the composite reading wins. It is worth pinning
+        // because hadith ids in this dataset **do** contain underscores (`bukhari_1_1`), so
+        // the two shapes are one character apart and the classification is a convention, not
+        // a proof. A change to either side sends search hits into the chapter loader.
+        readerState.value = HadithReaderUiState(isLoading = false)
+
+        setContent(bookId = "", chapterId = "bukhari_1")
+
+        assertThat(events).containsExactly(HadithEvent.LoadChapter("bukhari_1"))
     }
 
     @Test
@@ -330,6 +353,33 @@ class HadithReaderScreenTest {
     }
 
     @Test
+    fun `a narrator field of nothing but spaces renders no badge`() {
+        // `narratorName?.trim()?.takeIf { it.isNotBlank() }`. The content artifact carries a
+        // whitespace-only narrator as readily as a null, and an unguarded badge is an empty
+        // accent pill above the Arabic.
+        loaded(hadith(narratorName = "   ", grade = null))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_narrated_by_format, "")).assertDoesNotExist()
+        composeRule.onNodeWithText("Actions are but by intention").assertExists()
+    }
+
+    @Test
+    fun `copying leaves out a reference that is only whitespace`() {
+        // The same shape again, in the copy text this time — where it would paste as a
+        // trailing blank line rather than as an empty pill.
+        loaded(hadith(narratorName = null, reference = "   "))
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_copy)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(clipboardText().trim()).doesNotContain("   \n")
+        assertThat(clipboardText()).contains("Actions are but by intention")
+    }
+
+    @Test
     fun `a hadith with no grade and no narrator renders neither badge`() {
         loaded(hadith(grade = null, narratorName = null, reference = null))
 
@@ -368,6 +418,56 @@ class HadithReaderScreenTest {
         setContent()
 
         composeRule.onNodeWithContentDescription(string(R.string.cd_bookmark)).assertExists()
+    }
+
+    @Test
+    fun `copying a hadith puts its whole citation on the clipboard`() {
+        // The copy text is built by a local function nothing else calls, and it is what a
+        // reader pastes into a message. Every optional field is guarded there separately from
+        // the page's own guards, so a hadith can render perfectly and still be copied with a
+        // blank line where its narrator should be.
+        loaded(
+            hadith(
+                textArabic = "إنما الأعمال بالنيات",
+                textEnglish = "Actions are but by intention",
+                narratorName = "Umar ibn al-Khattab",
+                reference = "Sahih al-Bukhari 1",
+            )
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_copy)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(ShadowToast.getTextOfLatestToast()).isEqualTo(string(R.string.hadith_copied))
+        val copied = clipboardText()
+        assertThat(copied).contains("إنما الأعمال بالنيات")
+        assertThat(copied).contains("Actions are but by intention")
+        assertThat(copied).contains(string(R.string.hadith_narrated_by_format, "Umar ibn al-Khattab"))
+        assertThat(copied).contains("Sahih al-Bukhari 1")
+    }
+
+    @Test
+    fun `copying a hadith with no narrator and no reference leaves no blank lines for them`() {
+        // Both fields are `takeIf { it.isNotBlank() }`, and the content artifact carries an
+        // empty string as often as a null. Without the guard the paste ends in two blank
+        // lines and, before it, the literal "Narrated by ".
+        loaded(
+            hadith(
+                textEnglish = "Actions are but by intention",
+                narratorName = "",
+                reference = null,
+            )
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_copy)).performClick()
+        composeRule.waitForIdle()
+
+        val copied = clipboardText()
+        assertThat(copied).contains("Actions are but by intention")
+        assertThat(copied).doesNotContain("Narrated by")
+        assertThat(copied.trimEnd()).isEqualTo(copied.trimEnd().trimEnd('\n'))
     }
 
     @Test

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/FavouritesScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/FavouritesScreenTest.kt
@@ -1,0 +1,201 @@
+package com.arshadshah.nimaz.presentation.screens.names
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.domain.model.Prophet
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogListState
+import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Everything the reader has starred, across three catalogues, in one place.
+ *
+ * The screen this replaced was an all/favourites chip *inside* each of the three name screens,
+ * so there was no answer to "what have I saved" — only "what have I saved in this one
+ * catalogue", asked three times. Two rules make the consolidated version work, and both are
+ * invisible until they break.
+ *
+ * **A section with nothing in it renders nothing at all** — not an empty heading. The check
+ * lives in `favouriteSection` rather than at the three call sites precisely so a fourth kind of
+ * favourite cannot forget it; with it forgotten, a reader who has starred one name sees three
+ * headings and one card.
+ *
+ * **The empty state belongs to the whole screen, not to a section.** A reader with two starred
+ * prophets and no starred names must see the prophets, not "no favourites yet" — which is what
+ * a per-section empty state would produce, three times over.
+ *
+ * These sections read `listState.favorites`, a different field from the `filteredItems` the
+ * Names tabs render. A section wired to the wrong one shows the whole catalogue as "favourites".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class FavouritesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val allahState = MutableStateFlow(CatalogListState<AsmaUlHusna>(isLoading = false))
+    private val prophetNamesState = MutableStateFlow(CatalogListState<AsmaUnNabi>(isLoading = false))
+    private val prophetsState = MutableStateFlow(CatalogListState<Prophet>(isLoading = false))
+
+    private val allahEvents = mutableListOf<CatalogEvent>()
+    private val prophetEvents = mutableListOf<CatalogEvent>()
+
+    private val allahViewModel: AsmaUlHusnaViewModel = mockk(relaxed = true) {
+        every { listState } returns allahState
+        every { onEvent(any()) } answers { allahEvents += firstArg<CatalogEvent>() }
+    }
+    private val prophetNamesViewModel: AsmaUnNabiViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetNamesState
+    }
+    private val prophetsViewModel: ProphetViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetsState
+        every { onEvent(any()) } answers { prophetEvents += firstArg<CatalogEvent>() }
+    }
+
+    private val opened = mutableListOf<String>()
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            FavouritesScreen(
+                onNavigateBack = { opened += "back" },
+                onNavigateToAsmaUlHusna = { opened += "allah:$it" },
+                onNavigateToAsmaUnNabi = { opened += "prophet-name:$it" },
+                onNavigateToProphet = { opened += "prophet:$it" },
+                asmaUlHusnaViewModel = allahViewModel,
+                asmaUnNabiViewModel = prophetNamesViewModel,
+                prophetViewModel = prophetsViewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    @Test
+    fun `nothing starred anywhere shows one empty state, not three`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.no_favorites_yet)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.favourites_empty_message)).assertExists()
+        composeRule.onNodeWithText(string(R.string.names_tab_allah)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a starred name from one catalogue does not raise the other two headings`() {
+        // The failure this catches is a wall of headings over a single card.
+        prophetsState.value = CatalogListState(
+            favorites = listOf(prophet(1, nameEnglish = "Abraham", isFavorite = true)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Abraham").assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.names_tab_prophets)).assertExists()
+        composeRule.onNodeWithText(string(R.string.names_tab_allah)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.names_tab_prophet)).assertDoesNotExist()
+        // Not the whole-screen empty state either.
+        composeRule.onNodeWithText(string(R.string.no_favorites_yet)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `all three kinds appear together, each under its own heading`() {
+        allahState.value = CatalogListState(
+            favorites = listOf(divineName(1, nameTransliteration = "Ar-Rahman", isFavorite = true)),
+            isLoading = false,
+        )
+        prophetNamesState.value = CatalogListState(
+            favorites = listOf(prophetName(1, nameTransliteration = "Muhammad", isFavorite = true)),
+            isLoading = false,
+        )
+        prophetsState.value = CatalogListState(
+            favorites = listOf(prophet(1, nameEnglish = "Abraham", isFavorite = true)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Ar-Rahman").assertExists()
+        composeRule.onNodeWithText("Muhammad").assertExists()
+        composeRule.onNodeWithText("Abraham").assertExists()
+        composeRule.onNodeWithText(string(R.string.names_tab_allah)).assertExists()
+        composeRule.onNodeWithText(string(R.string.names_tab_prophet)).assertExists()
+        composeRule.onNodeWithText(string(R.string.names_tab_prophets)).assertExists()
+    }
+
+    @Test
+    fun `the sections read favourites, not the whole catalogue`() {
+        // `items`/`filteredItems` is what the Names tabs render; a section wired to either
+        // would present the entire catalogue as the reader's favourites.
+        allahState.value = CatalogListState(
+            items = List(5) { divineName(it + 1, nameTransliteration = "Name ${it + 1}") },
+            filteredItems = List(5) { divineName(it + 1, nameTransliteration = "Name ${it + 1}") },
+            favorites = listOf(divineName(3, nameTransliteration = "Name 3", isFavorite = true)),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("Name 3").assertExists()
+        composeRule.onNodeWithText("Name 1").assertDoesNotExist()
+        composeRule.onNodeWithText("Name 5").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping a favourite opens its own catalogue's detail route`() {
+        allahState.value = CatalogListState(
+            favorites = listOf(divineName(7, nameTransliteration = "Al-Aziz", isFavorite = true)),
+            isLoading = false,
+        )
+        prophetsState.value = CatalogListState(
+            favorites = listOf(prophet(4, nameEnglish = "Moses", isFavorite = true)),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithText("Al-Aziz").performClick()
+        composeRule.onNodeWithText("Moses").performClick()
+
+        assertThat(opened).containsExactly("allah:7", "prophet:4").inOrder()
+    }
+
+    @Test
+    fun `unstarring from here goes to that item's own ViewModel`() {
+        // Three cards of the same component with three different `onFavoriteClick` lambdas;
+        // a swap unstars the wrong catalogue's item and the card the reader tapped stays lit.
+        prophetsState.value = CatalogListState(
+            favorites = listOf(prophet(4, nameEnglish = "Moses", isFavorite = true)),
+            isLoading = false,
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.remove_from_favorites))
+            .performClick()
+
+        assertThat(prophetEvents).containsExactly(CatalogEvent.ToggleFavorite(4))
+        assertThat(allahEvents).isEmpty()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/NamesFixtures.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/NamesFixtures.kt
@@ -1,0 +1,89 @@
+package com.arshadshah.nimaz.presentation.screens.names
+
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.domain.model.Prophet
+
+/** The three catalogues' items, with every field a screen branches on named. */
+internal fun divineName(
+    id: Int = 1,
+    nameArabic: String = "الرحمن",
+    nameTransliteration: String = "Ar-Rahman",
+    nameEnglish: String = "The Most Compassionate",
+    meaning: String = "The One whose mercy encompasses all",
+    explanation: String = "Mercy that reaches believer and disbeliever alike",
+    benefits: String = "Reciting it softens the heart",
+    quranReferences: List<String> = listOf("1:1", "55:1"),
+    usageInDua: String = "Ya Rahman, have mercy on me",
+    isFavorite: Boolean = false,
+) = AsmaUlHusna(
+    id = id,
+    number = id,
+    nameArabic = nameArabic,
+    nameTransliteration = nameTransliteration,
+    nameEnglish = nameEnglish,
+    meaning = meaning,
+    explanation = explanation,
+    benefits = benefits,
+    quranReferences = quranReferences,
+    usageInDua = usageInDua,
+    displayOrder = id,
+    isFavorite = isFavorite,
+)
+
+internal fun prophetName(
+    id: Int = 1,
+    nameArabic: String = "محمد",
+    nameTransliteration: String = "Muhammad",
+    nameEnglish: String = "The Praised One",
+    meaning: String = "The one who is much praised",
+    explanation: String = "Named before his birth",
+    source: String = "Sahih al-Bukhari 3532",
+    isFavorite: Boolean = false,
+) = AsmaUnNabi(
+    id = id,
+    number = id,
+    nameArabic = nameArabic,
+    nameTransliteration = nameTransliteration,
+    nameEnglish = nameEnglish,
+    meaning = meaning,
+    explanation = explanation,
+    source = source,
+    displayOrder = id,
+    isFavorite = isFavorite,
+)
+
+internal fun prophet(
+    id: Int = 1,
+    nameArabic: String = "إبراهيم",
+    nameEnglish: String = "Abraham",
+    nameTransliteration: String = "Ibrahim",
+    titleEnglish: String = "Friend of Allah",
+    storySummary: String = "Called his people away from idols",
+    keyLessons: List<String> = listOf("Tawhid before all", "Patience under trial"),
+    quranMentions: List<String> = listOf("2:124", "6:74"),
+    era: String = "circa 2000 BCE",
+    lineage: String = "Son of Azar",
+    yearsLived: String = "175 years",
+    placeOfPreaching: String = "Ur and Canaan",
+    miracles: List<String> = listOf("Unburned by the fire"),
+    isFavorite: Boolean = false,
+) = Prophet(
+    id = id,
+    number = id,
+    nameArabic = nameArabic,
+    nameEnglish = nameEnglish,
+    nameTransliteration = nameTransliteration,
+    titleArabic = "خليل الله",
+    titleEnglish = titleEnglish,
+    storySummary = storySummary,
+    keyLessons = keyLessons,
+    quranMentions = quranMentions,
+    era = era,
+    lineage = lineage,
+    yearsLived = yearsLived,
+    placeOfPreaching = placeOfPreaching,
+    miracles = miracles,
+    displayOrder = id,
+    isFavorite = isFavorite,
+)

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/NamesScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/names/NamesScreenTest.kt
@@ -1,0 +1,279 @@
+package com.arshadshah.nimaz.presentation.screens.names
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.NamesTab
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.domain.model.Prophet
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUlHusnaViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.AsmaUnNabiViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogListState
+import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Three catalogues behind one search box and one set of tabs.
+ *
+ * This screen replaced **three destinations** — three top bars, three search boxes, three
+ * all/favourites filters — and the consolidation is the whole of what is worth testing here.
+ * Two properties carry it.
+ *
+ * **One query reaches all three catalogues.** `search()` dispatches `CatalogEvent.Search` to
+ * each ViewModel in turn, which is what makes the per-tab match counts on the segmented control
+ * mean anything: you can see "Rahman" hits two of the three before tapping into either. A
+ * dispatch that reaches only the visible tab's ViewModel looks identical on the tab you are on.
+ *
+ * **Clearing dispatches `ClearSearch`, not `Search("")`.** They leave the same filtered list, so
+ * nothing on screen distinguishes them — but `Search("")` also pushes an empty query into the
+ * debounced analytics flow, which exists precisely to record what people type.
+ *
+ * The counts are suppressed with no query, because they would otherwise just restate how big
+ * each catalogue is, on every tab, forever — and the tab labels are what the assertions here
+ * read, so the suppression is visible.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class NamesScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val allahState = MutableStateFlow(CatalogListState<AsmaUlHusna>(isLoading = false))
+    private val prophetNamesState = MutableStateFlow(CatalogListState<AsmaUnNabi>(isLoading = false))
+    private val prophetsState = MutableStateFlow(CatalogListState<Prophet>(isLoading = false))
+
+    private val allahEvents = mutableListOf<CatalogEvent>()
+    private val prophetNameEvents = mutableListOf<CatalogEvent>()
+    private val prophetEvents = mutableListOf<CatalogEvent>()
+
+    private val allahViewModel: AsmaUlHusnaViewModel = mockk(relaxed = true) {
+        every { listState } returns allahState
+        every { onEvent(any()) } answers { allahEvents += firstArg<CatalogEvent>() }
+    }
+    private val prophetNamesViewModel: AsmaUnNabiViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetNamesState
+        every { onEvent(any()) } answers { prophetNameEvents += firstArg<CatalogEvent>() }
+    }
+    private val prophetsViewModel: ProphetViewModel = mockk(relaxed = true) {
+        every { listState } returns prophetsState
+        every { onEvent(any()) } answers { prophetEvents += firstArg<CatalogEvent>() }
+    }
+
+    private val opened = mutableListOf<String>()
+
+    private fun setContent(initialTab: NamesTab = NamesTab.ASMA_UL_HUSNA) {
+        composeRule.setThemedContent {
+            NamesScreen(
+                initialTab = initialTab,
+                onNavigateBack = { opened += "back" },
+                onNavigateToFavourites = { opened += "favourites" },
+                onNavigateToAsmaUlHusna = { opened += "allah:$it" },
+                onNavigateToAsmaUnNabi = { opened += "prophet-name:$it" },
+                onNavigateToProphet = { opened += "prophet:$it" },
+                asmaUlHusnaViewModel = allahViewModel,
+                asmaUnNabiViewModel = prophetNamesViewModel,
+                prophetViewModel = prophetsViewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun populate() {
+        allahState.value = CatalogListState(
+            items = listOf(divineName(1, nameTransliteration = "Ar-Rahman")),
+            filteredItems = listOf(divineName(1, nameTransliteration = "Ar-Rahman")),
+            isLoading = false,
+        )
+        prophetNamesState.value = CatalogListState(
+            items = listOf(prophetName(1, nameTransliteration = "Muhammad")),
+            filteredItems = listOf(prophetName(1, nameTransliteration = "Muhammad")),
+            isLoading = false,
+        )
+        prophetsState.value = CatalogListState(
+            items = listOf(prophet(1, nameEnglish = "Abraham")),
+            filteredItems = listOf(prophet(1, nameEnglish = "Abraham")),
+            isLoading = false,
+        )
+    }
+
+    @Test
+    fun `the route's tab is the tab that opens`() {
+        // `Route.Names(tab)` carries the ordinal, so a deep link or an announcement that names
+        // the Prophets tab must not land on the Names of Allah.
+        populate()
+
+        setContent(initialTab = NamesTab.PROPHETS)
+
+        composeRule.onNodeWithText("Abraham").assertIsDisplayed()
+        composeRule.onNodeWithText("Ar-Rahman").assertDoesNotExist()
+    }
+
+    @Test
+    fun `each tab shows its own catalogue`() {
+        populate()
+
+        setContent()
+        composeRule.onNodeWithText("Ar-Rahman").assertIsDisplayed()
+
+        composeRule.onNodeWithText(string(R.string.names_tab_prophet)).performClick()
+        composeRule.onNodeWithText("Muhammad").assertIsDisplayed()
+        composeRule.onNodeWithText("Ar-Rahman").assertDoesNotExist()
+
+        composeRule.onNodeWithText(string(R.string.names_tab_prophets)).performClick()
+        composeRule.onNodeWithText("Abraham").assertIsDisplayed()
+    }
+
+    @Test
+    fun `one query reaches all three catalogues`() {
+        // The reason the per-tab counts mean anything. A dispatch that reached only the visible
+        // tab would look identical from the tab you are standing on.
+        populate()
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.names_search_hint))
+            .performTextInput("Rahman")
+
+        assertThat(allahEvents).contains(CatalogEvent.Search("Rahman"))
+        assertThat(prophetNameEvents).contains(CatalogEvent.Search("Rahman"))
+        assertThat(prophetEvents).contains(CatalogEvent.Search("Rahman"))
+    }
+
+    @Test
+    fun `clearing the box sends ClearSearch, not an empty query`() {
+        // Both leave the same list on screen; only `ClearSearch` keeps an empty string out of
+        // the debounced analytics flow that exists to record what people type.
+        populate()
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.names_search_hint))
+            .performTextInput("Rah")
+        composeRule.onNodeWithContentDescription(string(R.string.cd_clear_search)).performClick()
+
+        assertThat(allahEvents).contains(CatalogEvent.ClearSearch)
+        assertThat(prophetEvents).contains(CatalogEvent.ClearSearch)
+        assertThat(allahEvents).doesNotContain(CatalogEvent.Search(""))
+    }
+
+    @Test
+    fun `the tab labels carry a match count only while a query is running`() {
+        allahState.value = CatalogListState(
+            items = List(3) { divineName(it + 1) },
+            filteredItems = List(2) { divineName(it + 1) },
+            isLoading = false,
+        )
+        prophetNamesState.value = CatalogListState(isLoading = false)
+        prophetsState.value = CatalogListState(isLoading = false)
+
+        setContent()
+
+        // No query: the bare label, because a count here would only restate the catalogue size.
+        composeRule.onNodeWithText(string(R.string.names_tab_allah)).assertExists()
+
+        composeRule.onNodeWithContentDescription(string(R.string.names_search_hint))
+            .performTextInput("Rah")
+
+        composeRule.onNodeWithText("${string(R.string.names_tab_allah)} (2)").assertExists()
+        composeRule.onNodeWithText("${string(R.string.names_tab_prophet)} (0)").assertExists()
+    }
+
+    @Test
+    fun `tapping a name opens that catalogue's own detail route`() {
+        // Three lists of near-identical cards and three navigate lambdas of the same type is
+        // exactly the shape where a copy-paste sends a prophet's id to the names route.
+        populate()
+
+        setContent()
+        composeRule.onNodeWithText("Ar-Rahman").performClick()
+
+        composeRule.onNodeWithText(string(R.string.names_tab_prophets)).performClick()
+        composeRule.onNodeWithText("Abraham").performClick()
+
+        assertThat(opened).containsExactly("allah:1", "prophet:1").inOrder()
+    }
+
+    @Test
+    fun `starring a name is dispatched to that name's own ViewModel`() {
+        populate()
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites)).performClick()
+
+        assertThat(allahEvents).contains(CatalogEvent.ToggleFavorite(1))
+        assertThat(prophetEvents).doesNotContain(CatalogEvent.ToggleFavorite(1))
+    }
+
+    @Test
+    fun `a prophet's card carries the title and era the other two do not`() {
+        // The one card that differs: the English name leads, and a title and era ride along.
+        populate()
+
+        setContent(initialTab = NamesTab.PROPHETS)
+
+        composeRule.onNodeWithText("Abraham").assertIsDisplayed()
+        composeRule.onNodeWithText("Friend of Allah").assertExists()
+        composeRule.onNodeWithText("circa 2000 BCE").assertExists()
+    }
+
+    @Test
+    fun `a search that matches nothing says so in that catalogue's own words`() {
+        // Three empty messages, one per catalogue, and `CatalogList` is handed whichever
+        // belongs to the tab. A shared string would be the easy wrong answer.
+        allahState.value = CatalogListState(
+            items = List(3) { divineName(it + 1) },
+            filteredItems = emptyList(),
+            isLoading = false,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_no_names_found)).assertExists()
+        composeRule.onNodeWithText(string(R.string.prophets_no_found)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a catalogue still loading shows a spinner rather than an empty message`() {
+        // `CatalogList` returns early while loading — without that, every tab claims its
+        // catalogue is empty for the whole first frame.
+        composeRule.mainClock.autoAdvance = false
+        allahState.value = CatalogListState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.asma_ul_husna_no_names_found))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `favourites are reachable from the top bar`() {
+        populate()
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_open_favourites))
+            .performClick()
+
+        assertThat(opened).containsExactly("favourites")
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prophets/ProphetDetailScreenTest.kt
@@ -1,0 +1,246 @@
+package com.arshadshah.nimaz.presentation.screens.prophets
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.Prophet
+import com.arshadshah.nimaz.presentation.screens.names.prophet
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogDetailState
+import com.arshadshah.nimaz.presentation.viewmodel.content.CatalogEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.ProphetViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * One prophet's page — the only catalogue detail screen that does **not** use the shared shell.
+ *
+ * It has its own scaffold because its sections are not prose cards: a bullet list appears twice,
+ * the Qur'an mentions are chips, and the timeline is a two-by-two grid of label/value pairs. That
+ * makes it the largest single file in the module and the one place where the shell's guarantees
+ * have to be re-established by hand — the loading branch, the null-item branch, the FAB that
+ * appears only when there is something to favourite.
+ *
+ * **Three of its six sections are conditional**, and the content artifact is what decides: a
+ * prophet the dataset records no miracles for, no key lessons for, or no cited verses for must
+ * render *no card* rather than a titled card with nothing under it. That is the failure mode
+ * this whole module shares — shipped content that does not carry a field, rendering as a hole.
+ *
+ * **The timeline always renders, with four values that are all plain strings.** Era, lineage,
+ * years lived and place of preaching are four `TimelineItem`s laid out in two rows, which is
+ * exactly the shape where two labels get swapped and nothing complains.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class ProphetDetailScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val detailState = MutableStateFlow(CatalogDetailState<Prophet>())
+    private val events = mutableListOf<CatalogEvent>()
+
+    private val viewModel: ProphetViewModel = mockk(relaxed = true) {
+        every { this@mockk.detailState } returns this@ProphetDetailScreenTest.detailState
+        every { onEvent(any()) } answers { events += firstArg<CatalogEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun setContent(prophetId: Int = 1) {
+        composeRule.setThemedContent {
+            ProphetDetailScreen(
+                prophetId = prophetId,
+                onNavigateBack = { backs++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    private fun loaded(item: Prophet) {
+        detailState.value = CatalogDetailState(isLoading = false, item = item)
+    }
+
+    @Test
+    fun `opening a prophet asks for the id the route carried`() {
+        loaded(prophet(1))
+
+        setContent(prophetId = 25)
+
+        assertThat(events).containsExactly(CatalogEvent.LoadDetail(25))
+    }
+
+    @Test
+    fun `the header leads with the English name and the title beneath it`() {
+        // No number medallion for prophets — the header is handed `number = null`, the one
+        // place in the app that path is taken.
+        loaded(prophet(nameArabic = "إبراهيم", nameEnglish = "Abraham", titleEnglish = "Friend of Allah"))
+
+        setContent()
+
+        composeRule.onNodeWithText("إبراهيم").assertIsDisplayed()
+        composeRule.onNodeWithText("Friend of Allah").assertExists()
+    }
+
+    @Test
+    fun `the story is always shown`() {
+        loaded(prophet(storySummary = "Called his people away from idols"))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_story)).assertExists()
+        composeRule.onNodeWithText("Called his people away from idols").assertExists()
+    }
+
+    @Test
+    fun `the key lessons are listed one per bullet`() {
+        loaded(prophet(keyLessons = listOf("Tawhid before all", "Patience under trial")))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_key_lessons)).assertExists()
+        composeRule.onNodeWithText("Tawhid before all").assertExists()
+        composeRule.onNodeWithText("Patience under trial").assertExists()
+    }
+
+    @Test
+    fun `a prophet the dataset records no lessons for shows no lessons card`() {
+        loaded(prophet(keyLessons = emptyList()))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_key_lessons)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.prophets_story)).assertExists()
+    }
+
+    @Test
+    fun `the cited verses are chips, and absent when the dataset cites none`() {
+        loaded(prophet(quranMentions = listOf("2:124", "6:74")))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_quran_mentions)).assertExists()
+        composeRule.onNodeWithText("2:124").assertExists()
+        composeRule.onNodeWithText("6:74").assertExists()
+    }
+
+    @Test
+    fun `no cited verses means no mentions card at all`() {
+        loaded(prophet(quranMentions = emptyList()))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_quran_mentions)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the miracles card appears only for a prophet the dataset records some for`() {
+        loaded(prophet(miracles = emptyList()))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_miracles)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `recorded miracles are listed as bullets of their own`() {
+        loaded(prophet(miracles = listOf("Unburned by the fire", "The birds returned to him")))
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_miracles)).assertExists()
+        composeRule.onNodeWithText("Unburned by the fire").assertExists()
+        composeRule.onNodeWithText("The birds returned to him").assertExists()
+    }
+
+    @Test
+    fun `each timeline value sits under its own label`() {
+        // Four label/value pairs in two rows: the shape where two get swapped and the page
+        // still reads as a perfectly well-formed timeline.
+        loaded(
+            prophet(
+                era = "circa 2000 BCE",
+                lineage = "Son of Azar",
+                yearsLived = "175 years",
+                placeOfPreaching = "Ur and Canaan",
+            )
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophets_timeline)).assertExists()
+        composeRule.onNodeWithText(string(R.string.prophets_era)).assertExists()
+        composeRule.onNodeWithText("circa 2000 BCE").assertExists()
+        composeRule.onNodeWithText(string(R.string.prophets_lineage)).assertExists()
+        composeRule.onNodeWithText("Son of Azar").assertExists()
+        composeRule.onNodeWithText(string(R.string.prophets_years_lived)).assertExists()
+        composeRule.onNodeWithText("175 years").assertExists()
+        composeRule.onNodeWithText(string(R.string.prophets_place)).assertExists()
+        composeRule.onNodeWithText("Ur and Canaan").assertExists()
+    }
+
+    @Test
+    fun `starring a prophet dispatches that prophet's id`() {
+        loaded(prophet(id = 4, nameEnglish = "Moses", isFavorite = false))
+
+        setContent(prophetId = 4)
+        events.clear()
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites)).performClick()
+
+        assertThat(events).containsExactly(CatalogEvent.ToggleFavorite(4))
+    }
+
+    @Test
+    fun `an already-starred prophet offers to remove`() {
+        loaded(prophet(id = 4, isFavorite = true))
+
+        setContent(prophetId = 4)
+
+        composeRule.onNodeWithContentDescription(string(R.string.remove_from_favorites))
+            .assertExists()
+    }
+
+    @Test
+    fun `the bar carries a generic title until the prophet arrives, and offers nothing to star`() {
+        composeRule.mainClock.autoAdvance = false
+        detailState.value = CatalogDetailState(isLoading = true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prophet_detail)).assertExists()
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `an id that resolves to nothing does not render a page of nulls`() {
+        // `isLoading = false` with no item — a stale deep link, or a prophet the content
+        // artifact no longer ships. This screen re-establishes the shared shell's guard by
+        // hand, so it is worth asserting here separately.
+        composeRule.mainClock.autoAdvance = false
+        detailState.value = CatalogDetailState(isLoading = false, item = null)
+
+        setContent(prophetId = 999)
+
+        composeRule.onNodeWithText(string(R.string.prophets_story)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.prophets_timeline)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.prophet_detail)).assertExists()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaFixtures.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaFixtures.kt
@@ -1,0 +1,137 @@
+package com.arshadshah.nimaz.presentation.screens.qaida
+
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.LineType
+import com.arshadshah.nimaz.domain.model.MakhrajArea
+import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLesson
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.domain.model.QaidaLetter
+import com.arshadshah.nimaz.domain.model.QaidaLine
+import com.arshadshah.nimaz.domain.model.QaidaLineContent
+import com.arshadshah.nimaz.domain.model.TokenType
+
+/** The Qaida course, as the screens receive it. */
+internal fun qaidaLesson(
+    id: Int = 1,
+    titleEnglish: String = "The Arabic Letters",
+    lessonNumber: Int = id,
+) = QaidaLesson(
+    id = id,
+    lessonNumber = lessonNumber,
+    titleEnglish = titleEnglish,
+    titleArabic = "الحروف",
+    titleTransliteration = "Al-Huruf",
+    description = "Recognise each letter on its own",
+    conceptTags = listOf("letters"),
+    icon = "alif",
+    displayOrder = id,
+)
+
+internal fun qaidaLessonState(
+    id: Int = 1,
+    titleEnglish: String = "The Arabic Letters",
+    status: LessonStatus = LessonStatus.IN_PROGRESS,
+    stars: Int = 0,
+    completedCells: Int = 0,
+    totalCells: Int = 10,
+) = QaidaLessonState(
+    lesson = qaidaLesson(id = id, titleEnglish = titleEnglish),
+    status = status,
+    stars = stars,
+    completedCells = completedCells,
+    totalCells = totalCells,
+    completionFraction = if (totalCells == 0) 0f else completedCells.toFloat() / totalCells,
+    lastCellId = null,
+)
+
+internal fun qaidaCourse(
+    lessons: List<QaidaLessonState> = listOf(qaidaLessonState()),
+    completedLessons: Int = 0,
+    totalStars: Int = 0,
+    nextLessonId: Int? = lessons.firstOrNull()?.lesson?.id,
+) = QaidaCourseProgress(
+    lessons = lessons,
+    completedLessons = completedLessons,
+    totalLessons = lessons.size,
+    totalStars = totalStars,
+    maxStars = lessons.size * 3,
+    totalCellsHeard = lessons.sumOf { it.completedCells },
+    overallFraction = if (lessons.isEmpty()) 0f else completedLessons.toFloat() / lessons.size,
+    nextLessonId = nextLessonId,
+)
+
+internal fun qaidaCell(
+    id: Int = 1,
+    lineId: Int = 1,
+    lessonId: Int = 1,
+    position: Int = id,
+    textArabic: String = "ا",
+    transliteration: String = "a",
+) = QaidaCell(
+    id = id,
+    lineId = lineId,
+    lessonId = lessonId,
+    position = position,
+    textArabic = textArabic,
+    transliteration = transliteration,
+    tokenType = TokenType.LETTER,
+    audioKey = "cell_$id",
+    audioPath = "qaida/cell_$id.mp3",
+    highlightGroup = null,
+    letterId = null,
+    notes = null,
+)
+
+internal fun qaidaLessonContent(
+    lessonId: Int = 1,
+    titleEnglish: String = "The Arabic Letters",
+    cells: List<QaidaCell> = listOf(
+        qaidaCell(id = 1, lessonId = lessonId, textArabic = "ا", transliteration = "alif"),
+        qaidaCell(id = 2, lessonId = lessonId, textArabic = "ب", transliteration = "ba"),
+    ),
+    instructionEnglish: String? = "Tap each letter to hear it",
+) = QaidaLessonContent(
+    lesson = qaidaLesson(id = lessonId, titleEnglish = titleEnglish),
+    lines = listOf(
+        QaidaLineContent(
+            line = QaidaLine(
+                id = 1,
+                lessonId = lessonId,
+                lineNumber = 1,
+                lineType = LineType.EXAMPLE,
+                instructionEnglish = instructionEnglish,
+                instructionArabic = null,
+                displayOrder = 1,
+            ),
+            cells = cells,
+        ),
+    ),
+)
+
+internal fun qaidaLetter(
+    id: Int = 1,
+    letterArabic: String = "ا",
+    nameTransliteration: String = "Alif",
+    nameArabic: String = "ألف",
+    isConnecting: Boolean = false,
+    phoneticHint: String? = "Like the 'a' in father",
+) = QaidaLetter(
+    id = id,
+    letterArabic = letterArabic,
+    nameArabic = nameArabic,
+    nameTransliteration = nameTransliteration,
+    isolatedForm = letterArabic,
+    initialForm = if (isConnecting) letterArabic else null,
+    medialForm = if (isConnecting) letterArabic else null,
+    finalForm = letterArabic,
+    isConnecting = isConnecting,
+    makhrajArea = MakhrajArea.JAWF,
+    makhrajDetail = "From the empty space of the mouth",
+    phoneticHint = phoneticHint,
+    audioKey = "letter_$id",
+    audioPath = "qaida/letter_$id.mp3",
+    displayOrder = id,
+)

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaHomeScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaHomeScreenTest.kt
@@ -1,0 +1,230 @@
+package com.arshadshah.nimaz.presentation.screens.qaida
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Qaida course map — the screen a child lands on, and the one place the whole journey can
+ * be thrown away.
+ *
+ * **Every value in the header is null-guarded, because `courseProgress` is null for the whole
+ * first frame.** Six `?:` fallbacks in as many lines, and the lesson-index one is not a plain
+ * default: it is `(completed + 1).coerceAtMost(total)`, so a finished course reads "Lesson 12
+ * of 12" rather than "13 of 12". A missing guard here is a crash on launch, and a wrong
+ * `coerceAtMost` is a course that claims a lesson that does not exist.
+ *
+ * **"Continue" resolves a title from an id.** `nextLessonId` is an id; the label is the matching
+ * lesson's own title, looked up in the list. An id with no lesson behind it — a course whose
+ * content artifact changed under a stored pointer — has to leave the label absent rather than
+ * render an empty button.
+ *
+ * **Reset is destructive and confirmed.** The event fires from the dialog's confirm, never from
+ * the menu row, and nothing in the UI distinguishes the two until a child taps "Reset journey"
+ * out of curiosity and loses every star.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class QaidaHomeScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val courseProgress = MutableStateFlow<QaidaCourseProgress?>(null)
+    private val events = mutableListOf<QaidaReaderEvent>()
+
+    private val viewModel: QaidaReaderViewModel = mockk(relaxed = true) {
+        every { this@mockk.courseProgress } returns this@QaidaHomeScreenTest.courseProgress
+        every { onEvent(any()) } answers { events += firstArg<QaidaReaderEvent>() }
+    }
+
+    private val openedLessons = mutableListOf<Int>()
+    private var lettersOpened = 0
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            QaidaHomeScreen(
+                onNavigateBack = {},
+                onOpenLesson = { openedLessons += it },
+                onOpenLetters = { lettersOpened++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the map renders before any progress has arrived`() {
+        // Every header value is read through a `?:` for exactly this frame. One missing guard
+        // is a null dereference on the screen's first composition.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qaida_journey_title)).assertExists()
+    }
+
+    @Test
+    fun `the lessons are laid out along the trail, each announced with its own state`() {
+        // The medallions are drawn art, addressable only by their a11y description — which is
+        // also the better contract: the description carries the lesson number, its title *and*
+        // whether it is locked, and that phrase is all a screen-reader user gets.
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters"),
+                qaidaLessonState(2, "Fatha", status = LessonStatus.LOCKED),
+            ),
+            nextLessonId = 1,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithContentDescription(
+            string(R.string.qaida_a11y_lesson_current_format, 1, "The Arabic Letters")
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.qaida_a11y_lesson_locked_format, 2, "Fatha")
+        ).assertExists()
+    }
+
+    @Test
+    fun `tapping a lesson on the trail opens that lesson`() {
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters"),
+                qaidaLessonState(2, "Fatha"),
+            ),
+            nextLessonId = 1,
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.qaida_a11y_lesson_current_format, 2, "Fatha")
+        ).performClick()
+
+        assertThat(openedLessons).containsExactly(2)
+    }
+
+    @Test
+    fun `continue opens the lesson the course points at, not the first one`() {
+        // `nextLessonId` is the resume pointer; opening lesson 1 instead sends a child who is
+        // on lesson 5 back to the beginning.
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters", status = LessonStatus.COMPLETED),
+                qaidaLessonState(2, "Fatha"),
+                qaidaLessonState(3, "Kasra"),
+            ),
+            completedLessons = 1,
+            nextLessonId = 2,
+        )
+
+        setContent()
+        composeRule.onNodeWithText(string(R.string.qaida_continue_format, "Fatha")).performClick()
+
+        assertThat(openedLessons).containsExactly(2)
+    }
+
+    @Test
+    fun `a resume pointer with no lesson behind it leaves the header without a label`() {
+        // The lookup is `lessons.firstOrNull { it.lesson.id == nextLessonId }` — a stored
+        // pointer can outlive the content artifact that had that lesson.
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(qaidaLessonState(1, "The Arabic Letters")),
+            nextLessonId = 99,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qaida_journey_title)).assertExists()
+    }
+
+    @Test
+    fun `a finished course does not claim a lesson beyond the last`() {
+        // `(completed + 1).coerceAtMost(total)`. Without the coerce a child who finished the
+        // course is told they are on lesson 3 of 2.
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters", status = LessonStatus.COMPLETED, stars = 3),
+                qaidaLessonState(2, "Fatha", status = LessonStatus.COMPLETED, stars = 3),
+            ),
+            completedLessons = 2,
+            totalStars = 6,
+            nextLessonId = null,
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("3").assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.qaida_journey_title)).assertExists()
+    }
+
+    @Test
+    fun `the letter explorer is reachable from the top bar`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.qaida_letter_explorer))
+            .performClick()
+
+        assertThat(lettersOpened).isEqualTo(1)
+    }
+
+    @Test
+    fun `resetting the journey is confirmed before anything is thrown away`() {
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(qaidaLessonState(1, status = LessonStatus.COMPLETED, stars = 3)),
+            completedLessons = 1,
+            totalStars = 3,
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.more)).performClick()
+        composeRule.onNodeWithText(string(R.string.qaida_reset_journey)).performClick()
+
+        // The menu row opens the dialog and dispatches nothing.
+        assertThat(events).isEmpty()
+        composeRule.onNodeWithText(string(R.string.qaida_reset_title)).assertIsDisplayed()
+
+        composeRule.onNodeWithText(string(R.string.reset)).performClick()
+        assertThat(events).containsExactly(QaidaReaderEvent.ResetJourney)
+    }
+
+    @Test
+    fun `cancelling the reset leaves the journey alone`() {
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(qaidaLessonState(1, status = LessonStatus.COMPLETED, stars = 3)),
+            completedLessons = 1,
+            totalStars = 3,
+        )
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.more)).performClick()
+        composeRule.onNodeWithText(string(R.string.qaida_reset_journey)).performClick()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(events).isEmpty()
+        composeRule.onNodeWithText(string(R.string.qaida_reset_title)).assertDoesNotExist()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaLettersScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaLettersScreenTest.kt
@@ -1,0 +1,212 @@
+package com.arshadshah.nimaz.presentation.screens.qaida
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.MakhrajArea
+import com.arshadshah.nimaz.domain.model.QaidaLetter
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The letter explorer: a board of the twenty-nine letters, and a sheet per letter.
+ *
+ * The screen itself is small, and what it owns is **the selection**: `selected` is local state,
+ * the sheet exists only while it is non-null, and dismissing must clear it. A sheet that stays
+ * open after dismissal, or one whose play button fires the *previous* letter, is a state bug
+ * that no component test can see — `QaidaLetterBoard` and `QaidaLetterDetailSheet` are tested
+ * separately in `src/testDebug`, each in isolation from the other.
+ *
+ * **The play event carries the letter, not an id.** `PlayLetter(letter)` is what reaches the
+ * audio manager, so sending the wrong one plays a different sound with the right letter on
+ * screen — audible, and silent to every other test.
+ *
+ * With the clock pinned, a bottom sheet's slide-in never finishes, so its content is attached
+ * but parked below the viewport: these assert with `assertExists`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class QaidaLettersScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val letters = MutableStateFlow<List<QaidaLetter>>(emptyList())
+    private val events = mutableListOf<QaidaReaderEvent>()
+
+    private val viewModel: QaidaReaderViewModel = mockk(relaxed = true) {
+        every { this@mockk.letters } returns this@QaidaLettersScreenTest.letters
+        every { onEvent(any()) } answers { events += firstArg<QaidaReaderEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            QaidaLettersScreen(
+                onNavigateBack = { backs++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    private companion object {
+        /** Five distinct glyphs, so a tap addresses exactly one tile. */
+        val GLYPHS = listOf("ا", "ب", "ت", "ث", "ج")
+    }
+
+    @Test
+    fun `the board renders every letter the catalogue ships`() {
+        letters.value = listOf(
+            qaidaLetter(1, "ا", "Alif"),
+            qaidaLetter(2, "ب", "Ba", isConnecting = true),
+            qaidaLetter(3, "ت", "Ta", isConnecting = true),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("ا").assertIsDisplayed()
+        composeRule.onNodeWithText("ب").assertIsDisplayed()
+        composeRule.onNodeWithText("ت").assertIsDisplayed()
+    }
+
+    @Test
+    fun `an empty board renders rather than crashing`() {
+        // The letters flow starts empty on every launch, and the board is composed on that
+        // frame.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qaida_arabic_letters)).assertExists()
+    }
+
+    @Test
+    fun `tapping a letter opens that letter's sheet`() {
+        letters.value = listOf(
+            qaidaLetter(1, "ا", "Alif"),
+            qaidaLetter(2, "ب", "Ba", isConnecting = true),
+        )
+
+        setContent()
+        composeRule.onNodeWithText("ب").performClick()
+        composeRule.waitForIdle()
+
+        // The sheet names the letter — the board shows the glyph alone.
+        composeRule.onNodeWithText("Ba").assertExists()
+    }
+
+    @Test
+    fun `no sheet is open until a letter is chosen`() {
+        letters.value = listOf(qaidaLetter(1, "ا", "Alif"))
+
+        setContent()
+
+        composeRule.onNodeWithText("Alif").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the sheet shows the chosen letter's reference, not the previous one's`() {
+        // `selected` is the screen's own state and the sheet is rendered from it. A stale
+        // value shows one glyph's reference under another's, which nothing else can see:
+        // `QaidaLetterBoard` and `QaidaLetterDetailSheet` are each tested in isolation from
+        // the other in `src/testDebug`.
+        letters.value = listOf(
+            qaidaLetter(1, "ا", "Alif", phoneticHint = "Like the 'a' in father"),
+            qaidaLetter(2, "ب", "Ba", isConnecting = true, phoneticHint = "Like 'b' in boy"),
+        )
+
+        setContent()
+        composeRule.onNodeWithText("ب").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Ba").assertExists()
+        composeRule.onNodeWithText("Like 'b' in boy").assertExists()
+        composeRule.onNodeWithText("Like the 'a' in father").assertDoesNotExist()
+    }
+
+    @Test
+    fun `every articulation point has its own words and its own cue`() {
+        // `makhrajLabel` and `makhrajEmoji` are two `when`s over the same five-value enum, and
+        // the sheet is the only place either runs. A missing arm is not a compile error for
+        // the emoji one — it is `private` and exhaustive today — but a *duplicated* arm is
+        // invisible either way, and this line is the whole of what the sheet teaches: where in
+        // the mouth the letter is made.
+        val areas = listOf(
+            MakhrajArea.JAWF to R.string.makhraj_jawf,
+            MakhrajArea.HALQ to R.string.makhraj_halq,
+            MakhrajArea.LISAN to R.string.makhraj_lisan,
+            MakhrajArea.SHAFATAIN to R.string.makhraj_shafatain,
+            MakhrajArea.KHAYSHUM to R.string.makhraj_khayshum,
+        )
+        letters.value = areas.mapIndexed { index, (area, _) ->
+            qaidaLetter(
+                id = index + 1,
+                letterArabic = GLYPHS[index],
+                nameTransliteration = "Letter ${index + 1}",
+            ).copy(makhrajArea = area, makhrajDetail = "Detail ${index + 1}")
+        }
+
+        setContent()
+
+        areas.forEachIndexed { index, (_, labelRes) ->
+            composeRule.onNodeWithText(GLYPHS[index]).performClick()
+            composeRule.waitForIdle()
+
+            composeRule.onNodeWithText(
+                context.getString(R.string.qaida_made_with_format, string(labelRes))
+            ).assertExists()
+            composeRule.onNodeWithText("Detail ${index + 1}").assertExists()
+        }
+    }
+
+    @Test
+    fun `a letter the artifact records no articulation detail for shows only the area`() {
+        // `detail.isNotBlank()` guards the second line; without it the sheet renders an empty
+        // row under the heading, which reads as a missing translation.
+        letters.value = listOf(qaidaLetter(1, "ا", "Alif").copy(makhrajDetail = ""))
+
+        setContent()
+        composeRule.onNodeWithText("ا").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.qaida_made_with_format, string(R.string.makhraj_jawf))
+        ).assertExists()
+    }
+
+    @Test
+    fun `the play control is absent while the audio UI is switched off`() {
+        // `QAIDA_AUDIO_UI_ENABLED` is `false` while the recordings are being regenerated, and
+        // the sheet is text-only until it flips. A play button that renders anyway is a
+        // control that does nothing — and the flag flipping back is exactly when this
+        // assertion should be inverted rather than deleted.
+        letters.value = listOf(qaidaLetter(1, "ا", "Alif"))
+
+        setContent()
+        composeRule.onNodeWithText("ا").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(string(R.string.qaida_play_letter))
+            .assertDoesNotExist()
+        assertThat(events).isEmpty()
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaReaderScreenTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/qaida/QaidaReaderScreenTest.kt
@@ -1,0 +1,361 @@
+package com.arshadshah.nimaz.presentation.screens.qaida
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderEvent
+import com.arshadshah.nimaz.presentation.viewmodel.content.QaidaReaderViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The lesson reader — tappable cells, a transliteration toggle, the course-walk bar, and the
+ * celebration that must fire exactly once.
+ *
+ * **The celebration is the subtle part.** It must fire when a lesson is completed *during this
+ * visit*, and must not fire when a child re-opens a lesson they already finished — that visit
+ * is practice, and a confetti overlay in front of it is a screen they have to dismiss to read.
+ * The screen holds `openedComplete` for this: captured on the first non-null status and reset
+ * per lesson. Both halves are silent failures — one loses the reward, the other makes finished
+ * lessons unusable.
+ *
+ * **The navigation bar's three buttons are each conditional.** Previous is disabled at the
+ * start, Next is disabled at the end *and* on a locked lesson, and Continue appears only when
+ * the open lesson is not the one the course points at — which is precisely when browsing
+ * backwards has left somewhere to return to. The `LOCKED` guard is duplicated from the
+ * ViewModel deliberately, so a locked lesson reads as unavailable rather than as a button that
+ * does nothing.
+ *
+ * The bar renders nothing at all when the open lesson is not in the course list, which is the
+ * state every navigation starts in.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class QaidaReaderScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val lessonContent = MutableStateFlow<QaidaLessonContent?>(null)
+    private val playingCell = MutableStateFlow<com.arshadshah.nimaz.domain.model.QaidaCell?>(null)
+    private val lessonProgress = MutableStateFlow<QaidaLessonState?>(null)
+    private val courseProgress = MutableStateFlow<QaidaCourseProgress?>(null)
+    private val completedCellIds = MutableStateFlow<Set<Int>>(emptySet())
+    private val selectedLessonId = MutableStateFlow<Int?>(null)
+    private val events = mutableListOf<QaidaReaderEvent>()
+
+    private val viewModel: QaidaReaderViewModel = mockk(relaxed = true) {
+        every { this@mockk.lessonContent } returns this@QaidaReaderScreenTest.lessonContent
+        every { this@mockk.playingCell } returns this@QaidaReaderScreenTest.playingCell
+        every { this@mockk.lessonProgress } returns this@QaidaReaderScreenTest.lessonProgress
+        every { this@mockk.courseProgress } returns this@QaidaReaderScreenTest.courseProgress
+        every { this@mockk.completedCellIds } returns this@QaidaReaderScreenTest.completedCellIds
+        every { this@mockk.selectedLessonId } returns this@QaidaReaderScreenTest.selectedLessonId
+        every { onEvent(any()) } answers { events += firstArg<QaidaReaderEvent>() }
+    }
+
+    private var backs = 0
+
+    private fun setContent(lessonId: Int = 1) {
+        composeRule.setThemedContent {
+            QaidaReaderScreen(
+                lessonId = lessonId,
+                onNavigateBack = { backs++ },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun threeLessonCourse(open: Int, nextLessonId: Int? = 2) {
+        selectedLessonId.value = open
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters", status = LessonStatus.COMPLETED),
+                qaidaLessonState(2, "Fatha"),
+                qaidaLessonState(3, "Kasra", status = LessonStatus.LOCKED),
+            ),
+            completedLessons = 1,
+            nextLessonId = nextLessonId,
+        )
+    }
+
+    @Test
+    fun `opening the reader selects the lesson named in the route`() {
+        setContent(lessonId = 7)
+
+        assertThat(events).contains(QaidaReaderEvent.SelectLesson(7))
+    }
+
+    @Test
+    fun `the lesson's cells and its instruction are on the page`() {
+        lessonContent.value = qaidaLessonContent(
+            lessonId = 1,
+            titleEnglish = "The Arabic Letters",
+            cells = listOf(
+                qaidaCell(1, textArabic = "ا", transliteration = "alif"),
+                qaidaCell(2, textArabic = "ب", transliteration = "ba"),
+            ),
+            instructionEnglish = "Tap each letter to hear it",
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("The Arabic Letters").assertExists()
+        composeRule.onNodeWithText("ا").assertIsDisplayed()
+        composeRule.onNodeWithText("ب").assertIsDisplayed()
+        composeRule.onNodeWithText("Tap each letter to hear it").assertExists()
+    }
+
+    @Test
+    fun `the transliteration toggle removes the transliteration`() {
+        // A learner reading the Arabic wants the crutch gone; the toggle is the only way, and
+        // the two icon states are the only signal of which way it is set.
+        lessonContent.value = qaidaLessonContent(
+            cells = listOf(qaidaCell(1, textArabic = "ا", transliteration = "alif")),
+        )
+
+        setContent()
+        composeRule.onNodeWithText("alif").assertExists()
+
+        composeRule.onNodeWithContentDescription(string(R.string.qaida_toggle_transliteration))
+            .performClick()
+
+        composeRule.onNodeWithText("alif").assertDoesNotExist()
+        composeRule.onNodeWithText("ا").assertExists()
+    }
+
+    @Test
+    fun `a cell the artifact records no transliteration for shows only the Arabic`() {
+        // The tile's guard is `showTransliteration && transliteration.isNotBlank()`. With only
+        // the first half, a cell the content artifact carries no transliteration for renders an
+        // empty line under the glyph — which shifts every tile in the row and reads as a
+        // layout bug rather than as missing data.
+        lessonContent.value = qaidaLessonContent(
+            cells = listOf(
+                qaidaCell(1, textArabic = "ا", transliteration = "alif"),
+                qaidaCell(2, textArabic = "ب", transliteration = ""),
+            ),
+        )
+
+        setContent()
+
+        composeRule.onNodeWithText("ا").assertIsDisplayed()
+        composeRule.onNodeWithText("ب").assertIsDisplayed()
+        composeRule.onNodeWithText("alif").assertExists()
+    }
+
+    @Test
+    fun `tapping a cell asks for that cell`() {
+        val alif = qaidaCell(1, textArabic = "ا", transliteration = "alif")
+        val ba = qaidaCell(2, textArabic = "ب", transliteration = "ba")
+        lessonContent.value = qaidaLessonContent(cells = listOf(alif, ba))
+
+        setContent()
+        composeRule.onNodeWithText("ب").performClick()
+
+        assertThat(events).contains(QaidaReaderEvent.CellTapped(ba))
+        assertThat(events).doesNotContain(QaidaReaderEvent.CellTapped(alif))
+    }
+
+    @Test
+    fun `the bar shows nothing while the open lesson is not yet in the course`() {
+        // `indexOfFirst` returns -1 and the whole bar returns early — the state every
+        // navigation spends its first frames in.
+        lessonContent.value = qaidaLessonContent()
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qaida_previous_lesson)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.qaida_next_lesson)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the first lesson cannot go back`() {
+        lessonContent.value = qaidaLessonContent(lessonId = 1)
+        threeLessonCourse(open = 1)
+
+        setContent(lessonId = 1)
+
+        composeRule.onNodeWithText(string(R.string.qaida_previous_lesson)).assertIsNotEnabled()
+        composeRule.onNodeWithText(string(R.string.qaida_next_lesson)).assertIsEnabled()
+    }
+
+    @Test
+    fun `a locked next lesson is offered as unavailable rather than as a dead button`() {
+        // Lesson 3 is LOCKED, so from lesson 2 the forward button must be disabled — the
+        // ViewModel would refuse the move anyway, and a button that silently does nothing is
+        // worse than one that says it cannot.
+        lessonContent.value = qaidaLessonContent(lessonId = 2, titleEnglish = "Fatha")
+        threeLessonCourse(open = 2)
+
+        setContent(lessonId = 2)
+
+        composeRule.onNodeWithText(string(R.string.qaida_next_lesson)).assertIsNotEnabled()
+        composeRule.onNodeWithText(string(R.string.qaida_previous_lesson)).assertIsEnabled()
+    }
+
+    @Test
+    fun `walking the course dispatches the move`() {
+        lessonContent.value = qaidaLessonContent(lessonId = 2, titleEnglish = "Fatha")
+        threeLessonCourse(open = 2)
+
+        setContent(lessonId = 2)
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.qaida_previous_lesson)).performClick()
+
+        assertThat(events).containsExactly(QaidaReaderEvent.PreviousLesson)
+    }
+
+    @Test
+    fun `continue appears only once browsing has left somewhere to return to`() {
+        // Standing on the lesson the course points at, there is nothing to resume; step back
+        // to lesson 1 and there is.
+        lessonContent.value = qaidaLessonContent(lessonId = 2, titleEnglish = "Fatha")
+        threeLessonCourse(open = 2, nextLessonId = 2)
+
+        setContent(lessonId = 2)
+
+        composeRule.onNodeWithText(string(R.string.qaida_resume_lesson)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `browsing backwards offers the way back to where the learner was`() {
+        lessonContent.value = qaidaLessonContent(lessonId = 1)
+        threeLessonCourse(open = 1, nextLessonId = 2)
+
+        setContent(lessonId = 1)
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.qaida_resume_lesson)).performClick()
+
+        assertThat(events).containsExactly(QaidaReaderEvent.Resume)
+    }
+
+    @Test
+    fun `a finished course still offers a way back to the first lesson`() {
+        // `nextLessonId` is null once everything is complete, and the bar falls back to the
+        // first lesson rather than hiding the control — otherwise a learner who has finished
+        // and stepped back to lesson 1 is offered nothing at all, on a screen whose other two
+        // buttons are both disabled at the ends.
+        lessonContent.value = qaidaLessonContent(lessonId = 3, titleEnglish = "Kasra")
+        selectedLessonId.value = 3
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters", status = LessonStatus.COMPLETED),
+                qaidaLessonState(2, "Fatha", status = LessonStatus.COMPLETED),
+                qaidaLessonState(3, "Kasra", status = LessonStatus.COMPLETED),
+            ),
+            completedLessons = 3,
+            nextLessonId = null,
+        )
+
+        setContent(lessonId = 3)
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.qaida_resume_lesson)).performClick()
+
+        assertThat(events).containsExactly(QaidaReaderEvent.Resume)
+    }
+
+    @Test
+    fun `a finished course standing on lesson one offers no resume`() {
+        // The fallback resolves to lesson 1, which is where the learner already is —
+        // `resumeId != openLessonId` is what keeps the control from pointing at itself.
+        lessonContent.value = qaidaLessonContent(lessonId = 1)
+        selectedLessonId.value = 1
+        courseProgress.value = qaidaCourse(
+            lessons = listOf(
+                qaidaLessonState(1, "The Arabic Letters", status = LessonStatus.COMPLETED),
+                qaidaLessonState(2, "Fatha", status = LessonStatus.COMPLETED),
+            ),
+            completedLessons = 2,
+            nextLessonId = null,
+        )
+
+        setContent(lessonId = 1)
+
+        composeRule.onNodeWithText(string(R.string.qaida_resume_lesson)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `finishing a lesson during this visit celebrates it`() {
+        lessonContent.value = qaidaLessonContent(lessonId = 1, titleEnglish = "The Arabic Letters")
+        threeLessonCourse(open = 1)
+        lessonProgress.value = qaidaLessonState(1, status = LessonStatus.IN_PROGRESS)
+
+        setContent(lessonId = 1)
+
+        // The completion arrives while the reader is open — the only case that celebrates.
+        lessonProgress.value = qaidaLessonState(
+            1,
+            status = LessonStatus.COMPLETED,
+            stars = 3,
+            completedCells = 10,
+        )
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.qaida_mashaallah)).assertExists()
+    }
+
+    @Test
+    fun `re-opening a finished lesson to practise does not celebrate it again`() {
+        // `openedComplete` is captured from the first non-null status. Without it, every visit
+        // to a completed lesson opens behind an overlay the child has to dismiss.
+        lessonContent.value = qaidaLessonContent(lessonId = 1, titleEnglish = "The Arabic Letters")
+        threeLessonCourse(open = 1)
+        lessonProgress.value = qaidaLessonState(
+            1,
+            status = LessonStatus.COMPLETED,
+            stars = 3,
+            completedCells = 10,
+        )
+
+        setContent(lessonId = 1)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.qaida_mashaallah)).assertDoesNotExist()
+        composeRule.onNodeWithText("ا").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the bar carries a generic title until the lesson arrives`() {
+        threeLessonCourse(open = 1)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qaida_lesson)).assertExists()
+    }
+
+    @Test
+    fun `back is reachable from the reader`() {
+        lessonContent.value = qaidaLessonContent()
+
+        setContent()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogueSearchFieldsTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/CatalogueSearchFieldsTest.kt
@@ -1,0 +1,331 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.AsmaUlHusna
+import com.arshadshah.nimaz.domain.model.AsmaUnNabi
+import com.arshadshah.nimaz.domain.model.Prophet
+import com.arshadshah.nimaz.domain.usecase.AsmaUlHusnaUseCases
+import com.arshadshah.nimaz.domain.usecase.AsmaUnNabiUseCases
+import com.arshadshah.nimaz.domain.usecase.ProphetUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * **Which fields each catalogue's search looks at** — the one thing that genuinely differs
+ * between the three ViewModels.
+ *
+ * `CatalogViewModel` collapsed three byte-identical classes into one generic, and what stayed
+ * per-feature is a `CatalogSource`: where the rows come from, and `matches`. `CatalogViewModelTest`
+ * drives the generic with a synthetic source, so it proves the *machinery* and can say nothing
+ * about the three real ones — which are private classes in three files, and the only thing a
+ * reader ever experiences of them.
+ *
+ * The fields are not the same across the three, and the difference is deliberate: the Prophets
+ * search also covers the **title** ("Friend of Allah") and the **era**, because those are how
+ * someone looks for a prophet whose name they cannot spell. Dropping either arm is a search that
+ * quietly stops finding things — no crash, no empty state, just fewer results than there should
+ * be.
+ *
+ * All three are case-insensitive on the transliterated and English fields **and on the Arabic**,
+ * which costs nothing and means a query pasted from anywhere still matches.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CatalogueSearchFieldsTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    // ---- the ninety-nine names --------------------------------------------------------
+
+    private val rahman = AsmaUlHusna(
+        id = 1,
+        number = 1,
+        nameArabic = "الرحمن",
+        nameTransliteration = "Ar-Rahman",
+        nameEnglish = "The Most Compassionate",
+        meaning = "The One whose mercy encompasses all creation",
+        explanation = "…",
+        benefits = "…",
+        quranReferences = listOf("1:1"),
+        usageInDua = "…",
+        displayOrder = 1,
+    )
+    private val aziz = rahman.copy(
+        id = 2,
+        nameArabic = "العزيز",
+        nameTransliteration = "Al-Aziz",
+        nameEnglish = "The Almighty",
+        meaning = "The One who is invincible",
+    )
+
+    private fun allahViewModel(
+        useCases: AsmaUlHusnaUseCases = mockk(relaxed = true),
+    ): Pair<AsmaUlHusnaViewModel, AsmaUlHusnaUseCases> {
+        every { useCases.getAllNames() } returns MutableStateFlow(listOf(rahman, aziz))
+        every { useCases.getFavorites() } returns flowOf(emptyList())
+        return AsmaUlHusnaViewModel(useCases, RecordingTelemetry()) to useCases
+    }
+
+    @Test
+    fun `a divine name is found by its transliteration, its English and its meaning`() = runTest {
+        val (vm, _) = allahViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("rahman"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(rahman)
+
+        vm.onEvent(CatalogEvent.Search("almighty"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(aziz)
+
+        // The meaning is the arm most easily dropped, and the one a reader uses when they know
+        // what a name means and not what it is called.
+        vm.onEvent(CatalogEvent.Search("invincible"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(aziz)
+    }
+
+    @Test
+    fun `a divine name is found by its Arabic`() = runTest {
+        val (vm, _) = allahViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("الرحمن"))
+
+        assertThat(vm.listState.value.filteredItems).containsExactly(rahman)
+    }
+
+    @Test
+    fun `starring a divine name re-reads the open item, by its own id`() = runTest {
+        val useCases: AsmaUlHusnaUseCases = mockk(relaxed = true)
+        val (vm, _) = allahViewModel(useCases)
+        coEvery { useCases.getNameById(2) } returns aziz.copy(isFavorite = true)
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.LoadDetail(2))
+        advanceUntilIdle()
+        vm.onEvent(CatalogEvent.ToggleFavorite(2))
+        advanceUntilIdle()
+
+        coVerify { useCases.toggleFavorite(2) }
+        assertThat(vm.detailState.value.item?.isFavorite).isTrue()
+    }
+
+    @Test
+    fun `starring a name that is not the one open does not re-read anything`() = runTest {
+        // `idOf(open) == itemId` guards the re-read: starring from the *list* while a different
+        // detail is loaded must not replace what the detail screen is showing.
+        val useCases: AsmaUlHusnaUseCases = mockk(relaxed = true)
+        val (vm, _) = allahViewModel(useCases)
+        coEvery { useCases.getNameById(1) } returns rahman
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.LoadDetail(1))
+        advanceUntilIdle()
+        vm.onEvent(CatalogEvent.ToggleFavorite(2))
+        advanceUntilIdle()
+
+        coVerify { useCases.toggleFavorite(2) }
+        assertThat(vm.detailState.value.item).isEqualTo(rahman)
+    }
+
+    @Test
+    fun `the slower of two detail reads cannot land on the newer one's screen`() {
+        // `requestedItemId` is set synchronously and checked after the suspension point,
+        // because a coroutine cancelled after its last suspension still runs to the end of its
+        // block. Open one name, go back, open another quickly — the detail screen fires
+        // `LoadDetail` from a `LaunchedEffect(id)` and all three catalogue screens share one
+        // ViewModel per back-stack entry — and the first read resolving second would put the
+        // first name's text under the second name's route, with `isLoading = false` to say it
+        // was ready.
+        val useCases: AsmaUlHusnaUseCases = mockk(relaxed = true)
+        val (vm, _) = allahViewModel(useCases)
+        coEvery { useCases.getNameById(1) } coAnswers {
+            kotlinx.coroutines.delay(100)
+            rahman
+        }
+        coEvery { useCases.getNameById(2) } returns aziz
+
+        runTest {
+            advanceUntilIdle()
+            vm.onEvent(CatalogEvent.LoadDetail(1))
+            vm.onEvent(CatalogEvent.LoadDetail(2))
+            advanceUntilIdle()
+
+            assertThat(vm.detailState.value.item).isEqualTo(aziz)
+        }
+    }
+
+    // ---- the names of the Prophet ﷺ ---------------------------------------------------
+
+    private val mustafa = AsmaUnNabi(
+        id = 1,
+        number = 1,
+        nameArabic = "المصطفى",
+        nameTransliteration = "Al-Mustafa",
+        nameEnglish = "The Chosen One",
+        meaning = "Selected above all creation",
+        explanation = "…",
+        source = "Sahih Muslim 2278",
+        displayOrder = 1,
+    )
+    private val amin = mustafa.copy(
+        id = 2,
+        nameArabic = "الأمين",
+        nameTransliteration = "Al-Amin",
+        nameEnglish = "The Trustworthy",
+        meaning = "Known for honesty before prophethood",
+    )
+
+    @Test
+    fun `a name of the Prophet is found by transliteration, English, Arabic and meaning`() =
+        runTest {
+            val useCases: AsmaUnNabiUseCases = mockk(relaxed = true)
+            every { useCases.getAllNames() } returns MutableStateFlow(listOf(mustafa, amin))
+            every { useCases.getFavorites() } returns flowOf(emptyList())
+            val vm = AsmaUnNabiViewModel(useCases, RecordingTelemetry())
+            advanceUntilIdle()
+
+            vm.onEvent(CatalogEvent.Search("mustafa"))
+            assertThat(vm.listState.value.filteredItems).containsExactly(mustafa)
+
+            vm.onEvent(CatalogEvent.Search("trustworthy"))
+            assertThat(vm.listState.value.filteredItems).containsExactly(amin)
+
+            vm.onEvent(CatalogEvent.Search("الأمين"))
+            assertThat(vm.listState.value.filteredItems).containsExactly(amin)
+
+            vm.onEvent(CatalogEvent.Search("honesty"))
+            assertThat(vm.listState.value.filteredItems).containsExactly(amin)
+        }
+
+    // ---- the prophets -----------------------------------------------------------------
+
+    private val ibrahim = Prophet(
+        id = 1,
+        number = 1,
+        nameArabic = "إبراهيم",
+        nameEnglish = "Abraham",
+        nameTransliteration = "Ibrahim",
+        titleArabic = "خليل الله",
+        titleEnglish = "Friend of Allah",
+        storySummary = "…",
+        keyLessons = emptyList(),
+        quranMentions = emptyList(),
+        era = "circa 2000 BCE",
+        lineage = "Son of Azar",
+        yearsLived = "175 years",
+        placeOfPreaching = "Ur and Canaan",
+        miracles = emptyList(),
+        displayOrder = 1,
+    )
+    private val musa = ibrahim.copy(
+        id = 2,
+        nameArabic = "موسى",
+        nameEnglish = "Moses",
+        nameTransliteration = "Musa",
+        titleEnglish = "The One who spoke with Allah",
+        era = "circa 1300 BCE",
+    )
+
+    private fun prophetViewModel(): ProphetViewModel {
+        val useCases: ProphetUseCases = mockk(relaxed = true)
+        every { useCases.getAllProphets() } returns MutableStateFlow(listOf(ibrahim, musa))
+        every { useCases.getFavorites() } returns flowOf(emptyList())
+        return ProphetViewModel(useCases, RecordingTelemetry())
+    }
+
+    @Test
+    fun `a prophet is found by every spelling of the name`() = runTest {
+        val vm = prophetViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("abraham"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(ibrahim)
+
+        vm.onEvent(CatalogEvent.Search("ibrahim"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(ibrahim)
+
+        vm.onEvent(CatalogEvent.Search("إبراهيم"))
+        assertThat(vm.listState.value.filteredItems).containsExactly(ibrahim)
+    }
+
+    @Test
+    fun `a prophet is found by his title`() = runTest {
+        // The arm the other two catalogues do not have. Someone searching "Friend of Allah"
+        // knows the epithet and not the spelling.
+        val vm = prophetViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("friend of allah"))
+
+        assertThat(vm.listState.value.filteredItems).containsExactly(ibrahim)
+    }
+
+    @Test
+    fun `a prophet is found by his era`() = runTest {
+        // The other arm unique to this catalogue: "who was around in 1300 BCE" is a real
+        // question and the only field that answers it.
+        val vm = prophetViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("1300 BCE"))
+
+        assertThat(vm.listState.value.filteredItems).containsExactly(musa)
+    }
+
+    @Test
+    fun `a query matching nothing in any field leaves the list empty`() = runTest {
+        val vm = prophetViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("zzzz"))
+
+        assertThat(vm.listState.value.filteredItems).isEmpty()
+        assertThat(vm.listState.value.items).hasSize(2)
+    }
+
+    @Test
+    fun `clearing the query restores every prophet`() = runTest {
+        val vm = prophetViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(CatalogEvent.Search("abraham"))
+        assertThat(vm.listState.value.filteredItems).hasSize(1)
+
+        vm.onEvent(CatalogEvent.ClearSearch)
+
+        assertThat(vm.listState.value.filteredItems).hasSize(2)
+        assertThat(vm.listState.value.searchQuery).isEmpty()
+    }
+
+    @Test
+    fun `the favourites flow feeds its own field, not the filtered list`() = runTest {
+        val useCases: ProphetUseCases = mockk(relaxed = true)
+        every { useCases.getAllProphets() } returns MutableStateFlow(listOf(ibrahim, musa))
+        every { useCases.getFavorites() } returns MutableStateFlow(listOf(musa))
+        val vm = ProphetViewModel(useCases, RecordingTelemetry())
+        advanceUntilIdle()
+
+        assertThat(vm.listState.value.favorites).containsExactly(musa)
+        assertThat(vm.listState.value.filteredItems).hasSize(2)
+    }
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/DuaCollectionSortTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/DuaCollectionSortTest.kt
@@ -1,0 +1,397 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Dua
+import com.arshadshah.nimaz.domain.model.DuaCategory
+import com.arshadshah.nimaz.domain.model.DuaOccasion
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.DuaUseCases
+import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The dua collection's filter and sort, and the reader's paging window.
+ *
+ * **`filterAndSortCategories` is the one piece of list logic the dua feature owns**, and it is
+ * two decisions in one function: which categories survive the query, and what order the
+ * survivors come back in. Both are user-visible and neither is asserted anywhere else — the
+ * screen renders whatever `filteredCategories` holds.
+ *
+ * The search arm matches on three fields, one of which is nullable, and each is a separate `||`
+ * with its own case rule: the English name and the description are case-insensitive, the
+ * **Arabic name is not**, because case-folding Arabic is meaningless and `ignoreCase` on it
+ * would only add cost. A reader who types a category's description and gets nothing has no way
+ * to tell that from "there is no such category".
+ *
+ * The sort arm is the toggle `DuasCollectionScreen` exposes: curated `displayOrder` — the order
+ * a scholar chose — or A–Z by lowercased English name. Sorting alphabetically *without*
+ * lowercasing puts every capitalised name before every lowercase one, which reads as random.
+ *
+ * **The reader's window is the other decision here.** Opening a dua loads its whole category so
+ * the pager can page, and `indexOfFirst(...).coerceAtLeast(0)` is what keeps a dua whose
+ * category query does not contain it from opening at index -1.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DuaCollectionSortTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var duaUseCases: DuaUseCases
+    private lateinit var tasbihUseCases: TasbihUseCases
+    private lateinit var settings: SettingsRepository
+
+    private val categories = MutableStateFlow<List<DuaCategory>>(emptyList())
+    private val sortAlphabetical = MutableStateFlow(false)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        duaUseCases = mockk(relaxed = true)
+        tasbihUseCases = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+
+        every { duaUseCases.getAllCategories() } returns categories
+        every { duaUseCases.getFavoriteDuas() } returns flowOf(emptyList())
+        every { duaUseCases.getProgressForDate(any()) } returns flowOf(emptyList())
+        every { settings.duaCategoriesSortAlphabetical } returns sortAlphabetical
+        every { settings.duaArabicFont } returns flowOf("amiri")
+        every { settings.duaArabicFontSize } returns flowOf(28f)
+        every { settings.duaTranslationFontSize } returns flowOf(16f)
+        every { settings.duaShowArabic } returns flowOf(true)
+        every { settings.duaShowTransliteration } returns flowOf(true)
+        every { settings.duaShowTranslation } returns flowOf(true)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = DuaViewModel(
+        duaUseCases = duaUseCases,
+        tasbihUseCases = tasbihUseCases,
+        duaSettings = settings,
+        todayProvider = FakeTodayProvider(LocalDate.of(2026, 8, 25)),
+        telemetry = RecordingTelemetry(),
+    )
+
+    private fun category(
+        id: String,
+        nameEnglish: String,
+        nameArabic: String = "أذكار",
+        description: String? = null,
+        displayOrder: Int = 0,
+    ) = DuaCategory(
+        id = id,
+        nameArabic = nameArabic,
+        nameEnglish = nameEnglish,
+        description = description,
+        iconName = null,
+        displayOrder = displayOrder,
+        duaCount = 1,
+    )
+
+    @Test
+    fun `with no query the curated order is the shipped display order`() = runTest {
+        categories.value = listOf(
+            category("c", "Zuhr", displayOrder = 3),
+            category("a", "Morning", displayOrder = 1),
+            category("b", "Evening", displayOrder = 2),
+        )
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.collectionState.value.filteredCategories.map { it.nameEnglish })
+            .containsExactly("Morning", "Evening", "Zuhr").inOrder()
+    }
+
+    @Test
+    fun `alphabetical order is by lowercased English name, not by raw string`() = runTest {
+        // Sorting without lowercasing puts every capitalised name before every lowercase one,
+        // which reads as no order at all.
+        categories.value = listOf(
+            category("a", "apple adhkar", displayOrder = 1),
+            category("b", "Banana adhkar", displayOrder = 2),
+            category("c", "Cherry adhkar", displayOrder = 3),
+        )
+        sortAlphabetical.value = true
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.collectionState.value.filteredCategories.map { it.nameEnglish })
+            .containsExactly("apple adhkar", "Banana adhkar", "Cherry adhkar").inOrder()
+        assertThat(vm.collectionState.value.sortAlphabetical).isTrue()
+    }
+
+    @Test
+    fun `toggling the sort persists the state it is moving to, not the one it is in`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.ToggleCategoriesSort)
+        advanceUntilIdle()
+
+        val written = slot<Boolean>()
+        coVerify { settings.setDuaCategoriesSortAlphabetical(capture(written)) }
+        assertThat(written.captured).isTrue()
+    }
+
+    @Test
+    fun `toggling back off persists the curated order`() = runTest {
+        sortAlphabetical.value = true
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.ToggleCategoriesSort)
+        advanceUntilIdle()
+
+        val written = slot<Boolean>()
+        coVerify { settings.setDuaCategoriesSortAlphabetical(capture(written)) }
+        assertThat(written.captured).isFalse()
+    }
+
+    @Test
+    fun `the filtered view is the whole catalogue, because no query can currently reach it`() =
+        runTest {
+            // **`filterAndSortCategories`'s search arm is unreachable today, and that is worth
+            // recording rather than dressing up.** `DuaCollectionUiState.searchQuery` is only
+            // ever written as `""` — by `ClearSearch` and by the collection collector — and no
+            // event sets it to anything else: `DuasCollectionScreen`'s search action navigates
+            // to `Route.DuaSearch`, which is `:feature:search`'s screen against a different
+            // ViewModel. So the three `||` arms over name, Arabic name and description are
+            // dead until something wires a query in, and no test here can take them without
+            // reaching past the public surface to pretend otherwise.
+            //
+            // What *is* live is the pass-through: every category survives, in sorted order.
+            categories.value = listOf(
+                category("a", "Morning Adhkar", displayOrder = 1),
+                category("b", "Evening Adhkar", displayOrder = 2),
+            )
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(DuaEvent.LoadAllCategories)
+            advanceUntilIdle()
+
+            assertThat(vm.collectionState.value.filteredCategories).hasSize(2)
+            assertThat(vm.collectionState.value.searchQuery).isEmpty()
+        }
+
+    @Test
+    fun `the categories and the filtered view stay the same list while no query is set`() =
+        runTest {
+            // The screen renders `filteredCategories` and nothing else, so the two falling out
+            // of step is invisible in the state and total in the UI.
+            categories.value = listOf(category("a", "Morning Adhkar", displayOrder = 1))
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            assertThat(vm.collectionState.value.filteredCategories)
+                .isEqualTo(vm.collectionState.value.categories)
+        }
+
+    @Test
+    fun `opening a dua loads its whole category so the pager has somewhere to go`() = runTest {
+        val target = dua("d2", "morning")
+        coEvery { duaUseCases.getDuaById("d2") } returns target
+        every { duaUseCases.getDuasByCategory("morning") } returns flowOf(
+            listOf(dua("d1", "morning"), target, dua("d3", "morning"))
+        )
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadDua("d2"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.duas.map { it.id })
+            .containsExactly("d1", "d2", "d3").inOrder()
+        assertThat(vm.readerState.value.initialIndex).isEqualTo(1)
+        assertThat(vm.readerState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `a dua whose category comes back empty still opens, alone`() = runTest {
+        // `categoryDuas.ifEmpty { listOf(dua) }`. Without it the reader resolves a real dua and
+        // then shows "not found", because the screen keys that message off an empty list.
+        val orphan = dua("lonely", "retired-category")
+        coEvery { duaUseCases.getDuaById("lonely") } returns orphan
+        every { duaUseCases.getDuasByCategory("retired-category") } returns flowOf(emptyList())
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadDua("lonely"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.duas.map { it.id }).containsExactly("lonely")
+        assertThat(vm.readerState.value.initialIndex).isEqualTo(0)
+        assertThat(vm.readerState.value.error).isNull()
+    }
+
+    @Test
+    fun `a dua missing from its own category list opens at the top, not at index -1`() = runTest {
+        // `indexOfFirst(...).coerceAtLeast(0)`. A -1 initial page is a crash in the pager.
+        val target = dua("d2", "morning")
+        coEvery { duaUseCases.getDuaById("d2") } returns target
+        every { duaUseCases.getDuasByCategory("morning") } returns flowOf(
+            listOf(dua("d1", "morning"), dua("d3", "morning"))
+        )
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadDua("d2"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.initialIndex).isEqualTo(0)
+    }
+
+    @Test
+    fun `a dua id that resolves to nothing clears the pages as well as saying so`() = runTest {
+        // Leaving the previous dua's pages loaded meant a reader who asked for a dua that does
+        // not exist kept paging through the one before it while the state said "not found".
+        coEvery { duaUseCases.getDuaById("present") } returns dua("present", "morning")
+        every { duaUseCases.getDuasByCategory("morning") } returns
+            flowOf(listOf(dua("present", "morning")))
+        coEvery { duaUseCases.getDuaById("ghost") } returns null
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadDua("present"))
+        advanceUntilIdle()
+        assertThat(vm.readerState.value.duas).isNotEmpty()
+
+        vm.onEvent(DuaEvent.LoadDua("ghost"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.duas).isEmpty()
+        assertThat(vm.readerState.value.error).isNotNull()
+    }
+
+    @Test
+    fun `the three reader toggles each flip only themselves`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.ToggleArabic)
+        assertThat(vm.readerState.value.showArabic).isFalse()
+        assertThat(vm.readerState.value.showTransliteration).isTrue()
+        assertThat(vm.readerState.value.showTranslation).isTrue()
+
+        vm.onEvent(DuaEvent.ToggleTransliteration)
+        assertThat(vm.readerState.value.showTransliteration).isFalse()
+        assertThat(vm.readerState.value.showTranslation).isTrue()
+
+        vm.onEvent(DuaEvent.ToggleTranslation)
+        assertThat(vm.readerState.value.showTranslation).isFalse()
+        assertThat(vm.readerState.value.showArabic).isFalse()
+    }
+
+    @Test
+    fun `the font-size events set the sizes they name`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.SetFontSize(22f))
+        vm.onEvent(DuaEvent.SetArabicFontSize(40f))
+
+        assertThat(vm.readerState.value.fontSize).isEqualTo(22f)
+        assertThat(vm.readerState.value.arabicFontSize).isEqualTo(40f)
+    }
+
+    @Test
+    fun `an occasion list replaces a category list on the surface they share`() = runTest {
+        every { duaUseCases.getDuasByCategory("morning") } returns
+            flowOf(listOf(dua("m1", "morning")))
+        coEvery { duaUseCases.getCategoryById("morning") } returns
+            category("morning", "Morning Adhkar")
+        every { duaUseCases.getDuasByOccasion(DuaOccasion.TRAVELING) } returns
+            flowOf(listOf(dua("t1", "travel")))
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadCategory("morning"))
+        advanceUntilIdle()
+        assertThat(vm.categoryState.value.duas.map { it.id }).containsExactly("m1")
+
+        vm.onEvent(DuaEvent.LoadDuasByOccasion(DuaOccasion.TRAVELING))
+        advanceUntilIdle()
+
+        assertThat(vm.categoryState.value.duas.map { it.id }).containsExactly("t1")
+        assertThat(vm.categoryState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `reloading the favourites and the categories is idempotent`() = runTest {
+        // Both events exist so a screen can ask again on resume — `DuasCollectionScreen`
+        // dispatches `LoadFavorites` from a `LaunchedEffect`. Asking twice must not leave two
+        // collectors on the same Room flow writing the same state.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadFavorites)
+        vm.onEvent(DuaEvent.LoadAllCategories)
+        advanceUntilIdle()
+
+        assertThat(vm.favoritesState.value.isLoading).isFalse()
+        assertThat(vm.collectionState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `clearing the search resets both the results and the category query`() = runTest {
+        // One event, two surfaces: the search results and the collection's own filter. Leaving
+        // the second set filters a list whose search box is visibly empty.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.ClearSearch)
+        advanceUntilIdle()
+
+        assertThat(vm.searchState.value.query).isEmpty()
+        assertThat(vm.searchState.value.results).isEmpty()
+        assertThat(vm.collectionState.value.searchQuery).isEmpty()
+    }
+
+    @Test
+    fun `progress is loaded for the date asked for`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DuaEvent.LoadProgressForDate(1_700_000_000_000L))
+        advanceUntilIdle()
+
+        assertThat(vm.dailyProgressState.value.date).isEqualTo(1_700_000_000_000L)
+        assertThat(vm.dailyProgressState.value.isLoading).isFalse()
+    }
+
+    private fun dua(id: String, categoryId: String) = Dua(
+        id = id,
+        categoryId = categoryId,
+        titleArabic = "دعاء",
+        titleEnglish = "Dua $id",
+        textArabic = "نص",
+        textTransliteration = null,
+        textEnglish = "Translation",
+        reference = null,
+        occasion = null,
+        benefits = null,
+        repeatCount = null,
+        audioUrl = null,
+        displayOrder = 1,
+    )
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/HadithReaderAnchorTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/HadithReaderAnchorTest.kt
@@ -1,0 +1,361 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Hadith
+import com.arshadshah.nimaz.domain.model.HadithBook
+import com.arshadshah.nimaz.domain.model.HadithChapter
+import com.arshadshah.nimaz.domain.model.HadithGrade
+import com.arshadshah.nimaz.domain.repository.settings.HadithDisplaySettings
+import com.arshadshah.nimaz.domain.usecase.HadithUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The hadith reader's **anchor** — the one piece of state that survives a content refresh.
+ *
+ * `getHadithsByChapter` is a Room flow: any write touching the hadiths table re-emits, and so
+ * does a whole content-database swap by `ContentArtifactInstaller`. The loader used to set
+ * `currentHadithIndex = 0` inside that collector, on *every* emission — so a background content
+ * refresh scrolled a reader at hadith 50 back to hadith 1, silently, mid-read.
+ *
+ * The anchor is held **by id rather than by index** so it survives a refresh that inserts or
+ * reorders rows, which an index would not. That is the difference this file exists to hold: an
+ * index-based anchor passes the "a refresh does not reset the reader" test and still moves the
+ * reader when the content changes underneath it.
+ *
+ * The rest is `retryFailedLoads`, which re-runs **only** the surfaces that are actually failing.
+ * A retry tapped in the reader must not also re-fetch the book list behind it, and there is
+ * nothing on screen to say whether it did.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HadithReaderAnchorTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var useCases: HadithUseCases
+    private lateinit var settings: HadithDisplaySettings
+
+    private val chapterHadiths = MutableStateFlow<List<Hadith>>(emptyList())
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        useCases = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+
+        every { settings.hadithArabicFont } returns flowOf("amiri")
+        every { settings.hadithArabicFontSize } returns flowOf(24f)
+        every { settings.hadithTranslationFontSize } returns flowOf(16f)
+        every { settings.hadithShowArabic } returns flowOf(true)
+        every { settings.hadithShowTranslation } returns flowOf(true)
+        every { settings.hadithShowGrade } returns flowOf(true)
+        every { settings.hadithShowChain } returns flowOf(true)
+
+        every { useCases.getAllBooks() } returns flowOf(emptyList())
+        every { useCases.getAllBookmarks() } returns flowOf(emptyList())
+        every { useCases.getHadithsByChapter(any()) } returns chapterHadiths
+        coEvery { useCases.getChapterById(any()) } returns chapter()
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = HadithViewModel(useCases, settings, RecordingTelemetry())
+
+    @Test
+    fun `a chapter opens at the top`() = runTest {
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(0)
+        assertThat(vm.readerState.value.hadiths).hasSize(5)
+    }
+
+    @Test
+    fun `a content refresh does not scroll the reader back to the first hadith`() = runTest {
+        // The defect this exists for: a background content swap re-emits the chapter, and the
+        // reader was at hadith 4.
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.NavigateToHadith(3))
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun `the anchor follows the hadith, not the position it was at`() = runTest {
+        // The reason the anchor is an id. A refresh that inserts a hadith above the reader
+        // shifts every index by one; an index-based anchor would leave them on the hadith
+        // before the one they were reading, which looks like a scroll glitch.
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.NavigateToHadith(3))
+
+        // A newly published hadith arrives at the top of the chapter.
+        chapterHadiths.value = listOf(hadith("h0", 0)) + (1..5).map { hadith("h$it", it) }
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(4)
+        assertThat(vm.readerState.value.hadiths[4].id).isEqualTo("h4")
+    }
+
+    @Test
+    fun `a refresh that removes the anchored hadith falls back to the top`() = runTest {
+        // `takeIf { it >= 0 } ?: 0`. Without it the reader indexes at -1.
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.NavigateToHadith(3))
+
+        chapterHadiths.value = listOf(hadith("h1", 1), hadith("h2", 2))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(0)
+    }
+
+    @Test
+    fun `opening a hadith by id lands on that hadith within its chapter`() = runTest {
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        coEvery { useCases.getHadithById("h3") } returns hadith("h3", 3)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.LoadHadithById("h3"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(2)
+    }
+
+    @Test
+    fun `a hadith id that is not in the collection is an answer, not a failure`() = runTest {
+        // Nothing went wrong, so nothing is reported — but the reader is told, in their own
+        // language rather than as the English literal this used to set.
+        coEvery { useCases.getHadithById("ghost") } returns null
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.LoadHadithById("ghost"))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.error).isNotNull()
+        assertThat(vm.readerState.value.isLoading).isFalse()
+        assertThat(vm.readerState.value.hadiths).isEmpty()
+    }
+
+    @Test
+    fun `opening a hadith by number resolves its chapter through the composite key`() = runTest {
+        // `getChapterById` is keyed on `bookId_chapterId`; passing the raw chapter id resolved
+        // the header to null for every hadith opened from a bookmark.
+        val target = hadith("m9", 9, bookId = "muslim", chapterId = "3")
+        chapterHadiths.value = listOf(hadith("m8", 8, bookId = "muslim", chapterId = "3"), target)
+        coEvery { useCases.getHadithByNumber("muslim", 2564) } returns target
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.LoadHadithByNumber("muslim", 2564))
+        advanceUntilIdle()
+
+        coVerify { useCases.getChapterById("muslim_3") }
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(1)
+    }
+
+    @Test
+    fun `browsing a grade clears the chapter it came from`() = runTest {
+        // Swapping the list while leaving `chapter` set rendered a foreign chapter header over
+        // the results, and `currentHadithIndex` still pointed into the old list.
+        chapterHadiths.value = (1..5).map { hadith("h$it", it) }
+        every { useCases.getHadithsByGrade(HadithGrade.SAHIH) } returns
+            flowOf(listOf(hadith("s1", 1), hadith("s2", 2)))
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.NavigateToHadith(4))
+
+        vm.onEvent(HadithEvent.FilterByGrade(HadithGrade.SAHIH))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.chapter).isNull()
+        assertThat(vm.readerState.value.currentHadithIndex).isEqualTo(0)
+        assertThat(vm.readerState.value.hadiths.map { it.id }).containsExactly("s1", "s2")
+    }
+
+    @Test
+    fun `retry re-runs only the surface that is failing`() = runTest {
+        // A retry tapped in the reader must not also re-fetch the book list behind it, and
+        // nothing on screen would say whether it did.
+        every { useCases.getHadithsByChapter("bukhari_9") } returns flow { throw IllegalStateException("disk") }
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_9"))
+        advanceUntilIdle()
+        assertThat(vm.readerState.value.error).isNotNull()
+
+        vm.onEvent(HadithEvent.Retry)
+        advanceUntilIdle()
+
+        // The book list never failed, so it is never re-fetched: once at init and no more.
+        verifyBooksLoadedOnce()
+    }
+
+    @Test
+    fun `retry does nothing at all when nothing is failing`() = runTest {
+        chapterHadiths.value = listOf(hadith("h1", 1))
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.Retry)
+        advanceUntilIdle()
+
+        verifyBooksLoadedOnce()
+        assertThat(vm.readerState.value.error).isNull()
+    }
+
+    @Test
+    fun `a failing book list is what a retry re-issues`() = runTest {
+        every { useCases.getAllBooks() } returns flow { throw IllegalStateException("no table") }
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertThat(vm.collectionState.value.error).isNotNull()
+
+        vm.onEvent(HadithEvent.Retry)
+        advanceUntilIdle()
+
+        io.mockk.verify(exactly = 2) { useCases.getAllBooks() }
+    }
+
+    @Test
+    fun `the font-size and Arabic events change only what they name`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.SetFontSize(20f))
+        vm.onEvent(HadithEvent.SetArabicFontSize(34f))
+        vm.onEvent(HadithEvent.ToggleArabic)
+
+        assertThat(vm.readerState.value.fontSize).isEqualTo(20f)
+        assertThat(vm.readerState.value.arabicFontSize).isEqualTo(34f)
+        assertThat(vm.readerState.value.showArabic).isFalse()
+        assertThat(vm.readerState.value.showTranslation).isTrue()
+    }
+
+    @Test
+    fun `clearing the search clears the chapter filter with it`() = runTest {
+        // Two surfaces, one event: the search results and the chapter list's own query box.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.ClearSearch)
+
+        assertThat(vm.searchState.value.query).isEmpty()
+        assertThat(vm.chaptersState.value.searchQuery).isEmpty()
+    }
+
+    @Test
+    fun `bookmarking is a write and never replaces what is on screen`() = runTest {
+        // Best-effort: blanking a perfectly readable hadith to report a failed star would be
+        // the worse outcome.
+        coEvery { useCases.toggleBookmark(any(), any(), any()) } throws IllegalStateException("db")
+        chapterHadiths.value = listOf(hadith("h1", 1))
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(HadithEvent.LoadChapter("bukhari_1"))
+        advanceUntilIdle()
+
+        vm.onEvent(HadithEvent.ToggleBookmark("h1", "bukhari", 1))
+        advanceUntilIdle()
+
+        assertThat(vm.readerState.value.hadiths).hasSize(1)
+        assertThat(vm.readerState.value.error).isNull()
+    }
+
+    @Test
+    fun `the book list feeds the collection surface`() = runTest {
+        every { useCases.getAllBooks() } returns flowOf(listOf(book()))
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.collectionState.value.books).hasSize(1)
+        assertThat(vm.collectionState.value.isLoading).isFalse()
+    }
+
+    private fun verifyBooksLoadedOnce() {
+        io.mockk.verify(exactly = 1) { useCases.getAllBooks() }
+    }
+
+    private fun book() = HadithBook(
+        id = "bukhari",
+        nameArabic = "صحيح البخاري",
+        nameEnglish = "Sahih al-Bukhari",
+        authorName = "Imam al-Bukhari",
+        authorArabic = "البخاري",
+        totalHadiths = 7563,
+        totalChapters = 97,
+        description = null,
+        displayOrder = 1,
+    )
+
+    private fun chapter() = HadithChapter(
+        id = "bukhari_1",
+        bookId = "bukhari",
+        chapterNumber = 1,
+        nameArabic = "بدء الوحي",
+        nameEnglish = "Revelation",
+        hadithCount = 7,
+        hadithStartNumber = 1,
+        hadithEndNumber = 7,
+    )
+
+    private fun hadith(
+        id: String,
+        number: Int,
+        bookId: String = "bukhari",
+        chapterId: String = "1",
+    ) = Hadith(
+        id = id,
+        bookId = bookId,
+        chapterId = chapterId,
+        hadithNumber = number,
+        hadithNumberInBook = number,
+        textArabic = "نص",
+        textEnglish = "Text $number",
+        narratorChain = null,
+        narratorName = null,
+        grade = HadithGrade.SAHIH,
+        gradeArabic = null,
+        reference = null,
+    )
+}

--- a/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaCourseWalkTest.kt
+++ b/feature/content/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/content/QaidaCourseWalkTest.kt
@@ -1,0 +1,605 @@
+package com.arshadshah.nimaz.presentation.viewmodel.content
+
+import app.cash.turbine.test
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.data.audio.QaidaAudioManager
+import com.arshadshah.nimaz.data.audio.QaidaAudioState
+import com.arshadshah.nimaz.domain.model.LessonStatus
+import com.arshadshah.nimaz.domain.model.LineType
+import com.arshadshah.nimaz.domain.model.QaidaCell
+import com.arshadshah.nimaz.domain.model.QaidaCourseProgress
+import com.arshadshah.nimaz.domain.model.QaidaLesson
+import com.arshadshah.nimaz.domain.model.QaidaLessonContent
+import com.arshadshah.nimaz.domain.model.QaidaLessonState
+import com.arshadshah.nimaz.domain.model.QaidaLetter
+import com.arshadshah.nimaz.domain.model.QaidaLine
+import com.arshadshah.nimaz.domain.model.QaidaLineContent
+import com.arshadshah.nimaz.domain.model.MakhrajArea
+import com.arshadshah.nimaz.domain.model.TokenType
+import com.arshadshah.nimaz.domain.usecase.GetCourseProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.GetLessonProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaCellUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonContentUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLessonsUseCase
+import com.arshadshah.nimaz.domain.usecase.GetQaidaLettersUseCase
+import com.arshadshah.nimaz.domain.usecase.MarkCellHeardUseCase
+import com.arshadshah.nimaz.domain.usecase.ObserveCompletedCellsUseCase
+import com.arshadshah.nimaz.domain.usecase.QaidaUseCases
+import com.arshadshah.nimaz.domain.usecase.ResetQaidaProgressUseCase
+import com.arshadshah.nimaz.domain.usecase.UnlockNextLessonUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Walking the Qaida course: next, previous, resume — and the guards on each.
+ *
+ * These three are how a learner moves between lessons from *inside* one, and every one of them
+ * is a sequence of early returns over a list that may not be loaded, may not contain the open
+ * lesson, and may end where the learner is standing. `QaidaReaderScreenTest` pins that the
+ * buttons appear and are enabled correctly; what it cannot see is what happens when a button
+ * that *should* be disabled is pressed anyway — which is the state the screen is in for the
+ * frames before `courseProgress` arrives.
+ *
+ * **The `LOCKED` guard on "next" is the one that matters.** It is duplicated between the screen
+ * and here on purpose: the screen's copy is cosmetic (a greyed button), and this one is the
+ * gate. `QaidaProgressRules` decides what unlocks; a next-lesson move that ignored the status
+ * would walk straight past it, and the whole progression is built on that gate holding.
+ *
+ * **Selecting the lesson already open is a no-op**, and that matters because `selectLesson`
+ * stops audio: without the guard, a `LaunchedEffect` re-firing on recomposition would cut off
+ * the clip the learner is listening to.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QaidaCourseWalkTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var getLessonContent: GetQaidaLessonContentUseCase
+    private lateinit var getLetters: GetQaidaLettersUseCase
+    private lateinit var getLessonProgress: GetLessonProgressUseCase
+    private lateinit var getCourseProgress: GetCourseProgressUseCase
+    private lateinit var useCases: QaidaUseCases
+    private lateinit var audioManager: QaidaAudioManager
+
+    private val course = MutableStateFlow(emptyCourse)
+    private val letters = MutableStateFlow<List<QaidaLetter>>(emptyList())
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        getLessonContent = mockk()
+        getLetters = mockk()
+        getLessonProgress = mockk()
+        getCourseProgress = mockk()
+
+        useCases = QaidaUseCases(
+            getLessons = mockk<GetQaidaLessonsUseCase>(relaxed = true),
+            getLessonContent = getLessonContent,
+            getLetters = getLetters,
+            getCell = mockk<GetQaidaCellUseCase>(relaxed = true),
+            markCellHeard = mockk<MarkCellHeardUseCase>(relaxed = true),
+            unlockNextLesson = mockk<UnlockNextLessonUseCase>(relaxed = true),
+            getLessonProgress = getLessonProgress,
+            getCourseProgress = getCourseProgress,
+            resetProgress = mockk<ResetQaidaProgressUseCase>(relaxed = true),
+            observeCompletedCells = mockk<ObserveCompletedCellsUseCase>(relaxed = true),
+        )
+
+        audioManager = mockk(relaxed = true)
+        every { audioManager.state } returns MutableStateFlow(QaidaAudioState())
+        every { audioManager.completions } returns MutableSharedFlow(extraBufferCapacity = 32)
+
+        every { getLetters.invoke() } returns letters
+        every { getCourseProgress.invoke() } returns course
+        every { getLessonProgress.invoke(any()) } returns flowOf(null)
+        every { getLessonContent.invoke(any()) } answers { flowOf(lessonContent(firstArg())) }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = QaidaReaderViewModel(useCases, audioManager, RecordingTelemetry())
+
+    /**
+     * The ViewModel with `courseProgress` actually subscribed.
+     *
+     * `courseProgress` is `stateIn(..., WhileSubscribed)`, so its `.value` is **null** until
+     * something collects it — and `nextLesson`, `previousLesson` and `resume` all read that
+     * `.value` and return early on null. On a device the reader screen is the subscriber; in a
+     * test, nothing is, so a walk asserted without this passes for the wrong reason: the move
+     * is refused rather than performed. This is exactly the "course has not loaded yet" state
+     * the guards exist for, which is why it is worth a named helper rather than a stray
+     * `collect`.
+     */
+    private fun TestScope.subscribedViewModel(): QaidaReaderViewModel {
+        val vm = viewModel()
+        backgroundScope.launch { vm.courseProgress.collect {} }
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun threeLessons(
+        thirdStatus: LessonStatus = LessonStatus.UNLOCKED,
+        nextLessonId: Int? = 2,
+    ) = QaidaCourseProgress(
+        lessons = listOf(
+            lessonState(1, LessonStatus.COMPLETED),
+            lessonState(2, LessonStatus.IN_PROGRESS),
+            lessonState(3, thirdStatus),
+        ),
+        completedLessons = 1,
+        totalLessons = 3,
+        totalStars = 3,
+        maxStars = 9,
+        totalCellsHeard = 2,
+        overallFraction = 0.33f,
+        nextLessonId = nextLessonId,
+    )
+
+    // ---- next -------------------------------------------------------------------------
+
+    @Test
+    fun `next moves to the following lesson when it is unlocked`() = runTest {
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(3)
+    }
+
+    @Test
+    fun `next refuses to walk past a locked lesson`() = runTest {
+        // The gate the whole progression rests on. The screen greys the button; this is what
+        // stops the move when it is pressed regardless.
+        course.value = threeLessons(thirdStatus = LessonStatus.LOCKED)
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    @Test
+    fun `next does nothing on the last lesson`() = runTest {
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(3))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(3)
+    }
+
+    @Test
+    fun `next does nothing when the open lesson is not in the course`() = runTest {
+        // `indexOfFirst` returns -1 — a content artifact that dropped the lesson a stored
+        // pointer names, or a deep link to a lesson that no longer ships.
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(99))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(99)
+    }
+
+    @Test
+    fun `next does nothing on a course with no lessons at all`() = runTest {
+        // An install whose content artifact has not landed yet: the rollup exists and is empty.
+        val vm = viewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    // ---- previous ---------------------------------------------------------------------
+
+    @Test
+    fun `previous moves back one lesson`() = runTest {
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PreviousLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(1)
+    }
+
+    @Test
+    fun `previous does nothing on the first lesson`() = runTest {
+        // `index <= 0` covers both "at the start" and "not in the list at all".
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PreviousLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(1)
+    }
+
+    @Test
+    fun `previous ignores a lesson that is not in the course`() = runTest {
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(99))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PreviousLesson)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(99)
+    }
+
+    // ---- resume -----------------------------------------------------------------------
+
+    @Test
+    fun `resume opens the lesson the course points at`() = runTest {
+        course.value = threeLessons(nextLessonId = 2)
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.Resume)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    @Test
+    fun `resume falls back to the first lesson once the course is finished`() = runTest {
+        // `nextLessonId` is null when everything is complete — without the fallback, "continue"
+        // does nothing at all for a learner who has finished, which reads as a broken button.
+        course.value = threeLessons(nextLessonId = null)
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(3))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.Resume)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(1)
+    }
+
+    @Test
+    fun `resume does nothing on a course with no lessons at all`() = runTest {
+        val vm = viewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.Resume)
+        advanceUntilIdle()
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    // ---- selecting --------------------------------------------------------------------
+
+    @Test
+    fun `re-selecting the open lesson does not cut off the clip playing`() = runTest {
+        // `selectLesson` stops audio, and a `LaunchedEffect(lessonId)` re-fires on every
+        // recomposition of the reader. Without the guard, a recomposition silences playback.
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { audioManager.stop() }
+    }
+
+    @Test
+    fun `changing lesson stops whatever the previous one was playing`() = runTest {
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        advanceUntilIdle()
+
+        verify(exactly = 2) { audioManager.stop() }
+    }
+
+    // ---- before the course is subscribed ----------------------------------------------
+
+    @Test
+    fun `a walk asked for before anything reads the course is refused, not guessed`() {
+        // `courseProgress` is `WhileSubscribed`, so its `.value` is genuinely null until a
+        // screen collects it — the state the reader is in for its first frames, and the state
+        // a deep link straight into a lesson starts in. All three moves read it and return.
+        val vm = viewModel()
+
+        vm.onEvent(QaidaReaderEvent.SelectLesson(2))
+        vm.onEvent(QaidaReaderEvent.NextLesson)
+        vm.onEvent(QaidaReaderEvent.PreviousLesson)
+        vm.onEvent(QaidaReaderEvent.Resume)
+
+        assertThat(vm.selectedLessonId.value).isEqualTo(2)
+    }
+
+    // ---- playing a whole line ----------------------------------------------------------
+
+    @Test
+    fun `playing a line queues its cells in order`() = runTest {
+        // The credit for each cell comes from playback finishing, not from this call — see
+        // `QaidaAudioManager.completions`. What this owns is *which* clips are queued.
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PlayLine(100))
+        advanceUntilIdle()
+
+        verify { audioManager.playSequence(listOf("l1_alif", "l1_baa")) }
+    }
+
+    @Test
+    fun `playing a line that is not in the open lesson does nothing`() = runTest {
+        // A line id from the lesson the learner just left — the content flow is `WhileSubscribed`
+        // and the tap can land after the lesson changed.
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PlayLine(9999))
+        advanceUntilIdle()
+
+        verify(exactly = 0) { audioManager.playSequence(any()) }
+    }
+
+    @Test
+    fun `playing a line before any lesson is open does nothing`() = runTest {
+        val vm = subscribedViewModel()
+
+        vm.onEvent(QaidaReaderEvent.PlayLine(100))
+        advanceUntilIdle()
+
+        verify(exactly = 0) { audioManager.playSequence(any()) }
+    }
+
+    @Test
+    fun `a line with no cells is not queued as an empty sequence`() = runTest {
+        // `playSequence(emptyList())` is a no-op in the manager, but the guard here is what
+        // keeps a heading line — which has no cells by design — from looking playable.
+        every { getLessonContent.invoke(1) } returns flowOf(
+            QaidaLessonContent(
+                lesson = lesson(1),
+                lines = listOf(
+                    QaidaLineContent(
+                        line = QaidaLine(
+                            id = 100,
+                            lessonId = 1,
+                            lineNumber = 1,
+                            lineType = LineType.HEADING,
+                            instructionEnglish = "Letters on their own",
+                            instructionArabic = null,
+                            displayOrder = 0,
+                        ),
+                        cells = emptyList(),
+                    ),
+                ),
+            )
+        )
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PlayLine(100))
+        advanceUntilIdle()
+
+        verify(exactly = 0) { audioManager.playSequence(any()) }
+    }
+
+    // ---- which cell is highlighted -----------------------------------------------------
+
+    @Test
+    fun `the sounding cell is resolved from the audio key against the open lesson`() = runTest {
+        // The reader highlights this cell. Resolving by index instead of by `audioKey` would
+        // light the wrong tile whenever a line is played out of order.
+        val audio = MutableStateFlow(QaidaAudioState())
+        every { audioManager.state } returns audio
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        backgroundScope.launch { vm.playingCell.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        audio.value = QaidaAudioState(currentKey = "l1_baa", isPlaying = true)
+        advanceUntilIdle()
+
+        assertThat(vm.playingCell.value?.id).isEqualTo(12)
+    }
+
+    @Test
+    fun `nothing is highlighted while nothing is sounding`() = runTest {
+        val audio = MutableStateFlow(QaidaAudioState())
+        every { audioManager.state } returns audio
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        backgroundScope.launch { vm.playingCell.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        assertThat(vm.playingCell.value).isNull()
+    }
+
+    @Test
+    fun `a clip from a lesson the learner has left highlights nothing`() = runTest {
+        // Audio outlives the screen, so a clip can still be sounding when the lesson changes.
+        // Keying on the *open* lesson's cells is what stops a foreign tile lighting up.
+        val audio = MutableStateFlow(QaidaAudioState())
+        every { audioManager.state } returns audio
+        course.value = threeLessons()
+        val vm = subscribedViewModel()
+        backgroundScope.launch { vm.lessonContent.collect {} }
+        backgroundScope.launch { vm.playingCell.collect {} }
+        vm.onEvent(QaidaReaderEvent.SelectLesson(1))
+        advanceUntilIdle()
+
+        audio.value = QaidaAudioState(currentKey = "l2_alif", isPlaying = true)
+        advanceUntilIdle()
+
+        assertThat(vm.playingCell.value).isNull()
+    }
+
+    // ---- the letter explorer ----------------------------------------------------------
+
+    @Test
+    fun `playing a letter plays that letter's clip and touches no progress`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(QaidaReaderEvent.PlayLetter(letter(audioKey = "letter_alif")))
+        advanceUntilIdle()
+
+        verify { audioManager.play("letter_alif") }
+    }
+
+    @Test
+    fun `the letters flow is what the explorer reads`() = runTest {
+        val vm = viewModel()
+        vm.letters.test {
+            assertThat(awaitItem()).isEmpty()
+            letters.value = listOf(letter(id = 1), letter(id = 2))
+            assertThat(awaitItem()).hasSize(2)
+        }
+    }
+
+    // ---- fixtures ---------------------------------------------------------------------
+
+    private companion object {
+        val emptyCourse = QaidaCourseProgress(
+            lessons = emptyList(),
+            completedLessons = 0,
+            totalLessons = 0,
+            totalStars = 0,
+            maxStars = 0,
+            totalCellsHeard = 0,
+            overallFraction = 0f,
+            nextLessonId = null,
+        )
+    }
+
+    private fun lesson(id: Int) = QaidaLesson(
+        id = id,
+        lessonNumber = id,
+        titleEnglish = "Lesson $id",
+        titleArabic = "درس",
+        titleTransliteration = "dars",
+        description = "",
+        conceptTags = emptyList(),
+        icon = "book",
+        displayOrder = id,
+    )
+
+    private fun lessonState(id: Int, status: LessonStatus) = QaidaLessonState(
+        lesson = lesson(id),
+        status = status,
+        stars = if (status == LessonStatus.COMPLETED) 3 else 0,
+        completedCells = if (status == LessonStatus.COMPLETED) 2 else 0,
+        totalCells = 2,
+        completionFraction = if (status == LessonStatus.COMPLETED) 1f else 0f,
+        lastCellId = null,
+    )
+
+    private fun cell(id: Int, lessonId: Int, audioKey: String) = QaidaCell(
+        id = id,
+        lineId = 100,
+        lessonId = lessonId,
+        position = id,
+        textArabic = "ا",
+        transliteration = "alif",
+        tokenType = TokenType.LETTER,
+        audioKey = audioKey,
+        audioPath = "qaida/$audioKey.mp3",
+        highlightGroup = null,
+        letterId = null,
+        notes = null,
+    )
+
+    private fun lessonContent(lessonId: Int) = QaidaLessonContent(
+        lesson = lesson(lessonId),
+        lines = listOf(
+            QaidaLineContent(
+                line = QaidaLine(
+                    id = 100,
+                    lessonId = lessonId,
+                    lineNumber = 1,
+                    lineType = LineType.EXAMPLE,
+                    instructionEnglish = null,
+                    instructionArabic = null,
+                    displayOrder = 0,
+                ),
+                cells = listOf(
+                    cell(11, lessonId, "l${lessonId}_alif"),
+                    cell(12, lessonId, "l${lessonId}_baa"),
+                ),
+            ),
+        ),
+    )
+
+    private fun letter(id: Int = 1, audioKey: String = "letter_$id") = QaidaLetter(
+        id = id,
+        letterArabic = "ا",
+        nameArabic = "ألف",
+        nameTransliteration = "Alif",
+        isolatedForm = "ا",
+        initialForm = null,
+        medialForm = null,
+        finalForm = "ـا",
+        isConnecting = false,
+        makhrajArea = MakhrajArea.JAWF,
+        makhrajDetail = "…",
+        phoneticHint = null,
+        audioKey = audioKey,
+        audioPath = "qaida/$audioKey.mp3",
+        displayOrder = id,
+    )
+}


### PR DESCRIPTION
**Stacked on #624** — review that first. This is the second and final pass over #612: the prophets, the three name catalogues, qaida, the catalog shells, the audio engine and `contentGraph`, plus the `nimazCoverage {}` declaration. **Merge #624 first**, then this.

Closes #612

## Before / after, across both passes

| | Before | After #624 | After this |
|---|---|---|---|
| Line | **28.8%** (1,380 / 4,785) | 61.6% (2,949) | **85.1%** (4,072 / 4,785) |
| Branch | **19.5%** (253 / 1,298) | 49.6% (644) | **80.4%** (1,043 / 1,298) |

**Locked at 80 / 80.** 219 tests across 22 new classes over the two PRs. No production code changed. **No `COVERAGE_EXCLUSIONS` entry added or widened.**

Nineteen files were at 0% before the campaign reached this module — every screen it owns.

## Why 80/80 and not the softened branch floor

This is the **seventh** Compose module to hold the standard branch floor, and the closest any of them has come to missing it: **80.4%, four branches above the gate.** The margin is thin, and the build file says so rather than papering over it — but the arithmetic does not justify 0.60 here:

- **125 of the 255 missing branches are the Compose compiler's `$dirty` bitmask** — one per parameter of every restartable composable, on the signature line and its closing paren, neither side reachable because which one runs depends on what the *caller* changed between recompositions. **Discount those and the module stands at 89.4%.**
- Three pockets account for half the remaining 130, each recorded in the build file with its reason:
  - **`QaidaAudioManager`'s `Player.Listener`** (12) — Robolectric has no media pipeline, the player never leaves `STATE_IDLE`, no callback fires. Reaching them means reflecting into ExoPlayer's private listener set, which breaks on a media3 bump and fails far from its cause. Its *consumer* is covered instead: `QaidaReaderViewModel` credits a cell from `completions` and from nowhere else.
  - **`DuaViewModel.filterAndSortCategories`'s search arms** (10) — **genuinely dead today.** `DuaCollectionUiState.searchQuery` is only ever written as `""`; the collection screen's search action navigates to `Route.DuaSearch`, which is `:feature:search`'s screen against a different ViewModel. `DuaCollectionSortTest` records that in place of a test that would have to reach past the public surface to pretend otherwise.
  - **`QaidaPlayLineButton`** (4) — behind `QAIDA_AUDIO_UI_ENABLED`, `false` while the recordings are regenerated. The test asserts the control is **absent**, so it gets inverted rather than deleted when the flag flips.

That the largest Compose surface locked so far still clears 80% is the point; that it clears it by four branches is worth knowing before the next refactor lands.

## What the new tests pin — and the failure each catches

**The largest graph in the app** (`ContentGraphTest`). Nineteen destinations, eleven of them argument-carrying. An unregistered destination throws `IllegalArgumentException: … is not a direct child of this NavGraph` at the moment a **user taps the row** — not at build time, and in none of the four gates `CLAUDE.md` lists. Four of the hadith destinations are the *same screen* reached four ways, so losing one breaks exactly one entry point and none of the others; the count is asserted as well as the membership.

**Which fields each catalogue searches** (`CatalogueSearchFieldsTest`). `CatalogViewModel` collapsed three byte-identical classes into one generic, and `CatalogViewModelTest` drives it with a *synthetic* source — so the three real ones were at 0%, and they are the only part a reader ever experiences. The prophets' search also covers the **title** ("Friend of Allah") and the **era**, which is how you look for a prophet whose name you cannot spell. Dropping an arm returns fewer results with no crash and no empty state.

**A slower detail read losing to a newer one** (same file). `requestedItemId` is checked *after* the suspension point, because a coroutine cancelled after its last suspension still runs to the end of its block — and all three catalogue screens share one ViewModel per back-stack entry, so this is one fast back-and-forward away.

**The Qaida course walk and its guards** (`QaidaCourseWalkTest`). "Next" refuses a **LOCKED** lesson — the gate the whole progression rests on, duplicated from the screen where it is only cosmetic. Re-selecting the open lesson is a no-op because `selectLesson` stops audio and a `LaunchedEffect` re-fires on every recomposition. Resume falls back to lesson 1 once `nextLessonId` is null, or a learner who has finished gets a button that does nothing.

**A lesson celebrated exactly once** (`QaidaReaderScreenTest`). `openedComplete` is captured from the first non-null status, so re-opening a finished lesson to practise does not put confetti in front of it — and finishing one while reading still celebrates. Both halves are silent failures.

**The hadith reader's anchor** (`HadithReaderAnchorTest`). Held **by id, not by index**, so a content refresh that inserts a row above the reader keeps them on the hadith they were reading. An index-based anchor passes "a refresh does not reset the reader" and still moves them — which is the whole reason this file exists.

**A clip resolving to the right file** (`QaidaAudioManagerTest`). A drop-in under `filesDir/qaida_audio/` beats the bundled asset — that is the entire on-demand delivery mode, one `if`, reachable through no setting. A **truncated** download is a zero-length file that *exists*, and trusting `exists()` alone plays silence forever with nothing on screen to say why.

**An id with an underscore** (`HadithReaderScreenTest`). `bookId.isEmpty() && !chapterId.contains("_")` is the whole classifier separating a composite chapter key from a hadith id — and hadith ids in this dataset **do** contain underscores (`bukhari_1_1`). The two shapes are one character apart and the rule is a convention, not a proof.

Plus: every optional prophet section, the shared catalogue shell's two guards, the consolidated favourites screen's empty-section rule, the three-catalogues-one-search-box wiring, where each letter is made, and the copy button's clipboard text.

## A documentation bug this surfaced

`ContentGraphTest` asserts 19 destinations against a graph whose KDoc **and** `docs/NAVIGATION.md` both said 21. Recounting every graph with `check_docs.py`'s own comment-stripping helper found **five wrong rows**:

| graph | documented | actual |
|---|---:|---:|
| `quranGraph` | 21 | **19** |
| `contentGraph` | 21 | **19** |
| `settingsGraph` | 16 | **20** |
| `trackerGraph` | 11 | **14** |
| `prayerGraph` | 8 | **5** |

The **total was right** (94), which is exactly why nothing caught it: NAV-03 compares that total against `Routes.kt`, not the split. All five rows are corrected, with a note in `NAVIGATION.md` recording how to recount, and the stale `21` in `ContentGraph.kt`'s own KDoc is fixed. Four of the five belong to other modules — the numbers are mechanical and the total is unchanged, so leaving four known-wrong rows in place seemed worse than the small widening of scope; flagging it here rather than burying it.

## The gate was proved to bite

Set to `0.99`, `:feature:content:coverageFloor` fails with the intended message, then restored to `0.80`:

```
> :feature:content:coverageFloor: line coverage 85.1% is below the floor this module is
  locked at (99.0%), covering 4072/4785 (85.1%).
  :feature:content:coverageFloor: branch coverage 80.4% is below the floor this module is
  locked at (99.0%), covering 1043/1298 (80.4%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to
  it is not meant to come back down.
```

## Verification

```
./gradlew :feature:content:testDebugUnitTest   BUILD SUCCESSFUL
./gradlew :feature:content:check               BUILD SUCCESSFUL
./gradlew :feature:content:lintDebug           BUILD SUCCESSFUL  (--rerun-tasks)
./gradlew coverageFloor                        BUILD SUCCESSFUL  (18 modules, none regressed)
python3 scripts/check_docs.py                  All 23 documentation checks passed
```

`:app:testDebugUnitTest` and `:app:lintDebug` need `NIMAZ_DATA_TOKEN` for the private content artifact and **were not run here** — CI's lane covers them. No `androidTest` was added, so there is nothing here awaiting an emulator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fa3T4hCpq7QU4Zb4PWR9xu)_