### PR TITLE
Coverage: bring :feature:tracker to 91.9% and lock it at 80/80

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -50,6 +50,7 @@ Two on-device/JVM test surfaces exist:
   - [About, Help and the More menu (`:feature:about/src/test`)](#about-help-and-the-more-menu-featureaboutsrctest)
   - [The repositories, the sync and the adhan store (`:core:data/src/test`)](#the-repositories-the-sync-and-the-adhan-store-coredatasrctest)
   - [The library, rendered (`:feature:content/src/test`)](#the-library-rendered-featurecontentsrctest)
+  - [What the user did (`:feature:tracker/src/test` and `src/testDebug`)](#what-the-user-did-featuretrackersrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -265,8 +266,8 @@ floors in its own `build.gradle.kts`.
 **The line floor is 80% everywhere; the branch floor is not.** `:core:database`, `:core:domain`,
 `:core:navigation`, `:core:common`, `:core:datastore` and `:core:data` are locked at 80/80 — none of
 them draws anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
-`:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:about` and
-`:feature:content`, which *are* Compose modules: the
+`:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:about`,
+`:feature:content` and `:feature:tracker`, which *are* Compose modules: the
 unreachable branch below is emitted **per parameter of every restartable composable**, so its
 weight scales with how many composables a module has, and six files — or eight, or the two screens
 in `:feature:tools`, or the one screen and four cards in `:feature:search`, or the seven screens in
@@ -280,6 +281,9 @@ so far — nineteen screens across five corpora — which is the point: even the
 branches below never accumulate enough to force the softened floor. What they do is eat the
 margin, and a module that reports 80.4% is one unrelated refactor from a red gate. That is the
 ratchet working, not a reason to soften it.
+`:feature:tracker` is the **eighth** Compose module to hold the standard, at **81.3%** across
+three trackers, twelve screens and two drawn surfaces — with **131 of its 280 missing branches**
+being that same bitmask, and 89.1% once they are discounted.
 
 **Two modules are softened to 80 line / 60 branch, and for two different reasons.**
 `:feature:prayer` is the second, and its reason is arithmetic rather than Compose:
@@ -315,7 +319,7 @@ split, and should say so where it sets its floors.
 | `:feature:about` | 94.1% | 83.8% | **locked** at 80/80 (#610) |
 | `:core:data` | 88.1% | 84.6% | **locked** at 80/80 (#611) |
 | `:core:ui` | 50.3% | 47.8% | |
-| `:feature:tracker` | 30.4% | 24.4% | |
+| `:feature:tracker` | 91.9% | 81.3% | **locked** at 80/80 (#613) |
 | `:feature:content` | 85.1% | 80.4% | **locked** at 80/80 (#612) |
 | `:feature:settings` | 11.3% | 14.9% | |
 
@@ -1147,6 +1151,120 @@ because `searchQuery` is only ever written as `""` and the collection's search a
 control asserted so the test is inverted rather than deleted when the flag flips). Sharing the
 hadith of the day is also uncovered: `shareBranded` hops to `Dispatchers.Default` to render a card
 before it shares anything, and that hop does not complete under the Compose test clock.
+**No `COVERAGE_EXCLUSIONS` entry was added or widened** — the list is shared with every locked
+module, so widening it would move their numbers too.
+
+### What the user did (`:feature:tracker/src/test` and `src/testDebug`)
+
+The sixteenth module locked: **30.4% lines to 91.9%**, from 1,575 covered lines to 4,755, and
+24.4% to **81.3%** branches. 341 tests over 34 classes, 23 of them new. No production code
+changed beyond one stale doc comment (`trackerGraph` said it held 11 destinations; it holds 14).
+
+**Nine files were at 0%** — every screen the module owns and both of its drawn surfaces:
+`TasbihScreen` (463 lines), `FastTrackerScreen` (281), `MakeupFastsScreen` (247),
+`ChooseDhikrScreen` (218), `PrayerStatsScreen` (218), `PrayerTrackerDayCard` (202),
+`TasbihHistoryScreen` (193), `FastingComingUp` (189), `RamadanCards` (161), `AddPresetScreen`
+(149), `TasbihBeads` (163 across four classes), `FastDaySheets` (104),
+`MakeupFastEditBottomSheet` (92), `TrackerGraph` (89) and `QadaPrayerContent` (79).
+`PrayerTrackerScreen` had seven covered lines of 232.
+
+**This is where the app writes the user's own record of worship, and none of it can be undone.**
+`:core:database` (#597) already pins the arithmetic underneath — that confirming a week of
+unrecorded prayers never overwrites a logged one, never marks sunrise and stops at the range's
+ends; that a missed fast leaves a `pending` row clearable by either door; that perfect days and
+per-prayer stats add up. What none of that can see is the **surface**: whether the offer is made
+at the right time, against the right day, and for the right count. A review banner that offered
+to mark a fully-logged week as missed is a one-tap way to fabricate a qada list, and the DAO test
+would still be green.
+
+#### The prayer tracker
+
+`PrayerTrackerScreenTest` (25) composes the tracker against a mocked ViewModel and pins the
+review banner in both directions: **no banner over a complete week**, a count that is the count of
+actually-unrecorded prayers, a `MISSED` row excluded because it is already an assertion, a
+`NOT_PRAYED` row *included* because clearing a status must read back as "nobody has said", and a
+confirmation that asks for the seven days **behind** today rather than today itself. It also pins
+the load window — the displayed month **and** the trailing review window, always, which is what
+stopped paging to another month leaving the banner counting days it had no records for — and that
+`QADA` is offered only once a prayer's time has passed, which used to be reachable by marking a
+prayer prayed early. `PrayerTrackerNavigationTest` (9) takes the day stepper: back one day at a
+time, forward only as far as today.
+
+`PrayerStatsScreenTest` (11) takes the three insights, which are derived in the screen and
+nowhere else: the weakest prayer is named only below 90%, a prayer with **no** record counts as
+100% rather than 0% (or it would be reported as the user's weakest every time), and a fresh
+install with everything at zero is offered no insight at all instead of opening on "Overall
+completion: 0%". `PrayerRadialChartTest` (4) draws the radar chart into a software canvas and
+asserts the polygon's *size follows the record* — three charts side by side in one composition,
+each measured by the pixels in which it differs from an empty one. `QadaPrayersScreenTest` (6)
+pins that an empty list says prayers land there only when the user says so, and that an empty
+list which is still **loading** is not called caught up.
+
+#### Fasting
+
+`FastTrackerScreenTest` (22) pins which Ramadan card shows — banner during, countdown within
+thirty days, neither outside, and the banner winning when both would qualify — the month-paging
+arithmetic across a year boundary in both directions, and that the exemption and note sheets
+write against the **selected** day rather than today. `FastingWindowTest` (7) supplies a fixed
+clock through `ProvideNimazClock`'s `timeSource` seam and walks the suhoor→iftar band through all
+four of its sentences, including the half-a-schedule case a location change can leave behind.
+`FastingComingUpTest` (11) pins the upcoming-fasts list: sorted by date (built unsorted it opened
+with next Monday when today was a Thursday), deduplicated across the two Hijri years it is
+gathered from, and marking a day logged only for a `FASTED` record.
+
+`MakeupFastsScreenTest` (16) is the debt: both ways of settling a fast filed under *Settled* and
+neither under *Owed*, only pending rows offering a way to act, and — the one that matters most —
+choosing fidya in the sheet raising `PayFidya` rather than `UpdateMakeupFast`, because recording
+a payment as a completed fast loses the money and the debt at once.
+`FastingRamadanTest` (6) reaches the arm of `loadRamadan` that runs one month a year, and pins the
+distinction the redesign is built on: **missed** means recorded as not fasted, **unlogged** means
+nobody has said. `FastingStatsAndDebtTest` (12) pins the three statistics windows and that a
+missed Ramadan day creates exactly **one** make-up fast however many times its status is changed.
+
+#### The tasbih
+
+`TasbihScreenTest` (17) and `TasbihSessionTest` (21) split the counter between what it shows and
+what it stores. The count lives in Room, so a lost tap is a permanently wrong total: the session
+test pins the two-taps-during-the-insert race that used to leave an orphan session and a counter
+reading 1, that a lap writes the **within-lap** count (the database sums `currentCount + laps ×
+target`, so writing the running total would double every lap), that switching dhikr mid-count
+completes the old session rather than abandoning it, and that a re-emission of the persisted
+selection does not reset a count in progress.
+
+`TasbihBeadsTest` (10) draws the strand into a software canvas: it paints edge to edge, it
+mirrors for a left-handed user — a setting with no other confirmation anywhere, since the strand
+is a `Canvas` with no text in it — each material paints in its own colours, an unknown design key
+falls back rather than blanking the counter, and one gesture is one bead whether it is a tap or a
+flick. `ChooseDhikrScreenTest` (15) pins that the tab and the search box narrow **together**, and
+that deleting a custom dhikr asks first and keeps it on cancel. `AddPresetScreenTest` (10) pins
+the edit form's seeding rule: the fields are copied from the loaded preset **once**, because the
+presets flow re-emits on any write to that table and re-seeding would discard whatever the user
+had typed. `TasbihHistoryScreenTest` (9) pins the live today total and the `%d:%02d` session
+length that is formatted nowhere else.
+
+`TrackerGraphTest` (6) asserts all **fourteen** destinations register, and register once. Seven of
+them share a screen composable with another route, so a copy-paste that registered the same
+`Route` twice would look right in review and leave the other one throwing at the tap that opens
+it. Fourteen is asserted as a number because #625 recounted every graph and found five documented
+counts wrong, this one among them — `check_docs.py`'s NAV-03 compares the 94-destination total
+against `Routes.kt`, not the per-graph split.
+
+**What stays uncovered, and why.** 131 of the 280 missing branches are the Compose compiler's
+`$dirty` bitmask — one per parameter of every restartable composable, on the signature line, its
+parameter lines and its closing paren, neither side reachable because which one runs depends on
+what the *caller* changed between recompositions. Discount those and the module stands at
+**89.1% branches**. Of the rest, four pockets are unreachable rather than untested:
+`TasbihCounterUiState.autoLap` is never false (~10 branches — no event sets it, so the manual-lap
+arm is dead until a control is wired to it); `TasbihPresetsUiState.selectedCategory` is never set
+(4 — `ChooseDhikrScreen` filters through its own tab state, though `TrackerDerivedStateTest` pins
+the derivation anyway, since it is the guard that stopped a re-emission of the presets flow
+silently dropping an active filter); the `PENDING`/`NOT_PRAYED` arms of the day card's picker
+mappings (3 — `PICKER_STATUSES` holds only the four assertions a user can make, and the `when`
+must still be exhaustive over six); and `PrayerStatsScreen`'s date-parse fallback (4 — neither
+`Long.MIN_VALUE` nor `Long.MAX_VALUE` actually throws on the way to a `LocalDate`, so no stored
+value a test can supply reaches the `catch`). `FastingComingUp`'s Hijri event arms (17) are the
+one date-dependent pocket: which of Ashura, Arafah, Shawwal and mid-Sha'ban fall ahead of "today"
+changes with the day the suite runs.
 **No `COVERAGE_EXCLUSIONS` entry was added or widened** — the list is shared with every locked
 module, so widening it would move their numbers too.
 

--- a/feature/tracker/build.gradle.kts
+++ b/feature/tracker/build.gradle.kts
@@ -16,6 +16,47 @@ android {
     }
 }
 
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
+// **80/80.** The eighth Compose module in a row to hold the standard branch floor, at
+// **81.3% branches** and **91.9% lines** — and the branch number was not free. Of the 280
+// branches still missing, **131 are the Compose compiler's `$dirty` bitmask**: one per parameter
+// of every restartable composable, on the signature line, its parameter lines and its closing
+// paren, and neither side reachable from a test because which side runs depends on what the
+// *caller* changed between recompositions. Discount those and the module stands at **89.1%**.
+//
+// The remaining 149 are spread thinly. Four pockets account for most of them, and each is
+// unreachable rather than untested:
+//
+//   - **`TasbihCounterUiState.autoLap` is never false** (about 10 branches, across the counter's
+//     lap arithmetic in `TasbihViewModel` and the capsule's `goalReached` in `TasbihScreen`).
+//     No `TasbihEvent` sets it and no setting writes it, so the manual-lap arm is dead today.
+//     Wiring a control to it is a change to make deliberately, not something to fake from a test.
+//   - **`TasbihPresetsUiState.selectedCategory` is never set** (4). `ChooseDhikrScreen` filters
+//     by its own tab state rather than through the ViewModel, so the state's category arm has no
+//     writer. `TrackerDerivedStateTest` pins the derivation anyway — it is the guard that stopped
+//     a re-emission of the presets flow silently dropping an active filter, and it is worth
+//     keeping correct against the day something does set it.
+//   - **The `PrayerStatus.PENDING`/`NOT_PRAYED` arms of `PrayerTrackerDayCard`'s picker
+//     mappings** (3). `PICKER_STATUSES` holds only the four assertions a user can make, so the
+//     two "nobody has said" values never reach `pickerLabel()` or `displayed()`. They exist
+//     because `PrayerStatus` has six values and a `when` over it must be exhaustive.
+//   - **`PrayerStatsScreen`'s date-parse fallback** (4). The `catch` runs only when a stored
+//     `startDate` cannot be resolved to a `LocalDate`; neither `Long.MIN_VALUE` nor
+//     `Long.MAX_VALUE` actually throws on the way through, so there is no value a test can
+//     supply to reach it. It stays as the defence it is.
+//
+// The Hijri arm of `FastingComingUp`'s event list (17) is the one genuinely date-dependent
+// pocket: which of Ashura, Arafah, Shawwal and mid-Sha'ban fall ahead of "today" changes with
+// the day the suite runs, so some of those `takeIf`s take only one side on any given run.
+//
+// **Nothing was excluded to reach these numbers** — no `COVERAGE_EXCLUSIONS` entry was added or
+// widened, and that list is shared with every locked module, so widening it would move theirs
+// too.
+
 // What the user did: prayer tracking, fasting, and the tasbih counter.
 //
 // One module for the same reason as `:feature:content` — `viewmodel/tracker` is a single package

--- a/feature/tracker/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/tracker/TrackerGraph.kt
+++ b/feature/tracker/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/tracker/TrackerGraph.kt
@@ -14,7 +14,12 @@ import com.arshadshah.nimaz.presentation.screens.fasting.MakeupFastsScreen
 import com.arshadshah.nimaz.presentation.screens.tasbih.TasbihScreen
 
 /**
- * The 11 Tracker destinations — the prayer tracker, fasting and tasbih.
+ * The 14 Tracker destinations — the prayer tracker, fasting and tasbih.
+ *
+ * Fourteen, not the eleven this said before #613: `docs/NAVIGATION.md` was corrected to 14 in
+ * #625 (which recounted every graph and found five wrong), and `TrackerGraphTest` now asserts the
+ * number against the graph itself. `check_docs.py`'s NAV-03 cannot catch a drift here — it
+ * compares the 94-destination total against `Routes.kt`, not the per-graph split.
  *
  * Split out of `NavGraph.kt` in PR 12 of #551. That file registered all 94 destinations and
  * imported 69 screen composables, which meant every screen in the app was reachable from one

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastTrackerScreenTest.kt
@@ -1,0 +1,450 @@
+package com.arshadshah.nimaz.presentation.screens.fasting
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatWeekdayDayMonth
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.ExemptionReason
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingCalendarUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingTrackerUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.MakeupFastsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.RamadanTrackerUiState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * The fasting tracker: one scroll that reports the selected day.
+ *
+ * Five sections and two sheets, none of which had ever been composed. Three things here are
+ * decided in this file and nowhere else, and each fails silently:
+ *
+ *  - **Which Ramadan card shows.** The banner runs during Ramadan and the countdown only within
+ *    thirty days of it. Both at once, or neither, is the failure — and it is a `when` over
+ *    ViewModel state that no ViewModel test can see the effect of.
+ *  - **Month paging arithmetic.** January's previous month is December *of the year before*, and
+ *    December's next is January of the next. Getting the year wrong loads a month of records
+ *    twelve months out and looks like an empty month.
+ *  - **The exemption and note sheets.** They write to the *selected* day, which is not
+ *    necessarily today; a sheet that saved against today would silently rewrite the wrong day's
+ *    record.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class FastTrackerScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val today: LocalDate = LocalDate.now()
+
+    private fun record(
+        date: LocalDate,
+        status: FastStatus,
+        reason: ExemptionReason? = null,
+        note: String? = null,
+    ) = FastRecord(
+        id = date.toEpochDay(),
+        date = date.toEpochDay() * MILLIS_PER_DAY,
+        hijriDate = null,
+        hijriMonth = null,
+        hijriYear = null,
+        fastType = FastType.VOLUNTARY,
+        status = status,
+        exemptionReason = reason,
+        suhoorTime = null,
+        iftarTime = null,
+        note = note,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val trackerState = MutableStateFlow(
+        FastingTrackerUiState(selectedDate = today, isSelectedToday = true, isLoading = false)
+    )
+    private val makeupState = MutableStateFlow(MakeupFastsUiState(isLoading = false))
+    private val ramadanState = MutableStateFlow(RamadanTrackerUiState(isLoading = false))
+    private val calendarState = MutableStateFlow(
+        FastingCalendarUiState(
+            selectedMonth = today.monthValue,
+            selectedYear = today.year,
+            isLoading = false,
+        )
+    )
+    private val events = mutableListOf<FastingEvent>()
+    private val navigations = mutableListOf<String>()
+
+    private val viewModel: FastingViewModel = mockk(relaxed = true) {
+        every { this@mockk.trackerState } returns this@FastTrackerScreenTest.trackerState
+        every { this@mockk.makeupState } returns this@FastTrackerScreenTest.makeupState
+        every { this@mockk.ramadanState } returns this@FastTrackerScreenTest.ramadanState
+        every { this@mockk.calendarState } returns this@FastTrackerScreenTest.calendarState
+        every { onEvent(any()) } answers { events += firstArg<FastingEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            FastTrackerScreen(
+                onNavigateBack = { navigations += "back" },
+                onNavigateToCalendar = { navigations += "calendar" },
+                onNavigateToMakeup = { navigations += "makeup" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /**
+     * The day card's third segment.
+     *
+     * "Exempt" is also the calendar legend's label for the same status further down the screen,
+     * so the word alone matches twice. The segment is the one that is selectable.
+     */
+    private fun exemptCell() = composeRule
+        .onAllNodesWithText(string(R.string.fasting_seg_exempt))
+        .filterToOne(isSelectable())
+
+    @Test
+    fun `outside Ramadan and outside the countdown window, neither card shows`() {
+        ramadanState.value = ramadanState.value.copy(
+            isRamadan = false,
+            daysUntilRamadan = 120,
+            ramadanStartsOn = today.plusDays(120),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_current)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_starts_in)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `inside the window the countdown shows, and it alone`() {
+        ramadanState.value = ramadanState.value.copy(
+            isRamadan = false,
+            daysUntilRamadan = 12,
+            ramadanStartsOn = today.plusDays(12),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_starts_in)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_days)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_current)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `during Ramadan the banner takes over from the countdown`() {
+        ramadanState.value = ramadanState.value.copy(
+            isRamadan = true,
+            currentDay = 9,
+            fastedDays = 7,
+            missedDays = 1,
+            remainingDays = 21,
+            // Still inside the window numerically — the banner must win anyway, or the screen
+            // shows a countdown to a Ramadan that has already begun.
+            daysUntilRamadan = 0,
+            ramadanStartsOn = today,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_current)).assertExists()
+        // Twice, and that is the point: the banner announces the day and the day card badges it,
+        // and the two read the same `currentDay` so they cannot disagree.
+        composeRule.onAllNodesWithText(string(R.string.fasting_ramadan_day, 9)).assertCountEquals(2)
+        composeRule.onNodeWithText("7/29").assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_starts_in)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the countdown says day or days as the number requires`() {
+        ramadanState.value = ramadanState.value.copy(
+            daysUntilRamadan = 1,
+            ramadanStartsOn = today.plusDays(1),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_day)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_days)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the countdown card is withheld when there is no start date to show`() {
+        ramadanState.value = ramadanState.value.copy(
+            daysUntilRamadan = 5,
+            ramadanStartsOn = null,
+        )
+        setContent()
+
+        // "5 days until — " is worse than nothing; the card needs both halves.
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_starts_in)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the month header counts only the days actually fasted`() {
+        calendarState.value = calendarState.value.copy(
+            records = listOf(
+                record(today.withDayOfMonth(1), FastStatus.FASTED),
+                record(today.withDayOfMonth(2), FastStatus.FASTED),
+                record(today.withDayOfMonth(3), FastStatus.NOT_FASTED),
+                record(today.withDayOfMonth(4), FastStatus.EXEMPTED),
+            ),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_your_month)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_fasted_count, 2)).assertExists()
+    }
+
+    @Test
+    fun `paging back from January lands in the December before it`() {
+        calendarState.value = calendarState.value.copy(selectedMonth = 1, selectedYear = 2026)
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_previous_month)).performClick()
+
+        // The year rolls with the month. Keeping 2026 would load a month of records a year away
+        // and present it as an empty January.
+        assertThat(events).contains(FastingEvent.SelectMonth(12, 2025))
+    }
+
+    @Test
+    fun `paging forward from December lands in the January after it`() {
+        calendarState.value = calendarState.value.copy(selectedMonth = 12, selectedYear = 2026)
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_next_month)).performClick()
+
+        assertThat(events).contains(FastingEvent.SelectMonth(1, 2027))
+    }
+
+    @Test
+    fun `paging within a year leaves the year alone`() {
+        calendarState.value = calendarState.value.copy(selectedMonth = 6, selectedYear = 2026)
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_previous_month)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_next_month)).performClick()
+
+        assertThat(events).containsExactly(
+            FastingEvent.SelectMonth(5, 2026),
+            FastingEvent.SelectMonth(7, 2026),
+        ).inOrder()
+    }
+
+    @Test
+    fun `the coming-up row lists the weekly sunnah days and Ayyam al-Beed`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_coming_up)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_monday)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_thursday)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_ayyam_al_beed)).assertExists()
+    }
+
+    @Test
+    fun `logging a coming-up fast selects that day and marks it fasted`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_monday)).performClick()
+
+        // Two events, in this order: the tap is "log *that* day", so selecting it first is what
+        // stops the status landing on whichever day was already selected.
+        val nextMonday = events.filterIsInstance<FastingEvent.SelectDate>().first().date
+        assertThat(events).containsExactly(
+            FastingEvent.SelectDate(nextMonday),
+            FastingEvent.SetFastStatus(nextMonday, FastStatus.FASTED),
+        ).inOrder()
+        assertThat(nextMonday.dayOfWeek.value).isEqualTo(1)
+    }
+
+    @Test
+    fun `a day already fasted reads as logged rather than as an invitation`() {
+        val nextMonday = today.with(java.time.temporal.TemporalAdjusters.nextOrSame(java.time.DayOfWeek.MONDAY))
+        calendarState.value = calendarState.value.copy(
+            records = listOf(record(nextMonday, FastStatus.FASTED)),
+        )
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_logged)).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the makeup row reports nothing outstanding when there is nothing`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_row_makeup)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_row_makeup_none)).assertExists()
+    }
+
+    @Test
+    fun `the makeup row badges what is owed and leads to the make-up screen`() {
+        makeupState.value = makeupState.value.copy(pendingCount = 3, totalFidyaPaid = 24.0)
+        setContent()
+
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.fasting_row_makeup_pending, 3, 3)
+        ).assertExists()
+
+        composeRule.onNodeWithText(string(R.string.fasting_row_makeup)).performClick()
+        assertThat(navigations).containsExactly("makeup")
+    }
+
+    @Test
+    fun `with nothing owed the row leads with the fidya already paid`() {
+        makeupState.value = makeupState.value.copy(
+            pendingCount = 0,
+            totalFidyaPaid = 24.0,
+            currency = "GBP",
+        )
+        setContent()
+
+        // The count lives in the badge, so the subtitle carries the other fact — and only when
+        // there is one.
+        composeRule.onNodeWithText(string(R.string.fasting_row_makeup_fidya, "£24.00")).assertExists()
+    }
+
+    @Test
+    fun `the exemption sheet writes its reason against the selected day, not today`() {
+        val yesterday = today.minusDays(1)
+        trackerState.value = trackerState.value.copy(
+            selectedDate = yesterday,
+            isSelectedToday = false,
+        )
+        setContent()
+
+        // The day card's third cell opens the sheet rather than setting a status: an exemption
+        // without a reason is not worth recording.
+        exemptCell().performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.fasting_why_exempt)).assertExists()
+        // Twice: the day card's header and the sheet's subtitle, both naming the selected day.
+        // That agreement is the assertion — a sheet subtitled with *today* would be editing a
+        // different record from the one on screen.
+        composeRule.onAllNodesWithText(yesterday.formatWeekdayDayMonth()).assertCountEquals(2)
+
+        composeRule.onNodeWithText(ExemptionReason.TRAVEL.displayName()).performClick()
+        composeRule.onNodeWithText(string(R.string.save)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).containsExactly(
+            FastingEvent.SaveExemption(yesterday, ExemptionReason.TRAVEL)
+        )
+    }
+
+    @Test
+    fun `saving an exemption without picking a reason records it as other`() {
+        setContent()
+
+        exemptCell().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.save)).performClick()
+        composeRule.waitForIdle()
+
+        // Making the user answer "why" to dismiss a sheet they opened by accident is worse than
+        // defaulting, and OTHER is honest about an unanswered question.
+        assertThat(events).containsExactly(
+            FastingEvent.SaveExemption(today, ExemptionReason.OTHER)
+        )
+    }
+
+    @Test
+    fun `cancelling the exemption sheet records nothing`() {
+        setContent()
+
+        exemptCell().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `the exemption sheet opens on the reason already on file`() {
+        trackerState.value = trackerState.value.copy(
+            selectedRecord = record(today, FastStatus.EXEMPTED, reason = ExemptionReason.ILLNESS),
+        )
+        setContent()
+
+        exemptCell().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.save)).performClick()
+        composeRule.waitForIdle()
+
+        // Re-saving an untouched sheet must not silently downgrade a recorded reason to OTHER.
+        assertThat(events).containsExactly(
+            FastingEvent.SaveExemption(today, ExemptionReason.ILLNESS)
+        )
+    }
+
+    @Test
+    fun `the note sheet saves what was typed against the selected day`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_add_note)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodes(hasSetTextAction())[0].performTextInput("Travelling home")
+        composeRule.onNodeWithText(string(R.string.save)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).containsExactly(FastingEvent.SaveNote(today, "Travelling home"))
+    }
+
+    @Test
+    fun `the note sheet opens on whatever note the day already carries`() {
+        trackerState.value = trackerState.value.copy(
+            selectedRecord = record(today, FastStatus.FASTED, note = "Kept it"),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_add_note)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.save)).performClick()
+        composeRule.waitForIdle()
+
+        // A note sheet that opened blank would wipe the note on the next save.
+        assertThat(events).containsExactly(FastingEvent.SaveNote(today, "Kept it"))
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(navigations).containsExactly("back")
+    }
+
+    private companion object {
+        const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastingComingUpTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastingComingUpTest.kt
@@ -1,0 +1,229 @@
+package com.arshadshah.nimaz.presentation.screens.fasting
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+/**
+ * Which voluntary fasts are coming up, and in what order.
+ *
+ * The list is built inside a composable — it needs `stringResource` for the phrasing — so it has
+ * never been run outside the app. Two of its rules are load-bearing and neither is visible when
+ * it breaks:
+ *
+ *  - **It is sorted by date.** Built unsorted it listed next Monday before today, because the
+ *    weekly days are added in a fixed Mon/Thu sequence which is only chronological for part of
+ *    the week. "Coming up" is a promise about order, and a list that opens with a day four days
+ *    out reads as though the nearer one is gone.
+ *  - **The Hijri events are deduplicated across two years.** They are gathered from this Hijri
+ *    year *and* the next so the list does not run dry in Dhul-Hijjah, which means Ashura and
+ *    Arafah each appear twice before the nearest-upcoming filter runs.
+ *
+ * The dates are the app's real Hijri arithmetic — that is `HijriDateCalculator`'s own tests'
+ * job. What is asserted here is the shape of the list built on top of it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class FastingComingUpTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val today: LocalDate = LocalDate.of(2026, 8, 13)
+
+    private fun record(date: LocalDate, status: FastStatus = FastStatus.FASTED) = FastRecord(
+        id = date.toEpochDay(),
+        date = date.toEpochDay() * MILLIS_PER_DAY,
+        hijriDate = null,
+        hijriMonth = null,
+        hijriYear = null,
+        fastType = FastType.VOLUNTARY,
+        status = status,
+        exemptionReason = null,
+        suhoorTime = null,
+        iftarTime = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /** Runs [rememberComingUpFasts] inside a composition and hands the result back. */
+    private fun comingUp(
+        records: List<FastRecord> = emptyList(),
+        daysUntilAyyamAlBeed: Int = 4,
+        on: LocalDate = today,
+    ): List<ComingUpFast> {
+        lateinit var result: List<ComingUpFast>
+        composeRule.setThemedContent {
+            Capture(records, daysUntilAyyamAlBeed, on) { result = it }
+        }
+        composeRule.waitForIdle()
+        return result
+    }
+
+    @Composable
+    private fun Capture(
+        records: List<FastRecord>,
+        daysUntilAyyamAlBeed: Int,
+        on: LocalDate,
+        onResult: (List<ComingUpFast>) -> Unit,
+    ) {
+        val fasts = rememberComingUpFasts(records, daysUntilAyyamAlBeed, on)
+        SideEffect { onResult(fasts) }
+    }
+
+    @Test
+    fun `the list is in date order`() {
+        val fasts = comingUp()
+
+        // 13 Aug 2026 is a Thursday, so the Thursday entry is today and the Monday entry is four
+        // days out. Built in Mon/Thu order this list opens with next Monday.
+        assertThat(fasts.map { it.date }).isInOrder()
+        assertThat(fasts.first().date).isEqualTo(today)
+    }
+
+    @Test
+    fun `both weekly sunnah days are offered, anchored to the next occurrence of each`() {
+        val fasts = comingUp()
+
+        val monday = fasts.single { it.name == string(R.string.fasting_monday) }
+        val thursday = fasts.single { it.name == string(R.string.fasting_thursday) }
+
+        assertThat(monday.date)
+            .isEqualTo(today.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY)))
+        assertThat(thursday.date)
+            .isEqualTo(today.with(TemporalAdjusters.nextOrSame(DayOfWeek.THURSDAY)))
+        assertThat(monday.why).isEqualTo(string(R.string.fasting_sunnah_desc))
+    }
+
+    @Test
+    fun `a weekly day that falls today is labelled today rather than dated`() {
+        val fasts = comingUp()
+
+        // `nextOrSame`, so on a Thursday the Thursday entry *is* today — "Next: 13 Aug" for a
+        // day that is already here is a small lie the label has to avoid.
+        assertThat(fasts.single { it.name == string(R.string.fasting_thursday) }.whenLabel)
+            .isEqualTo(string(R.string.fasting_today))
+        assertThat(fasts.single { it.name == string(R.string.fasting_monday) }.whenLabel)
+            .startsWith("Next")
+    }
+
+    @Test
+    fun `Ayyam al-Beed in progress is labelled today`() {
+        // The count comes from the ViewModel, where the clock and the user's Hijri day offset
+        // both live. Reading the clock here instead would answer yesterday's question on a
+        // screen left open across midnight, and would ignore the offset entirely.
+        assertThat(comingUp(daysUntilAyyamAlBeed = 0)
+            .single { it.name == string(R.string.fasting_ayyam_al_beed) }.whenLabel)
+            .isEqualTo(string(R.string.fasting_today))
+    }
+
+    @Test
+    fun `Ayyam al-Beed a day out is labelled tomorrow`() {
+        // A separate test rather than a second case in the one above: a compose rule composes
+        // once, so a before/after comparison has to be two tests.
+        assertThat(comingUp(daysUntilAyyamAlBeed = 1)
+            .single { it.name == string(R.string.fasting_ayyam_al_beed) }.whenLabel)
+            .isEqualTo(string(R.string.fasting_tomorrow))
+    }
+
+    @Test
+    fun `no fast is listed twice, even though the Hijri events span two years`() {
+        val fasts = comingUp()
+
+        // Ashura and Arafah are gathered from this Hijri year and the next so the list does not
+        // run dry late in the year; without the nearest-upcoming filter each arrives twice.
+        assertThat(fasts.map { it.name }).containsNoDuplicates()
+        // Three fixed entries plus at most three Hijri ones — a list that had kept both years'
+        // copies would be longer than the cap.
+        assertThat(fasts.size).isAtMost(6)
+    }
+
+    @Test
+    fun `nothing in the list is in the past`() {
+        comingUp().forEach { assertThat(it.date).isAtLeast(today) }
+    }
+
+    @Test
+    fun `a day already recorded as fasted is marked logged`() {
+        val nextMonday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+
+        val fasts = comingUp(records = listOf(record(nextMonday)))
+
+        assertThat(fasts.single { it.date == nextMonday && it.name == string(R.string.fasting_monday) }.isLogged)
+            .isTrue()
+        assertThat(fasts.filter { it.date != nextMonday }.none { it.isLogged }).isTrue()
+    }
+
+    @Test
+    fun `only a fasted record counts as logged`() {
+        val nextMonday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+
+        // A day recorded as *not* fasted is still worth offering — the card would otherwise show
+        // a tick against a day the user explicitly said they did not fast.
+        val fasts = comingUp(records = listOf(record(nextMonday, FastStatus.NOT_FASTED)))
+
+        assertThat(fasts.none { it.isLogged }).isTrue()
+    }
+
+    @Test
+    fun `a card reports the fast and offers to log it`() {
+        var logged: LocalDate? = null
+        composeRule.setThemedContent {
+            ComingUpRow(
+                fasts = listOf(
+                    ComingUpFast("Today", "Thursday fast", "Weekly sunnah", today, isLogged = false),
+                ),
+                onLogFast = { logged = it },
+            )
+        }
+
+        composeRule.onNodeWithText(string(R.string.fasting_log_this_fast)).assertExists()
+        composeRule.onNodeWithText("Thursday fast").performClick()
+
+        assertThat(logged).isEqualTo(today)
+    }
+
+    @Test
+    fun `an already-logged card says so instead of inviting a second log`() {
+        composeRule.setThemedContent {
+            ComingUpRow(
+                fasts = listOf(
+                    ComingUpFast("Today", "Thursday fast", "Weekly sunnah", today, isLogged = true),
+                ),
+                onLogFast = {},
+            )
+        }
+
+        composeRule.onNodeWithText(string(R.string.fasting_logged)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_log_this_fast)).assertDoesNotExist()
+    }
+
+    private companion object {
+        const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/MakeupFastsScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/MakeupFastsScreenTest.kt
@@ -1,0 +1,366 @@
+package com.arshadshah.nimaz.presentation.screens.fasting
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatMediumDate
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.MakeupFast
+import com.arshadshah.nimaz.domain.model.MakeupFastStatus
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.MakeupFastsUiState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * What is owed, and the two doors out of owing it.
+ *
+ * `FastingDaoTest` (#597) already pins that a missed fast leaves a `pending` row and that either
+ * completing it or paying fidya clears it. What it cannot pin is the *surface*: 247 lines that
+ * decide which section a make-up fast is filed under, which of the two doors a tap opens, and
+ * what the sheet sends when it closes. The failure mode is a debt that looks settled and is not,
+ * or a fidya payment recorded as a completed fast — both permanent, and neither visible.
+ *
+ * The split is the load-bearing rule here: `COMPLETED` and `FIDYA_PAID` are different acts, but
+ * from the reader's side they answer the same question, so both belong under "Settled" and
+ * neither may appear under "Owed".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class MakeupFastsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun makeupFast(
+        id: Long,
+        status: MakeupFastStatus,
+        reason: String = "Travel",
+        hijri: String? = null,
+        completedDate: Long? = null,
+        fidya: Double? = null,
+    ) = MakeupFast(
+        id = id,
+        originalDate = 1_700_000_000_000L,
+        originalHijriDate = hijri,
+        reason = reason,
+        status = status,
+        completedDate = completedDate,
+        fidyaAmount = fidya,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val owed = makeupFast(1, MakeupFastStatus.PENDING, hijri = "3 Ramadan 1445")
+    private val alsoOwed = makeupFast(2, MakeupFastStatus.PENDING, reason = "Illness")
+    private val madeUp = makeupFast(3, MakeupFastStatus.COMPLETED, completedDate = 1_710_000_000_000L)
+    private val paid =
+        makeupFast(4, MakeupFastStatus.FIDYA_PAID, completedDate = 1_715_000_000_000L, fidya = 5.0)
+
+    private val makeupState = MutableStateFlow(
+        MakeupFastsUiState(
+            pendingMakeupFasts = listOf(owed, alsoOwed),
+            allMakeupFasts = listOf(owed, alsoOwed, madeUp, paid),
+            pendingCount = 2,
+            isLoading = false,
+        )
+    )
+    private val events = mutableListOf<FastingEvent>()
+    private var backs = 0
+
+    private val viewModel: FastingViewModel = mockk(relaxed = true) {
+        every { this@mockk.makeupState } returns this@MakeupFastsScreenTest.makeupState
+        every { onEvent(any()) } answers { events += firstArg<FastingEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            MakeupFastsScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /** The same rendering the card does, so the assertion is about the label, not the format. */
+    private fun mediumDate(epochMillis: Long): String =
+        Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault())
+            .toLocalDate().formatMediumDate()
+
+    @Test
+    fun `with nothing owed and nothing settled the screen says so`() {
+        makeupState.value = MakeupFastsUiState(isLoading = false)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_no_makeup)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_all_up_to_date)).assertExists()
+        // The summary card belongs to the populated arm; an empty state that also showed
+        // "0 fasts to make up" would be saying the same thing twice.
+        composeRule.onNodeWithText(string(R.string.fasting_fasts_to_makeup)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the summary and the stats agree about how many are outstanding`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_fasts_to_makeup)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_pending_count, 2)).assertExists()
+        // Four in total. The grid's "completed" cell counts both settled statuses, which is the
+        // arithmetic worth pinning — counting only `COMPLETED` would under-report every fidya
+        // payment the user has made.
+        composeRule.onNodeWithText("4").assertExists()
+    }
+
+    @Test
+    fun `an owed fast is listed under Owed with its date and reason`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_makeup_owed)).assertExists()
+        // The Hijri date wins when there is one: a make-up fast is owed for a day of Ramadan,
+        // and that is the date the user remembers it by.
+        composeRule.onNodeWithText(owed.originalHijriDate!!).assertExists()
+        composeRule.onNodeWithText(alsoOwed.reason).assertExists()
+    }
+
+    @Test
+    fun `both ways of settling a fast are filed under Settled, and neither under Owed`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_makeup_settled)).assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.fasting_fasts_count, 2, 2)
+        ).assertExists()
+
+        // Only the two pending rows offer a way to act — a settled fast with a live "Mark
+        // Complete" button is an invitation to record the same debt twice.
+        composeRule.onAllNodesWithText(string(R.string.fasting_mark_complete)).assertCountEquals(2)
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit)).assertCountEquals(2)
+    }
+
+    @Test
+    fun `a settled fast reports which door it went out by`() {
+        setContent()
+
+        composeRule.onNodeWithText(
+            string(R.string.fasting_fidya_paid_on, mediumDate(paid.completedDate!!))
+        ).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.fasting_made_up_on, mediumDate(madeUp.completedDate!!))
+        ).assertExists()
+    }
+
+    @Test
+    fun `a settled fast with no completion date still says how it was settled`() {
+        makeupState.value = makeupState.value.copy(
+            pendingMakeupFasts = emptyList(),
+            allMakeupFasts = listOf(
+                madeUp.copy(completedDate = null),
+                paid.copy(completedDate = null),
+            ),
+            pendingCount = 0,
+        )
+        setContent()
+
+        // "Completed" twice: `fasting_completed_label` names the stats cell and
+        // `fasting_completed` is the row's own line, and the two strings render the same word.
+        // A count is the honest assertion — the alternative is matching one of them by position.
+        composeRule.onAllNodesWithText(string(R.string.fasting_completed)).assertCountEquals(2)
+        composeRule.onNodeWithText(string(R.string.fasting_fidya_paid)).assertExists()
+    }
+
+    @Test
+    fun `marking complete reports the fast that was marked`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_mark_complete))[0].performClick()
+
+        assertThat(events).containsExactly(FastingEvent.CompleteMakeupFast(owed.id))
+    }
+
+    @Test
+    fun `editing a fast opens the sheet on that fast`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[1].performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_edit_makeup)).assertExists()
+        // The sheet's own reason field, seeded from the *second* row — so the sheet is
+        // demonstrably on the fast that was tapped rather than on whichever one the list
+        // happened to hold first. Asserted on the field rather than on the text, because the
+        // row behind the sheet carries the same word.
+        composeRule.onAllNodes(hasSetTextAction())[0].assertTextContains(alsoOwed.reason)
+    }
+
+    @Test
+    fun `the sheet saves an edited reason back onto the same fast`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[0].performClick()
+        composeRule.waitForIdle()
+        // Reason, note, then the status chips: the first editable field is the reason.
+        composeRule.onAllNodes(hasSetTextAction())[0].performTextReplacement("Hospital stay")
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_save)).performClick()
+        composeRule.waitForIdle()
+
+        val updated = (events.single() as FastingEvent.UpdateMakeupFast).makeupFast
+        assertThat(updated.id).isEqualTo(owed.id)
+        assertThat(updated.reason).isEqualTo("Hospital stay")
+        assertThat(updated.status).isEqualTo(MakeupFastStatus.PENDING)
+    }
+
+    @Test
+    fun `choosing fidya in the sheet pays rather than completes`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[0].performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.fasting_fidya_paid)).performClick()
+        composeRule.waitForIdle()
+        // The amount field only exists once fidya is chosen — it is the fourth text field, after
+        // reason and note.
+        composeRule.onAllNodes(hasSetTextAction())[2].performTextReplacement("12.50")
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_save)).performClick()
+        composeRule.waitForIdle()
+
+        // Money, not a fast. Sending `UpdateMakeupFast` here would record the debt as fasted and
+        // lose the payment entirely.
+        assertThat(events).containsExactly(FastingEvent.PayFidya(owed.id, 12.50))
+    }
+
+    @Test
+    fun `an unreadable fidya amount is treated as nothing paid rather than crashing`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[0].performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.fasting_fidya_paid)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onAllNodes(hasSetTextAction())[2].performTextReplacement("not a number")
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_save)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(events).containsExactly(FastingEvent.PayFidya(owed.id, 0.0))
+    }
+
+    @Test
+    fun `marking a fast completed in the sheet stamps a completion date`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[0].performClick()
+        composeRule.waitForIdle()
+        // The stats grid behind the sheet is labelled "Completed" too; the chip is the one of
+        // the two that can be tapped.
+        composeRule.onAllNodesWithText(string(R.string.fasting_completed_label))
+            .filterToOne(hasClickAction())
+            .performClick()
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_save)).performClick()
+        composeRule.waitForIdle()
+
+        val updated = (events.single() as FastingEvent.UpdateMakeupFast).makeupFast
+        assertThat(updated.status).isEqualTo(MakeupFastStatus.COMPLETED)
+        // Without a date the settled row can only say "Completed" and never when — the whole
+        // point of the settled section is being able to show your working.
+        assertThat(updated.completedDate).isNotNull()
+    }
+
+    @Test
+    fun `the sheet opens on the note and the amount already stored`() {
+        makeupState.value = makeupState.value.copy(
+            pendingMakeupFasts = listOf(
+                owed.copy(note = "Second day of the journey", fidyaAmount = 7.5)
+            ),
+            allMakeupFasts = listOf(
+                owed.copy(note = "Second day of the journey", fidyaAmount = 7.5)
+            ),
+            pendingCount = 1,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_edit)).performClick()
+        composeRule.waitForIdle()
+
+        // Both fields are optional and both are seeded from the row. A sheet that opened blank
+        // would wipe whichever the user did not retype on the next save.
+        composeRule.onAllNodes(hasSetTextAction())[1]
+            .assertTextContains("Second day of the journey")
+        composeRule.onNodeWithText(string(R.string.fasting_fidya_paid)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onAllNodes(hasSetTextAction())[2].assertTextContains("7.5")
+    }
+
+    @Test
+    fun `clearing the note stores it as absent rather than as a blank`() {
+        makeupState.value = makeupState.value.copy(
+            pendingMakeupFasts = listOf(owed.copy(note = "Something")),
+            allMakeupFasts = listOf(owed.copy(note = "Something")),
+            pendingCount = 1,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.fasting_edit)).performClick()
+        composeRule.waitForIdle()
+        composeRule.onAllNodes(hasSetTextAction())[1].performTextClearance()
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_save)).performClick()
+        composeRule.waitForIdle()
+
+        // An empty string and "no note" render differently in the row, and only one of them is
+        // what the user meant by deleting the text.
+        assertThat((events.single() as FastingEvent.UpdateMakeupFast).makeupFast.note).isNull()
+    }
+
+    @Test
+    fun `the sheet names every status it can be set to`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.fasting_edit))[0].performClick()
+        composeRule.waitForIdle()
+
+        // Three chips, one per `MakeupFastStatus`. A `when` arm that fell through would leave a
+        // status the user can select and cannot read.
+        composeRule.onNodeWithText(string(R.string.fasting_sheet_status)).assertExists()
+        MakeupFastStatus.entries.forEach { status ->
+            val label = when (status) {
+                MakeupFastStatus.PENDING -> string(R.string.fasting_pending)
+                MakeupFastStatus.COMPLETED -> string(R.string.fasting_completed_label)
+                MakeupFastStatus.FIDYA_PAID -> string(R.string.fasting_fidya_paid)
+            }
+            composeRule.onAllNodesWithText(label).filterToOne(hasClickAction()).assertExists()
+        }
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerStatsScreenTest.kt
@@ -1,0 +1,271 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatMonthYear
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerStats
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.StatsPeriod
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * The statistics screen, and the three insights it derives.
+ *
+ * `PrayerDaoTest` (#597) pins the arithmetic underneath — perfect days, per-prayer counts,
+ * streaks. What lives only here is the **presentation** of it, and the insights in particular
+ * are computed in this file from `prayedByPrayer`/`missedByPrayer` and asserted nowhere:
+ *
+ *  - the weakest prayer is offered only below 90%, so a user who is doing well is not nagged;
+ *  - a prayer with no data at all counts as 100% rather than 0%, or every prayer the user has
+ *    never recorded would be reported as their weakest;
+ *  - with no prayers recorded at all, none of the three insights may appear — otherwise a fresh
+ *    install opens on "Overall completion: 0%".
+ *
+ * The screen also renders nothing but the period chips while `stats` is null, which is the state
+ * every launch passes through.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class PrayerStatsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun stats(
+        prayed: Int = 100,
+        missed: Int = 20,
+        prayedByPrayer: Map<PrayerName, Int> = mapOf(
+            PrayerName.FAJR to 10,
+            PrayerName.DHUHR to 25,
+            PrayerName.ASR to 25,
+            PrayerName.MAGHRIB to 20,
+            PrayerName.ISHA to 20,
+        ),
+        missedByPrayer: Map<PrayerName, Int> = mapOf(
+            PrayerName.FAJR to 15,
+            PrayerName.DHUHR to 0,
+            PrayerName.ASR to 0,
+            PrayerName.MAGHRIB to 5,
+            PrayerName.ISHA to 0,
+        ),
+        perfectDays: Int = 12,
+        startDate: Long = 1_710_000_000_000L,
+    ) = PrayerStats(
+        totalPrayed = prayed,
+        totalMissed = missed,
+        totalJamaah = 3,
+        prayedByPrayer = prayedByPrayer,
+        missedByPrayer = missedByPrayer,
+        currentStreak = 4,
+        longestStreak = 9,
+        perfectDays = perfectDays,
+        startDate = startDate,
+        endDate = startDate + 1,
+    )
+
+    private val statsState = MutableStateFlow(PrayerStatsUiState(isLoading = false))
+    private val events = mutableListOf<PrayerTrackerEvent>()
+    private var backs = 0
+
+    private val viewModel: PrayerTrackerViewModel = mockk(relaxed = true) {
+        every { this@mockk.statsState } returns this@PrayerStatsScreenTest.statsState
+        every { onEvent(any()) } answers { events += firstArg<PrayerTrackerEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            PrayerStatsScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `before any statistics arrive only the period chips are drawn`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.stats_period_week)).assertExists()
+        // Every launch passes through this state; a chart drawn over a null `stats` is a crash,
+        // and an insights section over one is a claim about nothing.
+        composeRule.onNodeWithText(string(R.string.prayer_completion)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.insights)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `all four periods are offered and choosing one reports it`() {
+        setContent()
+
+        StatsPeriod.entries.forEach { period ->
+            val label = when (period) {
+                StatsPeriod.WEEK -> string(R.string.stats_period_week)
+                StatsPeriod.MONTH -> string(R.string.stats_period_month)
+                StatsPeriod.YEAR -> string(R.string.stats_period_year)
+                StatsPeriod.ALL_TIME -> string(R.string.all_time)
+            }
+            composeRule.onNodeWithText(label).performClick()
+        }
+
+        assertThat(events).containsExactlyElementsIn(
+            StatsPeriod.entries.map { PrayerTrackerEvent.SetStatsPeriod(it) }
+        ).inOrder()
+    }
+
+    @Test
+    fun `the donut carries the counts, the perfect days and both streaks`() {
+        statsState.value = statsState.value.copy(
+            stats = stats(),
+            currentStreak = 4,
+            longestStreak = 9,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_completion)).assertExists()
+        composeRule.onNodeWithText(string(R.string.prayer_breakdown)).assertExists()
+        composeRule.onNodeWithText("100").assertExists()
+        composeRule.onNodeWithText("20").assertExists()
+        composeRule.onNodeWithText("12").assertExists()
+        composeRule.onNodeWithText("9").assertExists()
+    }
+
+    @Test
+    fun `the donut is subtitled with the month the statistics start in`() {
+        val startDate = 1_710_000_000_000L
+        statsState.value = statsState.value.copy(stats = stats(startDate = startDate))
+        setContent()
+
+        val expected = Instant.ofEpochMilli(startDate).atZone(ZoneId.systemDefault())
+            .toLocalDate().formatMonthYear()
+        composeRule.onNodeWithText(expected).assertExists()
+    }
+
+    @Test
+    fun `a prayer below ninety percent is flagged for attention`() {
+        statsState.value = statsState.value.copy(stats = stats())
+        setContent()
+
+        // Fajr at 10 of 25 is 40%: the weakest, and the one the user can act on.
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_needs_attention, string(R.string.prayer_fajr))
+        ).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_needs_attention_desc, string(R.string.prayer_fajr), 40)
+        ).assertExists()
+    }
+
+    @Test
+    fun `a strong record is not nagged about its weakest prayer`() {
+        statsState.value = statsState.value.copy(
+            stats = stats(
+                prayed = 100,
+                missed = 2,
+                prayedByPrayer = PrayerName.entries.associateWith { 20 },
+                missedByPrayer = PrayerName.entries.associateWith { 1 },
+            )
+        )
+        setContent()
+
+        // Every prayer is at 95%. There is always a weakest one; below 90% is what makes it
+        // worth saying, and a screen that always shows a warning teaches the user to ignore it.
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_needs_attention, string(R.string.prayer_fajr))
+        ).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.prayer_insight_overall, 98)).assertExists()
+    }
+
+    @Test
+    fun `the overall insight reports the completion percentage and the counts behind it`() {
+        statsState.value = statsState.value.copy(stats = stats(prayed = 90, missed = 10))
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_insight_overall, 90)).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_overall_desc, 90, 100)
+        ).assertExists()
+    }
+
+    @Test
+    fun `the best prayer is the one with the fewest misses`() {
+        statsState.value = statsState.value.copy(stats = stats())
+        setContent()
+
+        // Dhuhr, Asr and Isha are all at 100%; `maxByOrNull` keeps the first, which is Dhuhr.
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_best, string(R.string.prayer_dhuhr))
+        ).assertExists()
+    }
+
+    @Test
+    fun `a prayer with no record at all is not called the weakest`() {
+        statsState.value = statsState.value.copy(
+            stats = stats(
+                prayed = 40,
+                missed = 10,
+                prayedByPrayer = mapOf(PrayerName.FAJR to 10, PrayerName.DHUHR to 30),
+                missedByPrayer = mapOf(PrayerName.DHUHR to 10),
+            )
+        )
+        setContent()
+
+        // Asr, Maghrib and Isha have nothing recorded either way; counting them as 0% would make
+        // one of them the weakest every time and bury the prayer the user is actually behind on.
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_needs_attention, string(R.string.prayer_dhuhr))
+        ).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_needs_attention, string(R.string.prayer_asr))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `with nothing recorded at all, no insight is offered`() {
+        statsState.value = statsState.value.copy(
+            stats = stats(
+                prayed = 0,
+                missed = 0,
+                prayedByPrayer = emptyMap(),
+                missedByPrayer = emptyMap(),
+                perfectDays = 0,
+            )
+        )
+        setContent()
+
+        // A fresh install has statistics — all zero. "Overall completion: 0%" as the first thing
+        // it says is a judgement about a user who has not used the feature yet.
+        composeRule.onNodeWithText(string(R.string.prayer_insight_overall, 0)).assertDoesNotExist()
+        composeRule.onNodeWithText(
+            string(R.string.prayer_insight_best, string(R.string.prayer_fajr))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/PrayerTrackerScreenTest.kt
@@ -1,0 +1,521 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatFullDate
+import com.arshadshah.nimaz.core.common.toUtcMidnightMillis
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.model.PrayerTimes
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerHistoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.QadaPrayersUiState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * The prayer tracker, and the banner that is the only way into the qada list.
+ *
+ * `:core:database` (#597) pins what the confirm-unrecorded DAO call does — it never overwrites a
+ * logged prayer, never marks sunrise, and stops at the range's ends. What nothing pins is the
+ * *offer*: that the banner appears only when there is genuinely something to confirm, that its
+ * count is the count of unrecorded prayers in the last week, and that confirming asks for the
+ * right seven days. A banner that offered to mark a week missed when the week was fully logged
+ * would be a one-tap way to fabricate a qada list, and the DAO test cannot see it.
+ *
+ * The month load window is the other thing only this file can see. The screen deliberately loads
+ * the displayed month **and** the trailing review window, always — paging to a month that does
+ * not contain today used to leave the banner and the rail resolving the last seven real days
+ * from an empty record set, so every one read NOT_RECORDED and the banner announced a fabricated
+ * count.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class PrayerTrackerScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val today: LocalDate = LocalDate.now()
+
+    private val location = Location(
+        id = 1, name = "Test",
+        latitude = 0.0, longitude = 0.0,
+        timezone = "UTC",
+        country = null, city = null,
+        isCurrentLocation = true, isFavorite = false,
+        calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+        asrCalculation = AsrCalculation.STANDARD,
+        highLatitudeRule = null, fajrAngle = null, ishaAngle = null,
+    )
+
+    /** A schedule for [date] whose every prayer is in the small hours, so the day has "passed". */
+    private fun times(date: LocalDate) = PrayerTimes(
+        fajr = date.atTime(0, 1),
+        sunrise = date.atTime(0, 2),
+        dhuhr = date.atTime(0, 3),
+        asr = date.atTime(0, 4),
+        maghrib = date.atTime(0, 5),
+        isha = date.atTime(0, 6),
+        date = date,
+        location = location,
+    )
+
+    private fun record(date: LocalDate, prayer: PrayerName, status: PrayerStatus) = PrayerRecord(
+        id = date.toEpochDay() * 10 + prayer.ordinal,
+        date = date.toUtcMidnightMillis(),
+        prayerName = prayer,
+        status = status,
+        prayedAt = null,
+        scheduledTime = 0L,
+        isJamaah = false,
+        isQadaFor = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    /** Every tracked prayer on [date] recorded with [status]. */
+    private fun wholeDay(date: LocalDate, status: PrayerStatus) =
+        TRACKED_PRAYERS.map { record(date, it, status) }
+
+    /** The seven days the review window looks at, each fully recorded. */
+    private fun fullyLoggedWeek() =
+        (1..7L).flatMap { wholeDay(today.minusDays(it), PrayerStatus.PRAYED) }
+
+    private val trackerState = MutableStateFlow(
+        PrayerTrackerUiState(selectedDate = today, prayerTimes = times(today), isLoading = false)
+    )
+    private val statsState = MutableStateFlow(PrayerStatsUiState(isLoading = false))
+    private val historyState = MutableStateFlow(
+        PrayerHistoryUiState(
+            records = fullyLoggedWeek(),
+            startDate = today.minusDays(7),
+            endDate = today,
+            isLoading = false,
+        )
+    )
+    private val qadaState = MutableStateFlow(QadaPrayersUiState(isLoading = false))
+    private val events = mutableListOf<PrayerTrackerEvent>()
+    private val navigations = mutableListOf<String>()
+
+    private val viewModel: PrayerTrackerViewModel = mockk(relaxed = true) {
+        every { this@mockk.trackerState } returns this@PrayerTrackerScreenTest.trackerState
+        every { this@mockk.statsState } returns this@PrayerTrackerScreenTest.statsState
+        every { this@mockk.historyState } returns this@PrayerTrackerScreenTest.historyState
+        every { this@mockk.qadaState } returns this@PrayerTrackerScreenTest.qadaState
+        every { onEvent(any()) } answers { events += firstArg<PrayerTrackerEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            PrayerTrackerScreen(
+                onNavigateBack = { navigations += "back" },
+                onNavigateToStats = { navigations += "stats" },
+                onNavigateToQada = { navigations += "qada" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /**
+     * The picker's "On time" cell.
+     *
+     * A row that already carries the status shows it in the accordion header's badge too, and a
+     * clickable header merges its children's semantics — so the word matches the header as well
+     * as the cell. The cell is the selectable one.
+     */
+    private fun onTimeCell() = composeRule
+        .onAllNodesWithText(string(R.string.on_time))
+        .filterToOne(isSelectable())
+
+    private fun bannerText(count: Int) =
+        context.resources.getQuantityString(R.plurals.prayer_unrecorded_banner, count, count)
+
+    @Test
+    fun `the screen loads the displayed month and the trailing review window together`() {
+        setContent()
+
+        val load = events.filterIsInstance<PrayerTrackerEvent.LoadHistory>().first()
+        // Loading only the displayed month is what made the banner count days it had no records
+        // for. The window must reach back a week from *today*, whatever month is on screen.
+        assertThat(load.startDate).isAtMost(today.minusDays(7))
+        assertThat(load.endDate).isAtLeast(today)
+    }
+
+    @Test
+    fun `a fully logged week is offered no review banner`() {
+        setContent()
+
+        // The banner is the only door into the qada list, and it writes MISSED against every
+        // unrecorded prayer it counted. Offering it over a complete week would be a one-tap way
+        // to fabricate a debt that cannot be undone.
+        composeRule.onNodeWithText(string(R.string.prayer_unrecorded_banner_action))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the banner counts the prayers actually left unrecorded`() {
+        // Six of the seven days fully logged; yesterday has Fajr and nothing else, so four of
+        // the week's thirty-five prayers are unrecorded.
+        historyState.value = historyState.value.copy(
+            records = (2..7L).flatMap { wholeDay(today.minusDays(it), PrayerStatus.PRAYED) } +
+                    record(today.minusDays(1), PrayerName.FAJR, PrayerStatus.PRAYED),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(bannerText(4)).assertExists()
+    }
+
+    @Test
+    fun `a prayer explicitly marked missed is not counted as unrecorded`() {
+        historyState.value = historyState.value.copy(
+            records = (2..7L).flatMap { wholeDay(today.minusDays(it), PrayerStatus.PRAYED) } +
+                    wholeDay(today.minusDays(1), PrayerStatus.MISSED),
+        )
+        setContent()
+
+        // "You missed these" and "nobody has said" are different claims — the whole point of the
+        // redesign. A missed prayer is already recorded, so the banner has nothing to offer.
+        composeRule.onNodeWithText(string(R.string.prayer_unrecorded_banner_action))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `a NOT_PRAYED row reads as unrecorded rather than as an assertion`() {
+        historyState.value = historyState.value.copy(
+            records = (2..7L).flatMap { wholeDay(today.minusDays(it), PrayerStatus.PRAYED) } +
+                    wholeDay(today.minusDays(1), PrayerStatus.NOT_PRAYED),
+        )
+        setContent()
+
+        // Clearing a status writes NOT_PRAYED, and that has to read back as "nobody has said" —
+        // otherwise clearing a prayer would quietly hide it from the review.
+        composeRule.onNodeWithText(bannerText(5)).assertExists()
+    }
+
+    @Test
+    fun `confirming the review asks for the seven days behind today, not today itself`() {
+        historyState.value = historyState.value.copy(records = emptyList())
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_unrecorded_banner_action)).performClick()
+
+        // Today is excluded: its later prayers have not happened yet, and marking them missed
+        // would be an accusation about a day still in progress.
+        assertThat(events).contains(
+            PrayerTrackerEvent.ConfirmUnrecordedAsMissed(
+                from = today.minusDays(7),
+                to = today.minusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `the day card reports how many of the five are recorded`() {
+        trackerState.value = trackerState.value.copy(
+            prayerTimes = times(today),
+        )
+        historyState.value = historyState.value.copy(
+            records = fullyLoggedWeek() +
+                    record(today, PrayerName.FAJR, PrayerStatus.PRAYED) +
+                    record(today, PrayerName.DHUHR, PrayerStatus.LATE),
+        )
+        setContent()
+
+        // LATE counts as done — it is still an assertion that the prayer was performed.
+        composeRule.onNodeWithText(string(R.string.prayer_recorded_count_format, 2, 5))
+            .assertExists()
+        // The timeline carries the same sentence as its screen-reader description, so TalkBack
+        // gets the count rather than five bare prayer names with no status.
+        composeRule.onNodeWithContentDescription(
+            string(R.string.prayer_recorded_count_format, 2, 5)
+        ).assertExists()
+    }
+
+    @Test
+    fun `setting a prayer's status reports the prayer and the status`() {
+        setContent()
+
+        composeRule.onNodeWithText(PrayerName.FAJR.displayName()).performClick()
+        composeRule.waitForIdle()
+        onTimeCell().performClick()
+
+        assertThat(events).contains(
+            PrayerTrackerEvent.SetPrayerStatus(PrayerName.FAJR, PrayerStatus.PRAYED)
+        )
+    }
+
+    @Test
+    fun `choosing the status a prayer already has withdraws it`() {
+        historyState.value = historyState.value.copy(
+            records = fullyLoggedWeek() + record(today, PrayerName.ASR, PrayerStatus.PRAYED),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(PrayerName.ASR.displayName()).performClick()
+        composeRule.waitForIdle()
+        onTimeCell().performClick()
+
+        // Tap-to-clear. Without it there is no way to take back a status set by mistake, because
+        // the picker has no "unset" cell.
+        assertThat(events).contains(
+            PrayerTrackerEvent.SetPrayerStatus(PrayerName.ASR, null)
+        )
+    }
+
+    @Test
+    fun `an unrecorded prayer whose time has passed explains itself`() {
+        setContent()
+
+        composeRule.onNodeWithText(PrayerName.ISHA.displayName()).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.prayer_not_recorded_note)).assertExists()
+    }
+
+    @Test
+    fun `made-up is offered only once a prayer's time has passed`() {
+        // A schedule whose prayers are all still ahead of now, so nothing has passed yet.
+        val ahead = today.atTime(23, 59)
+        trackerState.value = trackerState.value.copy(
+            prayerTimes = times(today).copy(
+                fajr = ahead, dhuhr = ahead, asr = ahead, maghrib = ahead, isha = ahead,
+            ),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(PrayerName.FAJR.displayName()).performClick()
+        composeRule.waitForIdle()
+
+        // Marking a prayer that has not happened yet as *made up* is incoherent — and it used to
+        // be reachable by marking it prayed early, which flips its status without its time
+        // having arrived.
+        composeRule.onNodeWithText(string(R.string.made_up)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.on_time)).assertExists()
+    }
+
+    @Test
+    fun `with no schedule the card says the times are missing, not that the day is done`() {
+        trackerState.value = trackerState.value.copy(prayerTimes = null)
+        setContent()
+
+        // The same null makes all five rows read UPCOMING, so "Day complete" here would be the
+        // card contradicting itself over breakfast.
+        composeRule.onNodeWithText(string(R.string.prayer_day_no_schedule)).assertExists()
+        composeRule.onNodeWithText(string(R.string.prayer_day_complete)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a past day summarises what was recorded rather than counting down to it`() {
+        val yesterday = today.minusDays(1)
+        trackerState.value = trackerState.value.copy(
+            selectedDate = yesterday,
+            prayerTimes = times(yesterday),
+        )
+        historyState.value = historyState.value.copy(
+            records = wholeDay(yesterday, PrayerStatus.PRAYED),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_day_summary_past, 5, 5)).assertExists()
+    }
+
+    @Test
+    fun `a day other than today offers a way back to it`() {
+        trackerState.value = trackerState.value.copy(
+            selectedDate = today.minusDays(2),
+            prayerTimes = null,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.back_to_today)).performClick()
+
+        assertThat(events).contains(PrayerTrackerEvent.SelectDate(today))
+    }
+
+    @Test
+    fun `today's card offers no way back to today`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.back_to_today)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the streak badge appears only once there is a streak`() {
+        setContent()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.khatam_widget_streak, 4, 4)
+        ).assertDoesNotExist()
+
+        statsState.value = statsState.value.copy(currentStreak = 4)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.khatam_widget_streak, 4, 4)
+        ).assertExists()
+    }
+
+    @Test
+    fun `selecting a day from the rail reports it`() {
+        setContent()
+
+        // The rail is centred on the selected day, three either side, and future cells are
+        // disabled — so the cell two back is the first that is both present and selectable.
+        val twoBack = today.minusDays(2)
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_prayed, twoBack.formatFullDate())
+        ).performClick()
+
+        assertThat(events).contains(PrayerTrackerEvent.SelectDate(twoBack))
+    }
+
+    @Test
+    fun `the rail describes each day by what is recorded on it`() {
+        val partial = today.minusDays(1)
+        val missed = today.minusDays(2)
+        historyState.value = historyState.value.copy(
+            records = (3..7L).flatMap { wholeDay(today.minusDays(it), PrayerStatus.PRAYED) } +
+                    listOf(record(partial, PrayerName.FAJR, PrayerStatus.PRAYED)) +
+                    wholeDay(missed, PrayerStatus.MISSED),
+        )
+        setContent()
+
+        // Four states, four sentences — and TalkBack gets nothing else: the marker is a coloured
+        // dot with no text of its own, so a day that fell into the wrong bucket would be
+        // indistinguishable to a screen-reader user and to anyone reading the dots at a glance.
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_partial, partial.formatFullDate())
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_missed, missed.formatFullDate())
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_prayed, today.minusDays(3).formatFullDate())
+        ).assertExists()
+    }
+
+    @Test
+    fun `a day with nothing on it is described as not recorded, not as missed`() {
+        historyState.value = historyState.value.copy(records = emptyList())
+        setContent()
+
+        // The distinction the whole redesign turns on: "nobody has said" is not an accusation,
+        // and the rail must not paint it as one.
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_not_recorded, today.minusDays(1).formatFullDate())
+        ).assertExists()
+        composeRule.onNodeWithContentDescription(
+            string(R.string.a11y_prayer_state_missed, today.minusDays(1).formatFullDate())
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a future day on the rail cannot be selected`() {
+        setContent()
+
+        val tomorrow = today.plusDays(1)
+        composeRule.onNodeWithContentDescription(
+            "${tomorrow.formatFullDate()}, ${string(R.string.upcoming)}"
+        ).performClick()
+
+        // Disabled rather than absent: the rail is centred, so the days ahead are on screen and
+        // must simply not respond. Logging a prayer that has not happened is not a thing to
+        // offer.
+        assertThat(events.filterIsInstance<PrayerTrackerEvent.SelectDate>()).isEmpty()
+    }
+
+    @Test
+    fun `the month header counts the days on which all five were recorded`() {
+        historyState.value = historyState.value.copy(
+            records = fullyLoggedWeek() +
+                    wholeDay(today.minusDays(8), PrayerStatus.PRAYED) +
+                    listOf(record(today.minusDays(9), PrayerName.FAJR, PrayerStatus.PRAYED)),
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_month_section)).assertExists()
+        // The seven review-window days plus the eighth; the ninth has one prayer and does not
+        // count. Days after today are excluded whatever the records say.
+        val complete = (1..8L).count { !today.minusDays(it).isAfter(today) }
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.prayer_complete_days, complete, complete)
+        ).assertExists()
+    }
+
+    @Test
+    fun `the qada row says nothing is outstanding when nothing is`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qada_summary_empty)).assertExists()
+    }
+
+    @Test
+    fun `the qada row counts what is owed and leads to the list`() {
+        qadaState.value = qadaState.value.copy(
+            missedPrayers = listOf(
+                record(today.minusDays(3), PrayerName.FAJR, PrayerStatus.MISSED),
+                record(today.minusDays(4), PrayerName.ISHA, PrayerStatus.MISSED),
+            ),
+            totalMissed = 2,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.qada_summary_subtitle)).assertExists()
+        composeRule.onNodeWithText(string(R.string.qada_prayers)).performClick()
+
+        assertThat(navigations).containsExactly("qada")
+    }
+
+    @Test
+    fun `the statistics action navigates`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.view_statistics)).performClick()
+
+        assertThat(navigations).containsExactly("stats")
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.prayer_tracker_title))
+            .assertCountEquals(1)
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(navigations).containsExactly("back")
+    }
+
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/QadaPrayersScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/prayer/QadaPrayersScreenTest.kt
@@ -1,0 +1,159 @@
+package com.arshadshah.nimaz.presentation.screens.prayer
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.toUtcMidnightMillis
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.PrayerTrackerViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.QadaPrayersUiState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * The make-up list: every prayer the user has explicitly marked missed.
+ *
+ * The empty state is the assertion that matters most here, and it is a promise about the app's
+ * behaviour rather than a layout detail: **nothing lands in this list on the user's behalf**.
+ * The only way in is the tracker's review banner, which asks first. An empty-state message that
+ * drifted away from that would be the app quietly claiming to keep score.
+ *
+ * The month grouping is the other half — the ViewModel supplies `groupedByMonth` and this screen
+ * decides that an empty list plus a finished load is the empty state, while an empty list that is
+ * still loading is not. Showing "All caught up!" during the first frame of a load is a false
+ * reassurance to someone who has a debt.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class QadaPrayersScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val day: LocalDate = LocalDate.of(2026, 3, 14)
+
+    private fun missed(id: Long, prayer: PrayerName, date: LocalDate = day) = PrayerRecord(
+        id = id,
+        date = date.toUtcMidnightMillis(),
+        prayerName = prayer,
+        status = PrayerStatus.MISSED,
+        prayedAt = null,
+        scheduledTime = date.atTime(5, 0).toLocalTime().toSecondOfDay() * 1000L,
+        isJamaah = false,
+        isQadaFor = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val fajr = missed(1, PrayerName.FAJR)
+    private val isha = missed(2, PrayerName.ISHA)
+    private val lastMonth = missed(3, PrayerName.ASR, day.minusMonths(1))
+
+    private val qadaState = MutableStateFlow(
+        QadaPrayersUiState(
+            missedPrayers = listOf(fajr, isha, lastMonth),
+            groupedByMonth = mapOf(
+                "March 2026" to listOf(fajr, isha),
+                "February 2026" to listOf(lastMonth),
+            ),
+            totalMissed = 3,
+            isLoading = false,
+        )
+    )
+    private val events = mutableListOf<PrayerTrackerEvent>()
+    private var backs = 0
+
+    private val viewModel: PrayerTrackerViewModel = mockk(relaxed = true) {
+        every { this@mockk.qadaState } returns this@QadaPrayersScreenTest.qadaState
+        every { onEvent(any()) } answers { events += firstArg<PrayerTrackerEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            QadaPrayersScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the summary counts what is outstanding`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayers_to_make_up)).assertExists()
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.missed_prayers_pending, 3, 3)
+        ).assertExists()
+    }
+
+    @Test
+    fun `the list is grouped by month, newest heading first`() {
+        setContent()
+
+        composeRule.onNodeWithText("March 2026").assertExists()
+        composeRule.onNodeWithText("February 2026").assertExists()
+        composeRule.onAllNodesWithText(string(R.string.qada_mark_made_up)).assertCountEquals(3)
+    }
+
+    @Test
+    fun `marking one made up reports that prayer`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.qada_mark_made_up))[0].performClick()
+
+        assertThat(events).containsExactly(PrayerTrackerEvent.MarkQadaCompleted(fajr))
+    }
+
+    @Test
+    fun `an empty list says nothing was added on the user's behalf`() {
+        qadaState.value = QadaPrayersUiState(isLoading = false)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.all_caught_up)).assertExists()
+        // The message is a promise about the app: prayers land here only when the user says so.
+        composeRule.onNodeWithText(string(R.string.all_caught_up_message)).assertExists()
+        composeRule.onNodeWithText(string(R.string.all_caught_up_short)).assertExists()
+    }
+
+    @Test
+    fun `an empty list that is still loading is not called caught up`() {
+        qadaState.value = QadaPrayersUiState(isLoading = true)
+        setContent()
+
+        // "All caught up" on the first frame of a load is a false reassurance to someone who has
+        // a debt — and it is exactly the frame every open of this screen starts on.
+        composeRule.onNodeWithText(string(R.string.all_caught_up)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/AddPresetScreenTest.kt
@@ -1,0 +1,294 @@
+package com.arshadshah.nimaz.presentation.screens.tasbih
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihPresetsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The custom-dhikr form, in both of the modes one composable serves.
+ *
+ * The edit mode is the interesting one, and its seeding rule is the reason this file exists.
+ * `LaunchedEffect` copies the loaded preset into the fields **once** — the presets flow re-emits
+ * on every write to that table, so a form that re-seeded on each emission would silently discard
+ * whatever the user had typed the moment anything else touched the presets. That is a data-loss
+ * bug with no error message, and the `seeded` flag guarding it is checkable only from here.
+ *
+ * The rest are the ordinary ways a form goes wrong and stays plausible: creating when it should
+ * update (which leaves a duplicate rather than an edit), a blank name accepted, and a target of
+ * `""` silently becoming something other than the documented 33.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class AddPresetScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val existing = TasbihPreset(
+        id = 42L,
+        name = "My own dhikr",
+        arabicText = "ذِكْر",
+        transliteration = "Dhikr",
+        translation = "Remembrance",
+        targetCount = 100,
+        category = TasbihCategory.EVENING,
+        reference = "a note to keep",
+        isDefault = false,
+        displayOrder = 3,
+        createdAt = 1_000L,
+        updatedAt = 2_000L,
+    )
+
+    private val presetsState = MutableStateFlow(
+        TasbihPresetsUiState(customPresets = listOf(existing), isLoading = false)
+    )
+    private val events = mutableListOf<TasbihEvent>()
+    private var backs = 0
+
+    private val viewModel: TasbihViewModel = mockk(relaxed = true) {
+        every { this@mockk.presetsState } returns this@AddPresetScreenTest.presetsState
+        every { onEvent(any()) } answers { events += firstArg<TasbihEvent>() }
+    }
+
+    private fun setContent(presetId: Long? = null) {
+        composeRule.setThemedContent {
+            AddPresetScreen(
+                onNavigateBack = { backs++ },
+                presetId = presetId,
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /**
+     * The form's fields, in the order they are laid out: name, Arabic, transliteration,
+     * translation.
+     *
+     * Addressed by position rather than by placeholder because `preset_name_placeholder` and
+     * `transliteration_placeholder` are **the same string** — "e.g., SubhanAllah wa Bihamdihi" —
+     * so a placeholder finder matches two fields and fails on the count, which is a collision in
+     * the strings rather than anything wrong with the form.
+     */
+    private fun field(index: Int) = composeRule.onAllNodes(hasSetTextAction())[index]
+
+    private fun nameField() = field(0)
+
+    private fun createdPreset(): TasbihPreset =
+        (events.single() as TasbihEvent.CreateCustomPreset).preset
+
+    private fun updatedPreset(): TasbihPreset =
+        (events.single() as TasbihEvent.UpdateCustomPreset).preset
+
+    @Test
+    fun `a filled-in form creates the dhikr it describes and leaves`() {
+        setContent()
+
+        nameField()
+            .performTextInput("  Alhamdulillah  ")
+        field(1)
+            .performTextInput("الحمد لله")
+        field(2)
+            .performTextInput("Alhamdulillah")
+        field(3)
+            .performTextInput("All praise is due to Allah")
+        composeRule.onNodeWithText(string(R.string.tasbih_category_morning)).performClick()
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        val preset = createdPreset()
+        // Trimmed, because a trailing space is invisible and would sort and match differently.
+        assertThat(preset.name).isEqualTo("Alhamdulillah")
+        assertThat(preset.translation).isEqualTo("All praise is due to Allah")
+        assertThat(preset.category).isEqualTo(TasbihCategory.MORNING)
+        assertThat(preset.id).isEqualTo(0L)
+        assertThat(preset.isDefault).isFalse()
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `empty optional fields are stored as absent rather than as blanks`() {
+        setContent()
+
+        nameField()
+            .performTextInput("Bare")
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        // A blank string and "no Arabic text" render very differently — the row draws an empty
+        // Arabic line for one and nothing at all for the other.
+        val preset = createdPreset()
+        assertThat(preset.arabicText).isNull()
+        assertThat(preset.transliteration).isNull()
+        assertThat(preset.translation).isNull()
+        assertThat(preset.targetCount).isEqualTo(33)
+    }
+
+    @Test
+    fun `a nameless dhikr is refused, and saying so clears once typing resumes`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        assertThat(events).isEmpty()
+        assertThat(backs).isEqualTo(0)
+        composeRule.onNodeWithText(string(R.string.name_required_error)).assertExists()
+
+        nameField()
+            .performTextInput("Now named")
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.name_required_error)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the target stepper will not go below one`() {
+        setContent()
+
+        nameField()
+            .performTextInput("Bounded")
+        repeat(40) {
+            composeRule.onNodeWithContentDescription(string(R.string.cd_decrease)).performClick()
+        }
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        // A target of zero makes the counter's progress arithmetic divide by it.
+        assertThat(createdPreset().targetCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `editing seeds the form from the preset and updates rather than duplicates`() {
+        setContent(presetId = existing.id)
+        composeRule.waitForIdle()
+
+        // The title changes with the mode, and the button with it — a form that says "Create"
+        // over a loaded preset is one tap from a duplicate.
+        composeRule.onNodeWithText(string(R.string.edit_tasbih)).assertExists()
+        composeRule.onNodeWithText(existing.name).assertExists()
+        composeRule.onNodeWithText(existing.translation!!).assertExists()
+
+        composeRule.onNodeWithText(string(R.string.save_tasbih)).performClick()
+
+        val preset = updatedPreset()
+        assertThat(preset.id).isEqualTo(existing.id)
+        assertThat(preset.name).isEqualTo(existing.name)
+        assertThat(preset.targetCount).isEqualTo(existing.targetCount)
+        assertThat(preset.category).isEqualTo(TasbihCategory.EVENING)
+        // Carried through untouched: neither is editable here, and losing them on every save
+        // would quietly strip the reference off a dhikr the user had cited.
+        assertThat(preset.reference).isEqualTo(existing.reference)
+        assertThat(preset.createdAt).isEqualTo(existing.createdAt)
+        assertThat(preset.displayOrder).isEqualTo(existing.displayOrder)
+    }
+
+    @Test
+    fun `editing a dhikr that has only a name leaves the other fields empty`() {
+        val bare = existing.copy(
+            arabicText = null,
+            transliteration = null,
+            translation = null,
+            category = null,
+        )
+        presetsState.value = presetsState.value.copy(customPresets = listOf(bare))
+        setContent(presetId = bare.id)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.save_tasbih)).performClick()
+
+        // Seeding must turn a null field into an empty box, not into the string "null" — and it
+        // must come back out as null rather than as a blank the row would draw a gap for.
+        val preset = updatedPreset()
+        assertThat(preset.arabicText).isNull()
+        assertThat(preset.transliteration).isNull()
+        assertThat(preset.translation).isNull()
+        // A dhikr saved with no category is the user's own, so the form defaults it there rather
+        // than leaving it uncategorised and unfindable under any tab.
+        assertThat(preset.category).isEqualTo(TasbihCategory.CUSTOM)
+    }
+
+    @Test
+    fun `every category the form offers can be chosen`() {
+        setContent()
+
+        nameField().performTextInput("Categorised")
+        composeRule.onNodeWithText(string(R.string.tasbih_category_daily)).performClick()
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        // Five chips over five enum entries, each with its own label: a `when` arm that fell
+        // through would leave a category the user can pick and cannot read.
+        assertThat(createdPreset().category).isEqualTo(TasbihCategory.DAILY)
+    }
+
+    @Test
+    fun `a re-emission of the presets flow does not overwrite what has been typed`() {
+        setContent(presetId = existing.id)
+        composeRule.waitForIdle()
+
+        nameField().performTextReplacement("Renamed by hand")
+
+        // Anything writing to the presets table re-emits this flow — creating another dhikr,
+        // toggling a favourite, the seeder running. Re-seeding on that emission would throw the
+        // user's edit away mid-sentence, with nothing on screen to explain it.
+        presetsState.value = presetsState.value.copy(
+            customPresets = listOf(existing),
+            defaultPresets = presetsState.value.defaultPresets + existing.copy(id = 99L),
+        )
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.save_tasbih)).performClick()
+
+        assertThat(updatedPreset().name).isEqualTo("Renamed by hand")
+    }
+
+    @Test
+    fun `an unknown preset id falls back to creating`() {
+        setContent(presetId = 404L)
+        composeRule.waitForIdle()
+
+        // Nothing to seed from, so the form must be the blank create form rather than a save
+        // button pointed at a preset that does not exist.
+        composeRule.onNodeWithText(string(R.string.new_tasbih)).assertExists()
+        nameField()
+            .performTextInput("Fresh")
+        composeRule.onNodeWithText(string(R.string.create_tasbih)).performClick()
+
+        assertThat(createdPreset().id).isEqualTo(0L)
+    }
+
+    @Test
+    fun `the back arrow leaves without saving anything`() {
+        setContent()
+
+        nameField()
+            .performTextInput("Abandoned")
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(events).isEmpty()
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/ChooseDhikrScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/ChooseDhikrScreenTest.kt
@@ -1,0 +1,316 @@
+package com.arshadshah.nimaz.presentation.screens.tasbih
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihCounterUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihPresetsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Choosing what to count.
+ *
+ * Two filters compose here — a tab and a search box — and they are `&&`-ed inside the screen
+ * rather than derived in the ViewModel, so nothing outside this file has ever run them. The
+ * failure they hide is silent: a list that quietly shows the wrong set still looks like a list
+ * of adhkar, and the user's own custom dhikr simply appears to have vanished.
+ *
+ * Deleting is the other thing worth pinning. It is behind a confirmation because it is
+ * irreversible, and the dialog's cancel arm — the one that must *not* delete — is exactly the
+ * arm no manual pass ever exercises twice.
+ *
+ * Tall on purpose: the list is a `LazyColumn` and the tab strip a `LazyRow`, so at phone height
+ * neither composes in full and an assertion about filtering would be an assertion about
+ * viewport size instead.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class ChooseDhikrScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun preset(
+        id: Long,
+        name: String,
+        category: TasbihCategory?,
+        translation: String? = null,
+        target: Int = 33,
+        arabic: String? = null,
+    ) = TasbihPreset(
+        id = id,
+        name = name,
+        arabicText = arabic,
+        transliteration = null,
+        translation = translation,
+        targetCount = target,
+        category = category,
+        reference = null,
+        isDefault = category != TasbihCategory.CUSTOM,
+        displayOrder = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val subhanAllah =
+        preset(1, "SubhanAllah", TasbihCategory.AFTER_PRAYER, "Glory be", arabic = "سُبْحَانَ ٱللَّٰهِ")
+    private val morningDua = preset(2, "Morning remembrance", TasbihCategory.MORNING)
+    private val eveningDua = preset(3, "Evening remembrance", TasbihCategory.EVENING)
+    private val mine = preset(9, "My own dhikr", TasbihCategory.CUSTOM, target = 7)
+
+    private val presetsState = MutableStateFlow(
+        TasbihPresetsUiState(
+            defaultPresets = listOf(subhanAllah, morningDua, eveningDua),
+            customPresets = listOf(mine),
+            favorites = setOf(2L),
+            isLoading = false,
+        )
+    )
+    private val counterState = MutableStateFlow(TasbihCounterUiState())
+    private val events = mutableListOf<TasbihEvent>()
+    private var backs = 0
+    private var addPresetTaps = 0
+    private val edits = mutableListOf<Long>()
+
+    private val viewModel: TasbihViewModel = mockk(relaxed = true) {
+        every { this@mockk.presetsState } returns this@ChooseDhikrScreenTest.presetsState
+        every { this@mockk.counterState } returns this@ChooseDhikrScreenTest.counterState
+        every { onEvent(any()) } answers { events += firstArg<TasbihEvent>() }
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            ChooseDhikrScreen(
+                onBack = { backs++ },
+                onNavigateToAddPreset = { addPresetTaps++ },
+                onEditPreset = { edits += it },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the All tab shows every default and every custom dhikr`() {
+        setContent()
+
+        composeRule.onNodeWithText(subhanAllah.name).assertExists()
+        composeRule.onNodeWithText(morningDua.name).assertExists()
+        composeRule.onNodeWithText(eveningDua.name).assertExists()
+        composeRule.onNodeWithText(mine.name).assertExists()
+    }
+
+    @Test
+    fun `a category tab keeps only that category`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_category_morning)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(morningDua.name).assertExists()
+        composeRule.onNodeWithText(subhanAllah.name).assertDoesNotExist()
+        composeRule.onNodeWithText(eveningDua.name).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the Mine tab keeps only what the user created`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_category_mine)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(mine.name).assertExists()
+        composeRule.onNodeWithText(subhanAllah.name).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the star tab keeps only the favourites`() {
+        setContent()
+
+        // The tab's label is literally a star, which is the whole of its text.
+        composeRule.onNodeWithText("★").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(morningDua.name).assertExists()
+        composeRule.onNodeWithText(subhanAllah.name).assertDoesNotExist()
+        composeRule.onNodeWithText(mine.name).assertDoesNotExist()
+    }
+
+    @Test
+    fun `search matches a translation, not only a name`() {
+        setContent()
+
+        // `NimazSearchBar` carries its placeholder as a content description rather than as text.
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_search_dhikr))
+            .performTextInput("glory")
+        composeRule.waitForIdle()
+
+        // Case-insensitive, and against the English gloss — someone searching for what a dhikr
+        // *means* has no other way to find it.
+        composeRule.onNodeWithText(subhanAllah.name).assertExists()
+        composeRule.onNodeWithText(morningDua.name).assertDoesNotExist()
+    }
+
+    @Test
+    fun `search and tab narrow together rather than one replacing the other`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_category_morning)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_search_dhikr))
+            .performTextInput("evening")
+        composeRule.waitForIdle()
+
+        // "Evening remembrance" matches the query but not the tab, so nothing survives. A screen
+        // that let the query win would show a dhikr from a category the user filtered out.
+        composeRule.onNodeWithText(eveningDua.name).assertDoesNotExist()
+        composeRule.onNodeWithText(morningDua.name).assertDoesNotExist()
+    }
+
+    @Test
+    fun `picking a dhikr selects it and goes back`() {
+        setContent()
+
+        composeRule.onNodeWithText(subhanAllah.name).performClick()
+
+        assertThat(events).containsExactly(TasbihEvent.SelectPreset(subhanAllah))
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `free count clears the selection and goes back`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_free_count_subtitle)).performClick()
+
+        assertThat(events).containsExactly(TasbihEvent.ClearPreset)
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `the star on a row toggles that row's dhikr`() {
+        setContent()
+
+        // Every row publishes an identically-described star, so the list is narrowed to one row
+        // first — an unqualified match would assert against whichever row came first and pass
+        // whatever the tap actually reached.
+        composeRule.onNodeWithText(string(R.string.tasbih_category_mine)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(string(R.string.add_to_favorites)).performClick()
+
+        assertThat(events).containsExactly(TasbihEvent.ToggleFavorite(mine.id))
+    }
+
+    @Test
+    fun `only a custom dhikr offers an edit control`() {
+        setContent()
+
+        // Four rows are listed and exactly one of them is the user's own. The default adhkar are
+        // not theirs to change, and an edit control on one would let a typo be saved over
+        // shipped content.
+        composeRule.onAllNodesWithContentDescription(string(R.string.tasbih_edit_preset))
+            .assertCountEquals(1)
+
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_edit_preset))
+            .performClick()
+
+        assertThat(edits).containsExactly(mine.id)
+    }
+
+    @Test
+    fun `a row shows the dhikr's Arabic where it has some, and nothing where it has none`() {
+        setContent()
+
+        // The Arabic line is the dhikr as it is actually said; a row that dropped it would leave
+        // the user matching adhkar by their English names alone.
+        composeRule.onNodeWithText(subhanAllah.arabicText!!).assertExists()
+        // And a custom dhikr saved without Arabic gets no empty line where one would be.
+        composeRule.onNodeWithText(mine.name).assertExists()
+        composeRule.onAllNodesWithText(subhanAllah.arabicText!!).assertCountEquals(1)
+    }
+
+    @Test
+    fun `a row reports its target count`() {
+        setContent()
+
+        composeRule.onNodeWithText("${mine.targetCount}×").assertExists()
+    }
+
+    @Test
+    fun `swiping a custom dhikr asks before deleting, and cancelling keeps it`() {
+        setContent()
+
+        swipeAwayRowNamed(mine.name)
+
+        composeRule.onNodeWithText(string(R.string.tasbih_delete_preset_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+        composeRule.waitForIdle()
+
+        // The cancel arm is the one a manual pass never runs twice, and the one whose failure is
+        // unrecoverable: the row is gone and the dhikr with it.
+        assertThat(events).isEmpty()
+        composeRule.onNodeWithText(mine.name).assertExists()
+    }
+
+    @Test
+    fun `confirming the dialog deletes the dhikr that was swiped`() {
+        setContent()
+
+        swipeAwayRowNamed(mine.name)
+        composeRule.onNodeWithText(string(R.string.delete)).performClick()
+
+        assertThat(events).containsExactly(TasbihEvent.DeleteCustomPreset(mine.id))
+    }
+
+    @Test
+    fun `the add row leads to the form`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.new_tasbih)).performClick()
+
+        assertThat(addPresetTaps).isEqualTo(1)
+    }
+
+    /**
+     * Swipes the row named [rowText] end-to-start, far enough to pass the dismiss threshold.
+     *
+     * Explicit coordinates rather than a bare `swipeLeft()`: the gesture travels across the node
+     * it is addressed to, and a threshold measured against the row's width is not reached by a
+     * default swipe that starts at its centre.
+     */
+    private fun swipeAwayRowNamed(rowText: String) {
+        composeRule.onNodeWithText(rowText).performTouchInput {
+            swipeLeft(startX = right - 1f, endX = left + 1f, durationMillis = 200)
+        }
+        composeRule.waitForIdle()
+    }
+
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihHistoryScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihHistoryScreenTest.kt
@@ -1,0 +1,202 @@
+package com.arshadshah.nimaz.presentation.screens.tasbih
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.TasbihSession
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihCounterUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihHistoryUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * What the counter recorded, read back.
+ *
+ * Two things here are computed in the screen and nowhere else. The **today total** adds the
+ * session in progress to what is already saved — read `baseTotalToday` alone and the number
+ * someone opened this screen to check is short by everything they have counted since the last
+ * save. The **session subtitle** joins count, laps and duration into one line, and its `%d:%02d`
+ * is the only place a session's length is formatted at all; a minute rendered as `3:7` instead
+ * of `3:07` is wrong in a way no crash reports.
+ *
+ * The tab strip is the other half. `THIS_WEEK` and `ALL_TIME` deliberately read the same source
+ * — there is no all-time query yet — and that is worth pinning so it is a decision rather than
+ * something a later change quietly "fixes" into showing a week's data under an all-time label.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class TasbihHistoryScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun session(
+        id: Long,
+        name: String?,
+        count: Int,
+        target: Int = 33,
+        laps: Int = 0,
+        completed: Boolean = false,
+        duration: Long? = null,
+    ) = TasbihSession(
+        id = id,
+        presetId = null,
+        presetName = name,
+        date = 0L,
+        currentCount = count,
+        targetCount = target,
+        totalLaps = laps,
+        isCompleted = completed,
+        duration = duration,
+        startedAt = 0L,
+        completedAt = null,
+        note = null,
+    )
+
+    private val todaySession = session(1, "SubhanAllah", 33, completed = true, duration = 187_000L)
+    private val weekSession = session(2, null, 12, laps = 3)
+
+    private val historyState = MutableStateFlow(
+        TasbihHistoryUiState(
+            todaySessions = listOf(todaySession),
+            weekSessions = listOf(weekSession),
+            isLoading = false,
+        )
+    )
+    private val statsState = MutableStateFlow(
+        TasbihStatsUiState(
+            baseTotalToday = 100,
+            totalThisWeek = 700,
+            completedSessions = 4,
+            isLoading = false,
+        )
+    )
+    private val counterState = MutableStateFlow(TasbihCounterUiState())
+    private var backs = 0
+
+    private val viewModel: TasbihViewModel = mockk(relaxed = true) {
+        every { this@mockk.historyState } returns this@TasbihHistoryScreenTest.historyState
+        every { this@mockk.statsState } returns this@TasbihHistoryScreenTest.statsState
+        every { this@mockk.counterState } returns this@TasbihHistoryScreenTest.counterState
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            TasbihHistoryScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `while loading, no session list is drawn`() {
+        historyState.value = historyState.value.copy(isLoading = true)
+        setContent()
+
+        // The summary card is part of the list, so its absence is what says the loading arm ran
+        // rather than an empty one.
+        composeRule.onNodeWithText(string(R.string.sessions).uppercase()).assertDoesNotExist()
+        composeRule.onNodeWithText(todaySession.presetName!!).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the today total counts the session in progress on top of what is saved`() {
+        counterState.value = counterState.value.copy(count = 7, laps = 1, targetCount = 33)
+        setContent()
+
+        // 100 saved + (7 + 1×33). Reading `baseTotalToday` alone would report 100 while the
+        // user watches the counter say otherwise.
+        composeRule.onNodeWithText("140").assertExists()
+        composeRule.onNodeWithText("4").assertExists()
+        composeRule.onNodeWithText("700").assertExists()
+    }
+
+    @Test
+    fun `the today tab lists today's sessions`() {
+        setContent()
+
+        composeRule.onNodeWithText(todaySession.presetName!!).assertExists()
+    }
+
+    @Test
+    fun `a session's subtitle carries its count, its laps and its length`() {
+        setContent()
+
+        // 187 seconds is 3:07 — the zero-padded seconds are the whole point of the `%02d`, and
+        // "3:7" is the kind of wrong that ships.
+        composeRule.onNodeWithText("33/33 · 3:07").assertExists()
+    }
+
+    @Test
+    fun `a session with no preset is named as a custom count`() {
+        setContent()
+        composeRule.onNodeWithText(string(R.string.this_week)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.custom)).assertExists()
+        composeRule.onNodeWithText(
+            "12/33 · ${context.resources.getQuantityString(R.plurals.laps_format, 3, 3)}"
+        ).assertExists()
+    }
+
+    @Test
+    fun `only a completed session is badged done`() {
+        setContent()
+        composeRule.onNodeWithText(string(R.string.done).uppercase()).assertExists()
+
+        composeRule.onNodeWithText(string(R.string.this_week)).performClick()
+        composeRule.waitForIdle()
+
+        // The week's one session is unfinished, so the badge must go with it.
+        composeRule.onNodeWithText(string(R.string.done).uppercase()).assertDoesNotExist()
+    }
+
+    @Test
+    fun `all-time falls back to the week, because no wider query exists yet`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.all_time)).performClick()
+        composeRule.waitForIdle()
+
+        // Deliberate, and pinned so it stays deliberate: the tab shows the widest set the screen
+        // actually has rather than an empty list under an all-time label.
+        composeRule.onNodeWithText(string(R.string.custom)).assertExists()
+        composeRule.onNodeWithText(todaySession.presetName!!).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a tab with nothing in it says so instead of showing a blank page`() {
+        historyState.value = historyState.value.copy(todaySessions = emptyList())
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.no_sessions_yet)).assertExists()
+        composeRule.onNodeWithText(string(R.string.start_counting_hint)).assertExists()
+    }
+
+    @Test
+    fun `the back arrow goes back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreenTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihScreenTest.kt
@@ -1,0 +1,325 @@
+package com.arshadshah.nimaz.presentation.screens.tasbih
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.ScreenTags
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihCounterStyle
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihCounterUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihEvent
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihStatsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.TasbihViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The counter itself — 463 lines and, until now, not one of them ever run on the JVM.
+ *
+ * `TasbihCounterTest` in `:app/src/androidTest` taps the circle on a device; nothing asserted
+ * what the *screen* does with the state it is handed. The failures that leaves open are ones a
+ * user notices immediately and cannot work around: a tap that raises no `Increment` (the count
+ * is written to Room, so a lost tap is a permanently wrong total), a mode toggle that reports
+ * the wrong style, and a reset control wired to the wrong event. Every one of them looks
+ * identical on screen.
+ *
+ * The two counter modes are both pinned because they are different code paths behind one
+ * `Crossfade`: classic renders a semantics-addressable circle, beads render a `Canvas` with no
+ * text in it at all, and only the classic one has ever been exercised anywhere.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class TasbihScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val counterState = MutableStateFlow(TasbihCounterUiState(isActive = true))
+    private val statsState = MutableStateFlow(TasbihStatsUiState(isLoading = false))
+    private val events = mutableListOf<TasbihEvent>()
+    private val navigations = mutableListOf<String>()
+
+    private val viewModel: TasbihViewModel = mockk(relaxed = true) {
+        every { this@mockk.counterState } returns this@TasbihScreenTest.counterState
+        every { this@mockk.statsState } returns this@TasbihScreenTest.statsState
+        every { onEvent(any()) } answers { events += firstArg<TasbihEvent>() }
+    }
+
+    private val preset = TasbihPreset(
+        id = 7L,
+        name = "SubhanAllah",
+        arabicText = "سُبْحَانَ ٱللَّٰهِ",
+        transliteration = "SubhanAllah",
+        translation = "Glory be to Allah",
+        targetCount = 33,
+        category = TasbihCategory.AFTER_PRAYER,
+        reference = "Sahih Muslim",
+        isDefault = true,
+        displayOrder = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            TasbihScreen(
+                onNavigateToHistory = { navigations += "history" },
+                onNavigateToChooseDhikr = { navigations += "choose" },
+                onNavigateToAddPreset = { navigations += "add" },
+                onNavigateToSettings = { navigations += "settings" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the classic circle shows the running count and a tap on it increments`() {
+        counterState.value = counterState.value.copy(count = 12, targetCount = 33)
+        setContent()
+
+        composeRule.onNodeWithTag(ScreenTags.TasbihCount, useUnmergedTree = true)
+            .assertTextEquals("12")
+        composeRule.onNodeWithTag(ScreenTags.TasbihCounter).performClick()
+
+        // The single most consequential assertion in this file: the count is persisted, so a
+        // tap that reaches no event is a permanently wrong total with no way for the user to
+        // notice it happened.
+        assertThat(events).containsExactly(TasbihEvent.Increment)
+    }
+
+    @Test
+    fun `the circle invites a tap until a lap is done, then reports the laps`() {
+        setContent()
+        composeRule.onNodeWithText(string(R.string.tap_to_count)).assertExists()
+
+        counterState.value = counterState.value.copy(count = 4, laps = 2)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.tap_to_count)).assertDoesNotExist()
+        composeRule.onAllNodesWithText(
+            context.resources.getQuantityString(R.plurals.laps_format, 2, 2)
+        ).onFirst().assertExists()
+    }
+
+    @Test
+    fun `the capsule reads count over target`() {
+        counterState.value = counterState.value.copy(count = 9, targetCount = 100)
+        setContent()
+
+        composeRule.onNodeWithText("9 / 100").assertIsDisplayed()
+    }
+
+    @Test
+    fun `choosing beads reports BEADS and choosing classic reports CLASSIC`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_mode_beads)).performClick()
+        assertThat(events).containsExactly(
+            TasbihEvent.SetCounterStyle(TasbihCounterStyle.BEADS)
+        )
+
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.tasbih_mode_classic)).performClick()
+        assertThat(events).containsExactly(
+            TasbihEvent.SetCounterStyle(TasbihCounterStyle.CLASSIC)
+        )
+    }
+
+    @Test
+    fun `the design button belongs to beads mode alone`() {
+        setContent()
+        // Classic: the palette button would open a picker for a strand that is not on screen.
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_bead_design))
+            .assertDoesNotExist()
+
+        counterState.value = counterState.value.copy(counterStyle = TasbihCounterStyle.BEADS)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_bead_design))
+            .assertExists()
+    }
+
+    @Test
+    fun `the design button opens the picker and a choice is reported`() {
+        counterState.value = counterState.value.copy(counterStyle = TasbihCounterStyle.BEADS)
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_bead_design))
+            .performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_bead_jade)).performClick()
+
+        assertThat(events).contains(TasbihEvent.SetBeadDesign("jade"))
+    }
+
+    @Test
+    fun `handedness is set from the design sheet`() {
+        counterState.value = counterState.value.copy(counterStyle = TasbihCounterStyle.BEADS)
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.tasbih_bead_design))
+            .performClick()
+        composeRule.waitForIdle()
+        // The row's label is not the control — the switch beside it is, and it is the only
+        // toggleable node in the sheet.
+        composeRule.onNode(isToggleable()).performClick()
+
+        // The strand advances the other way for a left-handed user; nothing else on the screen
+        // says which way it currently goes.
+        assertThat(events).contains(TasbihEvent.SetLeftHanded(true))
+    }
+
+    @Test
+    fun `the three controls raise reset, sound and vibration`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.reset_action)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.toggle_sound)).performClick()
+        composeRule.onNodeWithContentDescription(string(R.string.toggle_vibration)).performClick()
+
+        // Each toggle sends the *opposite* of what is currently set — a control that echoed the
+        // current value back would look live and do nothing.
+        assertThat(events).containsExactly(
+            TasbihEvent.Reset,
+            TasbihEvent.ToggleSound(true),
+            TasbihEvent.ToggleVibration(false),
+        ).inOrder()
+    }
+
+    @Test
+    fun `the peek card names the selected dhikr and its target`() {
+        counterState.value = counterState.value.copy(selectedPreset = preset, targetCount = 33)
+        setContent()
+
+        composeRule.onNodeWithText(preset.name).assertExists()
+        composeRule.onNodeWithText(
+            "${preset.translation} · ${string(R.string.target_format, 33)}"
+        ).assertExists()
+    }
+
+    @Test
+    fun `with no dhikr chosen the peek card reads as a free count`() {
+        counterState.value = counterState.value.copy(selectedPreset = null, targetCount = 100)
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.free_count_label)).assertExists()
+        composeRule.onNodeWithText(string(R.string.target_format, 100)).assertExists()
+    }
+
+    @Test
+    fun `a dhikr saved without Arabic or a translation still names itself`() {
+        val bare = preset.copy(arabicText = null, translation = null, transliteration = null)
+        counterState.value = counterState.value.copy(selectedPreset = bare, targetCount = 7)
+        setContent()
+
+        // A custom dhikr typed with only a name is the common case, and every optional line here
+        // is a separate arm. An empty Arabic line renders as a gap in the peek card, which reads
+        // as a rendering fault rather than as an absent field.
+        composeRule.onNodeWithText(bare.name).assertExists()
+        composeRule.onNodeWithText(string(R.string.target_format, 7)).assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the tablet info card also copes with a dhikr that has only a name`() {
+        val bare = preset.copy(arabicText = null, translation = null, transliteration = null)
+        counterState.value = counterState.value.copy(selectedPreset = bare, targetCount = 7)
+        setContent()
+
+        composeRule.onNodeWithText(bare.name).assertExists()
+        composeRule.onNodeWithText(string(R.string.target_format, 7)).assertExists()
+    }
+
+    @Test
+    fun `the peek card opens the current sheet, which offers a way to change dhikr`() {
+        counterState.value = counterState.value.copy(selectedPreset = preset)
+        setContent()
+
+        composeRule.onNodeWithText(preset.name).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(string(R.string.tasbih_change_dhikr)).assertExists()
+    }
+
+    @Test
+    fun `changing dhikr from the sheet closes it and navigates`() {
+        counterState.value = counterState.value.copy(selectedPreset = preset)
+        setContent()
+
+        composeRule.onNodeWithText(preset.name).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(string(R.string.tasbih_change_dhikr)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigations).containsExactly("choose")
+    }
+
+    @Test
+    fun `the sheet's today tile counts the session in progress, not only what is saved`() {
+        // 40 already banked, plus a session standing at 2 laps of 33 and 5 more. Reading
+        // `baseTotalToday` alone would under-report by the whole live session — the number
+        // someone opens this sheet to see.
+        statsState.value = statsState.value.copy(baseTotalToday = 40)
+        counterState.value = counterState.value.copy(
+            selectedPreset = preset,
+            count = 5,
+            laps = 2,
+            targetCount = 33,
+        )
+        setContent()
+
+        composeRule.onNodeWithText(preset.name).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("111").assertExists()
+    }
+
+    @Test
+    fun `the history icon navigates`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.history)).performClick()
+
+        assertThat(navigations).containsExactly("history")
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `at tablet width the dhikr card and the counter share the screen`() {
+        counterState.value = counterState.value.copy(selectedPreset = preset, count = 3)
+        setContent()
+
+        // The expanded layout replaces the bottom peek with a left-hand info card, so the
+        // translation appears as its own line rather than folded into the peek's subtitle.
+        composeRule.onNodeWithText(preset.translation!!).assertExists()
+        composeRule.onNodeWithText(string(R.string.target_format, 33)).assertExists()
+        composeRule.onNodeWithTag(ScreenTags.TasbihCount, useUnmergedTree = true)
+            .assertTextEquals("3")
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tracker/TrackerGraphTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/tracker/TrackerGraphTest.kt
@@ -1,0 +1,134 @@
+package com.arshadshah.nimaz.presentation.screens.tracker
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Tracker feature's slice of the route graph — fourteen destinations across three trackers.
+ *
+ * A destination that fails to register throws
+ * `IllegalArgumentException: navigation destination … is not a direct child of this NavGraph`
+ * at the moment a **user taps the thing that opens it** — not at build time, and not in any of
+ * the four gates `CLAUDE.md` lists. Several of these are reachable only from a deep link or from
+ * a shipped announcement (`fasting`, `prayer_tracker`, `prayer/tracker/{tab}`), so nobody
+ * exercises them in a normal pass through the app at all.
+ *
+ * Fourteen is checked as a number as well as a set, because #625 found five graphs whose
+ * documented counts had drifted — `trackerGraph` among them, recorded as 11 while it held 14 —
+ * and `check_docs.py`'s NAV-03 could not catch it: it compares the total across all graphs
+ * against `Routes.kt`, not the per-graph split.
+ *
+ * The graph is built without a `NavHost`, so nothing composes and none of these screens' Hilt
+ * ViewModels is constructed. This asserts registration only; the screen tests beside it assert
+ * what each destination renders.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TrackerGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.PrayerTracker) {
+            trackerGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all fourteen tracker destinations are registered`() {
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(14)
+        listOf(
+            Route.PrayerTracker::class,
+            Route.PrayerStats::class,
+            Route.QadaPrayers::class,
+            Route.Tasbih::class,
+            Route.FastingHome::class,
+            Route.FastingTracker::class,
+            Route.FastingStats::class,
+            Route.MakeupFasts::class,
+            Route.TasbihHome::class,
+            Route.TasbihCounter::class,
+            Route.TasbihPresets::class,
+            Route.TasbihStats::class,
+            Route.TasbihHistory::class,
+            Route.TasbihAddPreset::class,
+        ).forEach { route ->
+            assertThat(routes.any { it.contains(route.qualifiedName!!) }).isTrue()
+        }
+    }
+
+    @Test
+    fun `every tracker destination is registered exactly once`() {
+        // Three of the fasting routes and four of the tasbih ones share a screen composable, so
+        // a copy-paste that registered the same `Route` twice under two names would still look
+        // right in review — and would leave the other route unreachable.
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).containsNoDuplicates()
+    }
+
+    @Test
+    fun `the three prayer-tracking destinations resolve in their own right`() {
+        // Split out of `prayerGraph` in PR 18 of #551 — they live in `screens/prayer` but drive
+        // `viewmodel/tracker`. All three are reached directly: the tracker from the menu, stats
+        // and qada from inside it.
+        assertStartDestination(Route.PrayerTracker)
+        assertStartDestination(Route.PrayerStats)
+        assertStartDestination(Route.QadaPrayers)
+    }
+
+    @Test
+    fun `all four fasting destinations resolve in their own right`() {
+        // `FastingHome`, `FastingTracker` and `FastingStats` are three routes over one screen,
+        // kept because shipped announcements and deep links name each of them.
+        assertStartDestination(Route.FastingHome)
+        assertStartDestination(Route.FastingTracker)
+        assertStartDestination(Route.FastingStats)
+        assertStartDestination(Route.MakeupFasts)
+    }
+
+    @Test
+    fun `all seven tasbih destinations resolve in their own right`() {
+        assertStartDestination(Route.Tasbih)
+        assertStartDestination(Route.TasbihHome)
+        assertStartDestination(Route.TasbihCounter())
+        assertStartDestination(Route.TasbihPresets)
+        assertStartDestination(Route.TasbihStats)
+        assertStartDestination(Route.TasbihHistory)
+    }
+
+    @Test
+    fun `the preset form resolves both with and without a preset to edit`() {
+        // `TasbihAddPreset` is the one argument-carrying route here, and it is entered both ways:
+        // empty from "New Tasbih", and with an id from a row's edit button. A route registered
+        // for only one of them fails at the tap.
+        assertStartDestination(Route.TasbihAddPreset())
+        assertStartDestination(Route.TasbihAddPreset(presetId = 42L))
+    }
+
+    private fun assertStartDestination(route: Route) {
+        // `createGraph` throws here if the route it is handed is not among the destinations the
+        // builder registered — the same failure the app would hit on the tap that opens it.
+        val graph = navController.createGraph(startDestination = route) {
+            trackerGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingRamadanTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingRamadanTest.kt
@@ -1,0 +1,215 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tracker
+
+import com.arshadshah.nimaz.core.common.toUtcMidnightMillis
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.calendar.HijriDateCalculator
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.domain.model.FastingStats
+import com.arshadshah.nimaz.domain.repository.FakeHijriSettings
+import com.arshadshah.nimaz.domain.repository.FakeZakatSettings
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.FakePrayerTimetableRepository
+import com.arshadshah.nimaz.domain.usecase.buildFastingUseCases
+import com.arshadshah.nimaz.domain.usecase.buildPrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.fasting.CountUnloggedRamadanDaysUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetDaysUntilAyyamAlBeedUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetRamadanCountdownUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Ramadan, from inside it — the arm of `loadRamadan` that only runs one month a year.
+ *
+ * Everything the fasting screen shows during Ramadan is decided here: the day number, the
+ * progress denominator, how many days are fasted, how many are missed, and how many have gone
+ * by with nothing recorded at all. The rest of the year the `else` arm runs instead, and that is
+ * the arm every other test in this module exercises — so this whole branch has, until now, been
+ * reachable only by waiting for Ramadan.
+ *
+ * The distinction the counts turn on is the one the redesign is built around: **missed** means a
+ * day explicitly recorded as not fasted, and **unlogged** means a day nobody has said anything
+ * about. Conflating them would have the app tell a user they missed days they simply had not got
+ * round to logging — an accusation, from a fasting tracker, during Ramadan.
+ *
+ * "Today" is supplied through `TodayProvider` and the Ramadan dates come from
+ * `HijriDateCalculator`, so the test asks the calculator when Ramadan is rather than hardcoding
+ * a Gregorian date that would stop being in Ramadan next year.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FastingRamadanTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var repository: FastingRepository
+    private val prayers = FakePrayerTimetableRepository()
+
+    /** The tenth of the Ramadan whose year contains today — always a real Ramadan day. */
+    private val ramadanYear = HijriDateCalculator.toHijri(LocalDate.now()).year + 1
+    private val firstDay: LocalDate = HijriDateCalculator.getFirstDayOfRamadan(ramadanYear)
+    private val dayTen: LocalDate = firstDay.plusDays(9)
+
+    private fun fasted(date: LocalDate, status: FastStatus) = FastRecord(
+        id = date.toEpochDay(),
+        date = date.toUtcMidnightMillis(),
+        hijriDate = null,
+        hijriMonth = 9,
+        hijriYear = ramadanYear,
+        fastType = FastType.RAMADAN,
+        status = status,
+        exemptionReason = null,
+        suhoorTime = null,
+        iftarTime = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        repository = mockk(relaxed = true)
+
+        coEvery { repository.getFastRecordForDate(any()) } returns null
+        every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(emptyList())
+        every { repository.getPendingMakeupFasts() } returns flowOf(emptyList())
+        every { repository.getAllMakeupFasts() } returns flowOf(emptyList())
+        coEvery { repository.getFastingStats(any(), any()) } returns FastingStats(
+            totalFasted = 0, ramadanFasted = 0, voluntaryFasted = 0,
+            pendingMakeupCount = 0, totalFidyaPaid = 0.0,
+            currentStreak = 0, startDate = 0, endDate = 0,
+        )
+        coEvery { repository.getRamadanFastedCount() } returns 0
+        coEvery { repository.getVoluntaryFastCount() } returns 0
+        coEvery { repository.getTotalFidyaPaid() } returns 0.0
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(today: LocalDate): FastingViewModel {
+        val provider = FakeTodayProvider(today)
+        return FastingViewModel(
+            buildFastingUseCases(repository),
+            buildPrayerUseCases(prayers),
+            provider,
+            GetDaysUntilAyyamAlBeedUseCase(provider),
+            GetRamadanCountdownUseCase(provider),
+            CountUnloggedRamadanDaysUseCase(provider),
+            FakeHijriSettings(),
+            FakeZakatSettings(),
+            RecordingTelemetry(),
+        )
+    }
+
+    @Test
+    fun `inside Ramadan the state says so and names the day`() = runTest {
+        val vm = viewModel(dayTen)
+        advanceUntilIdle()
+
+        val state = vm.ramadanState.value
+        assertThat(state.isRamadan).isTrue()
+        assertThat(state.currentDay).isEqualTo(10)
+        assertThat(state.isLoading).isFalse()
+        // Days left in the month, not days left in the fast — the banner's denominator is
+        // fasted + missed + remaining, and it has to add up to the month.
+        assertThat(state.currentDay + state.remainingDays)
+            .isEqualTo(HijriDateCalculator.getDaysInHijriMonth(ramadanYear, 9))
+    }
+
+    @Test
+    fun `fasted and missed count only what was actually recorded`() = runTest {
+        every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(
+            listOf(
+                fasted(firstDay, FastStatus.FASTED),
+                fasted(firstDay.plusDays(1), FastStatus.FASTED),
+                fasted(firstDay.plusDays(2), FastStatus.NOT_FASTED),
+                fasted(firstDay.plusDays(3), FastStatus.EXEMPTED),
+                fasted(firstDay.plusDays(4), FastStatus.MAKEUP_DUE),
+            )
+        )
+
+        val vm = viewModel(dayTen)
+        advanceUntilIdle()
+
+        val state = vm.ramadanState.value
+        assertThat(state.fastedDays).isEqualTo(2)
+        // An exempted day and a day owed are neither fasted nor missed — a user who was ill for
+        // a week has not "missed" seven fasts, and being told they did is the wrong reading of
+        // their own record.
+        assertThat(state.missedDays).isEqualTo(1)
+        assertThat(state.ramadanRecords).hasSize(5)
+    }
+
+    @Test
+    fun `days gone by with no record at all are counted separately from missed`() = runTest {
+        every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(
+            listOf(fasted(firstDay, FastStatus.FASTED))
+        )
+
+        val vm = viewModel(dayTen)
+        advanceUntilIdle()
+
+        val state = vm.ramadanState.value
+        // Today is day ten and still in progress, so nine days have elapsed; one of them is
+        // logged, leaving eight unlogged — and none of them is "missed", because nobody has
+        // said so.
+        assertThat(state.unloggedDays).isEqualTo(8)
+        assertThat(state.missedDays).isEqualTo(0)
+    }
+
+    @Test
+    fun `a fully logged Ramadan so far has nothing unlogged`() = runTest {
+        every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(
+            (0L until 10L).map { fasted(firstDay.plusDays(it), FastStatus.FASTED) }
+        )
+
+        val vm = viewModel(dayTen)
+        advanceUntilIdle()
+
+        assertThat(vm.ramadanState.value.unloggedDays).isEqualTo(0)
+        assertThat(vm.ramadanState.value.fastedDays).isEqualTo(10)
+    }
+
+    @Test
+    fun `outside Ramadan the state says so and counts down to it instead`() = runTest {
+        // Two months before the first day is comfortably outside Ramadan whichever year this
+        // runs in.
+        val vm = viewModel(firstDay.minusMonths(2))
+        advanceUntilIdle()
+
+        val state = vm.ramadanState.value
+        assertThat(state.isRamadan).isFalse()
+        assertThat(state.currentDay).isEqualTo(0)
+        assertThat(state.daysUntilRamadan).isGreaterThan(0)
+        assertThat(state.ramadanStartsOn).isNotNull()
+        assertThat(state.isLoading).isFalse()
+    }
+
+    @Test
+    fun `the countdown and the Ayyam al-Beed count are supplied whatever the month`() = runTest {
+        val vm = viewModel(dayTen)
+        advanceUntilIdle()
+
+        // Both are computed in the ViewModel, where the clock and the user's Hijri day offset
+        // live, precisely so the screen never reads the clock at composition (#492).
+        assertThat(vm.ramadanState.value.daysUntilAyyamAlBeed).isAtLeast(0)
+        assertThat(vm.ramadanState.value.ramadanStartsOn).isNotNull()
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingStatsAndDebtTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/FastingStatsAndDebtTest.kt
@@ -1,0 +1,341 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tracker
+
+import com.arshadshah.nimaz.core.common.toUtcMidnightMillis
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.ExemptionReason
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.domain.model.FastingStats
+import com.arshadshah.nimaz.domain.model.MakeupFast
+import com.arshadshah.nimaz.domain.repository.FakeHijriSettings
+import com.arshadshah.nimaz.domain.repository.FakeZakatSettings
+import com.arshadshah.nimaz.domain.repository.FastingRepository
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.FakePrayerTimetableRepository
+import com.arshadshah.nimaz.domain.usecase.buildFastingUseCases
+import com.arshadshah.nimaz.domain.usecase.buildPrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.fasting.CountUnloggedRamadanDaysUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetDaysUntilAyyamAlBeedUseCase
+import com.arshadshah.nimaz.domain.usecase.fasting.GetRamadanCountdownUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Statistics windows, and the debt a missed Ramadan fast creates.
+ *
+ * Two things here write to the user's record in ways they cannot undo from the screen that
+ * caused them:
+ *
+ *  - **A missed Ramadan day creates a make-up fast**, and creates *one*. The write path runs on
+ *    every status change, so without the count guard, changing a Ramadan day's status back and
+ *    forth would leave a make-up fast per tap — a debt of five for one missed day, with no way
+ *    to tell which is real.
+ *  - **An exemption's reason survives only while the day stays exempt.** Switching a day from
+ *    exempt to not-fasted must drop "Travel" with it; carrying it forward would attach a reason
+ *    to a claim the user never made, and the reason is what the make-up fast is filed under.
+ *
+ * The statistics windows are the third: three periods, three spans, and the only thing
+ * distinguishing them is the pair of epochs the query is handed. A `when` arm that returned the
+ * wrong span would show one period's numbers under another's label.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FastingStatsAndDebtTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val today = LocalDate.of(2026, 8, 13)
+
+    private lateinit var repository: FastingRepository
+    private val prayers = FakePrayerTimetableRepository()
+
+    private fun record(
+        date: LocalDate,
+        status: FastStatus,
+        type: FastType = FastType.VOLUNTARY,
+        reason: ExemptionReason? = null,
+        note: String? = null,
+    ) = FastRecord(
+        id = 1L,
+        date = date.toUtcMidnightMillis(),
+        hijriDate = null,
+        hijriMonth = null,
+        hijriYear = null,
+        fastType = type,
+        status = status,
+        exemptionReason = reason,
+        suhoorTime = null,
+        iftarTime = null,
+        note = note,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        repository = mockk(relaxed = true)
+
+        coEvery { repository.getFastRecordForDate(any()) } returns null
+        every { repository.getFastRecordsInRange(any(), any()) } returns flowOf(emptyList())
+        every { repository.getPendingMakeupFasts() } returns flowOf(emptyList())
+        every { repository.getAllMakeupFasts() } returns flowOf(emptyList())
+        coEvery { repository.getFastingStats(any(), any()) } returns FastingStats(
+            totalFasted = 0, ramadanFasted = 0, voluntaryFasted = 0,
+            pendingMakeupCount = 0, totalFidyaPaid = 0.0,
+            currentStreak = 0, startDate = 0, endDate = 0,
+        )
+        coEvery { repository.getRamadanFastedCount() } returns 0
+        coEvery { repository.getVoluntaryFastCount() } returns 0
+        coEvery { repository.getTotalFidyaPaid() } returns 0.0
+        coEvery { repository.getMakeupFastCountForDate(any()) } returns 0
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(): FastingViewModel {
+        val provider = FakeTodayProvider(today)
+        return FastingViewModel(
+            buildFastingUseCases(repository),
+            buildPrayerUseCases(prayers),
+            provider,
+            GetDaysUntilAyyamAlBeedUseCase(provider),
+            GetRamadanCountdownUseCase(provider),
+            CountUnloggedRamadanDaysUseCase(provider),
+            FakeHijriSettings(),
+            FakeZakatSettings(),
+            RecordingTelemetry(),
+        )
+    }
+
+    /**
+     * The (start, end) epoch pair the stats query was last handed.
+     *
+     * A `mutableList` rather than a `slot`, because the query runs on init as well as on every
+     * period change — mockk refuses to capture into a slot across more than one verified call.
+     */
+    private fun capturedStatsWindow(): Pair<Long, Long> {
+        val starts = mutableListOf<Long>()
+        val ends = mutableListOf<Long>()
+        coVerify { repository.getFastingStats(capture(starts), capture(ends)) }
+        return starts.last() to ends.last()
+    }
+
+    @Test
+    fun `this month asks for the month so far`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(FastingEvent.SetStatsPeriod(FastingStatsPeriod.THIS_MONTH))
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.period).isEqualTo(FastingStatsPeriod.THIS_MONTH)
+        assertThat(capturedStatsWindow().first)
+            .isEqualTo(today.withDayOfMonth(1).toUtcMidnightMillis())
+    }
+
+    @Test
+    fun `this year asks from the first of January`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(FastingEvent.SetStatsPeriod(FastingStatsPeriod.THIS_YEAR))
+        advanceUntilIdle()
+
+        assertThat(capturedStatsWindow().first)
+            .isEqualTo(today.withDayOfYear(1).toUtcMidnightMillis())
+    }
+
+    @Test
+    fun `all time reaches back a decade`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(FastingEvent.SetStatsPeriod(FastingStatsPeriod.ALL_TIME))
+        advanceUntilIdle()
+
+        val (start, end) = capturedStatsWindow()
+        assertThat(start).isEqualTo(today.minusYears(10).toUtcMidnightMillis())
+        // The end is exclusive — tomorrow's midnight — so today's own fast is inside every
+        // window rather than falling off the end of all of them.
+        assertThat(end).isEqualTo(today.plusDays(1).toUtcMidnightMillis())
+    }
+
+    @Test
+    fun `reloading statistics keeps the period the user chose`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetStatsPeriod(FastingStatsPeriod.THIS_MONTH))
+        advanceUntilIdle()
+
+        vm.onEvent(FastingEvent.LoadStats)
+        advanceUntilIdle()
+
+        assertThat(vm.statsState.value.period).isEqualTo(FastingStatsPeriod.THIS_MONTH)
+        assertThat(vm.statsState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `setting the status a day already has deletes the record`() = runTest {
+        val yesterday = today.minusDays(1)
+        coEvery {
+            repository.getFastRecordForDate(yesterday.toUtcMidnightMillis())
+        } returns record(yesterday, FastStatus.FASTED)
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(yesterday, FastStatus.FASTED))
+        advanceUntilIdle()
+
+        // Tap-to-clear: the segmented control has no "unset" cell, so choosing what the day
+        // already says is the only way to withdraw the claim.
+        coVerify { repository.deleteFastRecordByDate(yesterday.toUtcMidnightMillis()) }
+    }
+
+    @Test
+    fun `an exemption reason is dropped when the day stops being exempt`() = runTest {
+        val yesterday = today.minusDays(1)
+        coEvery {
+            repository.getFastRecordForDate(yesterday.toUtcMidnightMillis())
+        } returns record(yesterday, FastStatus.EXEMPTED, reason = ExemptionReason.TRAVEL)
+
+        val written = slot<FastRecord>()
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(yesterday, FastStatus.NOT_FASTED))
+        advanceUntilIdle()
+
+        coVerify { repository.updateFastRecord(capture(written)) }
+        // "Travel" is a reason for being exempt, not for not fasting. Carrying it forward would
+        // attach a justification to a claim the user never made — and it is the string the
+        // make-up fast is filed under.
+        assertThat(written.captured.status).isEqualTo(FastStatus.NOT_FASTED)
+        assertThat(written.captured.exemptionReason).isNull()
+    }
+
+    @Test
+    fun `a note survives a status change`() = runTest {
+        val yesterday = today.minusDays(1)
+        coEvery {
+            repository.getFastRecordForDate(yesterday.toUtcMidnightMillis())
+        } returns record(yesterday, FastStatus.FASTED, note = "Kept it")
+
+        val written = slot<FastRecord>()
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(yesterday, FastStatus.NOT_FASTED))
+        advanceUntilIdle()
+
+        coVerify { repository.updateFastRecord(capture(written)) }
+        // Unlike the reason, a note is the user's own words about the day and applies whatever
+        // they later say about the fast.
+        assertThat(written.captured.note).isEqualTo("Kept it")
+    }
+
+    @Test
+    fun `a missed Ramadan day creates the make-up fast it owes`() = runTest {
+        val ramadanDay = ramadanDay()
+        val makeup = slot<MakeupFast>()
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(ramadanDay, FastStatus.NOT_FASTED))
+        advanceUntilIdle()
+
+        coVerify { repository.insertMakeupFast(capture(makeup)) }
+        assertThat(makeup.captured.originalDate).isEqualTo(ramadanDay.toUtcMidnightMillis())
+        // Filed under a Hijri date, because a Ramadan fast is owed for a day of Ramadan and that
+        // is what the make-up list shows.
+        assertThat(makeup.captured.originalHijriDate).isNotEmpty()
+    }
+
+    @Test
+    fun `a Ramadan day already carrying a debt does not gain a second one`() = runTest {
+        coEvery { repository.getMakeupFastCountForDate(any()) } returns 1
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(ramadanDay(), FastStatus.NOT_FASTED))
+        advanceUntilIdle()
+
+        // The write path runs on every status change. Without this guard, toggling a Ramadan
+        // day back and forth would leave one make-up fast per tap.
+        coVerify(exactly = 0) { repository.insertMakeupFast(any()) }
+    }
+
+    @Test
+    fun `a missed day outside Ramadan owes nothing`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.SetFastStatus(today.minusDays(1), FastStatus.NOT_FASTED))
+        advanceUntilIdle()
+
+        // A voluntary fast not kept is not a debt — only a Ramadan fast is owed back.
+        coVerify(exactly = 0) { repository.insertMakeupFast(any()) }
+    }
+
+    @Test
+    fun `completing a make-up fast and paying fidya both reach the repository`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(FastingEvent.CompleteMakeupFast(7L))
+        vm.onEvent(FastingEvent.PayFidya(8L, 12.5))
+        advanceUntilIdle()
+
+        // The two doors out of a debt, and they must not be each other: one records a fast, the
+        // other records money.
+        coVerify { repository.markMakeupFastCompleted(7L, any()) }
+        coVerify { repository.markFidyaPaid(8L, 12.5) }
+    }
+
+    @Test
+    fun `editing a make-up fast writes it back unchanged but for the edit`() = runTest {
+        val edited = MakeupFast(
+            id = 9L,
+            originalDate = 1_700_000_000_000L,
+            originalHijriDate = "3 Ramadan 1445",
+            reason = "Hospital stay",
+            status = com.arshadshah.nimaz.domain.model.MakeupFastStatus.PENDING,
+            completedDate = null,
+            fidyaAmount = null,
+            note = null,
+            createdAt = 1L,
+            updatedAt = 2L,
+        )
+        val written = slot<MakeupFast>()
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(FastingEvent.UpdateMakeupFast(edited))
+        advanceUntilIdle()
+
+        coVerify { repository.updateMakeupFast(capture(written)) }
+        assertThat(written.captured.id).isEqualTo(9L)
+        assertThat(written.captured.reason).isEqualTo("Hospital stay")
+    }
+
+    /** A real day of Ramadan, asked of the calculator rather than hardcoded. */
+    private fun ramadanDay(): LocalDate =
+        com.arshadshah.nimaz.domain.calendar.HijriDateCalculator
+            .getFirstDayOfRamadan(
+                com.arshadshah.nimaz.domain.calendar.HijriDateCalculator.toHijri(today).year
+            )
+            .plusDays(2)
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/PrayerTrackerNavigationTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/PrayerTrackerNavigationTest.kt
@@ -1,0 +1,213 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tracker
+
+import com.arshadshah.nimaz.core.common.toUtcMidnightMillis
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerRecord
+import com.arshadshah.nimaz.domain.model.PrayerStatus
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Moving between days, and the four load events that refresh what a day shows.
+ *
+ * The day-step guard is the behaviour worth the most here: **you cannot step forward past
+ * today.** The tracker records what you did, so a tomorrow with five empty rows invites logging
+ * a prayer that has not happened — and every downstream count (the review banner, the month's
+ * complete days, the streak) then has to decide what to make of it. The rail disables its future
+ * cells for the same reason; this is the same rule on the other side of the seam, where a deep
+ * link or a stale saved date can also land.
+ *
+ * `today` comes from `TodayProvider`, faked here. A ViewModel that read `LocalDate.now()` would
+ * make this untestable and would freeze at whatever day the object was constructed — the
+ * rollover shape behind #363.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrayerTrackerNavigationTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private val today = LocalDate.of(2026, 8, 13)
+
+    private lateinit var prayerUseCases: PrayerUseCases
+
+    private val qada = MutableStateFlow<List<PrayerRecord>>(emptyList())
+
+    private fun record(date: LocalDate, prayer: PrayerName, status: PrayerStatus) = PrayerRecord(
+        id = date.toEpochDay() * 10 + prayer.ordinal,
+        date = date.toUtcMidnightMillis(),
+        prayerName = prayer,
+        status = status,
+        prayedAt = null,
+        scheduledTime = 0L,
+        isJamaah = false,
+        isQadaFor = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        prayerUseCases = mockk(relaxed = true)
+
+        every { prayerUseCases.getPrayerRecordsForDate(any()) } returns flowOf(emptyList())
+        every { prayerUseCases.getPrayerRecordsInRange(any(), any()) } returns flowOf(emptyList())
+        every { prayerUseCases.getMissedPrayersRequiringQada() } returns qada
+        every { prayerUseCases.getCurrentLocation() } returns flowOf(null)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = PrayerTrackerViewModel(
+        prayerUseCases,
+        FakeTodayProvider(today),
+        telemetry,
+    )
+
+    @Test
+    fun `the tracker opens on today`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(today)
+    }
+
+    @Test
+    fun `stepping back moves one day at a time`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.NavigateToPreviousDay)
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.NavigateToPreviousDay)
+        advanceUntilIdle()
+
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(today.minusDays(2))
+    }
+
+    @Test
+    fun `stepping forward from a past day is allowed`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.SelectDate(today.minusDays(3)))
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.NavigateToNextDay)
+        advanceUntilIdle()
+
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(today.minusDays(2))
+    }
+
+    @Test
+    fun `stepping forward stops at today`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.NavigateToNextDay)
+        advanceUntilIdle()
+
+        // Not tomorrow. A future day would offer five empty rows to log prayers that have not
+        // happened, and every count downstream would then have to decide what to make of them.
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(today)
+    }
+
+    @Test
+    fun `selecting a day loads that day's records`() = runTest {
+        val chosen = today.minusDays(5)
+        every {
+            prayerUseCases.getPrayerRecordsForDate(chosen.toUtcMidnightMillis())
+        } returns flowOf(listOf(record(chosen, PrayerName.FAJR, PrayerStatus.PRAYED)))
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.SelectDate(chosen))
+        advanceUntilIdle()
+
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(chosen)
+        assertThat(vm.trackerState.value.prayerRecords).hasSize(1)
+    }
+
+    @Test
+    fun `reloading today returns the selection to today`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.SelectDate(today.minusDays(4)))
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.LoadToday)
+        advanceUntilIdle()
+
+        assertThat(vm.trackerState.value.selectedDate).isEqualTo(today)
+    }
+
+    @Test
+    fun `the qada list is what the user has marked missed`() = runTest {
+        qada.value = listOf(
+            record(today.minusDays(2), PrayerName.FAJR, PrayerStatus.MISSED),
+            record(today.minusDays(3), PrayerName.ISHA, PrayerStatus.MISSED),
+        )
+
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(PrayerTrackerEvent.LoadQadaPrayers)
+        advanceUntilIdle()
+
+        assertThat(vm.qadaState.value.missedPrayers).hasSize(2)
+        assertThat(vm.qadaState.value.totalMissed).isEqualTo(2)
+        // Grouped by month for the list's headings; two different days of one month are one
+        // group, not two.
+        assertThat(vm.qadaState.value.groupedByMonth).hasSize(1)
+        assertThat(vm.qadaState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `an empty qada list is reported as loaded, not as still loading`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(PrayerTrackerEvent.LoadQadaPrayers)
+        advanceUntilIdle()
+
+        // The screen tells "nothing owed" from "not yet known" by this flag alone, and shows
+        // "All caught up!" only for the first.
+        assertThat(vm.qadaState.value.missedPrayers).isEmpty()
+        assertThat(vm.qadaState.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `each stats period asks for its own window`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        StatsPeriod.entries.forEach { period ->
+            vm.onEvent(PrayerTrackerEvent.SetStatsPeriod(period))
+            advanceUntilIdle()
+            assertThat(vm.statsState.value.period).isEqualTo(period)
+        }
+
+        // All four are distinct spans; a `when` missing an arm would silently reuse the previous
+        // period's numbers under the new chip's label.
+        vm.onEvent(PrayerTrackerEvent.LoadStats)
+        advanceUntilIdle()
+        assertThat(vm.statsState.value.period).isEqualTo(StatsPeriod.ALL_TIME)
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/TasbihSessionTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/TasbihSessionTest.kt
@@ -1,0 +1,474 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tracker
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.arshadshah.nimaz.domain.model.TasbihSession
+import com.arshadshah.nimaz.domain.repository.CounterFeedback
+import com.arshadshah.nimaz.domain.repository.settings.TasbihSettings
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.TasbihUseCases
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The counter's session lifecycle — the part of the tasbih that survives a relaunch.
+ *
+ * The count lives in Room, so every defect here is permanent from the user's side: a tap that
+ * starts a second session leaves an orphan row inflating the day's total, a lap that is not
+ * written loses thirty-three counts, and a preset switch that abandons a session loses the whole
+ * sitting. None of it is visible on screen — the number keeps going up either way.
+ *
+ * Four races and guards are pinned here that no screen test can reach:
+ *
+ *  - **Two taps 20 ms apart.** Both used to see `currentSession == null` and both inserted a
+ *    session; the second hard-set `count = 1`, so the user tapped twice and the counter read 1.
+ *    `startingSession` is checked and set in the same synchronous block, and the taps that land
+ *    while the insert is in flight are counted rather than dropped.
+ *  - **Auto-lap.** A lap rolls the count to zero and the lap count up, and the row written is the
+ *    *within-lap* count — the database sums `currentCount + laps × target`, so writing the
+ *    running total would double-count every lap.
+ *  - **Switching dhikr mid-session.** The old session is completed, not abandoned. Switching to
+ *    the same preset must not complete anything.
+ *  - **`applyPersistedSelection`.** The Choose-Dhikr screen holds a *different* ViewModel
+ *    instance and communicates through DataStore, so this runs on every emission; without the
+ *    id guard it would reset the counter each time the flow re-emitted the id already selected.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TasbihSessionTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+    private val todayProvider = FakeTodayProvider(LocalDate.of(2026, 8, 14))
+
+    private lateinit var useCases: TasbihUseCases
+    private lateinit var settings: TasbihSettings
+    private lateinit var feedback: CounterFeedback
+
+    private val selectedPresetId = MutableStateFlow(-1L)
+    private val favorites = MutableStateFlow<Set<String>>(emptySet())
+
+    private var nextSessionId = 1L
+    private val inserted = mutableMapOf<Long, TasbihSession>()
+
+    private fun preset(id: Long, target: Int = 33, name: String = "Dhikr $id") = TasbihPreset(
+        id = id,
+        name = name,
+        arabicText = null,
+        transliteration = null,
+        translation = null,
+        targetCount = target,
+        category = TasbihCategory.CUSTOM,
+        reference = null,
+        isDefault = false,
+        displayOrder = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+
+        useCases = mockk(relaxed = true)
+        feedback = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+
+        every { settings.tasbihBeadMode } returns flowOf(false)
+        every { settings.tasbihBeadDesign } returns flowOf("wood")
+        every { settings.tasbihSelectedPresetId } returns selectedPresetId
+        every { settings.tasbihFavorites } returns favorites
+        every { settings.tasbihLeftHanded } returns flowOf(false)
+        every { settings.tasbihPresetSeedVersion } returns flowOf(100)
+
+        // A store that behaves like the DAO: an insert gets an id, and reading it back returns
+        // the row. The ViewModel reads its own insert back before counting the pending taps.
+        coEvery { useCases.insertSession(any()) } answers {
+            val session = firstArg<TasbihSession>().copy(id = nextSessionId++)
+            inserted[session.id] = session
+            session.id
+        }
+        coEvery { useCases.getSessionById(any()) } answers { inserted[firstArg()] }
+        coEvery { useCases.getActiveSession() } returns null
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = TasbihViewModel(
+        tasbihUseCases = useCases,
+        tasbihSettings = settings,
+        feedback = feedback,
+        todayProvider = todayProvider,
+        telemetry = telemetry,
+    )
+
+    @Test
+    fun `the first tap opens a session and the counter reads one`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.count).isEqualTo(1)
+        assertThat(vm.counterState.value.isActive).isTrue()
+        assertThat(vm.counterState.value.currentSession).isNotNull()
+        coVerify(exactly = 1) { useCases.insertSession(any()) }
+    }
+
+    @Test
+    fun `two taps during the insert count two and open one session`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // Both taps land before the insert's coroutine has run — the exact race that used to
+        // leave an orphan session and a counter reading 1.
+        vm.onEvent(TasbihEvent.Increment)
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.count).isEqualTo(2)
+        coVerify(exactly = 1) { useCases.insertSession(any()) }
+    }
+
+    @Test
+    fun `a tap is felt before it is counted`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.ToggleVibration(true))
+        vm.onEvent(TasbihEvent.ToggleSound(true))
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.Increment)
+        advanceUntilIdle()
+
+        // The tick is emitted synchronously, so it stays in step with the finger rather than
+        // waiting on a Room write.
+        coVerify { feedback.tick(vibrate = true, sound = true) }
+    }
+
+    @Test
+    fun `reaching the target rolls a lap and writes the within-lap count`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.SelectPreset(preset(1, target = 3)))
+        advanceUntilIdle()
+
+        repeat(3) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+
+        assertThat(vm.counterState.value.laps).isEqualTo(1)
+        assertThat(vm.counterState.value.count).isEqualTo(0)
+        // The row stores the within-lap count; the database sums `currentCount + laps × target`,
+        // so writing the running total would report 6 for three taps of a target of three.
+        coVerify { useCases.updateSessionCount(any(), 0, 1) }
+    }
+
+    @Test
+    fun `a completed lap is worth an analytics event, a tap is not`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.SelectPreset(preset(1, target = 2)))
+        advanceUntilIdle()
+
+        repeat(2) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+
+        // Instrumenting the tap itself would emit one event per finger on a counter people run
+        // past 100 — the lap is the bounded unit that answers "is the tasbih used".
+        assertThat(telemetry.featureUsages.map { it.action }).contains("lap_completed")
+        assertThat(telemetry.featureUsages.count { it.action == "session_started" }).isEqualTo(1)
+    }
+
+    @Test
+    fun `raising the target mid-lap converts the overflow into laps`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.SelectPreset(preset(1, target = 100)))
+        advanceUntilIdle()
+        repeat(7) { vm.onEvent(TasbihEvent.Increment) }
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.SetTargetCount(3))
+        advanceUntilIdle()
+
+        // Seven counted against a target of three is two laps and one over — not seven, and not
+        // a reset. The user's count is the thing that must survive the change.
+        assertThat(vm.counterState.value.laps).isEqualTo(2)
+        assertThat(vm.counterState.value.count).isEqualTo(1)
+    }
+
+    @Test
+    fun `a target below one is refused`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.SetTargetCount(0))
+        advanceUntilIdle()
+
+        // The counter's progress arithmetic divides by the target, and `% 0` throws.
+        assertThat(vm.counterState.value.targetCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `reset zeroes the count and says so to the database`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        repeat(4) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+
+        vm.onEvent(TasbihEvent.Reset)
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.count).isEqualTo(0)
+        assertThat(vm.counterState.value.laps).isEqualTo(0)
+        // A reset that only cleared the UI would come back on the next launch.
+        coVerify { useCases.updateSessionCount(any(), 0, 0) }
+    }
+
+    @Test
+    fun `switching dhikr mid-count completes the session rather than abandoning it`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.SelectPreset(preset(1)))
+        advanceUntilIdle()
+        repeat(5) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+        val sessionId = vm.counterState.value.currentSession!!.id
+
+        vm.onEvent(TasbihEvent.SelectPreset(preset(2, target = 99)))
+        advanceUntilIdle()
+
+        // Without this the five counts vanish from the history: the row stays open forever and
+        // is never totalled.
+        coVerify { useCases.completeSession(sessionId, any(), any()) }
+        assertThat(vm.counterState.value.count).isEqualTo(0)
+        assertThat(vm.counterState.value.targetCount).isEqualTo(99)
+        assertThat(vm.counterState.value.currentSession).isNull()
+    }
+
+    @Test
+    fun `re-choosing the dhikr already counting does not close its session`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val chosen = preset(1)
+        vm.onEvent(TasbihEvent.SelectPreset(chosen))
+        advanceUntilIdle()
+        repeat(3) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+        val sessionId = vm.counterState.value.currentSession!!.id
+
+        vm.onEvent(TasbihEvent.SelectPreset(chosen))
+        advanceUntilIdle()
+
+        // Tapping the row you are already counting is a no-op the user expects; completing the
+        // session there would split one sitting into two history rows.
+        coVerify(exactly = 0) { useCases.completeSession(sessionId, any(), any()) }
+    }
+
+    @Test
+    fun `clearing to a free count completes what was in progress and resets the target`() =
+        runTest {
+            val vm = viewModel()
+            advanceUntilIdle()
+            vm.onEvent(TasbihEvent.SelectPreset(preset(1, target = 7)))
+            advanceUntilIdle()
+            repeat(2) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+            val sessionId = vm.counterState.value.currentSession!!.id
+
+            vm.onEvent(TasbihEvent.ClearPreset)
+            advanceUntilIdle()
+
+            coVerify { useCases.completeSession(sessionId, any(), any()) }
+            assertThat(vm.counterState.value.selectedPreset).isNull()
+            assertThat(vm.counterState.value.targetCount).isEqualTo(33)
+            coVerify { settings.setTasbihSelectedPresetId(-1L) }
+        }
+
+    @Test
+    fun `clearing with nothing counted writes no session`() = runTest {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(TasbihEvent.SelectPreset(preset(1)))
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.ClearPreset)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { useCases.completeSession(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a selection persisted by the other screen is applied here`() = runTest {
+        coEvery { useCases.getPresetById(5L) } returns preset(5, target = 11)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // `ChooseDhikrScreen` holds its own ViewModel instance; DataStore is the only channel
+        // between the two.
+        selectedPresetId.value = 5L
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.selectedPreset?.id).isEqualTo(5L)
+        assertThat(vm.counterState.value.targetCount).isEqualTo(11)
+    }
+
+    @Test
+    fun `re-emitting the id already selected does not reset the count`() = runTest {
+        coEvery { useCases.getPresetById(5L) } returns preset(5)
+        val vm = viewModel()
+        advanceUntilIdle()
+        selectedPresetId.value = 5L
+        advanceUntilIdle()
+        repeat(4) { vm.onEvent(TasbihEvent.Increment); advanceUntilIdle() }
+
+        // DataStore re-emits on any write to the file, not only on a change to this key.
+        selectedPresetId.value = 5L
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.count).isEqualTo(4)
+    }
+
+    @Test
+    fun `a persisted id of minus one clears a selection that is in place`() = runTest {
+        coEvery { useCases.getPresetById(5L) } returns preset(5, target = 11)
+        val vm = viewModel()
+        advanceUntilIdle()
+        selectedPresetId.value = 5L
+        advanceUntilIdle()
+
+        selectedPresetId.value = -1L
+        advanceUntilIdle()
+
+        assertThat(vm.counterState.value.selectedPreset).isNull()
+        assertThat(vm.counterState.value.targetCount).isEqualTo(33)
+    }
+
+    @Test
+    fun `favouriting adds an id and favouriting again takes it away`() = runTest {
+        val saved = slot<Set<String>>()
+        coEvery { settings.setTasbihFavorites(capture(saved)) } answers {
+            favorites.value = saved.captured
+        }
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(TasbihEvent.ToggleFavorite(7L))
+        advanceUntilIdle()
+        assertThat(favorites.value).containsExactly("7")
+        assertThat(vm.presetsState.value.favorites).containsExactly(7L)
+
+        vm.onEvent(TasbihEvent.ToggleFavorite(7L))
+        advanceUntilIdle()
+        // One control, both directions: a star that could only be set would leave the user no
+        // way to unpick a dhikr they starred by mistake.
+        assertThat(favorites.value).isEmpty()
+    }
+
+    @Test
+    fun `a favourite id that is not a number is ignored rather than crashing`() = runTest {
+        favorites.value = setOf("3", "not-an-id")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // The set is stored as strings in DataStore, so a corrupted or hand-edited entry is
+        // reachable — and it must not take the presets screen down.
+        assertThat(vm.presetsState.value.favorites).containsExactly(3L)
+    }
+
+    @Test
+    fun `an unfinished session from a previous launch is picked back up`() = runTest {
+        val session = TasbihSession(
+            id = 42L,
+            presetId = 5L,
+            presetName = "Dhikr 5",
+            date = 0L,
+            currentCount = 8,
+            targetCount = 11,
+            totalLaps = 2,
+            isCompleted = false,
+            duration = null,
+            startedAt = 0L,
+            completedAt = null,
+            note = null,
+        )
+        coEvery { useCases.getActiveSession() } returns session
+        coEvery { useCases.getPresetById(5L) } returns preset(5, target = 11)
+        // The persisted selection agrees with the session's preset, as it does on a real
+        // relaunch — the two are written together.
+        selectedPresetId.value = 5L
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        // The count is in Room precisely so it survives a relaunch; dropping it on open would
+        // lose whatever was counted before the app was swiped away.
+        assertThat(vm.counterState.value.currentSession?.id).isEqualTo(42L)
+        assertThat(vm.counterState.value.count).isEqualTo(8)
+        assertThat(vm.counterState.value.laps).isEqualTo(2)
+        assertThat(vm.counterState.value.targetCount).isEqualTo(11)
+    }
+
+    @Test
+    fun `a stored session with a target of zero is repaired rather than dividing by it`() =
+        runTest {
+            coEvery { useCases.getActiveSession() } returns TasbihSession(
+                id = 43L,
+                presetId = null,
+                presetName = null,
+                date = 0L,
+                currentCount = 4,
+                targetCount = 0,
+                totalLaps = 0,
+                isCompleted = false,
+                duration = null,
+                startedAt = 0L,
+                completedAt = null,
+                note = null,
+            )
+
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            // Every writer coerces to at least one, but a legacy or imported row need not have —
+            // and this runs at init, so one bad row would take the counter down on open rather
+            // than degrade. The row is still picked up; only the modulo is guarded.
+            assertThat(vm.counterState.value.currentSession?.id).isEqualTo(43L)
+            assertThat(vm.counterState.value.count).isEqualTo(0)
+            assertThat(telemetry.exceptions).isEmpty()
+        }
+
+    @Test
+    fun `the default adhkar are seeded once per version`() = runTest {
+        every { settings.tasbihPresetSeedVersion } returns flowOf(0)
+
+        viewModel()
+        advanceUntilIdle()
+
+        // Adhkar added after the prepackaged database shipped reach an existing install only
+        // this way, and re-seeding on every launch would duplicate them.
+        coVerify(exactly = 1) { useCases.seedMissingDefaults() }
+        coVerify { settings.setTasbihPresetSeedVersion(any()) }
+    }
+
+    @Test
+    fun `an install already at the current seed version is left alone`() = runTest {
+        viewModel()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { useCases.seedMissingDefaults() }
+    }
+}

--- a/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/TrackerDerivedStateTest.kt
+++ b/feature/tracker/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/tracker/TrackerDerivedStateTest.kt
@@ -1,0 +1,124 @@
+package com.arshadshah.nimaz.presentation.viewmodel.tracker
+
+import com.arshadshah.nimaz.domain.model.FastRecord
+import com.arshadshah.nimaz.domain.model.FastStatus
+import com.arshadshah.nimaz.domain.model.FastType
+import com.arshadshah.nimaz.domain.model.TasbihCategory
+import com.arshadshah.nimaz.domain.model.TasbihPreset
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * The two properties the tracker's UI states **derive** rather than store.
+ *
+ * Both exist because storing them went wrong. `filteredPresets` used to be a stored field that
+ * every input had to remember to recompute, and the two Room collectors in `loadPresets` rebuilt
+ * it as `defaults + customs` without consulting the selected category — so saving or deleting a
+ * custom dhikr re-emitted the presets flow and silently dropped the active filter while the
+ * category chip carried on looking selected. `canToggleToday` replaced a switch that looked live
+ * over an exempt day and did nothing when tapped.
+ *
+ * Deriving them means there is no site left to forget, which is precisely why the derivation
+ * itself is the thing worth a test: it is hand-written logic on a data class, and it is what the
+ * screens read.
+ */
+class TrackerDerivedStateTest {
+
+    private fun preset(id: Long, category: TasbihCategory?) = TasbihPreset(
+        id = id,
+        name = "Dhikr $id",
+        arabicText = null,
+        transliteration = null,
+        translation = null,
+        targetCount = 33,
+        category = category,
+        reference = null,
+        isDefault = id < 100,
+        displayOrder = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val morning = preset(1, TasbihCategory.MORNING)
+    private val evening = preset(2, TasbihCategory.EVENING)
+    private val mine = preset(100, TasbihCategory.CUSTOM)
+    private val uncategorised = preset(101, null)
+
+    private fun presets(selected: TasbihCategory?) = TasbihPresetsUiState(
+        defaultPresets = listOf(morning, evening),
+        customPresets = listOf(mine, uncategorised),
+        selectedCategory = selected,
+        isLoading = false,
+    )
+
+    private fun record(status: FastStatus) = FastRecord(
+        id = 1L,
+        date = 0L,
+        hijriDate = null,
+        hijriMonth = null,
+        hijriYear = null,
+        fastType = FastType.VOLUNTARY,
+        status = status,
+        exemptionReason = null,
+        suhoorTime = null,
+        iftarTime = null,
+        note = null,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun fasting(todayRecord: FastRecord?) = FastingTrackerUiState(
+        selectedDate = LocalDate.of(2026, 8, 13),
+        todayRecord = todayRecord,
+        isLoading = false,
+    )
+
+    @Test
+    fun `with no category chosen every dhikr is listed, defaults before customs`() {
+        val filtered = presets(selected = null).filteredPresets
+
+        assertThat(filtered).containsExactly(morning, evening, mine, uncategorised).inOrder()
+    }
+
+    @Test
+    fun `a chosen category keeps only its own, across defaults and customs alike`() {
+        assertThat(presets(selected = TasbihCategory.MORNING).filteredPresets)
+            .containsExactly(morning)
+        // The user's own dhikr is filtered by the same rule as a shipped one — the two lists are
+        // concatenated first, not filtered separately.
+        assertThat(presets(selected = TasbihCategory.CUSTOM).filteredPresets)
+            .containsExactly(mine)
+    }
+
+    @Test
+    fun `a dhikr with no category survives only the unfiltered list`() {
+        // `category` is nullable all the way down: an imported or hand-edited row need not carry
+        // one, and it must not silently match whichever category happens to be selected.
+        TasbihCategory.entries.forEach { category ->
+            assertThat(presets(selected = category).filteredPresets).doesNotContain(uncategorised)
+        }
+        assertThat(presets(selected = null).filteredPresets).contains(uncategorised)
+    }
+
+    @Test
+    fun `an unlogged day and the two ends of the toggle are all actionable`() {
+        assertThat(fasting(todayRecord = null).canToggleToday).isTrue()
+        assertThat(fasting(record(FastStatus.FASTED)).canToggleToday).isTrue()
+        assertThat(fasting(record(FastStatus.NOT_FASTED)).canToggleToday).isTrue()
+
+        assertThat(fasting(todayRecord = null).toggleBlockedReason).isNull()
+    }
+
+    @Test
+    fun `a day with a reason on file blocks the toggle and says which reason`() {
+        // `EXEMPTED` and `MAKEUP_DUE` are recorded in the day sheet with a reason attached, so a
+        // single tap must not overwrite them. The blocked reason is what the control shows in
+        // place of looking live and doing nothing, which is what it used to do.
+        listOf(FastStatus.EXEMPTED, FastStatus.MAKEUP_DUE).forEach { status ->
+            val state = fasting(record(status))
+            assertThat(state.canToggleToday).isFalse()
+            assertThat(state.toggleBlockedReason).isEqualTo(status)
+        }
+    }
+}

--- a/feature/tracker/src/test/resources/robolectric.properties
+++ b/feature/tracker/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Robolectric 4.11.x ships instrumented SDKs up to API 34, while the app
+# compiles against a newer compileSdk. Pin the test runtime to 34 so the
+# Compose UI tests for the atoms have a supported, downloadable android-all jar.
+sdk=34
+
+# A plain Application, not the app's @HiltAndroidApp NimazApp — which this module cannot see
+# anyway, and which would drag Hilt/WorkManager initialisation into tests that only exercise
+# the design system.
+application=android.app.Application

--- a/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/RamadanCardsTest.kt
+++ b/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/RamadanCardsTest.kt
@@ -1,0 +1,141 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.formatLongDate
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * The three Ramadan cards, on their own.
+ *
+ * They are tested here rather than only through `FastTrackerScreen` because two of their
+ * failure modes are numbers, and the tracker screen has a month calendar on it — every integer
+ * from 1 to 31 already appears as a day cell, so "the countdown reads 12" cannot be asserted
+ * there without matching a date.
+ *
+ * `RamadanMissedFastsTracker` is the third card and has **no caller at all** today: the tracker
+ * redesign dropped it from the screen, and it survives because the count it renders
+ * (`unloggedDays`, from `CountUnloggedRamadanDaysUseCase`) is still computed and still in the
+ * state. Its contract is that it draws *nothing* at zero so a caller can place it
+ * unconditionally — which is exactly the behaviour a future caller will rely on without
+ * checking, and exactly what nothing else here would catch.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class RamadanCardsTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the banner reports the day, the progress and the three counts`() {
+        composeRule.setThemedContent {
+            RamadanBanner(
+                fastedDays = 7,
+                totalDays = 30,
+                currentDay = 8,
+                missedDays = 1,
+                remainingDays = 22,
+            )
+        }
+
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_day, 8)).assertExists()
+        composeRule.onNodeWithText("7/30").assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_fasted)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_missed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_remaining)).assertExists()
+        composeRule.onNodeWithText("22").assertExists()
+    }
+
+    @Test
+    fun `the banner's stat row is withheld when there are no counts to show`() {
+        composeRule.setThemedContent {
+            RamadanBanner(fastedDays = 0, totalDays = 0, currentDay = 1)
+        }
+
+        // `totalDays = 0` is the day Ramadan is detected before the record set has loaded. The
+        // card must still draw — and its progress bar must not divide by zero.
+        composeRule.onNodeWithText("0/0").assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_missed)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.fasting_remaining)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the banner reports whichever counts it is given`() {
+        composeRule.setThemedContent {
+            RamadanBanner(fastedDays = 4, totalDays = 30, currentDay = 5, missedDays = 1)
+        }
+
+        // The three counts are independently optional: the calendar's caller supplies missed and
+        // remaining, and a caller with only one of them must get a row with only that one rather
+        // than a row with a hole in it.
+        composeRule.onNodeWithText(string(R.string.fasting_missed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_remaining)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.fasting_fasted)).assertExists()
+    }
+
+    @Test
+    fun `the countdown names the number of days and the date it starts`() {
+        val startsOn = LocalDate.of(2027, 2, 8)
+        composeRule.setThemedContent {
+            RamadanCountdownCard(daysAway = 12, startsOn = startsOn)
+        }
+
+        composeRule.onNodeWithText(string(R.string.fasting_ramadan_starts_in)).assertExists()
+        composeRule.onNodeWithText("12").assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_days)).assertExists()
+        composeRule.onNodeWithText(startsOn.formatLongDate()).assertExists()
+    }
+
+    @Test
+    fun `the countdown says day, singular, on the eve`() {
+        composeRule.setThemedContent {
+            RamadanCountdownCard(daysAway = 1, startsOn = LocalDate.of(2027, 2, 8))
+        }
+
+        composeRule.onNodeWithText(string(R.string.fasting_day)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_days)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the unlogged-days nudge counts the days and says what to do`() {
+        composeRule.setThemedContent { RamadanMissedFastsTracker(unloggedDays = 3) }
+
+        composeRule.onNodeWithText("3").assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_unlogged_days)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_log_calendar_hint)).assertExists()
+    }
+
+    @Test
+    fun `the nudge is singular for a single day`() {
+        composeRule.setThemedContent { RamadanMissedFastsTracker(unloggedDays = 1) }
+
+        composeRule.onNodeWithText(string(R.string.fasting_unlogged_day)).assertExists()
+        composeRule.onNodeWithText(string(R.string.fasting_unlogged_days)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the nudge draws nothing when nothing is unlogged`() {
+        composeRule.setThemedContent { RamadanMissedFastsTracker(unloggedDays = 0) }
+
+        // The documented contract, and the reason a caller may place it unconditionally: a card
+        // that rendered an empty shell at zero would leave a blank box on the screen instead.
+        composeRule.onNodeWithText(string(R.string.fasting_log_calendar_hint)).assertDoesNotExist()
+        composeRule.onNodeWithText("0").assertDoesNotExist()
+    }
+}

--- a/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/TasbihSheetsTest.kt
+++ b/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/TasbihSheetsTest.kt
@@ -1,13 +1,16 @@
 package com.arshadshah.nimaz.presentation.components.molecules
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.arshadshah.nimaz.domain.model.TasbihCategory
 import com.arshadshah.nimaz.domain.model.TasbihPreset
 import com.arshadshah.nimaz.presentation.components.molecules.tasbih.BeadDesignPickerSheet
 import com.arshadshah.nimaz.presentation.components.molecules.tasbih.CurrentTasbihSheet
 import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
 import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -89,5 +92,95 @@ class TasbihSheetsTest {
         // free-count branch composed.
         composeRule.onNodeWithText("Free Count").assertIsDisplayed()
         composeRule.onNodeWithText("Change Dhikr").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the current sheet shows a preset's reference and transliteration`() {
+        composeRule.setThemedContent {
+            CurrentTasbihSheet(
+                preset = samplePreset(),
+                targetCount = 33,
+                totalToday = 66,
+                laps = 2,
+                onChangeDhikr = {},
+                onTargetChange = {},
+                onDismiss = {}
+            )
+        }
+        composeRule.waitForIdle()
+
+        // The reference is what makes a dhikr checkable — "Sahih Muslim" is the difference
+        // between a remembrance and a claim about one. It is optional, so it renders only when
+        // the preset carries it, which is exactly the arm that goes unnoticed when it breaks.
+        composeRule.onNodeWithText("Sahih Muslim").assertIsDisplayed()
+        composeRule.onNodeWithText("SubhanAllah").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a preset with no reference or transliteration renders neither`() {
+        composeRule.setThemedContent {
+            CurrentTasbihSheet(
+                preset = samplePreset().copy(
+                    transliteration = null,
+                    reference = null,
+                    arabicText = null,
+                ),
+                targetCount = 33,
+                totalToday = 0,
+                laps = 0,
+                onChangeDhikr = {},
+                onTargetChange = {},
+                onDismiss = {}
+            )
+        }
+        composeRule.waitForIdle()
+
+        // A bare custom dhikr is the common case — no blank lines where the optional parts
+        // would be, and the translation still standing in as the name.
+        composeRule.onNodeWithText("Sahih Muslim").assertDoesNotExist()
+        composeRule.onNodeWithText("Glory be to Allah").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the free count sheet dials the target`() {
+        var target = 100
+        composeRule.setThemedContent {
+            CurrentTasbihSheet(
+                preset = null,
+                targetCount = 100,
+                totalToday = 0,
+                laps = 0,
+                onChangeDhikr = {},
+                onTargetChange = { target = it },
+                onDismiss = {}
+            )
+        }
+        composeRule.waitForIdle()
+
+        // The stepper is offered only for a free count — a preset's target is the preset's, and
+        // this is the one place a user can set their own.
+        composeRule.onNodeWithContentDescription("Increase").performClick()
+
+        assertThat(target).isGreaterThan(100)
+    }
+
+    @Test
+    fun `the bead sheet says which way the beads advance`() {
+        composeRule.setThemedContent {
+            BeadDesignPickerSheet(
+                selectedKey = "jade",
+                onSelect = {},
+                leftHanded = true,
+                onToggleHanded = {},
+                onDismiss = {}
+            )
+        }
+        composeRule.waitForIdle()
+
+        // The handedness switch has no other confirmation on screen: the strand is a Canvas with
+        // no text in it, so this line is the only thing that tells the user what they just
+        // changed.
+        composeRule.onNodeWithText("Beads advance left → right").assertIsDisplayed()
+        composeRule.onNodeWithText("Jade").assertIsDisplayed()
     }
 }

--- a/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/PrayerRadialChartTest.kt
+++ b/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/organisms/PrayerRadialChartTest.kt
@@ -1,0 +1,191 @@
+package com.arshadshah.nimaz.presentation.components.organisms
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import com.arshadshah.nimaz.domain.model.PrayerName
+import com.arshadshah.nimaz.domain.model.PrayerStats
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The radial chart, drawn for real.
+ *
+ * `PrayerStatsChartTest` composes this chart and asserts it does not crash, which is as far as a
+ * semantics-based test can go: the whole figure — grid rings, spokes, the data polygon and its
+ * five points — is one `Canvas` block, and composing runs the `Canvas(modifier)` call without
+ * executing a line of it.
+ *
+ * What that leaves unchecked is the one thing the chart is for: **the polygon's size follows the
+ * record.** A figure built at a constant radius, or from `prayedByPrayer` with the misses
+ * ignored, draws a perfectly plausible five-pointed shape that means nothing — and nobody
+ * eyeballing a screenshot would catch it, because a radar chart with no reference looks like a
+ * radar chart.
+ *
+ * The technique is #604's playbook item 5 — draw into a software `android.graphics.Canvas` under
+ * `@GraphicsMode(NATIVE)` and read the pixels back. A compose rule composes once, so the records
+ * being compared are drawn **side by side in one composition** rather than across tests, and each
+ * is measured by the pixels in which it *differs from an empty chart drawn beside it*. Counting
+ * non-background pixels does not work here: the card fills its whole area with a surface colour,
+ * so every pixel is painted whatever the data says.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+// 999dp at mdpi is 999px, so the three equal-weight thirds land on exact pixel
+// boundaries and two identical charts rasterise identically. Density is pinned for the same
+// reason #604 pins it elsewhere: it is a real input to layout, not an incidental.
+@Config(qualifiers = "w999dp-h1200dp-mdpi")
+class PrayerRadialChartTest {
+
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val tracked = listOf(
+        PrayerName.FAJR,
+        PrayerName.DHUHR,
+        PrayerName.ASR,
+        PrayerName.MAGHRIB,
+        PrayerName.ISHA,
+    )
+
+    private fun stats(prayedEach: Int, missedEach: Int) = PrayerStats(
+        totalPrayed = prayedEach * tracked.size,
+        totalMissed = missedEach * tracked.size,
+        totalJamaah = 0,
+        prayedByPrayer = tracked.associateWith { prayedEach },
+        missedByPrayer = tracked.associateWith { missedEach },
+        currentStreak = 0,
+        longestStreak = 0,
+        perfectDays = 0,
+        startDate = 0L,
+        endDate = 0L,
+    )
+
+    private val empty = PrayerStats(
+        totalPrayed = 0,
+        totalMissed = 0,
+        totalJamaah = 0,
+        prayedByPrayer = emptyMap(),
+        missedByPrayer = emptyMap(),
+        currentStreak = 0,
+        longestStreak = 0,
+        perfectDays = 0,
+        startDate = 0L,
+        endDate = 0L,
+    )
+
+    /** Draws three radial charts side by side, sharing one composition. */
+    private fun drawThree(first: PrayerStats, second: PrayerStats, third: PrayerStats): Bitmap {
+        composeRule.setContent {
+            MaterialTheme {
+                Row(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+                    listOf(first, second, third).forEach { stats ->
+                        Box(modifier = Modifier.weight(1f)) {
+                            PrayerStatsChart(
+                                stats = stats,
+                                chartType = PrayerChartType.RADIAL,
+                                summaryItems = emptyList(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val root: View = composeRule.activity
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0)
+        val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+        root.draw(Canvas(bitmap))
+        return bitmap
+    }
+
+    private fun Bitmap.third(index: Int): IntArray {
+        val w = width / 3
+        return IntArray(w * height).also { getPixels(it, 0, w, index * w, 0, w, height) }
+    }
+
+    /**
+     * How many pixels differ between two thirds of the bitmap.
+     *
+     * Each third holds the same card, the same grid, the same spokes and the same labels, so a
+     * differing pixel is essentially one the polygon put there — "essentially" because
+     * anti-aliasing does not fall identically across three separately-laid-out cards, which
+     * leaves a small floor even between two identical records. The first test below measures
+     * that floor rather than assuming it away.
+     */
+    private fun Bitmap.pixelsDiffering(a: Int, b: Int): Int {
+        val left = third(a)
+        val right = third(b)
+        return left.indices.count { left[it] != right[it] }
+    }
+
+    @Test
+    fun `the polygon dwarfs the noise between two identical charts`() {
+        val bitmap = drawThree(stats(30, 0), stats(30, 0), empty)
+
+        // Two thirds holding the same record still differ a little — anti-aliasing does not fall
+        // identically across three separately-laid-out cards. The third holds an empty record,
+        // whose polygon collapses to a point, so the difference against *it* is the polygon
+        // itself. Establishing that it is several times the floor is what makes the comparison
+        // in the next test mean something.
+        val floor = bitmap.pixelsDiffering(0, 1)
+        val polygon = bitmap.pixelsDiffering(0, 2)
+
+        assertThat(polygon).isGreaterThan(floor * 3)
+    }
+
+    @Test
+    fun `a stronger record paints a bigger polygon than a weaker one`() {
+        // Strong, weak, and an empty chart to measure both against — all three drawn once, so
+        // the comparison lives inside a single composition.
+        val bitmap = drawThree(stats(30, 0), stats(1, 29), empty)
+
+        val strongPolygon = bitmap.pixelsDiffering(0, 2)
+        val weakPolygon = bitmap.pixelsDiffering(1, 2)
+
+        // A polygon at a constant radius — or one read from `prayedByPrayer` with the misses
+        // ignored — would make these two equal, and would look entirely convincing on screen.
+        assertThat(weakPolygon).isGreaterThan(0)
+        assertThat(strongPolygon).isGreaterThan(weakPolygon)
+    }
+
+    @Test
+    fun `a chart with nothing recorded still draws its frame`() {
+        val bitmap = drawThree(empty, empty, stats(30, 0))
+
+        // Every prayer divides by a total of zero and the polygon collapses to a point. The
+        // rings, spokes and labels do not depend on the data, so the frame must still be there —
+        // an empty chart is a legitimate state on a fresh install, and a blank card is not.
+        assertThat(bitmap.pixelsDiffering(0, 2)).isGreaterThan(0)
+        composeRule.onAllNodesWithText("0%").assertCountEquals(2)
+    }
+
+    @Test
+    fun `the centre label reads the totals, not the polygon`() {
+        drawThree(stats(30, 0), stats(30, 0), stats(30, 0))
+
+        // A full record puts every point on the outer ring, and the percentage is still computed
+        // from `totalPrayed`/`totalMissed` rather than from the geometry.
+        composeRule.onAllNodesWithText("100%").assertCountEquals(3)
+    }
+}

--- a/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastingWindowTest.kt
+++ b/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/fasting/FastingWindowTest.kt
@@ -1,0 +1,170 @@
+package com.arshadshah.nimaz.presentation.screens.fasting
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.components.atoms.ProvideNimazClock
+import com.arshadshah.nimaz.presentation.viewmodel.tracker.FastingTrackerUiState
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * The suhoor→iftar band, and the one line above it that says how long is left.
+ *
+ * Four sentences share one `when`, and which one a user sees depends on where *now* falls
+ * against the selected day's window. That makes it the part of the fasting tracker most likely
+ * to be wrong for exactly the reader who needs it — someone opening the app an hour before
+ * iftar — and the least likely to be caught by hand, because reproducing each case means waiting
+ * for the right hour of the right day.
+ *
+ * Time is supplied through `ProvideNimazClock`'s `timeSource` seam rather than read from the
+ * machine, so each case is a fixed point in the window rather than whatever the CI runner's
+ * clock happens to say.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class FastingWindowTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val today: LocalDate = LocalDate.of(2026, 8, 13)
+    /**
+     * A minute-aligned "now".
+     *
+     * `rememberNow(MINUTES)` truncates whatever it is handed, so an instant with seconds on it
+     * would make every expected duration a few seconds short of the rendered one.
+     */
+    private val now: Instant = Instant.fromEpochMilliseconds(
+        Clock.System.now().toEpochMilliseconds() / 60_000L * 60_000L
+    )
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    /** The countdown formats, from the resources — the phrasing is the translators' to change. */
+    private fun hoursAndMinutes(hours: Int, minutes: Int) =
+        string(R.string.countdown_hm, hours, minutes)
+
+    private fun minutesOnly(minutes: Int) = string(R.string.countdown_m, minutes)
+
+    private fun render(
+        suhoorAt: Instant?,
+        iftarAt: Instant?,
+        isSelectedToday: Boolean = true,
+    ) {
+        composeRule.setThemedContent {
+            ProvideNimazClock(timeSource = { now }) {
+                FastingDayCard(
+                    state = FastingTrackerUiState(
+                        selectedDate = today,
+                        selectedSuhoorAt = suhoorAt,
+                        selectedIftarAt = iftarAt,
+                        isSelectedToday = isSelectedToday,
+                        isLoading = false,
+                    ),
+                    ramadanDay = null,
+                    onSetStatus = {},
+                    onOpenExemption = {},
+                    onOpenNote = {},
+                    onBackToToday = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `before suhoor the lede counts down to suhoor`() {
+        render(suhoorAt = now + 40.minutes, iftarAt = now + 14.hours)
+
+        // The reader is awake and eating; the number that matters is how long they have left to.
+        composeRule.onNodeWithText(
+            string(R.string.fasting_window_suhoor_in, minutesOnly(40)),
+        ).assertExists()
+    }
+
+    @Test
+    fun `inside the fast the lede counts down to iftar`() {
+        render(suhoorAt = now - 6.hours, iftarAt = now + 3.hours - 42.minutes)
+
+        composeRule.onNodeWithText(
+            string(R.string.fasting_window_iftar_in, hoursAndMinutes(2, 18)),
+        ).assertExists()
+    }
+
+    @Test
+    fun `after iftar the window is reported closed rather than counting down to nothing`() {
+        render(suhoorAt = now - 16.hours, iftarAt = now - 1.hours)
+
+        // Both ends are behind us, so there is no duration to report. A countdown here would
+        // run backwards or wrap.
+        composeRule.onNodeWithText(string(R.string.fasting_window_closed)).assertExists()
+    }
+
+    @Test
+    fun `a day that is not today reports the window's length, not a countdown`() {
+        render(
+            suhoorAt = now - 30.hours,
+            iftarAt = now - 30.hours + 15.hours + 30.minutes,
+            isSelectedToday = false,
+        )
+
+        // "Iftar in −6h" for yesterday is meaningless; how long that day's fast ran is not.
+        composeRule.onNodeWithText(
+            string(R.string.fasting_window_length, hoursAndMinutes(15, 30)),
+        ).assertExists()
+    }
+
+    @Test
+    fun `with no schedule the band shows placeholders and says the window is closed`() {
+        render(suhoorAt = null, iftarAt = null)
+
+        composeRule.onNodeWithText(string(R.string.fasting_window_closed)).assertExists()
+        // Not "00:00", which would read as a real time of day at the top of the band.
+        composeRule.onNodeWithContentDescription(
+            string(R.string.fasting_window_a11y, "--:--", "--:--"),
+        ).assertExists()
+    }
+
+    @Test
+    fun `half a schedule is treated as no schedule`() {
+        // A partial day is reachable: the two instants are resolved separately, so a location
+        // change between them can leave one set. Counting down to an iftar with no suhoor would
+        // report a fast that has not started.
+        render(suhoorAt = now - 2.hours, iftarAt = null)
+
+        composeRule.onNodeWithText(string(R.string.fasting_window_closed)).assertExists()
+    }
+
+    @Test
+    fun `the band is described for a screen reader by both of its ends`() {
+        render(suhoorAt = now - 6.hours, iftarAt = now + 3.hours)
+
+        // The track sets its own semantics over the whole band, so its end labels are not
+        // addressable as text — the description is the only thing TalkBack gets where the
+        // whole day's shape is. Matched on the format's leading words rather than a rendered
+        // clock time, which depends on the 12/24-hour setting.
+        val prefix = string(R.string.fasting_window_a11y, "@", "@").substringBefore("@")
+        composeRule.onNodeWithContentDescription(prefix, substring = true).assertExists()
+        // …and it is a real schedule, not the placeholder one.
+        composeRule.onNodeWithContentDescription(
+            string(R.string.fasting_window_a11y, "--:--", "--:--"),
+        ).assertDoesNotExist()
+    }
+}

--- a/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihBeadsTest.kt
+++ b/feature/tracker/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/screens/tasbih/TasbihBeadsTest.kt
@@ -1,0 +1,229 @@
+package com.arshadshah.nimaz.presentation.screens.tasbih
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The bead strand, drawn for real and read back off a bitmap.
+ *
+ * Beads mode is one of the two ways the tasbih counts, and it is **entirely** `Canvas` geometry:
+ * no text, no semantics, nothing an `onNodeWith…` finder can reach. Composing the tree runs the
+ * `Canvas(modifier)` call and none of `drawStrand`, so every line of the strand — the arc-length
+ * table, the two bunches, the loose bead crossing the gap — was unexecuted by any test anywhere.
+ *
+ * What that hides is not cosmetic. The strand runs **top-right → bottom-left** by default and
+ * mirrors for a left-handed user, which is a setting with no other visible confirmation: get the
+ * mirror wrong and the beads advance the wrong way for exactly the users who asked for it. The
+ * design registry is the same shape of problem — six materials, one `byKey` lookup, and a
+ * fallback that silently returns wood for anything it does not recognise.
+ *
+ * The technique is #604's playbook item 5: draw the `ComposeView` into a **software**
+ * `android.graphics.Canvas`, which makes Compose's `RenderNodeLayer` invoke the draw block
+ * directly instead of replaying a render node. `@GraphicsMode(NATIVE)` because the assertions are
+ * about pixels — under the legacy shadow canvas every draw is a no-op and the bitmap comes back
+ * blank whether the strand worked or not. One draw per test, so a comparison of two renders has
+ * to be two tests feeding one helper.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w411dp-h891dp")
+class TasbihBeadsTest {
+
+    // The v1 rule rather than the shared `createComponentComposeRule()`: this needs the
+    // activity's own view to draw into a bitmap, which the shared fixture's rule type does not
+    // expose.
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun draw(content: @Composable () -> Unit): Bitmap {
+        composeRule.setContent {
+            MaterialTheme {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Black)) { content() }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val root: View = composeRule.activity
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0)
+        val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+        root.draw(Canvas(bitmap))
+        return bitmap
+    }
+
+    private fun strand(
+        count: Int = 7,
+        targetCount: Int = 33,
+        design: BeadDesign = BeadDesigns.Wood,
+        leftHanded: Boolean = false,
+        onIncrement: () -> Unit = {},
+    ): Bitmap = draw {
+        TasbihBeads(
+            count = count,
+            onIncrement = onIncrement,
+            targetCount = targetCount,
+            design = design,
+            leftHanded = leftHanded,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+
+    /** Pixels in the given half that are not the black backdrop — i.e. strand actually painted. */
+    private fun Bitmap.inkInHalf(rightHalf: Boolean): Int {
+        val half = width / 2
+        val left = if (rightHalf) half else 0
+        val pixels = IntArray(half * height)
+        getPixels(pixels, 0, half, left, 0, half, height)
+        return pixels.count { it != android.graphics.Color.BLACK }
+    }
+
+    private fun Bitmap.ink(): Int = inkInHalf(false) + inkInHalf(true)
+
+    /** Mean colour of everything painted, as (r, g, b). Ignores the backdrop. */
+    private fun Bitmap.paintedColour(): Triple<Double, Double, Double> {
+        val pixels = IntArray(width * height)
+        getPixels(pixels, 0, width, 0, 0, width, height)
+        val painted = pixels.filter { it != android.graphics.Color.BLACK }
+        check(painted.isNotEmpty()) { "nothing was painted" }
+        return Triple(
+            painted.map { android.graphics.Color.red(it).toDouble() }.average(),
+            painted.map { android.graphics.Color.green(it).toDouble() }.average(),
+            painted.map { android.graphics.Color.blue(it).toDouble() }.average(),
+        )
+    }
+
+    @Test
+    fun `the strand paints beads across the whole surface`() {
+        val bitmap = strand()
+
+        // Edge to edge is the design: the loop is hidden and the visible strand runs off both
+        // sides, so a render confined to one half means the geometry collapsed.
+        assertThat(bitmap.inkInHalf(rightHalf = false)).isGreaterThan(0)
+        assertThat(bitmap.inkInHalf(rightHalf = true)).isGreaterThan(0)
+    }
+
+    @Test
+    fun `the counted bunch hangs toward the bottom-left for a right-handed strand`() {
+        val bitmap = strand()
+
+        // p0 sits at 82% of the width and p2 at 16%, so the strand leans left overall. This is
+        // the reference the mirrored case below is measured against.
+        assertThat(bitmap.inkInHalf(rightHalf = false))
+            .isGreaterThan(bitmap.inkInHalf(rightHalf = true))
+    }
+
+    @Test
+    fun `a left-handed strand leans the other way`() {
+        val bitmap = strand(leftHanded = true)
+
+        // The mirror is the whole of what `tasbihLeftHanded` does to the strand, and nothing else
+        // on the screen reports which way the beads advance.
+        assertThat(bitmap.inkInHalf(rightHalf = true))
+            .isGreaterThan(bitmap.inkInHalf(rightHalf = false))
+    }
+
+    @Test
+    fun `wood beads are painted in wood colours`() {
+        val (r, g, b) = strand(design = BeadDesigns.Wood).paintedColour()
+
+        // Warm: red dominates. The check that matters is against jade below — a `drawBead` that
+        // ignored the design's stops would paint every material identically.
+        assertThat(r).isGreaterThan(b)
+        assertThat(r).isGreaterThan(g)
+    }
+
+    @Test
+    fun `jade beads are painted in jade colours`() {
+        val (r, g, _) = strand(design = BeadDesigns.Jade).paintedColour()
+
+        assertThat(g).isGreaterThan(r)
+    }
+
+    @Test
+    fun `an unknown design key falls back to the default rather than failing`() {
+        // A persisted key from a design that has since been removed must not leave the counter
+        // blank — `byKey` is the only thing standing between that and an empty screen.
+        assertThat(BeadDesigns.byKey("no-such-material")).isSameInstanceAs(BeadDesigns.Default)
+        assertThat(BeadDesigns.byKey(null)).isSameInstanceAs(BeadDesigns.Default)
+        assertThat(BeadDesigns.byKey("jade")).isSameInstanceAs(BeadDesigns.Jade)
+        assertThat(BeadDesigns.all.map { it.key }).containsNoDuplicates()
+    }
+
+    @Test
+    fun `a tap on the strand counts one bead`() {
+        var increments = 0
+        strand(onIncrement = { increments++ })
+
+        composeRule.onRoot().performClick()
+        composeRule.waitForIdle()
+
+        // A press with no movement is a tap, and one gesture is one bead — this is the beads-mode
+        // equivalent of the classic circle's tap, and it writes to Room the same way.
+        assertThat(increments).isEqualTo(1)
+    }
+
+    @Test
+    fun `a flick across the gap counts one bead`() {
+        var increments = 0
+        strand(onIncrement = { increments++ })
+
+        // The strand runs top-right → bottom-left, so a drag that direction is a bead crossing
+        // the gap. One gesture is one bead however far it travels — a flick that counted by
+        // distance would run the tasbih up by ten on a fast swipe.
+        composeRule.onRoot().performTouchInput {
+            swipeLeft(startX = right - 1f, endX = left + 1f, durationMillis = 200)
+        }
+        composeRule.waitForIdle()
+
+        assertThat(increments).isEqualTo(1)
+    }
+
+    @Test
+    fun `a drag that does not cross the gap settles back without counting`() {
+        var increments = 0
+        strand(onIncrement = { increments++ })
+
+        // A finger that moves and changes its mind must not count. The crossing is tracked
+        // synchronously as the gesture runs precisely so a fast flick is decided correctly —
+        // which means a short one has to be decided correctly too.
+        composeRule.onRoot().performTouchInput {
+            val start = center
+            down(start)
+            moveTo(start + androidx.compose.ui.geometry.Offset(-6f, 6f))
+            up()
+        }
+        composeRule.waitForIdle()
+
+        assertThat(increments).isEqualTo(0)
+    }
+
+    @Test
+    fun `a target of zero still draws a strand`() {
+        // `beadCount` coerces to at least one; without that the modulo in the imame test divides
+        // by zero and the counter crashes on a preset somebody saved with no target.
+        assertThat(strand(count = 0, targetCount = 0).ink()).isGreaterThan(0)
+    }
+}


### PR DESCRIPTION
Closes #613. Part of #604.

| | Before | After |
|---|---|---|
| **Line** | 30.4% (1,575 / 5,176) | **91.9%** (4,755 / 5,176) |
| **Branch** | 24.4% | **81.3%** |
| Tests | 118 over 14 classes | **341 over 34 classes** |

Floors declared at **80 line / 80 branch** — the eighth Compose module in a row to hold the standard.

**One PR, not the three #613 suggests.** [#604's comment on stacked PRs](https://github.com/arshad-shah/Nimaz/issues/604#issuecomment-5410762328) settles that: `pr_checks.yml` filters `branches: [ master, dev, 'mm/**', 'epic/**' ]`, so a PR stacked on `claude/*` gets **no `check` lane at all**, and GitHub does not re-evaluate the filter when the base auto-retargets. Its own recommended workaround is to merge the first before opening the second — which is one PR with extra steps. This one gets a real lane.

## Nine files were at 0%

Every screen the module owns, and both of its drawn surfaces: `TasbihScreen` (463 lines), `FastTrackerScreen` (281), `MakeupFastsScreen` (247), `ChooseDhikrScreen` (218), `PrayerStatsScreen` (218), `PrayerTrackerDayCard` (202), `TasbihHistoryScreen` (193), `FastingComingUp` (189), `RamadanCards` (161), `AddPresetScreen` (149), `TasbihBeads` (163 across four classes), `FastDaySheets` (104), `MakeupFastEditBottomSheet` (92), `TrackerGraph` (89), `QadaPrayerContent` (79). `PrayerTrackerScreen` had 7 covered lines of 232.

## What the new tests pin, and the failure each catches

This is where the app writes the user's own record of worship, and none of it can be undone. `:core:database` (#597) already pins the arithmetic underneath — that confirming a week never overwrites a logged prayer, that a missed fast leaves a `pending` row clearable by either door, that perfect days add up. What nothing could see is the **surface**.

**The review banner is the sharpest one.** It is the only door into the qada list, and confirming it writes `MISSED` against every prayer it counted. `PrayerTrackerScreenTest` pins that it is **not offered over a fully-logged week**, that its count is the count of actually-unrecorded prayers, and that confirming asks for the seven days *behind* today rather than today itself. An over-eager banner is a one-tap way to fabricate a debt the user then has to work off — and the DAO test would still be green.

**"Nobody has said" is not "you missed these."** A `MISSED` row is excluded from the banner because it is already an assertion; a `NOT_PRAYED` row is *included*, because clearing a status has to read back as unrecorded. The same distinction is pinned on the day rail's screen-reader descriptions, where the marker is a coloured dot with no text of its own.

**A lap that writes the wrong number is permanent.** The database sums `currentCount + laps × target`, so `TasbihSessionTest` pins that a lap writes the **within-lap** count — writing the running total would double every lap in the history, silently. It also pins the two-taps-20ms-apart race that used to leave an orphan session and a counter reading 1, and that switching dhikr mid-count completes the old session rather than abandoning it.

**Fidya is money, not a fast.** `MakeupFastsScreenTest` pins that choosing fidya in the edit sheet raises `PayFidya` and not `UpdateMakeupFast` — sending the wrong one loses the payment and the debt together — and that both settled statuses are filed under *Settled* with neither offering a live "Mark Complete".

**One missed Ramadan day is one debt.** The write path runs on every status change, so `FastingStatsAndDebtTest` pins the count guard: toggling a Ramadan day back and forth must not leave a make-up fast per tap. It also pins that an exemption's reason is dropped when the day stops being exempt, while a note survives — the reason is what the make-up fast is filed under.

**A form that re-seeds loses what you typed.** `AddPresetScreenTest` pins that the edit form copies the loaded preset into its fields *once*: the presets flow re-emits on any write to that table, so re-seeding would discard the user's edit mid-sentence with nothing on screen to explain it.

**Fourteen destinations, each registered once.** Seven tracker routes share a screen composable with another route, so a copy-paste that registered the same `Route` twice would look right in review and leave the other throwing at the tap that opens it.

### Two surfaces are drawn, not composed

Both go through #604's playbook item 5 — a software `android.graphics.Canvas` under `@GraphicsMode(NATIVE)`:

- **`TasbihBeads`** is entirely `Canvas` geometry with no semantics at all. The strand **mirrors for a left-handed user**, and that setting has no other confirmation anywhere in the app. Also pinned: each material paints in its own colours, an unknown design key falls back rather than blanking the counter, and one gesture is one bead whether tap or flick.
- **`PrayerStatsChart`**'s radial chart. `PrayerStatsChartTest` could only assert it does not crash; a polygon at a constant radius draws a perfectly convincing radar chart that means nothing. Three charts are drawn side by side in one composition and each is measured by the pixels in which it differs from an empty one.

`FastingWindowTest` uses `ProvideNimazClock`'s `timeSource` seam to walk the suhoor→iftar band through all four of its sentences — the part of the tracker most likely to be wrong for exactly the reader who needs it, and the least likely to be caught by hand.

## The gate bites

Floor set to `0.99` temporarily:

```
> :feature:tracker:coverageFloor: line coverage 91.9% is below the floor this
  module is locked at (99.0%), covering 4755/5176 (91.9%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been
  brought up to it is not meant to come back down.
```

Restored to `0.80`, which passes.

## What stays uncovered, and why

**131 of the 280 missing branches are the Compose compiler's `$dirty` bitmask** — one per parameter of every restartable composable, neither side reachable because which one runs depends on what the *caller* changed between recompositions. Discount those and the module stands at **89.1% branches**. Four further pockets are unreachable rather than untested, and are enumerated in the build file and `docs/TESTING.md`: `autoLap` is never false, `selectedCategory` is never set, the `PENDING`/`NOT_PRAYED` arms of the picker mappings are outside `PICKER_STATUSES`, and `PrayerStatsScreen`'s date-parse `catch` has no input that reaches it (neither `Long.MIN_VALUE` nor `Long.MAX_VALUE` throws on the way to a `LocalDate`).

**No `COVERAGE_EXCLUSIONS` entry was added or widened.** That list is shared with every locked module.

## Production change

One line, and only because a test surfaced it: `trackerGraph`'s KDoc said it held **11** destinations. It holds **14** — the number `docs/NAVIGATION.md` was corrected to in #625, which recounted every graph and found five wrong. `check_docs.py`'s NAV-03 cannot catch a per-graph drift; `TrackerGraphTest` now can.

## Verification

```
./gradlew :feature:tracker:testDebugUnitTest   BUILD SUCCESSFUL  (341 tests)
./gradlew :feature:tracker:check               BUILD SUCCESSFUL  (incl. coverageFloor, moduleBoundary, lint)
./gradlew :feature:tracker:lintDebug           BUILD SUCCESSFUL  (--rerun-tasks)
./gradlew coverageFloor                        BUILD SUCCESSFUL  (all 19 modules — no locked module regressed)
python3 scripts/check_docs.py                  All 23 documentation checks passed
```

**`:app:lintDebug` and `:app:testDebugUnitTest` were not run** — they need `NIMAZ_DATA_TOKEN` for the private content artifact, which this session does not have. No `androidTest` source was added, so there is nothing here awaiting an emulator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBMt7QbatZo5Guu6DSTmNr)_