### PR TITLE
Coverage: bring :feature:settings to 94.2% and lock it at 80/80

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,7 @@ Two on-device/JVM test surfaces exist:
   - [The library, rendered (`:feature:content/src/test`)](#the-library-rendered-featurecontentsrctest)
   - [What the user did (`:feature:tracker/src/test` and `src/testDebug`)](#what-the-user-did-featuretrackersrctest-and-srctestdebug)
   - [The design system itself (`:core:ui/src/test` and `src/testDebug`)](#the-design-system-itself-coreuisrctest-and-srctestdebug)
+  - [Every preference the app can change (`:feature:settings/src/test` and `src/testDebug`)](#every-preference-the-app-can-change-featuresettingssrctest-and-srctestdebug)
 - [Conventions](#conventions)
 
 ## Running the unit tests
@@ -268,7 +269,7 @@ floors in its own `build.gradle.kts`.
 `:core:navigation`, `:core:common`, `:core:datastore` and `:core:data` are locked at 80/80 — none of
 them draws anything, so every branch is one somebody wrote and a test can take both sides of. So are `:feature:calendar`,
 `:feature:onboarding`, `:feature:tools`, `:feature:search`, `:feature:widget`, `:feature:about`,
-`:feature:content` and `:feature:tracker`, which *are* Compose modules: the
+`:feature:content`, `:feature:tracker` and `:feature:settings`, which *are* Compose modules: the
 unreachable branch below is emitted **per parameter of every restartable composable**, so its
 weight scales with how many composables a module has, and six files — or eight, or the two screens
 in `:feature:tools`, or the one screen and four cards in `:feature:search`, or the seven screens in
@@ -292,6 +293,14 @@ the reason is arithmetic rather than thoroughness: **1,979 of its lines are `@Pr
 `*Showcase` functions**, 15.2% of the module, permanently at 0% because they are `private` tooling
 that would pin the previews rather than the product. Counting them, everything else has to clear
 **94.4%**. See [the design system's audit section](#the-design-system-itself-coreuisrctest-and-srctestdebug).
+`:feature:settings` is the **tenth** and the last module in the repo to join the ratchet, at
+**94.2% lines and 82.6% branches** across 24 screens, a 1,400-line `SettingsViewModel`, sync and
+location. **141 of its 279 missing branches sit on composable signature and parameter lines** —
+the `$dirty` skippability check and the `$default` parameter mask together — and discounting them
+it stands at **89.9%**. Its line margin is the widest of any locked module and its branch margin
+is 41; what bought both was that the module's *screens* had never been composed at all, so the
+work was breadth rather than the last twenty branches.
+**With this one locked, every module in the repo is on the ratchet.**
 
 **Two modules are softened to 80 line / 60 branch, and for two different reasons.**
 `:feature:prayer` is the second, and its reason is arithmetic rather than Compose:
@@ -329,7 +338,7 @@ split, and should say so where it sets its floors.
 | `:core:ui` | 80.5% | 80.5% | **locked** at 80/80 (#614) |
 | `:feature:tracker` | 91.9% | 81.3% | **locked** at 80/80 (#613) |
 | `:feature:content` | 85.1% | 80.4% | **locked** at 80/80 (#612) |
-| `:feature:settings` | 11.3% | 14.9% | |
+| `:feature:settings` | 94.2% | 82.6% | **locked** at 80/80 (#615) |
 
 `:app` is absent because its own suite needs the private content artifact and cannot be measured
 locally; CI's merged report covers it.
@@ -1364,6 +1373,59 @@ manifest, so a library unit test cannot reach it (`:app`'s instrumented suite do
 band in `PrayerSkyScene` is blitted through `ColorFilter.tint(…, BlendMode.Modulate)`, which does
 not survive Robolectric's canvas — the bake and the wrap-around double blit run, the composite
 does not.
+
+
+### Every preference the app can change (`:feature:settings/src/test` and `src/testDebug`)
+
+The last module to join the ratchet, and the largest by surface: 24 screens, a 1,400-line
+`SettingsViewModel`, device-to-device sync and the location picker. It went from **11.3% lines**
+to **94.2%** over 35 test classes and 521 `@Test` methods, with no production code changed and no
+`COVERAGE_EXCLUSIONS` entry added or widened.
+
+**The loader had never run in a test at all.** `SettingsViewModel.loadSettings()` reads fifty-odd
+preferences with `.first()`, and the module's existing suite built the ViewModel on a
+`mockk(relaxed = true)` `SettingsRepository` — whose flow properties answer with a relaxed `Flow`
+that never emits. `first()` on that throws, `launchSafely` swallows it, and all 152 of the
+loader's lines were dead behind a green test. What that hides is the worst thing a settings screen
+can do: every control renders its **compile-time default** rather than the user's choice, and the
+first toggle they touch writes that default back over the real preference.
+`testing/SettingsRepositoryStub.kt` fixes it by making the *reads* real `MutableStateFlow`s while
+leaving the writes on the mockk, so the loader runs and `coVerify { repo.setHapticFeedback(false) }`
+still works. Reuse it for anything that takes the whole `SettingsRepository`.
+
+| File | Pins |
+|---|---|
+| `SettingsLoadTest` (24) | Every stored preference reaching the state holder that owns it, and the three string-parsed values' fallbacks — an unreadable calculation method silently becomes Muslim World League, which changes every prayer time in the app, so the telemetry error is asserted rather than the fallback alone. Also that the Quran state *collects* DataStore rather than snapshotting it, which is why a reciter picked on one screen shows on the one behind it. |
+| `SettingsEventTableTest` (51) | The whole 78-branch `when`, each event against the exact setter it must write — the crossing this module is most exposed to, since a branch that updates the right field and writes the wrong setter is invisible from the screen. Also which events rearm the alarms and which must not: a preference that changes *when* a notification fires has to reschedule, one that changes only *how* must not. |
+| `SettingsGraphTest` (5) | All twenty destinations registered, exactly once each — including the four that live under `screens/{dua,hadith,quran}` and are registered here because the module boundary follows the ViewModel axis. |
+| `PrayerNotificationsScreenTest` (19) | The highest-stakes screen: that sunrise is not a sixth prayer (no alert style, no reminder, its toggle inside Fajr's row), and that "remind me before every prayer" writes the app-wide pair **and** all five per-prayer events — the pair alone changes no notification, which is what the control did before the per-prayer split. |
+| `NotificationSettingsScreenTest` (16), `NotificationSoundScreenTest` (14), `NotificationWeeklyScreenTest` (11), `WorshipRemindersScreenTest` (15) | The notification tree. Each hub subtitle is handed the settings that belong to it; the master switch *removes* the rows rather than dimming them; closing the voice picker stops whatever it was auditioning, by any of four routes; and the Ramadan reminders stay visible outside Ramadan — a regression to hiding them would be invisible for eleven months a year. |
+| `NotificationDiagnosticsScreenTest` (12), `NotificationDiagnosticsTest` (5) | Each badge against an arranged device state, and each row opening the system screen it reports on rather than a neighbour's. `hasProblem` is an OR, and before Android 12 exact alarms are reported allowed rather than as a fault the device cannot clear. |
+| `SyncScreenTest` (36), `SyncViewModelTest` (23) | Sync is one screen wearing seven faces chosen by an *ordered* `when`, so the ordering is the logic: a cancelled sync must not offer "Accept" for a connection the partner already dropped, and an error must outrank a completed connection, because "Sync Complete!" over a failed import tells the user their data moved when it did not. On the ViewModel side: the sender exporting on connect and the receiver not, each cancellation reason recorded separately, and the Ack that lets the other device stop waiting. Every key `SyncPayload.categories()` can produce has a label, so a new category cannot appear in the manifest as *No data* beside a real count. |
+| `WidgetsScreenTest` (11) | Six live previews built by the real `PrayerTimeCalculator` — pinned by *five formatted clock times*, because an unwired gallery renders an em dash for every one and looks entirely plausible in a screenshot. Plus the fallbacks: a blank stored name, and an unset location computing against Dublin rather than (0, 0) in the Atlantic. |
+| `LocationScreenTest` (22), `LocationViewModelTest` (24) | The GPS button's two paths, with the permission launcher answered from the test — the only way to reach the callback where "fine **or** coarse counts as granted" lives. Selecting a place writes both the preference the calculator reads and the database row the recents list is built from; a save that fails must not leave the card showing a city the calculator has never heard of. |
+| `SearchSettingsScreenTest` (24) | The AI opt-in: enabling must open the disclosure sheet rather than write the preference, and a consent write that fails must say so instead of closing over a switch that quietly stayed off. Also that the last search source on cannot be switched off, since `SearchPreferences.sanitised` reads an empty set straight back as "everything" — a switch that flips itself. |
+| `AdaptiveSettingsScreenTest` (12) | The same rows behaving differently by width: navigating on a phone, opening a detail pane on a tablet, and the two that still navigate on a tablet because they are not panes. Reached without Hilt through a pre-seeded `ViewModelStore` — four ViewModels, because four of the nine panes take one of their own. |
+| `QuranSettingsScreenTest` (19), `DuaSettingsScreenTest` (11), `HadithSettingsScreenTest` (10), `SelectReciterScreenTest` (9), `SelectTranslationScreenTest` (12) | The reading settings and their two pickers. Tajweed is gated on the Madani script and *says why* it is unavailable; the colour-blind underline is gated on tajweed. The reciter preview auditions the reciter whose row it is in — that button previously played silence from a fresh ViewModel's empty playlist. |
+| `AppearanceSettingsScreenTest` (16), `LanguageScreenTest` (7), `SettingsScreenTest` (11), `PrayerSettingsScreenTest` (16), `ZakatSettingsScreenTest` (12) | Theme, language, the hub and the two calculation screens. "Follow device" is a switch above two cards, so three states are expressed through two controls and turning following *off* must land on the theme the device currently resolves to. The hub's two destructive confirmations are asserted apart, because crossing them makes "reset settings" clear every tracked prayer. |
+| `VoiceOptionCardTest` (14, `src/testDebug`) | The shared voice row: its two taps stay separate, so pressing play does not also change the user's reciter. |
+
+**Two matchers were needed and are worth knowing about.** `testing/SettingsRowMatchers.kt` holds
+them. A settings row must be addressed as `hasText(title) and hasClickAction()` rather than by
+text, because a section header repeats its rows' words *and* because `NimazSettingsItem` expresses
+"disabled" by dropping its `clickable` — so a bare `onNodeWithText` lands on the raw `Text`, which
+reports neither enabled nor disabled and makes "this row is off-limits" unassertable. Inside an
+**accordion** even that fails: the accordion is a clickable card and merges its whole body into one
+node carrying every row's text and the card's own `OnClick`. There, `tappableAncestorCount(title)`
+is the assertion — an enabled row has two tappable ancestors, a disabled one has only the card.
+
+Three things are left at zero or partly covered rather than excluded, and the shapes are worth
+recognising: **`SyncMode.NONE` in the two role helpers**, reached only from a `when` arm that has
+already established the mode is SEND or RECEIVE; **the `check()` guarding
+`IMPORT_STEP_COUNT`** against the list beside it, whose failing arm exists so a future edit to one
+and not the other stops the import rather than reporting "step 13 of 10"; and the
+**`Locale`-dependent `replaceFirstChar` arms** in the widget preview's date formatting, whose
+empty-string branch cannot be reached from a `Month` or `DayOfWeek` name.
 
 
 ## Conventions

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -94,6 +94,9 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(testFixtures(project(":core:domain")))
     testImplementation(testFixtures(project(":core:common")))
+    // `createComponentComposeRule()` / `setThemedContent {}` — the one Compose harness, published
+    // from `:core:ui` rather than copied per module.
+    testImplementation(testFixtures(project(":core:ui")))
 
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.junit)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -27,6 +27,38 @@ android {
     }
 }
 
+nimazCoverage {
+    lineFloor.set(0.80)
+    branchFloor.set(0.80)
+}
+
+// **80/80 — the tenth Compose module in a row to hold the standard**, and the last module in the
+// repo to join the ratchet. It stands at **94.2% lines** and **82.6% branches**, which is the
+// widest line margin of any module locked so far and a branch margin of 41.
+//
+// The branch number is the one that took work. Of the 279 branches still missing, **141 sit on
+// composable signature and parameter lines** — the Compose compiler's `$dirty` skippability check
+// and its `$default` parameter mask, emitted once per parameter of every restartable composable
+// across 24 screens. Discount those and the module stands at **89.9%**.
+//
+// The remaining 138 are spread thin, and the pockets worth naming are unreachable rather than
+// untested:
+//
+//   - **`SyncMode.NONE` inside the two role helpers.** `RoleBadge` and `AuthTokenContent`'s role
+//     line are both reached only from a `when` arm that has already established the mode is SEND
+//     or RECEIVE — the screen shows the mode-selection content while it is NONE. The `NONE` arm
+//     is exhaustiveness, not a state.
+//   - **`check(totalImportSteps == IMPORT_STEP_COUNT)`** in `SyncViewModel.importWithProgress`.
+//     It guards a hand-maintained constant against the list beside it, and both sides are in the
+//     same file: the failing arm exists so a future edit to one and not the other stops the
+//     import rather than reporting "step 13 of 10", which is what shipped before it. Making it
+//     fire from a test would mean changing the constant, which is the thing it guards.
+//   - **`Locale`-dependent `replaceFirstChar` arms** in the widget preview's date formatting (8).
+//     The empty-string branch of `replaceFirstChar` cannot be reached from a `Month` or
+//     `DayOfWeek` name.
+//
+// No `COVERAGE_EXCLUSIONS` entry was added or widened for any of it.
+//
 // The last feature module: 24 screens and the 1,324-line `SettingsViewModel`, plus location and
 // sync. The most cross-referenced module in the app, and the one the epic deliberately left until
 // every other feature had already taken what it owned.
@@ -97,6 +129,10 @@ dependencies {
     // `createComponentComposeRule()` / `setThemedContent {}` — the one Compose harness, published
     // from `:core:ui` rather than copied per module.
     testImplementation(testFixtures(project(":core:ui")))
+    // `LocationScreen` answers a permission launcher, and its test needs the activity that
+    // launcher belongs to. `LocalActivity` rather than casting `LocalContext`, which lint
+    // rejects — a Context is not always an Activity.
+    testImplementation(libs.androidx.activity.compose)
 
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.junit)

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/core/util/NotificationDiagnosticsTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/core/util/NotificationDiagnosticsTest.kt
@@ -1,0 +1,126 @@
+package com.arshadshah.nimaz.core.util
+
+import android.content.Context
+import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.annotation.Config
+
+/**
+ * The three device-level prerequisites for a prayer alert arriving on time, read from the OS.
+ *
+ * `hasProblem` is what the notifications hub's warning banner and its "needs attention" badge key
+ * off, so getting it wrong goes one of two ways and both are bad: a banner that never appears
+ * leaves someone wondering why their Fajr alert is twenty minutes late with nothing in the app to
+ * explain it, and a banner that always appears trains them to ignore it before the day it is real.
+ * `&&` where `||` belongs produces exactly the first.
+ *
+ * The API-31 boundary is the other half. `canScheduleExactAlarms` does not exist before Android 12
+ * — exact alarms are simply always allowed there — so a version check that reported anything but
+ * "fine" on an older device would invent a fault the user cannot fix.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NotificationDiagnosticsTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun batteryExempt(exempt: Boolean) {
+        shadowOf(context.getSystemService(PowerManager::class.java))
+            .setIgnoringBatteryOptimizations(context.packageName, exempt)
+    }
+
+    /**
+     * Robolectric denies exact alarms by default, which is the *realistic* default — Android 12
+     * grants `SCHEDULE_EXACT_ALARM` to nobody without a user action — so the healthy case has to
+     * be arranged rather than assumed.
+     */
+    private fun exactAlarmsAllowed(allowed: Boolean) {
+        ShadowAlarmManager.setCanScheduleExactAlarms(allowed)
+    }
+
+    @Test
+    fun `a device with all three prerequisites reports no problem`() {
+        batteryExempt(true)
+        exactAlarmsAllowed(true)
+
+        val diagnostics = NotificationDiagnostics.read(context)
+
+        assertThat(diagnostics.notificationsPermitted).isTrue()
+        assertThat(diagnostics.exactAlarmsAllowed).isTrue()
+        assertThat(diagnostics.batteryUnrestricted).isTrue()
+        assertThat(diagnostics.hasProblem).isFalse()
+    }
+
+    @Test
+    fun `battery optimisation on its own is a problem`() {
+        // Doze holds alarms back, so this alone makes alerts late — which is the single most
+        // common reason a prayer notification does not arrive when it should.
+        exactAlarmsAllowed(true)
+        batteryExempt(false)
+
+        val diagnostics = NotificationDiagnostics.read(context)
+
+        assertThat(diagnostics.batteryUnrestricted).isFalse()
+        assertThat(diagnostics.hasProblem).isTrue()
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `before Android 12 exact alarms are reported as allowed, not as a fault`() {
+        // The permission does not exist on API 30, and nothing is arranged here on purpose:
+        // reporting it as missing would put a warning on the hub that nothing on the device can
+        // clear.
+        batteryExempt(true)
+
+        val diagnostics = NotificationDiagnostics.read(context)
+
+        assertThat(diagnostics.exactAlarmsAllowed).isTrue()
+        assertThat(diagnostics.hasProblem).isFalse()
+    }
+
+    @Test
+    fun `a denied exact-alarm permission is a problem on Android 12 and later`() {
+        // Without it the OS is free to batch the alarm, and a prayer alert that drifts by
+        // minutes is wrong in the one way this app cannot afford.
+        batteryExempt(true)
+        exactAlarmsAllowed(false)
+
+        val diagnostics = NotificationDiagnostics.read(context)
+
+        assertThat(diagnostics.exactAlarmsAllowed).isFalse()
+        assertThat(diagnostics.hasProblem).isTrue()
+    }
+
+    @Test
+    fun `hasProblem is an OR over the three, not an AND`() {
+        // Asserted on the data class directly rather than through the OS reads, because the
+        // mixed cases are the ones an `&&` would get wrong and only one of them is arrangeable
+        // from a shadow.
+        assertThat(
+            NotificationDiagnostics(
+                notificationsPermitted = false,
+                exactAlarmsAllowed = true,
+                batteryUnrestricted = true,
+            ).hasProblem
+        ).isTrue()
+        assertThat(
+            NotificationDiagnostics(
+                notificationsPermitted = true,
+                exactAlarmsAllowed = false,
+                batteryUnrestricted = true,
+            ).hasProblem
+        ).isTrue()
+        assertThat(
+            NotificationDiagnostics(
+                notificationsPermitted = true,
+                exactAlarmsAllowed = true,
+                batteryUnrestricted = true,
+            ).hasProblem
+        ).isFalse()
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveSettingsScreenTest.kt
@@ -18,12 +18,21 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.navigation.Route
 import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.location.LocationUiState
+import com.arshadshah.nimaz.presentation.viewmodel.location.LocationViewModel
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncViewModel
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsViewModel
 import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
 import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
 import com.arshadshah.nimaz.testing.compose.setThemedContent
 import com.arshadshah.nimaz.testing.settingsRow
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,6 +64,16 @@ class AdaptiveSettingsScreenTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val viewModel = FakeSettingsScreenViewModel()
+
+    private val locationViewModel: LocationViewModel = mockk(relaxed = true) {
+        every { state } returns MutableStateFlow(LocationUiState())
+    }
+    private val zakatViewModel: ZakatSettingsViewModel = mockk(relaxed = true) {
+        every { uiState } returns MutableStateFlow(ZakatSettingsUiState())
+    }
+    private val syncViewModel: SyncViewModel = mockk(relaxed = true) {
+        every { uiState } returns MutableStateFlow(SyncUiState())
+    }
 
     private val navigated = mutableListOf<Route>()
     private var backs = 0
@@ -223,6 +242,34 @@ class AdaptiveSettingsScreenTest {
     }
 
     @Test
+    @Config(qualifiers = "w1000dp-h2600dp")
+    fun `every settings row has a pane behind it`() {
+        // Nine rows against a nine-arm `when` over `SettingsDetailPane`. A row wired to the
+        // wrong arm opens the wrong screen inside a correct-looking layout, and the `when` is
+        // exhaustive over the enum so nothing about it fails to compile.
+        setContent()
+
+        val panes = listOf(
+            R.string.calculation_method to R.string.manual_adjustments,
+            R.string.notifications to R.string.notification_settings_enable,
+            R.string.quran_settings to R.string.tajweed_section,
+            R.string.appearance to R.string.appearance_theme,
+            R.string.location to R.string.location_use_current_location,
+            R.string.language to R.string.app_language_section,
+            R.string.widgets to R.string.widgets_how_to,
+            R.string.sync_data to R.string.sync_device_to_device,
+            R.string.zakat_settings to R.string.zakat_metal_prices,
+        )
+
+        panes.forEach { (row, marker) ->
+            composeRule.settingsRow(string(row)).performClick()
+            composeRule.waitForIdle()
+            composeRule.onAllNodesWithText(string(marker)).onFirst().assertExists()
+        }
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
     @Config(qualifiers = "w1000dp-h1200dp")
     fun `nothing is shown in the detail pane until a row is chosen`() {
         // `currentDestination?.contentKey` is null on open, and the `if` around it is the only
@@ -233,9 +280,20 @@ class AdaptiveSettingsScreenTest {
         composeRule.onNodeWithText(string(R.string.app_language_section)).assertDoesNotExist()
     }
 
+    /**
+     * Four ViewModels, because four of the nine panes take one of their own.
+     *
+     * Seeding only `SettingsViewModel` works until a test opens the Location, Zakat or Sync
+     * pane, at which point `hiltViewModel()` finds nothing in the store, reaches for a factory
+     * and fails with "Cannot create an instance of …" — a message that names the ViewModel and
+     * says nothing about the store being short one entry.
+     */
     private fun seededOwner(): ViewModelStoreOwner {
         val store = ViewModelStore()
         seed(store, SettingsViewModel::class.java, viewModel.mock)
+        seed(store, LocationViewModel::class.java, locationViewModel)
+        seed(store, ZakatSettingsViewModel::class.java, zakatViewModel)
+        seed(store, SyncViewModel::class.java, syncViewModel)
         return object : ViewModelStoreOwner {
             override val viewModelStore: ViewModelStore = store
         }

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/adaptive/AdaptiveSettingsScreenTest.kt
@@ -1,0 +1,258 @@
+package com.arshadshah.nimaz.presentation.screens.adaptive
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsViewModel
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The settings entry point, which is two different screens depending on how wide the window is.
+ *
+ * On a phone every row is a `navigate` to its own destination. On a tablet the same rows open a
+ * **detail pane** instead, and the difference is not cosmetic: a row that navigated on a tablet
+ * would push a full-screen destination over the list-detail scaffold, losing the list, and a row
+ * that opened a pane on a phone would do nothing visible at all.
+ *
+ * Two rows are deliberately exceptions on the wide layout — Search settings and the Quran
+ * pickers still navigate, because they are not panes — and those are exactly the ones a
+ * refactor would "tidy" into the pane path.
+ *
+ * `hiltViewModel()` is reached without Hilt here: `SettingsScreen` and every detail screen take
+ * their ViewModel by default argument, and `hiltViewModel()` builds a Hilt factory **only when
+ * the `ViewModelStoreOwner` it is handed supplies a default factory**. A plain owner whose store
+ * already holds the ViewModel answers from the store first, before any factory is consulted.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdaptiveSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+
+    private val navigated = mutableListOf<Route>()
+    private var backs = 0
+    private var restarts = 0
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            CompositionLocalProvider(LocalViewModelStoreOwner provides seededOwner()) {
+                AdaptiveSettingsScreen(
+                    onNavigate = { navigated += it },
+                    onBack = { backs++ },
+                    onRestartApp = { restarts++ },
+                )
+            }
+        }
+    }
+
+    private fun string(@StringRes res: Int): String = context.getString(res)
+
+    // ── Compact: every row is a destination ──────────────────────────────────────────────────
+
+    @Test
+    @Config(qualifiers = "w411dp-h4000dp")
+    fun `on a phone the settings list is the whole screen`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.settings)).onFirst().assertIsDisplayed()
+        composeRule.onAllNodesWithText(string(R.string.prayer_settings)).onFirst().assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h4000dp")
+    fun `on a phone each row navigates to its own route`() {
+        // Nine rows, nine routes, wired in one block. A row pointing at its neighbour's route is
+        // invisible in review and obvious to a user exactly once.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.calculation_method)).performClick()
+        composeRule.settingsRow(string(R.string.notifications)).performClick()
+        composeRule.settingsRow(string(R.string.quran_settings)).performClick()
+        composeRule.settingsRow(string(R.string.appearance)).performClick()
+        composeRule.settingsRow(string(R.string.location)).performClick()
+        composeRule.settingsRow(string(R.string.language)).performClick()
+        composeRule.settingsRow(string(R.string.widgets)).performClick()
+        composeRule.settingsRow(string(R.string.sync_data)).performClick()
+        composeRule.settingsRow(string(R.string.zakat_settings)).performClick()
+
+        assertThat(navigated).containsExactly(
+            Route.SettingsPrayerCalculation,
+            Route.SettingsNotifications,
+            Route.SettingsQuran,
+            Route.SettingsAppearance,
+            Route.SettingsLocation,
+            Route.SettingsLanguage,
+            Route.SettingsWidgets,
+            Route.SettingsSync,
+            Route.SettingsZakat,
+        ).inOrder()
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h4000dp")
+    fun `search settings navigates on a phone too`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.search_settings)).performClick()
+
+        assertThat(navigated).containsExactly(Route.SearchSettings)
+    }
+
+    @Test
+    @Config(qualifiers = "w411dp-h4000dp")
+    fun `the back arrow leaves settings on a phone`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    // ── Expanded: rows open panes instead ────────────────────────────────────────────────────
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet the list is still shown`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.settings)).onFirst().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.calculation_method)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `on a tablet a row opens its detail pane rather than navigating away`() {
+        // Navigating here would push a full-screen destination over the scaffold and lose the
+        // list beside it — the one thing a two-pane layout exists to keep.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.appearance)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+        composeRule.onAllNodesWithText(string(R.string.appearance_theme)).onFirst().assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `a second row replaces the pane rather than stacking one on the other`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.appearance)).performClick()
+        composeRule.waitForIdle()
+        composeRule.settingsRow(string(R.string.language)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(string(R.string.app_language_section)).onFirst()
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.appearance_theme)).assertDoesNotExist()
+        assertThat(navigated).isEmpty()
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `search settings still navigates on a tablet, because it is not a pane`() {
+        // The exception a refactor would "tidy" away. Sending it down the pane path would open
+        // a `when` arm that does not exist and show an empty detail pane.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.search_settings)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).containsExactly(Route.SearchSettings)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `the prayer pane can open the notifications pane beside it`() {
+        // The one cross-pane hop: from prayer settings to the notifications hub, still inside
+        // the scaffold rather than out of it.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.calculation_method)).performClick()
+        composeRule.waitForIdle()
+        composeRule.settingsRow(string(R.string.adhan_notifications)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).isEmpty()
+        composeRule.onAllNodesWithText(string(R.string.notification_settings_enable)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    // Taller than the rest of the class: the Quran pane's audio section is far down a
+    // `LazyColumn`, and a `LazyColumn` composes only a screenful.
+    @Config(qualifiers = "w1000dp-h2600dp")
+    fun `the Quran pane's pickers navigate, because they are their own destinations`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.quran_settings)).performClick()
+        composeRule.waitForIdle()
+        composeRule.settingsRow(string(R.string.reciter)).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(navigated).containsExactly(Route.SelectReciter)
+    }
+
+    @Test
+    @Config(qualifiers = "w1000dp-h1200dp")
+    fun `nothing is shown in the detail pane until a row is chosen`() {
+        // `currentDestination?.contentKey` is null on open, and the `if` around it is the only
+        // thing between that and a crash on entry for every tablet user.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.appearance_theme)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.app_language_section)).assertDoesNotExist()
+    }
+
+    private fun seededOwner(): ViewModelStoreOwner {
+        val store = ViewModelStore()
+        seed(store, SettingsViewModel::class.java, viewModel.mock)
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+    }
+
+    /**
+     * Keyed by asking a real `ViewModelProvider` for it rather than spelling out
+     * `androidx.lifecycle.ViewModelProvider.DefaultKey:…` — a hand-written key silently stops
+     * matching if the library changes how it derives one, and the symptom is Hilt being reached
+     * for and the test failing far from the cause.
+     */
+    private fun <VM : ViewModel> seed(store: ViewModelStore, type: Class<VM>, instance: VM) {
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                instance as T
+        }
+        ViewModelProvider.create(store, factory)[type]
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/dua/DuaSettingsScreenTest.kt
@@ -1,0 +1,200 @@
+package com.arshadshah.nimaz.presentation.screens.dua
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.DuaSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Dua reader's display settings, and the preview card that is supposed to show the result.
+ *
+ * Two things go wrong on a screen like this and neither shows up in review. The first is the one
+ * #615 names: three toggles whose rows are byte-identical apart from a string, so a row wired to
+ * its neighbour's event moves the switch the user tapped and changes the *other* preference. The
+ * second is the preview: the card exists so someone can see the effect of a setting before leaving
+ * the screen, and a preview that ignores a toggle is a preview that lies.
+ *
+ * The Dua and Hadith screens deliberately mirror each other and share `readerTypographySettings`,
+ * so the crossing that matters most is between *screens* — `SetDuaArabicFontSize` against
+ * `SetHadithArabicFontSize`. That is asserted by type here and again in the Hadith file.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class DuaSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(state: DuaSettingsUiState = DuaSettingsUiState()) {
+        viewModel.duaState.value = state
+        composeRule.setThemedContent {
+            DuaSettingsScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the screen opens on the dua settings, not the shared reader ones`() {
+        // Four screens in this module carry the same three rows. The title is the only thing on
+        // screen that says which corpus's preferences are being edited.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.dua_settings)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.display_options)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the preview renders all three parts when all three are switched on`() {
+        setContent(
+            DuaSettingsUiState(
+                showArabic = true,
+                showTransliteration = true,
+                showTranslation = true,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_arabic))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_transliteration))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_translation))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching Arabic off removes it from the preview and leaves the rest`() {
+        // Three `if` blocks in one card. Dropping the wrong one is invisible until someone reads
+        // the preview against the toggles — which is exactly what the preview is for.
+        setContent(
+            DuaSettingsUiState(
+                showArabic = false,
+                showTransliteration = true,
+                showTranslation = true,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_arabic))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_transliteration))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_translation))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching transliteration off removes only the transliteration`() {
+        setContent(
+            DuaSettingsUiState(
+                showArabic = true,
+                showTransliteration = false,
+                showTranslation = true,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_arabic))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_transliteration))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_translation))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching translation off removes only the translation`() {
+        setContent(
+            DuaSettingsUiState(
+                showArabic = true,
+                showTransliteration = true,
+                showTranslation = false,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_translation))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.dua_settings_preview_arabic))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the show-Arabic row toggles Arabic and nothing else`() {
+        setContent(DuaSettingsUiState(showArabic = true))
+
+        composeRule.onNodeWithText(string(R.string.show_arabic)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetDuaShowArabic>().enabled).isFalse()
+        assertThat(viewModel.events).hasSize(1)
+    }
+
+    @Test
+    fun `the show-transliteration row toggles transliteration and nothing else`() {
+        setContent(DuaSettingsUiState(showTransliteration = false))
+
+        composeRule.onNodeWithText(string(R.string.show_transliteration)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetDuaShowTransliteration>().enabled).isTrue()
+        assertThat(viewModel.events).hasSize(1)
+    }
+
+    @Test
+    fun `the show-translation row toggles translation and nothing else`() {
+        setContent(DuaSettingsUiState(showTranslation = true))
+
+        composeRule.onNodeWithText(string(R.string.show_translation)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetDuaShowTranslation>().enabled).isFalse()
+        assertThat(viewModel.events).hasSize(1)
+    }
+
+    @Test
+    fun `a toggle sends the opposite of what is stored, not a fixed value`() {
+        // `onCheckedChange = { onEvent(Set…(!state.value)) }` ignores the boolean the switch
+        // hands it and reads state instead. Wiring it to a constant makes the row a one-way
+        // switch: it turns the setting on and can never turn it off again.
+        setContent(DuaSettingsUiState(showArabic = false))
+
+        composeRule.onNodeWithText(string(R.string.show_arabic)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetDuaShowArabic>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the typography rows show the sizes this screen's own state holds`() {
+        // `readerTypographySettings` is shared with the Hadith screen, so it is handed the state
+        // by the caller. A caller that passed the wrong field would render the other reader's
+        // size and write it back on the first drag.
+        setContent(DuaSettingsUiState(arabicFontSize = 30f, translationFontSize = 18f))
+
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 30)).assertExists()
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 18)).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/hadith/HadithSettingsScreenTest.kt
@@ -1,0 +1,168 @@
+package com.arshadshah.nimaz.presentation.screens.hadith
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.HadithSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Hadith reader's display settings — the Dua screen's twin, plus two rows of its own.
+ *
+ * Written as a separate file rather than a parameterisation of the Dua one on purpose. The two
+ * screens are deliberate copies, and the bug a shared test cannot catch is precisely the one a copy
+ * invites: a Hadith row still dispatching the `SetDua…` event it was copied from. Asserting the
+ * event *type* per screen is the only thing that catches that, and it only works if each screen
+ * has its own assertions.
+ *
+ * The grade badge is the interesting extra. It renders in the preview's header row rather than in
+ * the body, so a toggle that dropped the wrong `if` would leave the badge showing with the whole
+ * hadith hidden.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class HadithSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(state: HadithSettingsUiState = HadithSettingsUiState()) {
+        viewModel.hadithState.value = state
+        composeRule.setThemedContent {
+            HadithSettingsScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the screen opens on the hadith settings, not the dua ones`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.hadith_settings)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_show_grade)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_show_chain)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the preview shows the hadith, its translation and its grade badge`() {
+        setContent(
+            HadithSettingsUiState(showArabic = true, showTranslation = true, showGrade = true)
+        )
+
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_arabic))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_translation))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching the grade off removes only the badge`() {
+        // The badge lives in the header row, not the body — so the `if` that hides it is the one
+        // furthest from the two it sits beside.
+        setContent(
+            HadithSettingsUiState(showArabic = true, showTranslation = true, showGrade = false)
+        )
+
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_arabic))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_translation))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching the Arabic off leaves the translation and the badge`() {
+        setContent(
+            HadithSettingsUiState(showArabic = false, showTranslation = true, showGrade = true)
+        )
+
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_arabic))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_translation))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.hadith_grade_sahih)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching the translation off leaves the Arabic`() {
+        setContent(
+            HadithSettingsUiState(showArabic = true, showTranslation = false, showGrade = true)
+        )
+
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_translation))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.hadith_settings_preview_arabic))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the show-Arabic row dispatches the Hadith event, not the Dua one it was copied from`() {
+        setContent(HadithSettingsUiState(showArabic = true))
+
+        composeRule.onNodeWithText(string(R.string.show_arabic)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHadithShowArabic>().enabled).isFalse()
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetDuaShowArabic>()).isEmpty()
+    }
+
+    @Test
+    fun `the show-translation row toggles the hadith translation`() {
+        setContent(HadithSettingsUiState(showTranslation = true))
+
+        composeRule.onNodeWithText(string(R.string.show_translation)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHadithShowTranslation>().enabled).isFalse()
+        assertThat(viewModel.events).hasSize(1)
+    }
+
+    @Test
+    fun `the grade row toggles the grade and the chain row toggles the chain`() {
+        // Adjacent rows, adjacent event names, one letter apart in the string resources. This is
+        // the pair most likely to be crossed on this screen.
+        setContent(HadithSettingsUiState(showGrade = true, showChain = false))
+
+        composeRule.onNodeWithText(string(R.string.hadith_show_grade)).performClick()
+        composeRule.onNodeWithText(string(R.string.hadith_show_chain)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHadithShowGrade>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetHadithShowChain>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the typography rows show this reader's own sizes`() {
+        setContent(HadithSettingsUiState(arabicFontSize = 26f, translationFontSize = 14f))
+
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 26)).assertExists()
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 14)).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/quran/SelectReciterScreenTest.kt
@@ -1,0 +1,202 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.QuranReciter
+import com.arshadshah.nimaz.presentation.viewmodel.settings.QuranSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ReciterPreviewUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The reciter picker: search, a "currently selected" hero, and a card per voice.
+ *
+ * The preview button is the reason this file exists. It never made a sound before PR 21 of #551 —
+ * the screen took a second `hiltViewModel<QuranViewModel>()`, which on this destination is a
+ * *fresh* instance whose reader state is empty, so the playlist it built was empty and
+ * `playFromAyah` returned without playing. The button set its spinner and played silence, and
+ * nothing about that was visible from the screen. What is asserted here is that the button
+ * dispatches `PreviewReciter` **for the reciter whose row it is in**, and that a second tap on a
+ * playing row stops it rather than restarting it.
+ *
+ * The hero is the other half: it resolves through `QuranReciter.fromId`, which accepts aliases
+ * from older builds, so a stored id the enum has since renamed still highlights the right voice
+ * instead of silently falling back to the default.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class SelectReciterScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private val first = QuranReciter.entries.first()
+    private val second = QuranReciter.entries[1]
+
+    private fun setContent(
+        state: QuranSettingsUiState = QuranSettingsUiState(),
+        preview: ReciterPreviewUiState = ReciterPreviewUiState(),
+    ) {
+        viewModel.quranState.value = state
+        viewModel.reciterPreview.value = preview
+        composeRule.setThemedContent {
+            SelectReciterScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the hero names the selected reciter and marks it active`() {
+        setContent(QuranSettingsUiState(selectedReciterId = second.id))
+
+        composeRule.onAllNodesWithText(second.displayName).onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.active)).assertExists()
+        composeRule.onNodeWithText(string(R.string.select_reciter_currently_selected))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a stored id the enum has since renamed still resolves to a real reciter`() {
+        // `QuranReciter.fromId` accepts aliases from older builds. Without that, an install
+        // that predates a rename silently reverts to the default voice on this screen.
+        setContent(QuranSettingsUiState(selectedReciterId = "not-a-reciter"))
+
+        composeRule.onAllNodesWithText(QuranReciter.fromId("not-a-reciter").displayName)
+            .onFirst().assertExists()
+    }
+
+    @Test
+    fun `every reciter is listed with its style and country`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(first.displayName).onFirst().assertExists()
+        composeRule.onAllNodesWithText(first.country).onFirst().assertExists()
+        composeRule.onAllNodesWithText(recitationStyleLabelFor(first)).onFirst().assertExists()
+    }
+
+    @Test
+    fun `searching narrows the list to matching reciters`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.select_reciter_search_hint))
+            .performTextInput(second.displayName)
+
+        val expected = QuranReciter.search(second.displayName)
+        assertThat(expected).contains(second)
+        composeRule.onAllNodesWithText(second.displayName).onFirst().assertExists()
+    }
+
+    @Test
+    fun `tapping a reciter's card selects it`() {
+        setContent(QuranSettingsUiState(selectedReciterId = first.id))
+
+        composeRule.onAllNodesWithText(second.displayName).onFirst().performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetReciter>().reciterId).isEqualTo(second.id)
+    }
+
+    @Test
+    fun `the preview button auditions the reciter whose row it is in`() {
+        // The bug this replaces played silence from a fresh ViewModel's empty playlist. The
+        // assertion that matters is the id, not that a preview happened.
+        setContent()
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_preview)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.only<SettingsEvent.PreviewReciter>().reciterId).isEqualTo(first.id)
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetReciter>()).isEmpty()
+    }
+
+    @Test
+    fun `tapping preview on the reciter that is already playing stops it`() {
+        // Otherwise the only way to stop a running preview is to leave the screen.
+        composeRule.mainClock.autoAdvance = false
+        setContent(
+            preview = ReciterPreviewUiState(reciterId = first.id, isPlaying = true)
+        )
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_preview)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.StopReciterPreview)
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.PreviewReciter>()).isEmpty()
+    }
+
+    @Test
+    fun `a preview that is still buffering is not treated as playing`() {
+        // `isPlaying` and `isDownloading` are separate for this reason: tapping again while a
+        // sample is still arriving must start it, not stop something that never began.
+        composeRule.mainClock.autoAdvance = false
+        setContent(
+            preview = ReciterPreviewUiState(
+                reciterId = first.id,
+                isPlaying = false,
+                isDownloading = true,
+            )
+        )
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_preview)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.PreviewReciter>()).isNotEmpty()
+    }
+
+    @Test
+    fun `a preview running on another reciter does not make this row a stop button`() {
+        // `preview.reciterId == reciter.id` rather than `preview.isPlaying` alone — otherwise
+        // every row on the screen becomes a stop button the moment any one of them plays.
+        composeRule.mainClock.autoAdvance = false
+        setContent(
+            preview = ReciterPreviewUiState(reciterId = second.id, isPlaying = true)
+        )
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_preview)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.only<SettingsEvent.PreviewReciter>().reciterId).isEqualTo(first.id)
+    }
+
+    @Test
+    fun `the title is Select Reciter and the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.select_reciter_title)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    private fun recitationStyleLabelFor(reciter: QuranReciter): String = context.getString(
+        when (reciter.style) {
+            com.arshadshah.nimaz.domain.model.RecitationStyle.MURATTAL ->
+                R.string.recitation_style_murattal
+            com.arshadshah.nimaz.domain.model.RecitationStyle.MUJAWWAD ->
+                R.string.recitation_style_mujawwad
+        }
+    )
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/quran/SelectTranslationScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/quran/SelectTranslationScreenTest.kt
@@ -1,0 +1,200 @@
+package com.arshadshah.nimaz.presentation.screens.quran
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.QuranTranslation
+import com.arshadshah.nimaz.presentation.viewmodel.settings.QuranSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The translation picker — fifteen translations across eleven languages, grouped by language.
+ *
+ * The hero card is what the screen is for: it renders the Bismillah in the selected translation,
+ * so a translation can be judged by *reading* it rather than by its translator's name. Two things
+ * about that are worth pinning. It falls back to the bundled sample only until the first real read
+ * resolves — a card permanently on the fallback would show every translation as identical. And the
+ * previous text is kept while a newly-tapped one loads, because the first read of a translation
+ * also seeds its 6,236 rows, so the card would otherwise flash empty on every tap.
+ *
+ * The search is deliberately three-way: translator, English language name, and endonym. Someone
+ * looking for the Urdu translation may type "Urdu", "اردو" or "Maududi", and a search that
+ * matched only the translator's name fails two of those three — which reads as the translation not
+ * being there at all.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class SelectTranslationScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private val first = QuranTranslation.entries.first()
+    private val other = QuranTranslation.entries.first { it.language != first.language }
+
+    private fun setContent(state: QuranSettingsUiState = QuranSettingsUiState()) {
+        viewModel.quranState.value = state
+        composeRule.setThemedContent {
+            SelectTranslationScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun search(query: String) {
+        composeRule.onNodeWithContentDescription(string(R.string.select_translation_search_hint))
+            .performTextInput(query)
+    }
+
+    @Test
+    fun `the hero names the selected translation and marks it active`() {
+        setContent(QuranSettingsUiState(selectedTranslatorId = other.id))
+
+        composeRule.onAllNodesWithText(other.translator).onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.active)).assertExists()
+    }
+
+    @Test
+    fun `the hero shows the real text of the selected translation`() {
+        setContent(
+            QuranSettingsUiState(
+                selectedTranslatorId = first.id,
+                previewTranslation = "A distinctive rendering",
+            )
+        )
+
+        composeRule.onNodeWithText("A distinctive rendering").assertExists()
+        composeRule.onNodeWithText(string(R.string.quran_settings_preview_translation))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the hero falls back to the sample only before the first read resolves`() {
+        // A card permanently on the fallback shows every translation as identical, which
+        // defeats the entire purpose of the screen.
+        setContent(QuranSettingsUiState(previewTranslation = null))
+
+        composeRule.onNodeWithText(string(R.string.quran_settings_preview_translation))
+            .assertExists()
+    }
+
+    @Test
+    fun `every translation is listed under its own language`() {
+        setContent()
+
+        val languages = QuranTranslation.entries.map { it.language }.distinct()
+        assertThat(languages.size).isAtLeast(2)
+        composeRule.onAllNodesWithText(languages.first().englishName).onFirst().assertExists()
+        composeRule.onAllNodesWithText(first.translator).onFirst().assertExists()
+    }
+
+    @Test
+    fun `each language heading carries its endonym as well as its English name`() {
+        // The endonym is written in its own script, in its own face — someone who does not read
+        // English finds their language by the endonym or not at all.
+        setContent()
+
+        val language = QuranTranslation.entries
+            .map { it.language }
+            .first { it.nativeName != it.englishName }
+
+        composeRule.onAllNodesWithText(language.nativeName).onFirst().assertExists()
+    }
+
+    @Test
+    fun `picking a translation dispatches that translator's id`() {
+        setContent(QuranSettingsUiState(selectedTranslatorId = first.id))
+
+        composeRule.onAllNodesWithText(other.translator).onLast().performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTranslator>().translatorId)
+            .isEqualTo(other.id)
+    }
+
+    @Test
+    fun `searching by the translator's name finds the translation`() {
+        setContent()
+
+        search(other.translator)
+
+        composeRule.onAllNodesWithText(other.translator).onFirst().assertExists()
+    }
+
+    @Test
+    fun `searching by the English language name finds it too`() {
+        setContent()
+
+        search(other.language.englishName)
+
+        composeRule.onAllNodesWithText(other.translator).onFirst().assertExists()
+    }
+
+    @Test
+    fun `searching by the endonym finds it as well`() {
+        // "اردو" and "Urdu" must reach the same row. A search over the translator alone fails
+        // this, and the translation reads as missing.
+        val language = QuranTranslation.entries
+            .map { it.language }
+            .first { it.nativeName != it.englishName }
+        val translation = QuranTranslation.entries.first { it.language == language }
+        setContent()
+
+        search(language.nativeName)
+
+        composeRule.onAllNodesWithText(translation.translator).onFirst().assertExists()
+    }
+
+    @Test
+    fun `a search that matches nothing says so rather than showing an empty screen`() {
+        setContent()
+
+        search("zzzzzzzz")
+
+        composeRule.onNodeWithText(string(R.string.picker_no_matches)).assertExists()
+        composeRule.onNodeWithText(string(R.string.no_results_hint)).assertExists()
+    }
+
+    @Test
+    fun `the hero stays visible while a search matches nothing`() {
+        // It is the only thing on screen naming what is currently selected, and clearing an
+        // over-narrow search is easier when you can still see where you started.
+        setContent(QuranSettingsUiState(selectedTranslatorId = first.id))
+
+        search("zzzzzzzz")
+
+        composeRule.onAllNodesWithText(first.translator).onFirst().assertExists()
+    }
+
+    @Test
+    fun `the title is Translation and the back button navigates back`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.translation)).onFirst().assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/AppearanceSettingsScreenTest.kt
@@ -1,0 +1,249 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
+import com.arshadshah.nimaz.presentation.viewmodel.settings.AppTheme
+import com.arshadshah.nimaz.presentation.viewmodel.settings.GeneralSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Appearance screen: the theme picker, the ornament row, and the display toggles.
+ *
+ * The theme control is the part worth pinning, because it is the one place in the app where the
+ * stored value and the control are deliberately *not* one-to-one. "System" is a switch above two
+ * cards rather than a third card, so three states are expressed through two controls and the
+ * mapping has to be exact in both directions:
+ *
+ * - Following the device must show **neither** card as picked, or the user reads their theme as
+ *   pinned when it is not.
+ * - Turning following **off** must land on the theme the device currently resolves to, not on a
+ *   fixed one — otherwise switching the toggle off visibly changes the app's appearance, which is
+ *   the opposite of what "stop following" means.
+ *
+ * The ornament row is a `LazyRow`, so it composes only what fits; the swatch tests run wide enough
+ * for all five. Its five labels come from a `when` over the enum, which is the shape that goes
+ * stale silently when a style is added.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class AppearanceSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(state: GeneralSettingsUiState = GeneralSettingsUiState()) {
+        viewModel.generalState.value = state
+        composeRule.setThemedContent {
+            AppearanceSettingsScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the four sections all render`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.appearance_theme)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.appearance_pattern)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.appearance_display)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.appearance_home_screen)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the light card pins the light theme`() {
+        setContent(GeneralSettingsUiState(theme = AppTheme.SYSTEM))
+
+        composeRule.onNodeWithText(string(R.string.theme_light)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTheme>().theme).isEqualTo(AppTheme.LIGHT)
+    }
+
+    @Test
+    fun `tapping the dark card pins the dark theme`() {
+        setContent(GeneralSettingsUiState(theme = AppTheme.SYSTEM))
+
+        composeRule.onNodeWithText(string(R.string.theme_dark)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTheme>().theme).isEqualTo(AppTheme.DARK)
+    }
+
+    @Test
+    fun `switching follow-device on stores SYSTEM`() {
+        setContent(GeneralSettingsUiState(theme = AppTheme.DARK))
+
+        composeRule.onNodeWithText(string(R.string.theme_follow_device)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTheme>().theme).isEqualTo(AppTheme.SYSTEM)
+    }
+
+    @Test
+    fun `switching follow-device off lands on the theme the device currently resolves to`() {
+        // The test runs under the light system theme, so stopping following must pin LIGHT. A
+        // hardcoded `AppTheme.DARK` here would compile, pass a naive assertion, and visibly flip
+        // the app dark the moment someone stopped following their device.
+        setContent(GeneralSettingsUiState(theme = AppTheme.SYSTEM))
+
+        composeRule.onNodeWithText(string(R.string.theme_follow_device)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTheme>().theme).isEqualTo(AppTheme.LIGHT)
+    }
+
+    @Test
+    fun `both theme cards are offered whichever theme is stored`() {
+        // The cards are a radio pair rendered by one composable with `dark` flipped. A card that
+        // rendered only its selected state would leave no way back to the other theme.
+        setContent(GeneralSettingsUiState(theme = AppTheme.DARK))
+
+        composeRule.onNodeWithText(string(R.string.theme_light)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.theme_dark)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "w2000dp-h2200dp")
+    fun `every ornament style is offered, including the None that turns it off`() {
+        // "None" is the first swatch and doubles as the off switch — there is no separate toggle,
+        // so a `when` that missed it would leave the ornament permanently on.
+        setContent()
+
+        NimazPatternStyle.entries.forEach { style ->
+            val label = when (style) {
+                NimazPatternStyle.NONE -> R.string.pattern_none
+                NimazPatternStyle.CORNER_MEDALLION -> R.string.pattern_medallion
+                NimazPatternStyle.LATTICE -> R.string.pattern_lattice
+                NimazPatternStyle.STAR_FIELD -> R.string.pattern_star_field
+                NimazPatternStyle.ATELIER -> R.string.pattern_atelier
+            }
+            composeRule.onNodeWithText(string(label)).assertExists()
+        }
+    }
+
+    @Test
+    fun `picking an ornament sends that style and not its neighbour`() {
+        setContent(GeneralSettingsUiState(patternStyle = NimazPatternStyle.NONE))
+
+        composeRule.onNodeWithText(string(R.string.pattern_lattice)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetPatternStyle>().style)
+            .isEqualTo(NimazPatternStyle.LATTICE)
+    }
+
+    @Test
+    fun `picking None is how the ornament is switched off`() {
+        setContent(GeneralSettingsUiState(patternStyle = NimazPatternStyle.ATELIER))
+
+        composeRule.onNodeWithText(string(R.string.pattern_none)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetPatternStyle>().style)
+            .isEqualTo(NimazPatternStyle.NONE)
+    }
+
+    @Test
+    fun `each display toggle dispatches its own event`() {
+        // Three identical rows, three near-identical events. This is the crossing the module's
+        // instrumented `SettingsBehaviorTest` covers for four toggles end-to-end; this is the
+        // same check on the JVM, and it runs on every PR rather than on the emulator lane.
+        setContent(
+            GeneralSettingsUiState(
+                animationsEnabled = true,
+                hapticFeedback = true,
+                use24HourFormat = false,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.appearance_animations)).performClick()
+        composeRule.onNodeWithText(string(R.string.appearance_haptic)).performClick()
+        composeRule.onNodeWithText(string(R.string.appearance_24hour)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetAnimationsEnabled>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetHapticFeedback>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.Set24HourFormat>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the Islamic date toggle dispatches the hijri event`() {
+        setContent(GeneralSettingsUiState(useHijriPrimary = false))
+
+        composeRule.onNodeWithText(string(R.string.appearance_show_islamic_date)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHijriPrimary>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the hijri offset stepper moves one day at a time`() {
+        setContent(GeneralSettingsUiState(hijriDayOffset = 0))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_increase)).onLast()
+            .performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHijriDayOffset>().days).isEqualTo(1)
+    }
+
+    @Test
+    fun `the hijri offset stepper stops at its two-day bound`() {
+        // The Hijri date is corrected by at most two days either way — that is the whole range of
+        // moon-sighting disagreement. The stepper expresses the bound by *disabling* the button
+        // rather than clamping the value, so at +2 the tap must produce no event at all. A
+        // stepper that clamped instead would still be correct arithmetically and would keep
+        // firing writes on every tap at the limit.
+        setContent(GeneralSettingsUiState(hijriDayOffset = 2))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_increase)).onLast()
+            .performClick()
+
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `the hijri offset stepper stops at its negative bound too`() {
+        setContent(GeneralSettingsUiState(hijriDayOffset = -2))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_decrease)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `the hijri offset stepper decrements to negative offsets`() {
+        setContent(GeneralSettingsUiState(hijriDayOffset = 0))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_decrease)).onFirst()
+            .performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHijriDayOffset>().days).isEqualTo(-1)
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LanguageScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LanguageScreenTest.kt
@@ -1,0 +1,138 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.AppLanguage
+import com.arshadshah.nimaz.presentation.viewmodel.settings.GeneralSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The language picker — six rows built from `AppLanguage.entries`.
+ *
+ * The list being enum-driven is what makes it worth testing: a seventh language is added by
+ * appending an enum constant, and the only thing standing between that and a row that never
+ * appears is that the screen iterates the entries rather than listing them. Asserting against
+ * `entries` rather than against six hardcoded names is the whole point — a test that named the
+ * six would pass forever while the seventh was invisible.
+ *
+ * The native name is the second half. A picker that shows only English names is unusable by
+ * exactly the people who need it: someone looking for Türkçe is not searching for "Turkish".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class LanguageScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(language: AppLanguage = AppLanguage.ENGLISH) {
+        viewModel.generalState.value = GeneralSettingsUiState(language = language)
+        composeRule.setThemedContent {
+            LanguageScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `every declared language is offered`() {
+        setContent()
+
+        AppLanguage.entries.forEach { language ->
+            composeRule.onNodeWithText(language.displayName).assertExists()
+        }
+    }
+
+    @Test
+    fun `each language shows its own name in its own script`() {
+        // "Türkçe" and "Bahasa Indonesia" are what someone who does not read English will
+        // recognise. A row showing only the English name is a picker they cannot use.
+        setContent()
+
+        AppLanguage.entries
+            .filter { it.nativeName != it.displayName }
+            .forEach { composeRule.onNodeWithText(it.nativeName).assertExists() }
+    }
+
+    @Test
+    fun `each language shows its country code badge`() {
+        setContent()
+
+        AppLanguage.entries.forEach { composeRule.onNodeWithText(it.flag).assertExists() }
+    }
+
+    @Test
+    fun `picking a language sends that language, not its neighbour in the list`() {
+        // Six identical rows in an indexed loop. Capturing the loop's `index` instead of its
+        // `language` — or reusing a variable across the iteration — sends the wrong one, and the
+        // app restarts into a language nobody chose.
+        setContent(AppLanguage.ENGLISH)
+
+        composeRule.onNodeWithText(AppLanguage.MALAY.displayName).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetLanguage>().language)
+            .isEqualTo(AppLanguage.MALAY)
+    }
+
+    @Test
+    fun `picking the last language in the list works too`() {
+        // The loop skips the divider after the final row (`index < size - 1`), which is exactly
+        // the kind of index arithmetic that gets applied to the row itself by mistake.
+        setContent()
+
+        composeRule.onNodeWithText(AppLanguage.entries.last().displayName).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetLanguage>().language)
+            .isEqualTo(AppLanguage.entries.last())
+    }
+
+    @Test
+    fun `re-picking the language already in use still dispatches`() {
+        // The row is not disabled when selected, and it should not be: tapping your current
+        // language is how someone confirms it is applied after a failed restart.
+        setContent(AppLanguage.GERMAN)
+
+        composeRule.onNodeWithText(AppLanguage.GERMAN.displayName).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetLanguage>().language)
+            .isEqualTo(AppLanguage.GERMAN)
+    }
+
+    @Test
+    fun `the screen warns that changing the language restarts the app`() {
+        // A restart with no warning reads as a crash.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.language_change_info)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.app_language_section)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LocationScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LocationScreenTest.kt
@@ -73,7 +73,9 @@ class LocationScreenTest {
     private fun setContent(uiState: LocationUiState = LocationUiState()) {
         state.value = uiState
         composeRule.setThemedContent {
-            activity = androidx.compose.ui.platform.LocalContext.current as? Activity
+            // `LocalActivity` rather than casting `LocalContext`: a Context is not always an
+            // Activity, and lint rejects the cast.
+            activity = androidx.activity.compose.LocalActivity.current
             LocationScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
         }
     }

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LocationScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/LocationScreenTest.kt
@@ -1,0 +1,355 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.CityRegion
+import com.arshadshah.nimaz.domain.model.SearchLocation
+import com.arshadshah.nimaz.domain.model.citiesForRegion
+import com.arshadshah.nimaz.domain.model.defaultPopularCities
+import com.arshadshah.nimaz.presentation.viewmodel.location.CurrentLocationState
+import com.arshadshah.nimaz.presentation.viewmodel.location.LocationEvent
+import com.arshadshah.nimaz.presentation.viewmodel.location.LocationUiState
+import com.arshadshah.nimaz.presentation.viewmodel.location.LocationViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Choosing where prayer times are calculated for — search, GPS, recents, and the curated
+ * catalogue.
+ *
+ * This is the screen behind every prayer time in the app, so the failure mode is severe and
+ * quiet: pick the wrong city and every time shifts, and nothing on any other screen says why.
+ *
+ * The GPS button carries the interesting logic. It takes one of two paths depending on whether
+ * the permission is already held, and the callback treats **fine or coarse** as granted — an app
+ * that demanded fine location would refuse to work for someone who granted approximate, whose
+ * accuracy is far more than enough to calculate a prayer time. That callback body is reachable
+ * only by answering the launcher from the test, so it is answered here rather than left uncovered.
+ *
+ * The other structural claim is the browse list: with no region filter the catalogue is *grouped*
+ * under region headings, and with one selected it is a flat list of that region only. Getting that
+ * backwards leaves either an unheaded wall of cities or a filter that filters nothing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class LocationScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MutableStateFlow(LocationUiState())
+    private val events = mutableListOf<LocationEvent>()
+    private val viewModel: LocationViewModel = mockk(relaxed = true) {
+        every { this@mockk.state } returns this@LocationScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<LocationEvent>() }
+    }
+    private var backs = 0
+    private var activity: Activity? = null
+
+    private fun setContent(uiState: LocationUiState = LocationUiState()) {
+        state.value = uiState
+        composeRule.setThemedContent {
+            activity = androidx.compose.ui.platform.LocalContext.current as? Activity
+            LocationScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun grantLocationPermission() {
+        shadowOf(context.applicationContext as android.app.Application)
+            .grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    private val london = SearchLocation(
+        name = "London",
+        country = "United Kingdom",
+        latitude = 51.5074,
+        longitude = -0.1278,
+        region = CityRegion.entries.first(),
+        flag = "🇬🇧",
+    )
+
+    // ── Search ───────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `typing in the search bar reports each keystroke`() {
+        // The bar puts its placeholder on the field as a `contentDescription` rather than as
+        // text, which is the only way to address it.
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.location_search_hint))
+            .performTextInput("Lon")
+
+        assertThat(events.filterIsInstance<LocationEvent.UpdateSearchQuery>()).isNotEmpty()
+    }
+
+    @Test
+    fun `search results are listed under their own heading`() {
+        setContent(LocationUiState(searchQuery = "London", searchResults = listOf(london)))
+
+        // `NimazSectionTitle` uppercases its text by default.
+        composeRule.onNodeWithText(string(R.string.location_search_results).uppercase())
+            .assertExists()
+        composeRule.onAllNodesWithText("London").onFirst().assertExists()
+    }
+
+    @Test
+    fun `picking a search result selects that location`() {
+        setContent(LocationUiState(searchResults = listOf(london)))
+
+        composeRule.onAllNodesWithText("London").onFirst().performClick()
+
+        val event = events.filterIsInstance<LocationEvent.SelectLocation>().single()
+        assertThat(event.location).isEqualTo(london)
+    }
+
+    @Test
+    fun `the catalogue is hidden while live search results are showing`() {
+        // Otherwise the results the user asked for are followed by a hundred cities they did
+        // not, and the first tap after a search is likely to land on the wrong one.
+        setContent(LocationUiState(searchResults = listOf(london)))
+
+        composeRule.onNodeWithText(string(R.string.location_browse_by_region).uppercase())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the catalogue returns once the search is cleared`() {
+        setContent(LocationUiState(searchResults = emptyList()))
+
+        composeRule.onNodeWithText(string(R.string.location_browse_by_region).uppercase())
+            .assertExists()
+    }
+
+    // ── The current location card ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a set location shows its name, its coordinates and the current badge`() {
+        setContent(
+            LocationUiState(
+                currentLocation = CurrentLocationState.Set("London", 51.5074, -0.1278)
+            )
+        )
+
+        composeRule.onAllNodesWithText("London").onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.location_current)).assertExists()
+    }
+
+    @Test
+    fun `an unset location says so rather than rendering an empty card`() {
+        setContent(LocationUiState(currentLocation = CurrentLocationState.NotSet))
+
+        composeRule.onNodeWithText(string(R.string.location_not_set)).assertExists()
+        composeRule.onNodeWithText(string(R.string.location_current)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a location being detected says it is detecting`() {
+        setContent(LocationUiState(currentLocation = CurrentLocationState.Loading))
+
+        composeRule.onNodeWithText(string(R.string.location_detecting)).assertExists()
+    }
+
+    @Test
+    fun `the city matching the current location is shown as selected`() {
+        // Matched on coordinates within a thousandth of a degree, not on the name — the
+        // Geocoder and the curated catalogue spell the same place differently, and a name match
+        // would leave the user's own city looking unselected in the list.
+        setContent(
+            LocationUiState(
+                currentLocation = CurrentLocationState.Set("LONDON", 51.5074, -0.1278),
+                searchResults = listOf(london),
+            )
+        )
+
+        // The selected row carries a check; the unselected ones do not.
+        composeRule.onAllNodesWithText("United Kingdom").onFirst().assertExists()
+    }
+
+    // ── GPS ──────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with permission already held, the GPS button detects straight away`() {
+        grantLocationPermission()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.location_use_current_location)).performClick()
+
+        assertThat(events).contains(LocationEvent.UseCurrentGpsLocation)
+    }
+
+    @Test
+    fun `without permission, the GPS button asks first and detects nothing yet`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.location_use_current_location)).performClick()
+
+        assertThat(events.filterIsInstance<LocationEvent.UseCurrentGpsLocation>()).isEmpty()
+        assertThat(shadowOf(activity).lastRequestedPermission).isNotNull()
+    }
+
+    @Test
+    fun `granting coarse location alone is enough to detect`() {
+        // Approximate location is far more accuracy than a prayer time needs. Requiring fine
+        // location would refuse to work for someone who deliberately granted the coarser one —
+        // and that arm of the callback is reachable only by answering the launcher.
+        setContent()
+        composeRule.onNodeWithText(string(R.string.location_use_current_location)).performClick()
+
+        val request = shadowOf(activity).lastRequestedPermission
+        activity!!.onRequestPermissionsResult(
+            request.requestCode,
+            arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION),
+            intArrayOf(PackageManager.PERMISSION_GRANTED),
+        )
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(LocationEvent.UseCurrentGpsLocation)
+    }
+
+    @Test
+    fun `a denied permission detects nothing`() {
+        setContent()
+        composeRule.onNodeWithText(string(R.string.location_use_current_location)).performClick()
+
+        val request = shadowOf(activity).lastRequestedPermission
+        activity!!.onRequestPermissionsResult(
+            request.requestCode,
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+            intArrayOf(PackageManager.PERMISSION_DENIED, PackageManager.PERMISSION_DENIED),
+        )
+        composeRule.waitForIdle()
+
+        assertThat(events.filterIsInstance<LocationEvent.UseCurrentGpsLocation>()).isEmpty()
+    }
+
+    @Test
+    fun `the GPS button reports that it is working and cannot be tapped twice`() {
+        // Two concurrent detections is two Geocoder round-trips racing to write the location.
+        setContent(LocationUiState(isLoadingGps = true))
+
+        composeRule.onNodeWithText(string(R.string.location_detecting_location)).assertExists()
+        composeRule.onNodeWithText(string(R.string.location_detecting_location)).performClick()
+
+        assertThat(events).isEmpty()
+    }
+
+    // ── Recents and the catalogue ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `recent locations get their own section, and only when there are some`() {
+        setContent(LocationUiState(recentLocations = emptyList()))
+        composeRule.onNodeWithText(string(R.string.location_recent).uppercase())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `a recent location is offered and selectable`() {
+        val cairo = SearchLocation("Cairo", "Egypt", 30.0444, 31.2357)
+        setContent(LocationUiState(recentLocations = listOf(cairo)))
+
+        composeRule.onNodeWithText(string(R.string.location_recent).uppercase()).assertExists()
+        composeRule.onAllNodesWithText("Cairo").onFirst().performClick()
+
+        assertThat(events.filterIsInstance<LocationEvent.SelectLocation>().single().location)
+            .isEqualTo(cairo)
+    }
+
+    @Test
+    fun `with no region filter the catalogue is grouped under region headings`() {
+        setContent(LocationUiState(selectedRegion = null))
+
+        // Every region that has cities contributes a heading.
+        val regions = defaultPopularCities.mapNotNull { it.region }.distinct()
+        assertThat(regions).isNotEmpty()
+        composeRule.onAllNodesWithText(regions.first().label).onFirst().assertExists()
+    }
+
+    @Test
+    fun `selecting a region flattens the list to that region's cities`() {
+        val region = defaultPopularCities.mapNotNull { it.region }.distinct().first()
+        setContent(LocationUiState(selectedRegion = region))
+
+        val inRegion = citiesForRegion(defaultPopularCities, region)
+        val outOfRegion = defaultPopularCities.filter { it.region != null && it.region != region }
+
+        assertThat(inRegion).isNotEmpty()
+        composeRule.onAllNodesWithText(inRegion.first().name).onFirst().assertExists()
+        if (outOfRegion.isNotEmpty()) {
+            composeRule.onNodeWithText(outOfRegion.first().name).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `the All chip clears the region filter`() {
+        val region = defaultPopularCities.mapNotNull { it.region }.distinct().first()
+        setContent(LocationUiState(selectedRegion = region))
+
+        composeRule.onNodeWithText(string(R.string.location_region_all)).performClick()
+
+        assertThat(events.filterIsInstance<LocationEvent.SelectRegion>().single().region).isNull()
+    }
+
+    @Test
+    fun `a region chip selects that region`() {
+        setContent()
+
+        val region = CityRegion.entries.sortedBy { it.order }.first()
+        composeRule.onAllNodesWithText(region.label).onFirst().performClick()
+
+        assertThat(events.filterIsInstance<LocationEvent.SelectRegion>().single().region)
+            .isEqualTo(region)
+    }
+
+    // ── Errors and navigation ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an error is shown and then dismissed, so it cannot repeat`() {
+        // The dismiss is what stops the snackbar re-showing on every recomposition for the rest
+        // of the screen's life.
+        setContent(LocationUiState(error = "No network"))
+        composeRule.mainClock.advanceTimeBy(10_000)
+        composeRule.waitForIdle()
+
+        assertThat(events).contains(LocationEvent.DismissError)
+    }
+
+    @Test
+    fun `the title is Location and the back button navigates back`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.location)).onFirst().assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationDiagnosticsScreenTest.kt
@@ -1,0 +1,227 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.shadows.ShadowToast
+
+/**
+ * Diagnostics: what the OS is currently allowing, and the three actions that fix it.
+ *
+ * The badges are the whole screen. Someone opens this because their prayer alerts are not
+ * arriving, so a row reporting "Granted" while the permission is denied does not just fail to
+ * help — it sends them looking for the fault somewhere else entirely. Each badge is therefore
+ * asserted against an arranged device state rather than against the default.
+ *
+ * Every row is tappable regardless of whether it passes, deliberately: making only the failing
+ * ones tappable leaves a row that looks like its neighbours and does nothing, and someone who
+ * wants to see *why* a check passes has nowhere to go. The `Intent` each one starts is what makes
+ * that useful, and it is readable from the shadow.
+ *
+ * Reset is destructive — it cancels every armed alarm before rebuilding — so it asks first, and
+ * the cancel path must not dispatch.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class NotificationDiagnosticsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun healthyDevice() {
+        ShadowAlarmManager.setCanScheduleExactAlarms(true)
+        shadowOf(context.getSystemService(PowerManager::class.java))
+            .setIgnoringBatteryOptimizations(context.packageName, true)
+    }
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            NotificationDiagnosticsScreen(
+                onNavigateBack = { backs++ },
+                viewModel = viewModel.mock,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun lastStartedAction(): String? =
+        shadowOf(ApplicationProvider.getApplicationContext<android.app.Application>())
+            .nextStartedActivity?.action
+
+    @Test
+    fun `all three checks are listed`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_permission)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_exact_alarms)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_battery)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_status_section)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a healthy device reports all three as passing`() {
+        healthyDevice()
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_granted)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_allowed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_unrestricted)).assertExists()
+    }
+
+    @Test
+    fun `a denied exact-alarm permission is reported as not allowed, not as allowed`() {
+        // The badge is the only evidence on the device that this is why the adhan is late.
+        ShadowAlarmManager.setCanScheduleExactAlarms(false)
+        shadowOf(context.getSystemService(PowerManager::class.java))
+            .setIgnoringBatteryOptimizations(context.packageName, true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_not_allowed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_allowed)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `battery restriction is reported as restricted`() {
+        ShadowAlarmManager.setCanScheduleExactAlarms(true)
+        shadowOf(context.getSystemService(PowerManager::class.java))
+            .setIgnoringBatteryOptimizations(context.packageName, false)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_restricted)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_unrestricted)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `each row opens the system screen it reports on, not a neighbour's`() {
+        // Three near-identical rows, each carrying a different `Intent` action. Crossing two of
+        // them sends someone to the battery screen to fix a notification permission.
+        healthyDevice()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_permission)).performClick()
+        assertThat(lastStartedAction()).isEqualTo(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_exact_alarms)).performClick()
+        assertThat(lastStartedAction())
+            .isEqualTo(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_battery)).performClick()
+        assertThat(lastStartedAction())
+            .isEqualTo(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+    }
+
+    @Test
+    fun `a passing row is still tappable`() {
+        // Deliberate: a row that looked like its neighbours and did nothing would be worse than
+        // one that explains a check that already passes.
+        healthyDevice()
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_permission)).performClick()
+
+        assertThat(lastStartedAction()).isEqualTo(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    fun `the single test notification is sent and confirmed`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_test)).performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.TestNotification)
+        assertThat(viewModel.events).doesNotContain(SettingsEvent.TestAllNotifications)
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo(string(R.string.notification_settings_test_sent))
+    }
+
+    @Test
+    fun `the all-prayers test is a different action with a different confirmation`() {
+        // Two adjacent buttons, one word apart. Crossing them makes "test all five" send one.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_test_all)).performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.TestAllNotifications)
+        assertThat(viewModel.events).doesNotContain(SettingsEvent.TestNotification)
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo(string(R.string.notification_settings_test_all_sent))
+    }
+
+    @Test
+    fun `reset asks before cancelling every armed alarm`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_reset)).performClick()
+
+        composeRule.onNodeWithText(string(R.string.notif_diag_reset_confirm_title)).assertExists()
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `cancelling the reset dialog resets nothing`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_reset)).performClick()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(viewModel.events).doesNotContain(SettingsEvent.ResetNotifications)
+    }
+
+    @Test
+    fun `confirming the reset dispatches it and confirms`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_reset)).performClick()
+        composeRule.onNodeWithText(string(R.string.notif_diag_reset_confirm_action)).performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.ResetNotifications)
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo(string(R.string.notification_settings_reset_success))
+    }
+
+    @Test
+    fun `the screen explains why battery optimisation matters`() {
+        setContent()
+
+        composeRule
+            .onNodeWithText(string(R.string.notification_settings_battery_explanation))
+            .assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreenTest.kt
@@ -1,0 +1,319 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import android.os.PowerManager
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSummary
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.annotation.Config
+
+/**
+ * The notifications hub: a master switch, five rows into subscreens, and subtitles that report
+ * what is actually set.
+ *
+ * The subtitles are the reason this is more than a menu, and they are also the thing most likely
+ * to go quietly wrong. `NotificationHubSubtitlesTest` pins *which string* each state chooses; this
+ * pins that the screen hands each helper the settings that belong to it. Feeding the weekly row's
+ * helper the worship counts, or the prayer row Fajr's reminder minutes where it wants its style,
+ * both compile and both produce a plausible sentence that is false.
+ *
+ * The master switch is the structural half. Everything below it is inside
+ * `if (notificationsEnabled)`, so switching it off must remove the rows rather than dim them —
+ * a hub that still offers "Prayers · Adhan · 15 minutes before" while notifications are off is
+ * telling the user alerts are configured when none will arrive.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class NotificationSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+    private var prayers = 0
+    private var worship = 0
+    private var weekly = 0
+    private var sound = 0
+    private var diagnostics = 0
+
+    private fun setContent(
+        state: NotificationSettingsUiState = NotificationSettingsUiState(),
+        summary: NotificationSummary = NotificationSummary(),
+    ) {
+        viewModel.notificationState.value = state
+        viewModel.notificationSummary.value = summary
+        composeRule.setThemedContent {
+            NotificationSettingsScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToPrayers = { prayers++ },
+                onNavigateToWorshipReminders = { worship++ },
+                onNavigateToWeekly = { weekly++ },
+                onNavigateToSound = { sound++ },
+                onNavigateToDiagnostics = { diagnostics++ },
+                viewModel = viewModel.mock,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the hub offers all five rows when notifications are on`() {
+        setContent(NotificationSettingsUiState(notificationsEnabled = true))
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_hub_sound_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.worship_settings_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_hub_weekly_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_hub_diagnostics_title)).assertExists()
+    }
+
+    @Test
+    fun `switching notifications off hides every row rather than dimming them`() {
+        // A hub that still reports "Prayers · Adhan · 2 of 5" while the master switch is off is
+        // telling the user alerts are configured when none can arrive.
+        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.notif_hub_sound_title)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.worship_settings_title)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.notif_hub_weekly_title)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.notif_hub_diagnostics_title))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the master switch stays reachable when it is off, so it can be switched back on`() {
+        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+
+        composeRule.settingsRow(string(R.string.notification_settings_enable)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetNotificationsEnabled>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the master switch passes the value the switch reports, not the negation of state`() {
+        // This is the one row on the screen wired as `onCheckedChange = { onEvent(Set…(it)) }`
+        // rather than `!state`. Rewriting it to match its neighbours would invert it.
+        setContent(NotificationSettingsUiState(notificationsEnabled = true))
+
+        composeRule.settingsRow(string(R.string.notification_settings_enable)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetNotificationsEnabled>().enabled).isFalse()
+    }
+
+    @Test
+    fun `the prayers row reports how many of the five are on`() {
+        setContent(summary = NotificationSummary(enabledPrayerCount = 3))
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_of, 3, 5)).assertExists()
+    }
+
+    @Test
+    fun `the prayers row reports the alert style, and the reminder when there is one`() {
+        setContent(
+            summary = NotificationSummary(
+                fajrAlertStyle = PrayerAlertStyle.ADHAN,
+                reminderEnabled = true,
+                reminderMinutes = 20,
+            )
+        )
+
+        val expected = string(
+            R.string.notif_prayer_summary,
+            string(R.string.notif_alert_style_adhan),
+            context.resources.getQuantityString(R.plurals.notif_reminder_minutes_before, 20, 20),
+        )
+        composeRule.onNodeWithText(expected).assertExists()
+    }
+
+    @Test
+    fun `the prayers row reports only the style when no reminder is set`() {
+        // The early return exists so the row does not claim a reminder that will not fire.
+        setContent(
+            summary = NotificationSummary(
+                fajrAlertStyle = PrayerAlertStyle.SILENT,
+                reminderEnabled = false,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_alert_style_silent)).assertExists()
+    }
+
+    @Test
+    fun `the sound row names the chosen adhan and the rule most likely to surprise`() {
+        // Do Not Disturb outranks vibration in the subtitle because it is the one that stops a
+        // sound the user is expecting.
+        setContent(
+            NotificationSettingsUiState(
+                respectDnd = true,
+                vibrationEnabled = true,
+                selectedAdhanSound = "MISHARY",
+            )
+        )
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.notif_hub_sound_dnd,
+                com.arshadshah.nimaz.data.audio.AdhanSound.fromName("MISHARY").displayName,
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `the sound row falls through to vibration when DnD is not respected`() {
+        setContent(
+            NotificationSettingsUiState(respectDnd = false, vibrationEnabled = true)
+        )
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.notif_hub_sound_vibration,
+                com.arshadshah.nimaz.data.audio.AdhanSound
+                    .fromName(NotificationSettingsUiState().selectedAdhanSound).displayName,
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `the worship row counts the reminders that are on, not the ones that exist`() {
+        // `count { it.value }` against `size`. Eleven reminders exist and default to off, so the
+        // wrong one reads "11 on" for a user who has enabled none.
+        setContent(
+            NotificationSettingsUiState(
+                worshipReminders = mapOf(
+                    "tahajjud" to true,
+                    "witr" to false,
+                    "suhoor" to true,
+                    "iftar" to false,
+                )
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_on, 2)).assertExists()
+    }
+
+    @Test
+    fun `the weekly row names which of the two weekly reminders are on`() {
+        setContent(
+            NotificationSettingsUiState(
+                fridayReminderEnabled = true,
+                khatamReminderEnabled = false,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_weekly_jumuah)).assertExists()
+    }
+
+    @Test
+    fun `the weekly row says neither when neither is on`() {
+        setContent(
+            NotificationSettingsUiState(
+                fridayReminderEnabled = false,
+                khatamReminderEnabled = false,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_weekly_none)).assertExists()
+    }
+
+    @Test
+    fun `each row opens its own subscreen`() {
+        // Five rows, five callbacks, all wired in one block. A row pointing at its neighbour's
+        // destination is invisible in review and obvious to a user exactly once.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.notif_hub_prayers_title)).performClick()
+        composeRule.settingsRow(string(R.string.notif_hub_sound_title)).performClick()
+        composeRule.settingsRow(string(R.string.worship_settings_title)).performClick()
+        composeRule.settingsRow(string(R.string.notif_hub_weekly_title)).performClick()
+        composeRule.settingsRow(string(R.string.notif_hub_diagnostics_title)).performClick()
+
+        assertThat(listOf(prayers, sound, worship, weekly, diagnostics))
+            .containsExactly(1, 1, 1, 1, 1)
+    }
+
+    @Test
+    fun `a device that would delay alerts is warned about, and the warning links to diagnostics`() {
+        // Robolectric reports the app as battery-*restricted* by default, so `hasProblem` is
+        // true here without arranging anything — the same state a real device is in until
+        // someone grants the exemption. The banner is the only thing that tells a user their
+        // prayer alerts will arrive late, and the row badge is what they see if they scroll
+        // past it, so both are asserted.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_delivery_warning)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_diag_needs_attention)).assertExists()
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_delivery_warning)).performClick()
+
+        assertThat(diagnostics).isEqualTo(1)
+    }
+
+    @Test
+    fun `a healthy device shows no delivery warning at all`() {
+        // The other half, and the one that matters for trust: a banner that always showed would
+        // train people to ignore the one time it is real. Both prerequisites Robolectric denies
+        // by default have to be granted for that, which is itself the point — the banner keys
+        // off `hasProblem`, not off any single one of them.
+        ShadowAlarmManager.setCanScheduleExactAlarms(true)
+        shadowOf(context.getSystemService(PowerManager::class.java))
+            .setIgnoringBatteryOptimizations(context.packageName, true)
+
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_delivery_warning))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.notif_diag_needs_attention))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the warning stays hidden while notifications are switched off entirely`() {
+        // The banner lives inside the `if (notificationsEnabled)` block. Warning that alerts
+        // may be delayed, when the user has switched alerts off, is noise about a setting they
+        // have already decided.
+        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_delivery_warning))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the title is the notifications hub`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notifications)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSoundScreenTest.kt
@@ -1,0 +1,245 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.data.audio.DownloadState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+/**
+ * Adhan and delivery: the voice picker, vibration, and the Do Not Disturb rule.
+ *
+ * The voice picker is the part with real behaviour behind it. Auditioning a muezzin means playing
+ * several in a row, so the sheet **stays open on selection** (`autoDismiss = false`) — and that
+ * makes stopping the preview a matter of closing it, from any of four routes. Every dismissal is
+ * funnelled through one lambda for exactly that reason: a sheet that closed without stopping
+ * leaves the adhan playing over whatever the user does next, with no visible control to stop it.
+ *
+ * The preview button carries the same double duty. It plays, and it *stops* when the sound it
+ * names is the one playing — a button that only ever started playback would give the user no way
+ * to interrupt a two-minute recitation. It also selects the sound before previewing it, so what
+ * you last auditioned is what you have chosen.
+ *
+ * The failure path is a Toast rather than a banner, and it is cleared after showing so it cannot
+ * repeat on the next recomposition.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class NotificationSoundScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private val mishary = AdhanSound.entries.first()
+    private val other = AdhanSound.entries[1]
+
+    private fun setContent(state: NotificationSettingsUiState = NotificationSettingsUiState()) {
+        viewModel.notificationState.value = state
+        composeRule.setThemedContent {
+            NotificationSoundScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun openVoicePicker() {
+        composeRule.settingsRow(string(R.string.notif_sound_voice)).performClick()
+    }
+
+    @Test
+    fun `the adhan section and the delivery toggles render`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_adhan_section))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.notification_settings_enable_adhan))
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.notification_settings_vibration)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notification_settings_dnd)).assertExists()
+    }
+
+    @Test
+    fun `the voice row appears only once the adhan is switched on`() {
+        // Choosing a muezzin for an adhan that will not play is a setting with no effect.
+        setContent(NotificationSettingsUiState(adhanEnabled = false))
+
+        composeRule.onNodeWithText(string(R.string.notif_sound_voice)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the voice row names the selected muezzin and where they are from`() {
+        setContent(
+            NotificationSettingsUiState(adhanEnabled = true, selectedAdhanSound = other.name)
+        )
+
+        composeRule.onNodeWithText(other.displayName).assertExists()
+        composeRule.onNodeWithText(other.origin).assertExists()
+    }
+
+    @Test
+    fun `the vibration and DnD toggles dispatch their own events`() {
+        // Two adjacent rows on a screen about sound. Crossing them silences the adhan for
+        // someone who asked only to stop the buzz.
+        setContent(
+            NotificationSettingsUiState(vibrationEnabled = true, respectDnd = true)
+        )
+
+        composeRule.settingsRow(string(R.string.notification_settings_vibration)).performClick()
+        composeRule.settingsRow(string(R.string.notification_settings_dnd)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetVibrationEnabled>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetRespectDnd>().enabled).isFalse()
+    }
+
+    @Test
+    fun `the adhan master switch dispatches the adhan event`() {
+        setContent(NotificationSettingsUiState(adhanEnabled = false))
+
+        composeRule.onAllNodes(isToggleable()).onFirst().performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetAdhanEnabled>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the picker offers every shipped muezzin`() {
+        setContent(NotificationSettingsUiState(adhanEnabled = true))
+
+        openVoicePicker()
+
+        AdhanSound.entries.forEach {
+            composeRule.onAllNodesWithText(it.displayName).onFirst().assertExists()
+        }
+    }
+
+    @Test
+    fun `picking a voice stores it and leaves the sheet open to audition another`() {
+        // `autoDismiss = false`. A sheet that closed on selection would make comparing two
+        // muezzins a matter of reopening it between each.
+        setContent(NotificationSettingsUiState(adhanEnabled = true))
+
+        openVoicePicker()
+        composeRule.onAllNodesWithText(other.displayName).onLast().performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetAdhanSound>().sound).isEqualTo(other.name)
+        composeRule.onAllNodesWithText(AdhanSound.entries.last().displayName).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `the preview button selects the voice before playing it`() {
+        // Otherwise the sound you last auditioned is not the one you end up with, and there is
+        // nothing on screen to tell you that.
+        setContent(
+            NotificationSettingsUiState(adhanEnabled = true, selectedAdhanSound = mishary.name)
+        )
+
+        openVoicePicker()
+        composeRule.onAllNodesWithContentDescription(string(R.string.notification_settings_preview))
+            .onLast().performClick()
+
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetAdhanSound>()).isNotEmpty()
+        assertThat(viewModel.events).contains(SettingsEvent.PreviewAdhanSound)
+    }
+
+    @Test
+    fun `the preview button stops the sound it is already playing`() {
+        // A two-minute recitation with no way to interrupt it is the failure this prevents.
+        viewModel.isAdhanPlaying.value = true
+        viewModel.currentlyPlayingAdhan.value = mishary
+        setContent(
+            NotificationSettingsUiState(adhanEnabled = true, selectedAdhanSound = mishary.name)
+        )
+
+        openVoicePicker()
+        composeRule.onAllNodesWithContentDescription(string(R.string.notification_settings_preview))
+            .onFirst().performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.StopAdhanPreview)
+        assertThat(viewModel.events).doesNotContain(SettingsEvent.PreviewAdhanSound)
+    }
+
+    @Test
+    fun `a voice being downloaded cannot be previewed`() {
+        // Tapping play on a file that is still arriving plays nothing, and the second tap would
+        // start a second download.
+        viewModel.adhanDownloadState.value =
+            mapOf(mishary to DownloadState.Downloading(progress = 40))
+        setContent(
+            NotificationSettingsUiState(adhanEnabled = true, selectedAdhanSound = mishary.name)
+        )
+
+        openVoicePicker()
+        composeRule.onAllNodesWithContentDescription(string(R.string.notification_settings_preview))
+            .onFirst().performClick()
+
+        assertThat(viewModel.events).doesNotContain(SettingsEvent.PreviewAdhanSound)
+    }
+
+    @Test
+    fun `closing the picker stops whatever it was previewing`() {
+        // Dismissal is funnelled through one lambda so this holds for Done, Cancel, a swipe and
+        // the back gesture alike — a sheet that closed without stopping leaves the adhan playing
+        // over the next screen with no control in sight.
+        setContent(NotificationSettingsUiState(adhanEnabled = true))
+
+        openVoicePicker()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(viewModel.events).contains(SettingsEvent.StopAdhanPreview)
+    }
+
+    @Test
+    fun `a preview failure is shown to the user and then cleared`() {
+        // Cleared, or the Toast repeats on every recomposition for the rest of the screen's life.
+        viewModel.adhanPreviewError.value = "Failed to download adhan audio."
+        setContent(NotificationSettingsUiState(adhanEnabled = true))
+
+        assertThat(ShadowToast.getTextOfLatestToast())
+            .isEqualTo("Failed to download adhan audio.")
+        io.mockk.verify { viewModel.mock.clearAdhanPreviewError() }
+    }
+
+    @Test
+    fun `no toast is shown when nothing has failed`() {
+        setContent(NotificationSettingsUiState(adhanEnabled = true))
+
+        assertThat(ShadowToast.getTextOfLatestToast()).isNull()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationWeeklyScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationWeeklyScreenTest.kt
@@ -1,0 +1,241 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The weekly reminders: Jumu'ah with a lead-time stepper, and Khatam with a time picker.
+ *
+ * Each row is an accordion whose *subtitle reports the setting* when it is on and describes the
+ * feature when it is off. That is a real contract, not decoration: it is the only way to read your
+ * Friday lead time or your Khatam time without opening the row, and the two branches are one `if`
+ * apart. Inverted, the row would advertise "Weekly reminder before Friday prayer" for someone who
+ * had set it to 90 minutes, and "90 min" for someone who had it switched off.
+ *
+ * The lead-time stepper's bounds are the other half. Jumu'ah leads by 15 to 120 minutes in
+ * quarter-hour steps, because a reminder for a prayer that happens at one fixed time each week is
+ * only useful in that window — a stepper moving by one minute would need 105 taps to cross it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class NotificationWeeklyScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(state: NotificationSettingsUiState = NotificationSettingsUiState()) {
+        viewModel.notificationState.value = state
+        composeRule.setThemedContent {
+            NotificationWeeklyScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `both weekly reminders are offered`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_friday_reminder))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.notification_settings_khatam_reminder))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a switched-off Friday reminder describes the feature rather than a time`() {
+        setContent(
+            NotificationSettingsUiState(fridayReminderEnabled = false, fridayReminderMinutes = 90)
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_friday_subtitle))
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.notification_settings_minutes_value, 90))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `a switched-on Friday reminder reports its own lead time`() {
+        setContent(
+            NotificationSettingsUiState(fridayReminderEnabled = true, fridayReminderMinutes = 90)
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_minutes_value, 90))
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.notification_settings_friday_subtitle))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `a switched-off Khatam reminder describes the feature rather than a time`() {
+        setContent(
+            NotificationSettingsUiState(
+                khatamReminderEnabled = false,
+                khatamReminderTime = "21:30",
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_khatam_subtitle))
+            .assertExists()
+    }
+
+    @Test
+    fun `an afternoon Khatam time is not read as a morning one`() {
+        // The stored string is 24-hour and the wheel is not. Reading "21:30" as 9 AM would move
+        // the reminder twelve hours and still look like a valid setting on every screen.
+        setContent(
+            NotificationSettingsUiState(khatamReminderEnabled = true, khatamReminderTime = "09:30")
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_khatam_reminder))
+            .performClick()
+
+        composeRule.onAllNodesWithText(string(R.string.time_period_am), useUnmergedTree = true)
+            .onFirst().assertExists()
+    }
+
+    @Test
+    fun `a switched-on Khatam reminder reports the time it will fire`() {
+        setContent(
+            NotificationSettingsUiState(
+                khatamReminderEnabled = true,
+                khatamReminderTime = "21:30",
+            )
+        )
+
+        composeRule.onNodeWithText("21:30").assertExists()
+    }
+
+    @Test
+    fun `the first switch is Jumuah's and the second is Khatam's`() {
+        // Two accordions built from one block, in an order only the source states. A switch
+        // wired to its neighbour's event silently swaps which reminder the user just turned on,
+        // and the row it sits in still reads correctly.
+        setContent(
+            NotificationSettingsUiState(
+                fridayReminderEnabled = false,
+                khatamReminderEnabled = false,
+            )
+        )
+
+        val switches = composeRule.onAllNodes(isToggleable())
+        switches[0].performClick()
+        assertThat(viewModel.only<SettingsEvent.SetFridayReminderEnabled>().enabled).isTrue()
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetKhatamReminderEnabled>())
+            .isEmpty()
+
+        switches[1].performClick()
+        assertThat(viewModel.only<SettingsEvent.SetKhatamReminderEnabled>().enabled).isTrue()
+    }
+
+    @Test
+    fun `a switch passes what it reports rather than negating state`() {
+        setContent(
+            NotificationSettingsUiState(
+                fridayReminderEnabled = true,
+                khatamReminderEnabled = true,
+            )
+        )
+
+        composeRule.onAllNodes(isToggleable())[0].performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetFridayReminderEnabled>().enabled).isFalse()
+    }
+
+    @Test
+    fun `the Jumuah lead time steps in quarter hours, not minutes`() {
+        // A reminder for a prayer at one fixed time each week is only useful in a 15-to-120
+        // minute window; a one-minute step would need 105 taps to cross it.
+        setContent(
+            NotificationSettingsUiState(fridayReminderEnabled = true, fridayReminderMinutes = 30)
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_friday_reminder))
+            .performClick()
+        // The accordion is a clickable card, so it *merges* its children's semantics — the
+        // stepper's own +/- nodes exist only in the unmerged tree, and the merged card reports
+        // `ContentDescription=[Decrease, Increase]` as its own.
+        composeRule
+            .onAllNodesWithContentDescription(string(R.string.cd_increase), useUnmergedTree = true)
+            .onFirst()
+            .performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetFridayReminderMinutes>().minutes).isEqualTo(45)
+    }
+
+    @Test
+    fun `the Jumuah lead time will not step below its quarter-hour floor`() {
+        // Below 15 minutes the reminder and the adhan land together, which is not a reminder.
+        setContent(
+            NotificationSettingsUiState(fridayReminderEnabled = true, fridayReminderMinutes = 15)
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_friday_reminder))
+            .performClick()
+        composeRule
+            .onAllNodesWithContentDescription(string(R.string.cd_decrease), useUnmergedTree = true)
+            .onFirst()
+            .performClick()
+
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetFridayReminderMinutes>())
+            .isEmpty()
+    }
+
+    @Test
+    fun `expanding the Khatam row opens a picker positioned on the stored time`() {
+        // The stored preference is an "HH:mm" string and the control is a pair of wheels, so the
+        // parse is the seam: `NimazTime.parse` failing quietly would open the picker at midnight
+        // and the first nudge would move the reminder to a time nobody chose. The wheels are
+        // driven by drag rather than by a click action, so what is pinned here is the position
+        // they open at; `SettingsEventTableTest` pins the write that a change produces.
+        setContent(
+            NotificationSettingsUiState(khatamReminderEnabled = true, khatamReminderTime = "21:30")
+        )
+
+        composeRule.onNodeWithText(string(R.string.notification_settings_khatam_reminder))
+            .performClick()
+
+        // The test locale is 12-hour, so 21:30 must open the wheel on 09 in the afternoon. A
+        // parse that quietly failed would give 00:00 — which reads as 12 AM, the one value that
+        // looks deliberate and is not.
+        composeRule.onAllNodesWithText("09", useUnmergedTree = true).onFirst().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.time_period_pm), useUnmergedTree = true)
+            .onFirst().assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/PrayerNotificationsScreenTest.kt
@@ -1,0 +1,397 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.PrayerTimes
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.accordionRow
+import com.arshadshah.nimaz.testing.settingsRow
+import com.arshadshah.nimaz.testing.tappableAncestorCount
+import com.arshadshah.nimaz.testing.testLocation
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * Prayer notifications — the highest-stakes screen in the module, because it decides whether a
+ * user's prayer alerts fire at all.
+ *
+ * Two structural claims are worth pinning above everything else.
+ *
+ * **Sunrise is not a sixth prayer.** It has no alert style and no reminder — it is the end of
+ * Fajr's window — so its toggle lives *inside* Fajr's accordion and writes the "sunrise" key.
+ * `:core:datastore` pins that it defaults off and can never carry an adhan; this pins that the
+ * screen agrees, and in particular that the five rows are built from `PRAYER_KEYS` rather than
+ * from a six-element list that would give sunrise controls it must not have.
+ *
+ * **"Remind me before every prayer" writes seven things, not one.** The app-wide pair
+ * (`SetShowReminderBefore` / `SetReminderMinutes`) is what a delivered reminder falls back to; the
+ * five per-prayer events are what actually rearms the alarms. Writing only the app-wide pair —
+ * which is what the control did before the per-prayer split — ships a switch that changes no
+ * notification at all, and looks correct on every screen.
+ *
+ * The header summaries are the third: this screen is usually opened to answer "what happens at
+ * Asr?", and a header that reported the wrong prayer's setting would answer it wrongly without
+ * ever being opened.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class PrayerNotificationsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private val times = PrayerTimes(
+        fajr = LocalDateTime.of(2026, 8, 26, 4, 30),
+        sunrise = LocalDateTime.of(2026, 8, 26, 6, 5),
+        dhuhr = LocalDateTime.of(2026, 8, 26, 13, 5),
+        asr = LocalDateTime.of(2026, 8, 26, 16, 45),
+        maghrib = LocalDateTime.of(2026, 8, 26, 20, 10),
+        isha = LocalDateTime.of(2026, 8, 26, 21, 40),
+        date = LocalDate.of(2026, 8, 26),
+        location = testLocation(),
+    )
+
+    private fun setContent(
+        state: NotificationSettingsUiState = NotificationSettingsUiState(),
+        prayerTimes: PrayerTimes? = times,
+    ) {
+        viewModel.notificationState.value = state
+        viewModel.todayPrayerTimes.value = prayerTimes
+        composeRule.setThemedContent {
+            PrayerNotificationsScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private fun minutesBefore(minutes: Int): String =
+        context.resources.getQuantityString(
+            R.plurals.notif_reminder_minutes_before, minutes, minutes
+        )
+
+    @Test
+    fun `there are five prayer rows and sunrise is not one of them`() {
+        // Sunrise has no alert style and no reminder. A sixth row would offer it both.
+        setContent()
+
+        listOf(
+            R.string.prayer_fajr,
+            R.string.prayer_dhuhr,
+            R.string.prayer_asr,
+            R.string.prayer_maghrib,
+            R.string.prayer_isha,
+        ).forEach { composeRule.onNodeWithText(string(it)).assertExists() }
+
+        composeRule.onNode(hasText(string(R.string.notif_sunrise)) and isToggleable())
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `each row shows that prayer's own time`() {
+        // Five parallel lists indexed together. An off-by-one puts Asr's time on Dhuhr's row,
+        // and the row still reads as a plausible prayer time.
+        setContent()
+
+        composeRule.onNodeWithText("04:30").assertExists()
+        composeRule.onNodeWithText("13:05").assertExists()
+        composeRule.onNodeWithText("16:45").assertExists()
+        composeRule.onNodeWithText("20:10").assertExists()
+        composeRule.onNodeWithText("21:40").assertExists()
+    }
+
+    @Test
+    fun `a row renders without a time when today's times are not known yet`() {
+        // The times arrive from a `WhileSubscribed` flow that starts null, so every row composes
+        // at least once with no time. A non-null assumption crashes the screen on open.
+        setContent(prayerTimes = null)
+
+        composeRule.onNodeWithText(string(R.string.prayer_fajr)).assertExists()
+        composeRule.onNodeWithText("04:30").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a switched-off prayer says so instead of describing an alert that will not fire`() {
+        setContent(NotificationSettingsUiState(asrNotification = false))
+
+        composeRule.onNodeWithText(string(R.string.notif_prayer_off)).assertExists()
+    }
+
+    @Test
+    fun `a row's summary reports that prayer's own alert style`() {
+        setContent(
+            NotificationSettingsUiState(
+                alertStyles = mapOf(
+                    "fajr" to PrayerAlertStyle.ADHAN,
+                    "dhuhr" to PrayerAlertStyle.SILENT,
+                )
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_alert_style_adhan)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_alert_style_silent)).assertExists()
+    }
+
+    @Test
+    fun `a row's summary adds the lead time only when that prayer has a reminder`() {
+        setContent(
+            NotificationSettingsUiState(
+                alertStyles = PrayerAlertStyle.PRAYER_KEYS
+                    .associateWith { PrayerAlertStyle.NOTIFICATION },
+                reminderEnabled = mapOf("maghrib" to true),
+                reminderOffsets = mapOf("maghrib" to 25),
+            )
+        )
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.notif_prayer_summary,
+                string(R.string.notif_alert_style_notification),
+                minutesBefore(25),
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `a reminder switched on with no stored offset falls back to the documented default`() {
+        // `reminderOffsets[prayer] ?: DEFAULT_REMINDER_MINUTES`. Falling back to 0 instead would
+        // fire the reminder at the same moment as the adhan, which is not a reminder.
+        setContent(
+            NotificationSettingsUiState(
+                alertStyles = PrayerAlertStyle.PRAYER_KEYS
+                    .associateWith { PrayerAlertStyle.NOTIFICATION },
+                reminderEnabled = mapOf("isha" to true),
+                reminderOffsets = emptyMap(),
+            )
+        )
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.notif_prayer_summary,
+                string(R.string.notif_alert_style_notification),
+                minutesBefore(PrayerAlertStyle.DEFAULT_REMINDER_MINUTES),
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `a prayer's switch toggles that prayer, keyed by its own name`() {
+        setContent()
+
+        // Row order is Fajr, Dhuhr, Asr, Maghrib, Isha. The "all prayers" row is a
+        // `NimazSettingsItem`, whose switch defers its click to the enclosing row, so the only
+        // toggleable nodes on screen are the five accordion switches — in prayer order.
+        composeRule.onAllNodes(isToggleable())[1].performClick()
+
+        val event = viewModel.events.filterIsInstance<SettingsEvent.SetPrayerNotification>().single()
+        assertThat(event.prayer).isEqualTo("dhuhr")
+    }
+
+    @Test
+    fun `sunrise's toggle lives under Fajr and writes the sunrise key`() {
+        // It renders only inside Fajr's expanded body, and it must not write "fajr".
+        setContent(NotificationSettingsUiState(sunriseNotification = false))
+
+        composeRule.onNodeWithText(string(R.string.prayer_fajr)).performClick()
+        composeRule.accordionRow(string(R.string.notif_sunrise)).performClick()
+
+        val event = viewModel.events.filterIsInstance<SettingsEvent.SetPrayerNotification>().single()
+        assertThat(event.prayer).isEqualTo("sunrise")
+        assertThat(event.enabled).isTrue()
+    }
+
+    @Test
+    fun `no other prayer's accordion offers the sunrise toggle`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.prayer_isha)).performClick()
+
+        assertThat(composeRule.tappableAncestorCount(string(R.string.notif_sunrise))).isEqualTo(0)
+    }
+
+    @Test
+    fun `a switched-off prayer's alert style and reminder rows are off-limits`() {
+        // Choosing an alert style for a prayer that sends nothing is a setting with no effect,
+        // and offering it suggests the notification will arrive.
+        setContent(NotificationSettingsUiState(fajrNotification = false))
+
+        composeRule.onNodeWithText(string(R.string.prayer_fajr)).performClick()
+
+        // Only the accordion card encloses them — the rows themselves have dropped their
+        // `clickable`, which is how `NimazSettingsItem` expresses "disabled".
+        assertThat(composeRule.tappableAncestorCount(string(R.string.notif_alert_style)))
+            .isEqualTo(1)
+        assertThat(composeRule.tappableAncestorCount(string(R.string.notif_reminder_before)))
+            .isEqualTo(1)
+
+        // And tapping there opens nothing.
+        composeRule.accordionRow(string(R.string.notif_alert_style)).performClick()
+        composeRule.onNodeWithText(string(R.string.notif_alert_style_adhan_subtitle))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `picking an alert style writes it against the prayer whose row was opened`() {
+        // One nullable `openSheet` rather than a boolean per prayer per setting. The sheet has
+        // to carry *which* prayer, or every pick lands on whichever prayer the code names.
+        setContent(NotificationSettingsUiState(asrNotification = true))
+
+        composeRule.onNodeWithText(string(R.string.prayer_asr)).performClick()
+        composeRule.accordionRow(string(R.string.notif_alert_style)).performClick()
+        composeRule.onNodeWithText(string(R.string.notif_alert_style_silent_subtitle))
+            .performClick()
+
+        val event = viewModel.only<SettingsEvent.SetPrayerAlertStyle>()
+        assertThat(event.prayer).isEqualTo("asr")
+        assertThat(event.style).isEqualTo(PrayerAlertStyle.SILENT)
+    }
+
+    @Test
+    fun `picking a lead time switches that prayer's reminder on and stores the number`() {
+        setContent(NotificationSettingsUiState(maghribNotification = true))
+
+        composeRule.onNodeWithText(string(R.string.prayer_maghrib)).performClick()
+        composeRule.accordionRow(string(R.string.notif_reminder_before)).performClick()
+        composeRule.onNodeWithText(minutesBefore(30)).performClick()
+
+        val enabled = viewModel.only<SettingsEvent.SetPrayerReminderEnabled>()
+        assertThat(enabled.prayer).isEqualTo("maghrib")
+        assertThat(enabled.enabled).isTrue()
+        val minutes = viewModel.only<SettingsEvent.SetPrayerReminderMinutes>()
+        assertThat(minutes.prayer).isEqualTo("maghrib")
+        assertThat(minutes.minutes).isEqualTo(30)
+    }
+
+    @Test
+    fun `picking No reminder switches it off without writing a lead time`() {
+        // The `if (minutes != null)` guard. Writing 0 minutes instead would leave the reminder
+        // stored as "0 minutes before", which reads back as a reminder that fires with the adhan.
+        setContent(
+            NotificationSettingsUiState(
+                ishaNotification = true,
+                reminderEnabled = mapOf("isha" to true),
+                reminderOffsets = mapOf("isha" to 20),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.prayer_isha)).performClick()
+        composeRule.accordionRow(string(R.string.notif_reminder_before)).performClick()
+        composeRule.onNodeWithText(string(R.string.notif_reminder_none)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetPrayerReminderEnabled>().enabled).isFalse()
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetPrayerReminderMinutes>())
+            .isEmpty()
+    }
+
+    @Test
+    fun `remind-me-before-every-prayer writes the app-wide pair and all five prayers`() {
+        // Seven events. The app-wide pair alone is what the control used to write, and it
+        // changes no notification; the five per-prayer events are what rearms the alarms.
+        setContent(
+            NotificationSettingsUiState(showReminderBefore = false, reminderMinutes = 15)
+        )
+
+        composeRule.settingsRow(string(R.string.notif_all_prayers_reminder_title)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetShowReminderBefore>().enabled).isTrue()
+        assertThat(viewModel.only<SettingsEvent.SetReminderMinutes>().minutes).isEqualTo(15)
+        assertThat(
+            viewModel.events.filterIsInstance<SettingsEvent.SetPrayerReminderEnabled>()
+                .map { it.prayer }
+        ).containsExactlyElementsIn(PrayerAlertStyle.PRAYER_KEYS)
+        assertThat(
+            viewModel.events.filterIsInstance<SettingsEvent.SetPrayerReminderMinutes>()
+                .map { it.minutes }
+        ).containsExactly(15, 15, 15, 15, 15)
+    }
+
+    @Test
+    fun `switching it off keeps the chosen lead time so switching back on restores it`() {
+        // The minutes are written even while turning the reminder off, deliberately: otherwise
+        // the next "on" silently reverts to the default rather than to what the user chose.
+        setContent(
+            NotificationSettingsUiState(showReminderBefore = true, reminderMinutes = 45)
+        )
+
+        composeRule.settingsRow(string(R.string.notif_all_prayers_reminder_title)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetShowReminderBefore>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetReminderMinutes>().minutes).isEqualTo(45)
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetPrayerReminderMinutes>())
+            .isEmpty()
+    }
+
+    @Test
+    fun `the bulk lead-time row reports no reminder while the bulk switch is off`() {
+        setContent(
+            NotificationSettingsUiState(showReminderBefore = false, reminderMinutes = 30)
+        )
+
+        composeRule.onNodeWithText(string(R.string.notif_reminder_none)).assertExists()
+    }
+
+    @Test
+    fun `the bulk lead-time row reports the stored minutes while it is on`() {
+        setContent(
+            NotificationSettingsUiState(showReminderBefore = true, reminderMinutes = 30)
+        )
+
+        composeRule.onNodeWithText(minutesBefore(30)).assertExists()
+    }
+
+    @Test
+    fun `picking a bulk lead time applies it to every prayer`() {
+        setContent(
+            NotificationSettingsUiState(showReminderBefore = true, reminderMinutes = 15)
+        )
+
+        composeRule.settingsRow(string(R.string.notif_all_prayers_lead_title)).performClick()
+        composeRule.onNodeWithText(minutesBefore(60)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetReminderMinutes>().minutes).isEqualTo(60)
+        assertThat(
+            viewModel.events.filterIsInstance<SettingsEvent.SetPrayerReminderMinutes>()
+                .map { it.minutes }
+        ).containsExactly(60, 60, 60, 60, 60)
+    }
+
+    @Test
+    fun `the sections and the title render`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.notif_all_prayers_section)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.notif_prayers_section)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/PrayerSettingsScreenTest.kt
@@ -1,0 +1,312 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.presentation.viewmodel.settings.LocationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSummary
+import com.arshadshah.nimaz.presentation.viewmodel.settings.PrayerSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.arshadshah.nimaz.testing.testLocation
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Prayer calculation settings: the three method pickers, six manual offsets, and two rows that
+ * report the notification state.
+ *
+ * The pickers matter because a wrong calculation method changes every prayer time in the app
+ * without anything looking broken — the times are simply, quietly, someone else's. Each picker
+ * therefore has to write the value the user chose rather than a positional index, and the three
+ * pickers must not be crossed with each other: they open from three adjacent rows with the same
+ * shape, and picking Hanafi from the "wrong" sheet would set a high-latitude rule.
+ *
+ * The manual offsets are six identical steppers in a row and the classic place for an off-by-one.
+ * They are asserted by which prayer key each one writes, which is the only thing distinguishing
+ * them in the source.
+ *
+ * The notification rows read a `WhileSubscribed` rollup collected from DataStore so they stay
+ * true after an edit made on the notifications hub, which runs its own ViewModel instance. Their
+ * four-arm `when` covers off, all-on, none-on and a count — and the difference between "No
+ * prayers enabled" and "Notifications off" is a real one, because only the first is fixed here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class PrayerSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+    private var notifications = 0
+
+    private fun setContent(
+        state: PrayerSettingsUiState = PrayerSettingsUiState(),
+        summary: NotificationSummary = NotificationSummary(),
+        location: LocationSettingsUiState = LocationSettingsUiState(isLoading = false),
+    ) {
+        viewModel.prayerState.value = state
+        viewModel.notificationSummary.value = summary
+        viewModel.locationState.value = location
+        composeRule.setThemedContent {
+            PrayerSettingsScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToNotifications = { notifications++ },
+                viewModel = viewModel.mock,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `the three sections render`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.calculation_method)).onFirst()
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.manual_adjustments)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notifications)).assertExists()
+    }
+
+    @Test
+    fun `each row reports the method that is actually stored`() {
+        setContent(
+            PrayerSettingsUiState(
+                calculationMethod = CalculationMethod.KARACHI,
+                asrMethod = AsrCalculation.HANAFI,
+                highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE,
+            )
+        )
+
+        composeRule.onNodeWithText(CalculationMethod.KARACHI.displayName()).assertExists()
+        composeRule.onAllNodesWithText(string(R.string.asr_hanafi)).onFirst().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.twilight_angle)).onFirst().assertExists()
+    }
+
+    @Test
+    fun `the calculation picker offers every method with the region it is used in`() {
+        // "Used in Pakistan" beats "Karachi" if you do not already know the acronym, and the
+        // `when` supplying those descriptions is the shape that goes stale when a method is
+        // added — it would not compile, but a *renamed* one silently keeps the old region.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.calculation_method)).performClick()
+
+        // The sheet is a `LazyColumn`, so only the first screenful composes — the assertion is
+        // that the list is built from the enum with a region beside each, not that all eleven
+        // are laid out at once.
+        CalculationMethod.entries.take(3).forEach { method ->
+            composeRule.onAllNodesWithText(method.displayName()).onFirst().assertExists()
+        }
+        composeRule.onNodeWithText(string(R.string.calc_region_karachi)).assertExists()
+    }
+
+    @Test
+    fun `picking a calculation method sends that method`() {
+        setContent(PrayerSettingsUiState(calculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE))
+
+        composeRule.settingsRow(string(R.string.calculation_method)).performClick()
+        composeRule.onNodeWithText(string(R.string.calc_region_egyptian)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetCalculationMethod>().method)
+            .isEqualTo(CalculationMethod.EGYPTIAN)
+    }
+
+    @Test
+    fun `the asr picker offers both schools and writes the one chosen`() {
+        setContent(PrayerSettingsUiState(asrMethod = AsrCalculation.STANDARD))
+
+        composeRule.settingsRow(string(R.string.asr_calculation)).performClick()
+        composeRule.onNodeWithText(string(R.string.asr_hanafi_desc)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetAsrMethod>().method)
+            .isEqualTo(AsrCalculation.HANAFI)
+    }
+
+    @Test
+    fun `the high-latitude picker offers all three rules and writes the one chosen`() {
+        // Three adjacent rows opening three same-shaped sheets. A picker wired to its
+        // neighbour's event would set an Asr school from the high-latitude sheet.
+        setContent(PrayerSettingsUiState(highLatitudeRule = HighLatitudeRule.MIDDLE_OF_THE_NIGHT))
+
+        composeRule.settingsRow(string(R.string.high_latitude_method)).performClick()
+        composeRule.onNodeWithText(string(R.string.high_lat_seventh_desc)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetHighLatitudeRule>().rule)
+            .isEqualTo(HighLatitudeRule.SEVENTH_OF_THE_NIGHT)
+        assertThat(viewModel.events.filterIsInstance<SettingsEvent.SetAsrMethod>()).isEmpty()
+    }
+
+    @Test
+    fun `each manual offset stepper writes its own prayer`() {
+        // Six identical steppers whose only distinguishing feature is a string literal. An
+        // off-by-one here moves the wrong prayer by the right number of minutes, which reads as
+        // a calculation bug rather than a settings one.
+        setContent()
+
+        val increments =
+            composeRule.onAllNodesWithContentDescription(string(R.string.cd_increase))
+        increments[0].performClick()
+        assertThat(viewModel.only<SettingsEvent.SetPrayerAdjustment>().prayer).isEqualTo("fajr")
+        viewModel.events.clear()
+
+        increments[3].performClick()
+        assertThat(viewModel.only<SettingsEvent.SetPrayerAdjustment>().prayer).isEqualTo("asr")
+        viewModel.events.clear()
+
+        increments[5].performClick()
+        assertThat(viewModel.only<SettingsEvent.SetPrayerAdjustment>().prayer).isEqualTo("isha")
+    }
+
+    @Test
+    fun `an offset stepper starts from the value that prayer already holds`() {
+        setContent(PrayerSettingsUiState(dhuhrAdjustment = 4))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_increase))[2].performClick()
+
+        val event = viewModel.only<SettingsEvent.SetPrayerAdjustment>()
+        assertThat(event.prayer).isEqualTo("dhuhr")
+        assertThat(event.minutes).isEqualTo(5)
+    }
+
+    @Test
+    fun `an offset can be moved backwards as well as forwards`() {
+        setContent(PrayerSettingsUiState(maghribAdjustment = 0))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_decrease))[4].performClick()
+
+        val event = viewModel.only<SettingsEvent.SetPrayerAdjustment>()
+        assertThat(event.prayer).isEqualTo("maghrib")
+        assertThat(event.minutes).isEqualTo(-1)
+    }
+
+    @Test
+    fun `the notification row says all prayers are on when all five are`() {
+        setContent(summary = NotificationSummary(enabledPrayerCount = 5))
+
+        composeRule.onNodeWithText(string(R.string.prayer_settings_all_prayers_enabled))
+            .assertExists()
+    }
+
+    @Test
+    fun `the notification row counts the prayers when only some are on`() {
+        setContent(summary = NotificationSummary(enabledPrayerCount = 2))
+
+        composeRule.onNodeWithText(string(R.string.prayer_settings_prayers_enabled_count, 2, 5))
+            .assertExists()
+    }
+
+    @Test
+    fun `no prayers enabled is reported differently from notifications being off`() {
+        // Only the first is fixable here; the second is the master switch on another screen.
+        // One string for both would send someone to the wrong place.
+        setContent(
+            summary = NotificationSummary(
+                notificationsMasterEnabled = true,
+                enabledPrayerCount = 0,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.prayer_settings_no_prayers_enabled))
+            .assertExists()
+    }
+
+    @Test
+    fun `the master switch being off outranks the per-prayer count`() {
+        // Five prayers "enabled" under a master switch that is off means no notification will
+        // arrive, so reporting "All prayers enabled" there would be a lie about delivery.
+        setContent(
+            summary = NotificationSummary(
+                notificationsMasterEnabled = false,
+                enabledPrayerCount = 5,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.prayer_settings_notifications_off))
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.prayer_settings_all_prayers_enabled))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the Fajr reminder row reports its lead time, or says it is off`() {
+        setContent(summary = NotificationSummary(reminderEnabled = true, reminderMinutes = 25))
+
+        composeRule.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.notif_reminder_minutes_before, 25, 25)
+        ).assertExists()
+    }
+
+    @Test
+    fun `a Fajr reminder that is off says so rather than showing a lead time`() {
+        setContent(summary = NotificationSummary(reminderEnabled = false, reminderMinutes = 25))
+
+        composeRule.onNodeWithText(string(R.string.prayer_settings_reminder_off)).assertExists()
+    }
+
+    @Test
+    fun `both notification rows open the notifications hub`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.adhan_notifications)).performClick()
+        composeRule.settingsRow(string(R.string.prayer_settings_fajr_reminder)).performClick()
+
+        assertThat(notifications).isEqualTo(2)
+    }
+
+    @Test
+    fun `the high-latitude notice names the user's own city`() {
+        setContent(location = LocationSettingsUiState(currentLocation = testLocation(city = "Oslo")))
+
+        composeRule.onNodeWithText(
+            string(R.string.prayer_settings_high_latitude_notice_format, "Oslo")
+        ).assertExists()
+    }
+
+    @Test
+    fun `the notice falls back to a neutral phrase when no city is known`() {
+        // The location arrives asynchronously, so this renders on every cold open. A non-null
+        // assumption crashes the screen; a raw "null" in the sentence is worse than a fallback.
+        setContent(location = LocationSettingsUiState(currentLocation = null))
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.prayer_settings_high_latitude_notice_format,
+                string(R.string.prayer_settings_your_location),
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/QuranSettingsScreenTest.kt
@@ -1,0 +1,283 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.QuranReciter
+import com.arshadshah.nimaz.domain.model.QuranTranslation
+import com.arshadshah.nimaz.presentation.viewmodel.settings.QuranSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.assertSettingsRowNotTappable
+import com.arshadshah.nimaz.testing.settingsRow
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Quran reader's settings — seven sections, and one cross-setting rule that is the reason
+ * this screen is ordered the way it is.
+ *
+ * **Tajweed is gated on the Mushaf script**, because only the Madani edition carries per-letter
+ * spans; the IndoPak layouts have none. The failure this guards against is the one #293 fixed: the
+ * toggles used to be tappable on every layout and silently did nothing, so a user switched
+ * tajweed on, saw no colour, and had no way to learn why. Three things must therefore hold
+ * together — the toggle is disabled, and the subtitle *says* why rather than describing a feature
+ * that will not happen.
+ *
+ * The second gate is inside tajweed itself: the colour-blind underline is meaningless without the
+ * colours, so it must be off-limits when the colours are.
+ *
+ * The preview card is the other half. It renders the *real* text of the selected translation, and
+ * the fallback to the bundled sample exists only for the moment before the first read resolves —
+ * so a card that never showed the loaded text would look correct in a screenshot and be wrong for
+ * every translation but one.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class QuranSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+    private var reciterPicker = 0
+    private var translationPicker = 0
+
+    private fun setContent(state: QuranSettingsUiState = QuranSettingsUiState()) {
+        viewModel.quranState.value = state
+        composeRule.setThemedContent {
+            QuranSettingsScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToSelectReciter = { reciterPicker++ },
+                onNavigateToSelectTranslation = { translationPicker++ },
+                viewModel = viewModel.mock,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `all seven sections render, in the order a reader thinks about the page`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.mushaf_layout)).onFirst().assertExists()
+        composeRule.onNodeWithText(string(R.string.arabic_text)).assertExists()
+        composeRule.onNodeWithText(string(R.string.tajweed_section)).assertExists()
+        composeRule.onNodeWithText(string(R.string.audio)).assertExists()
+        composeRule.onNodeWithText(string(R.string.reading_section)).assertExists()
+    }
+
+    @Test
+    fun `tajweed is offered on the Madani layout`() {
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.MADANI))
+
+        composeRule.settingsRow(string(R.string.show_tajweed_colors)).assertIsEnabled()
+        composeRule.onNodeWithText(string(R.string.show_tajweed_colors_subtitle)).assertExists()
+    }
+
+    @Test
+    fun `tajweed is disabled on an IndoPak layout, and says why`() {
+        // The disabled state alone is not enough: a greyed row with the usual subtitle reads as
+        // a bug. The unavailability text is what turns it into an explanation.
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.INDOPAK_16))
+
+        composeRule.assertSettingsRowNotTappable(string(R.string.show_tajweed_colors))
+        composeRule.onNodeWithText(string(R.string.show_tajweed_colors_unavailable)).assertExists()
+    }
+
+    @Test
+    fun `a disabled tajweed row cannot be toggled`() {
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.INDOPAK_13, showTajweed = false))
+
+        composeRule.assertSettingsRowNotTappable(string(R.string.show_tajweed_colors))
+
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `the colour-blind underline is off-limits while the colours are off`() {
+        // Underlining rule spans is a *second* channel on top of the colours. Offered while the
+        // colours are off it promises a rendering that cannot happen.
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.MADANI, showTajweed = false))
+
+        composeRule.assertSettingsRowNotTappable(string(R.string.tajweed_underline))
+    }
+
+    @Test
+    fun `the colour-blind underline becomes available once the colours are on`() {
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.MADANI, showTajweed = true))
+
+        composeRule.settingsRow(string(R.string.tajweed_underline)).assertIsEnabled()
+        composeRule.settingsRow(string(R.string.tajweed_underline)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetTajweedUnderline>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the tajweed toggle dispatches the tajweed event when it is available`() {
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.MADANI, showTajweed = false))
+
+        composeRule.settingsRow(string(R.string.show_tajweed_colors)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetShowTajweed>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the colour guide opens even on a layout that cannot show the colours`() {
+        // Deliberately reachable regardless of script, so someone can learn what the colours
+        // mean before switching editions to see them (#294).
+        setContent(QuranSettingsUiState(mushafScript = MushafScript.INDOPAK_16))
+
+        composeRule.settingsRow(string(R.string.tajweed_colour_guide)).performClick()
+        composeRule.waitForIdle()
+
+        // The legend renders its own heading, so the guide's title now appears twice — once on
+        // the row and once in the sheet. That second node *is* the assertion.
+        composeRule.onAllNodesWithText(string(R.string.tajweed_colour_guide))
+            .assertCountEquals(2)
+    }
+
+    @Test
+    fun `the translation row names the translator, not only the language`() {
+        // It used to pass the translator as `value` beside a `subtitle`, and the component
+        // renders `subtitle ?: value` — so it showed "English" and the one thing the row exists
+        // to report never appeared at all.
+        val translation = QuranTranslation.entries.first()
+        setContent(QuranSettingsUiState(selectedTranslatorId = translation.id))
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.settings_value_with_qualifier,
+                translation.translator,
+                translation.language.englishName,
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `the translation row opens the picker rather than editing in place`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.translation)).performClick()
+
+        assertThat(translationPicker).isEqualTo(1)
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `the reciter row names the reciter and opens the picker`() {
+        val reciter = QuranReciter.entries.first()
+        setContent(QuranSettingsUiState(selectedReciterId = reciter.id))
+
+        composeRule.onNodeWithText(
+            string(R.string.settings_value_with_qualifier, reciter.displayName, reciter.country)
+        ).assertExists()
+        composeRule.settingsRow(string(R.string.reciter)).performClick()
+
+        assertThat(reciterPicker).isEqualTo(1)
+    }
+
+    @Test
+    fun `the preview shows the loaded translation, not the bundled sample`() {
+        setContent(
+            QuranSettingsUiState(showTranslation = true, previewTranslation = "A loaded rendering")
+        )
+
+        composeRule.onNodeWithText("A loaded rendering").assertExists()
+        composeRule.onNodeWithText(string(R.string.quran_settings_preview_translation))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `the preview falls back to the sample only before the first load resolves`() {
+        setContent(QuranSettingsUiState(showTranslation = true, previewTranslation = null))
+
+        composeRule.onNodeWithText(string(R.string.quran_settings_preview_translation))
+            .assertExists()
+    }
+
+    @Test
+    fun `hiding the translation removes it from the preview`() {
+        setContent(
+            QuranSettingsUiState(showTranslation = false, previewTranslation = "A loaded rendering")
+        )
+
+        composeRule.onNodeWithText("A loaded rendering").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the transliteration card follows its own toggle`() {
+        setContent(QuranSettingsUiState(showTransliteration = true))
+        composeRule.onNodeWithText(string(R.string.quran_settings_preview_transliteration))
+            .assertExists()
+    }
+
+    @Test
+    fun `the translation size slider is disabled while the translation is hidden`() {
+        // A size control for something that is not on screen is a control with no effect.
+        setContent(QuranSettingsUiState(showTranslation = false))
+
+        composeRule.onNodeWithContentDescription(string(R.string.translation_font_size))
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `the show-translation and show-transliteration rows dispatch their own events`() {
+        setContent(QuranSettingsUiState(showTranslation = true, showTransliteration = false))
+
+        composeRule.settingsRow(string(R.string.show_translation)).performClick()
+        composeRule.settingsRow(string(R.string.show_transliteration)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetShowTranslation>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetShowTransliteration>().enabled).isTrue()
+    }
+
+    @Test
+    fun `the reading rows dispatch continuous playback and keep-screen-on`() {
+        setContent(QuranSettingsUiState(continuousReading = true, keepScreenOn = true))
+
+        composeRule.settingsRow(string(R.string.continuous_reading)).performClick()
+        composeRule.settingsRow(string(R.string.keep_screen_on)).performClick()
+
+        assertThat(viewModel.only<SettingsEvent.SetContinuousReading>().enabled).isFalse()
+        assertThat(viewModel.only<SettingsEvent.SetKeepScreenOn>().enabled).isFalse()
+    }
+
+    @Test
+    fun `the font size shown is the one this screen's state holds`() {
+        setContent(QuranSettingsUiState(arabicFontSize = 36f, translationFontSize = 22f))
+
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 36)).assertExists()
+        composeRule.onNodeWithText(string(R.string.arabic_font_size_value, 22)).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SearchSettingsScreenTest.kt
@@ -1,0 +1,413 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.LibrarySource
+import com.arshadshah.nimaz.domain.model.MatchStrictness
+import com.arshadshah.nimaz.domain.model.SearchPreferences
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SearchSettingsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SearchSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SearchSettingsViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.arshadshah.nimaz.testing.tappableAncestorCount
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Search and AI settings — the four local-search knobs, and the opt-in that lets a question leave
+ * the device.
+ *
+ * The consent flow is the part that matters most and the part most easily broken into something
+ * that still looks right. "Enable AI answers" must **not** be a plain toggle: switching it on has
+ * to open the disclosure sheet and wait for an explicit acceptance, because the whole feature is
+ * one where the user's question is sent to a Worker. A toggle that wrote the preference directly
+ * would look identical on screen and would opt someone in without ever showing them what is
+ * shared.
+ *
+ * The failure arm is the second half of that, and it is the shipped bug the state field exists
+ * for: when the consent write does not commit, the sheet stays up and says so. The alternative —
+ * closing over a switch that has quietly stayed off — leaves the user believing they enabled a
+ * feature that is not on.
+ *
+ * The source list has a rule of its own: **the last source on cannot be switched off.** An empty
+ * set is a search that returns nothing for every query, and `SearchPreferences.sanitised` reads it
+ * straight back as "everything" — so the switch would flip itself back on, which reads as the app
+ * ignoring the user.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class SearchSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MutableStateFlow(SearchSettingsUiState())
+    private val events = mutableListOf<SearchSettingsEvent>()
+    private val viewModel: SearchSettingsViewModel = mockk(relaxed = true) {
+        every { uiState } returns this@SearchSettingsScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<SearchSettingsEvent>() }
+    }
+    private var backs = 0
+
+    private fun setContent(uiState: SearchSettingsUiState = SearchSettingsUiState()) {
+        state.value = uiState
+        composeRule.setThemedContent {
+            SearchSettingsScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private inline fun <reified T : SearchSettingsEvent> only(): T = events.filterIsInstance<T>()
+        .also { check(it.size == 1) { "expected one ${T::class.simpleName}, got $events" } }
+        .single()
+
+    // ── Local search ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the four sections render`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.search_results_section)).assertExists()
+        composeRule.onNodeWithText(string(R.string.search_sources_section)).assertExists()
+        composeRule.onNodeWithText(string(R.string.ai_answers)).assertExists()
+        composeRule.onNodeWithText(string(R.string.ai_privacy)).assertExists()
+    }
+
+    @Test
+    fun `the results stepper reports the total across the sources that are on`() {
+        // The number people actually notice is the total: a search for الله returning exactly
+        // 180 results — three sources at a hidden 60 — read as a defect, and the subtitle exists
+        // so the cap is legible before it surprises anyone.
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(
+                    resultsPerSource = 20,
+                    sources = setOf(LibrarySource.QURAN, LibrarySource.HADITH),
+                )
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.search_results_per_source_subtitle, 40))
+            .assertExists()
+    }
+
+    @Test
+    fun `the results stepper moves in tens, within its own bounds`() {
+        setContent(SearchSettingsUiState(search = SearchPreferences(resultsPerSource = 20)))
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_increase)).onFirst()
+            .performClick()
+
+        assertThat(only<SearchSettingsEvent.SetResultsPerSource>().count).isEqualTo(30)
+    }
+
+    @Test
+    fun `the results stepper will not go below its floor`() {
+        // A floor of zero is a search that returns nothing, reached by holding a button.
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(
+                    resultsPerSource = SearchPreferences.MIN_RESULTS_PER_SOURCE
+                )
+            )
+        )
+
+        composeRule.onAllNodesWithContentDescription(string(R.string.cd_decrease)).onFirst()
+            .performClick()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `the strictness row reports the level and its explanation`() {
+        setContent(
+            SearchSettingsUiState(search = SearchPreferences(strictness = MatchStrictness.EXACT))
+        )
+
+        composeRule.onAllNodesWithText(string(R.string.search_strictness_exact)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `picking a strictness dispatches that level`() {
+        setContent(
+            SearchSettingsUiState(search = SearchPreferences(strictness = MatchStrictness.BALANCED))
+        )
+
+        composeRule.settingsRow(string(R.string.search_strictness)).performClick()
+        composeRule.onNodeWithText(string(R.string.search_strictness_broad_desc)).performClick()
+
+        assertThat(only<SearchSettingsEvent.SetStrictness>().strictness)
+            .isEqualTo(MatchStrictness.BROAD)
+    }
+
+    @Test
+    fun `the default scope row says Everything when there is no scope`() {
+        setContent(SearchSettingsUiState(search = SearchPreferences(defaultScope = null)))
+
+        composeRule.onAllNodesWithText(string(R.string.search_scope_everything)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `the scope picker offers only the sources that are actually searched`() {
+        // Opening the search screen filtered to a switched-off source shows an empty list that
+        // reads as "nothing matched" rather than "you turned this off".
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(sources = setOf(LibrarySource.QURAN))
+            )
+        )
+
+        // Counted rather than asserted absent: the hadith row below still renders its own
+        // description, so the question is whether the *picker* added a second one.
+        val hadithBefore = composeRule
+            .onAllNodesWithText(string(R.string.search_source_hadith_desc))
+            .fetchSemanticsNodes().size
+
+        composeRule.settingsRow(string(R.string.search_default_scope)).performClick()
+
+        composeRule.onNodeWithText(string(R.string.search_scope_everything_desc)).assertExists()
+        assertThat(
+            composeRule.onAllNodesWithText(string(R.string.search_source_hadith_desc))
+                .fetchSemanticsNodes().size
+        ).isEqualTo(hadithBefore)
+    }
+
+    @Test
+    fun `picking Everything clears the scope rather than choosing a source`() {
+        // "Everything" is the *absence* of a scope, so it cannot come from `LibrarySource
+        // .entries` — the picker models it as a nullable value, and a picker that mapped it to
+        // a source would silently filter every search.
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(defaultScope = LibrarySource.QURAN)
+            )
+        )
+
+        composeRule.settingsRow(string(R.string.search_default_scope)).performClick()
+        composeRule.onNodeWithText(string(R.string.search_scope_everything_desc)).performClick()
+
+        assertThat(only<SearchSettingsEvent.SetDefaultScope>().source).isNull()
+    }
+
+    // ── Sources ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every library source is offered`() {
+        setContent()
+
+        LibrarySource.entries.forEach { source ->
+            val label = when (source) {
+                LibrarySource.QURAN -> R.string.quran
+                LibrarySource.HADITH -> R.string.hadith
+                LibrarySource.DUAS -> R.string.duas
+                LibrarySource.NAMES -> R.string.names_title
+            }
+            composeRule.onAllNodesWithText(string(label)).onFirst().assertExists()
+        }
+    }
+
+    @Test
+    fun `switching a source off dispatches that source`() {
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(sources = LibrarySource.entries.toSet())
+            )
+        )
+
+        composeRule.settingsRow(string(R.string.search_source_hadith_desc)).performClick()
+
+        assertThat(only<SearchSettingsEvent.ToggleSource>().source)
+            .isEqualTo(LibrarySource.HADITH)
+    }
+
+    @Test
+    fun `the last source left on cannot be switched off, and says why`() {
+        // An empty set is a search that returns nothing for every query, and the sanitiser reads
+        // it straight back as "everything" — so obeying the tap produces a switch that flips
+        // itself back on, which reads as the app ignoring the user.
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(sources = setOf(LibrarySource.QURAN))
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.search_source_last_one)).assertExists()
+        assertThat(composeRule.tappableAncestorCount(string(R.string.search_source_last_one)))
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `a source that is not the last one keeps its ordinary description`() {
+        setContent(
+            SearchSettingsUiState(
+                search = SearchPreferences(
+                    sources = setOf(LibrarySource.QURAN, LibrarySource.HADITH)
+                )
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.search_source_last_one)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.search_source_quran_desc)).assertExists()
+    }
+
+    // ── The AI opt-in ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `enabling AI asks rather than writing the preference straight away`() {
+        // A plain toggle here would opt someone into sending their question to a Worker without
+        // ever showing them the disclosure. The screen must ask, and the ask is a separate event.
+        setContent(SearchSettingsUiState(aiEnabled = false))
+
+        composeRule.settingsRow(string(R.string.ai_answers_enable)).performClick()
+
+        assertThat(events).containsExactly(SearchSettingsEvent.ToggleAiRequested)
+    }
+
+    @Test
+    fun `the consent sheet states what leaves the device before offering to enable`() {
+        setContent(SearchSettingsUiState(showConsentSheet = true))
+
+        composeRule.onAllNodesWithText(string(R.string.ai_consent_title)).onFirst().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.ai_disclosure_full)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `accepting the consent is an explicit act`() {
+        setContent(SearchSettingsUiState(showConsentSheet = true))
+
+        composeRule.onNodeWithText(string(R.string.ai_consent_enable)).performClick()
+
+        assertThat(events).containsExactly(SearchSettingsEvent.ConsentAccepted)
+    }
+
+    @Test
+    fun `cancelling the consent sheet does not enable anything`() {
+        setContent(SearchSettingsUiState(showConsentSheet = true))
+
+        composeRule.onAllNodesWithText(string(R.string.cancel)).onFirst().performClick()
+
+        assertThat(events).containsExactly(SearchSettingsEvent.ConsentDismissed)
+    }
+
+    @Test
+    fun `a consent write that failed says so instead of closing over a switch that stayed off`() {
+        // The shipped bug this field exists for: the sheet closed, the switch went back to off,
+        // and nothing said why.
+        setContent(SearchSettingsUiState(showConsentSheet = true, consentFailed = true))
+
+        composeRule.onAllNodesWithText(string(R.string.ai_consent_save_failed)).onFirst()
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.ai_consent_enable)).assertExists()
+    }
+
+    @Test
+    fun `no failure message is shown on a first, clean consent`() {
+        setContent(SearchSettingsUiState(showConsentSheet = true, consentFailed = false))
+
+        composeRule.onNodeWithText(string(R.string.ai_consent_save_failed)).assertDoesNotExist()
+    }
+
+    // ── Privacy and history ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the history toggle passes what the switch reports`() {
+        setContent(SearchSettingsUiState(historyEnabled = false))
+
+        composeRule.settingsRow(string(R.string.ai_history)).performClick()
+
+        assertThat(only<SearchSettingsEvent.SetHistoryEnabled>().enabled).isTrue()
+    }
+
+    @Test
+    fun `clear history is off-limits while there is nothing to clear`() {
+        // Asserted by what the tap does rather than by the row's semantics: a confirmation
+        // listing nothing is a dialog with no purpose, and the row is disabled to avoid it.
+        setContent(SearchSettingsUiState(savedQuestions = emptyList()))
+
+        composeRule.settingsRow(string(R.string.ai_clear_history)).performClick()
+
+        composeRule.onNodeWithText(string(R.string.ai_clear_history_dialog_title))
+            .assertDoesNotExist()
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `clearing history lists what is about to go, and asks first`() {
+        // A destructive action whose scope is invisible is one people avoid; naming the
+        // questions is what makes the confirmation meaningful.
+        setContent(SearchSettingsUiState(savedQuestions = listOf("What is zakat?")))
+
+        composeRule.settingsRow(string(R.string.ai_clear_history)).performClick()
+
+        composeRule.onNodeWithText(string(R.string.ai_clear_history_dialog_title)).assertExists()
+        composeRule.onNodeWithText("•  What is zakat?").assertExists()
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `confirming the clear dispatches it`() {
+        setContent(SearchSettingsUiState(savedQuestions = listOf("What is zakat?")))
+
+        composeRule.settingsRow(string(R.string.ai_clear_history)).performClick()
+        composeRule.onNodeWithText(string(R.string.delete)).performClick()
+
+        assertThat(events).containsExactly(SearchSettingsEvent.ClearHistory)
+    }
+
+    @Test
+    fun `cancelling the clear dispatches nothing`() {
+        setContent(SearchSettingsUiState(savedQuestions = listOf("What is zakat?")))
+
+        composeRule.settingsRow(string(R.string.ai_clear_history)).performClick()
+        composeRule.onAllNodesWithText(string(R.string.cancel)).onFirst().performClick()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `the disclosure is readable from the screen without enabling anything`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.ai_what_gets_shared)).performClick()
+
+        composeRule.onAllNodesWithText(string(R.string.ai_disclosure_full)).onFirst()
+            .assertExists()
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `the title is Search and AI, and the back button navigates back`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.search_settings)).onFirst()
+            .assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SettingsGraphTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SettingsGraphTest.kt
@@ -1,0 +1,133 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.createGraph
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.navigation.Route
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Settings feature's slice of the route graph — twenty destinations, the largest of the ten.
+ *
+ * A destination that fails to register throws `IllegalArgumentException: navigation destination …
+ * is not a direct child of this NavGraph` at the moment a **user taps the row that opens it**, not
+ * at build time and not in any of the four gates `CLAUDE.md` lists. That matters more here than
+ * anywhere: five of these are two taps deep inside the notification tree, and nothing in an
+ * ordinary pass through the app opens them.
+ *
+ * Twenty is asserted as a number as well as a set, because #625 found five graphs whose documented
+ * counts had drifted — `settingsGraph` was the worst of them, recorded as 16 while it held 20 —
+ * and `check_docs.py`'s NAV-03 cannot catch it: it compares the 94 total against `Routes.kt`,
+ * never the per-graph split.
+ *
+ * Nothing is composed here, so none of these screens' Hilt ViewModels is constructed. This asserts
+ * registration; the screen tests beside it assert what each destination renders.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SettingsGraphTest {
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        navController = NavHostController(ApplicationProvider.getApplicationContext<Context>())
+        navController.navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+    private fun destinations(): List<NavDestination> =
+        navController.createGraph(startDestination = Route.Settings) {
+            settingsGraph(navController)
+        }.toList()
+
+    @Test
+    fun `all twenty settings destinations are registered`() {
+        val routes = destinations().mapNotNull { it.route }
+
+        assertThat(routes).hasSize(20)
+        listOf(
+            Route.Settings::class,
+            Route.SettingsPrayerCalculation::class,
+            Route.SettingsNotifications::class,
+            Route.SettingsWorshipReminders::class,
+            Route.SettingsNotificationsPrayers::class,
+            Route.SettingsNotificationsWeekly::class,
+            Route.SettingsNotificationsSound::class,
+            Route.SettingsNotificationsDiagnostics::class,
+            Route.SettingsAppearance::class,
+            Route.SettingsLanguage::class,
+            Route.SettingsLocation::class,
+            Route.SettingsQuran::class,
+            Route.SettingsWidgets::class,
+            Route.SettingsSync::class,
+            Route.SettingsZakat::class,
+            Route.SearchSettings::class,
+            Route.DuaSettings::class,
+            Route.HadithSettings::class,
+            Route.SelectReciter::class,
+            Route.SelectTranslation::class,
+        ).forEach { route ->
+            assertThat(routes.any { it.contains(route.qualifiedName!!) }).isTrue()
+        }
+    }
+
+    @Test
+    fun `every settings destination is registered exactly once`() {
+        // Five of these are near-identical two-line blocks in the notification tree, so a
+        // copy-paste that registered `SettingsNotificationsSound` twice under two names would
+        // still read correctly — and would leave the other route unreachable at the tap.
+        assertThat(destinations().mapNotNull { it.route }).containsNoDuplicates()
+    }
+
+    @Test
+    fun `the five notification destinations each resolve in their own right`() {
+        // Two taps deep from the settings hub, and each one decides whether a class of alert
+        // reaches the user at all.
+        assertStartDestination(Route.SettingsNotifications)
+        assertStartDestination(Route.SettingsNotificationsPrayers)
+        assertStartDestination(Route.SettingsNotificationsWeekly)
+        assertStartDestination(Route.SettingsNotificationsSound)
+        assertStartDestination(Route.SettingsNotificationsDiagnostics)
+    }
+
+    @Test
+    fun `the four screens that arrived from other features resolve here`() {
+        // `DuaSettings`, `HadithSettings`, `SelectReciter` and `SelectTranslation` live under
+        // `screens/{dua,hadith,quran}` and are registered by *this* graph, because the module
+        // boundary follows the ViewModel axis. A future reader moving them back to the graph
+        // matching their directory would unregister them from here and break the tap.
+        assertStartDestination(Route.DuaSettings)
+        assertStartDestination(Route.HadithSettings)
+        assertStartDestination(Route.SelectReciter)
+        assertStartDestination(Route.SelectTranslation)
+    }
+
+    @Test
+    fun `the remaining settings destinations resolve in their own right`() {
+        assertStartDestination(Route.Settings)
+        assertStartDestination(Route.SettingsPrayerCalculation)
+        assertStartDestination(Route.SettingsWorshipReminders)
+        assertStartDestination(Route.SettingsAppearance)
+        assertStartDestination(Route.SettingsLanguage)
+        assertStartDestination(Route.SettingsLocation)
+        assertStartDestination(Route.SettingsQuran)
+        assertStartDestination(Route.SettingsWidgets)
+        assertStartDestination(Route.SettingsSync)
+        assertStartDestination(Route.SettingsZakat)
+        assertStartDestination(Route.SearchSettings)
+    }
+
+    private fun assertStartDestination(route: Route) {
+        val graph = navController.createGraph(startDestination = route) {
+            settingsGraph(navController)
+        }
+
+        assertThat(graph.findNode(graph.startDestinationId)).isNotNull()
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SettingsScreenTest.kt
@@ -1,0 +1,230 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The settings hub: eleven rows into eleven destinations, and the two destructive actions.
+ *
+ * Eleven near-identical `NimazMenuItem`s each taking a different callback is the purest form of
+ * the crossing this module is full of — every row looks right, every row opens *a* settings
+ * screen, and one of them opens the wrong one. Nothing about that is visible in review, and a user
+ * meets it once.
+ *
+ * The destructive pair is the other half, and the asymmetry matters: "Reset settings" clears
+ * preferences and "Delete all data" clears the user database as well. Crossing those two
+ * confirmations makes a reset destroy every tracked prayer, with a dialog that said it would only
+ * reset settings. Both must confirm first, both must dispatch their *own* event, and cancelling
+ * must dispatch nothing.
+ *
+ * The restart is driven by a `shouldRestart` flag rather than by the tap, because the writes
+ * happen asynchronously — a restart fired from the button would race the write it exists to apply.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class SettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+
+    private val opened = mutableListOf<String>()
+    private var backs = 0
+    private var restarts = 0
+
+    private fun setContent() {
+        composeRule.setThemedContent {
+            SettingsScreen(
+                onNavigateBack = { backs++ },
+                onNavigateToPrayerSettings = { opened += "prayer" },
+                onNavigateToNotifications = { opened += "notifications" },
+                onNavigateToQuranSettings = { opened += "quran" },
+                onNavigateToAppearance = { opened += "appearance" },
+                onNavigateToLocation = { opened += "location" },
+                onNavigateToLanguage = { opened += "language" },
+                onNavigateToWidgets = { opened += "widgets" },
+                onNavigateToSync = { opened += "sync" },
+                onNavigateToSearchSettings = { opened += "search" },
+                onNavigateToZakatSettings = { opened += "zakat" },
+                onRestartApp = { restarts++ },
+                viewModel = viewModel.mock,
+            )
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `every section is present`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.prayer_settings)).onLast().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.quran)).onLast().assertExists()
+        composeRule.onAllNodesWithText(string(R.string.zakat)).onLast().assertExists()
+        composeRule.onNodeWithText(string(R.string.app_settings)).assertExists()
+        composeRule.onNodeWithText(string(R.string.data)).assertExists()
+    }
+
+    @Test
+    fun `each row opens its own destination`() {
+        // Eleven callbacks wired in one block. The assertion is the *order*, so a row pointing
+        // at its neighbour's destination shows up as the wrong name in the wrong place rather
+        // than as "something was opened".
+        setContent()
+
+        composeRule.settingsRow(string(R.string.calculation_method)).performClick()
+        composeRule.settingsRow(string(R.string.location)).performClick()
+        composeRule.settingsRow(string(R.string.notifications)).performClick()
+        composeRule.settingsRow(string(R.string.quran_settings)).performClick()
+        composeRule.settingsRow(string(R.string.zakat_settings)).performClick()
+        composeRule.settingsRow(string(R.string.appearance)).performClick()
+        composeRule.settingsRow(string(R.string.language)).performClick()
+        composeRule.settingsRow(string(R.string.widgets)).performClick()
+        composeRule.settingsRow(string(R.string.sync_data)).performClick()
+
+        assertThat(opened).containsExactly(
+            "prayer",
+            "location",
+            "notifications",
+            "quran",
+            "zakat",
+            "appearance",
+            "language",
+            "widgets",
+            "sync",
+        ).inOrder()
+    }
+
+    @Test
+    fun `the search and AI row opens the search settings`() {
+        // Its title and its section header are the same string, which is why it is addressed as
+        // a tappable row rather than by text alone.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.search_settings)).performClick()
+
+        assertThat(opened).containsExactly("search")
+    }
+
+    @Test
+    fun `resetting settings asks first and dispatches nothing until confirmed`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.reset_settings)).performClick()
+
+        composeRule.onAllNodesWithText(string(R.string.reset_settings_dialog_title)).onLast()
+            .assertExists()
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `confirming the reset dispatches reset, not delete`() {
+        // The two confirmations sit three rows apart and read almost identically. Crossing them
+        // makes "reset settings" destroy every tracked prayer.
+        setContent()
+
+        composeRule.settingsRow(string(R.string.reset_settings)).performClick()
+        composeRule.onNodeWithText(string(R.string.reset)).performClick()
+
+        assertThat(viewModel.events).containsExactly(SettingsEvent.ResetToDefaults)
+    }
+
+    @Test
+    fun `cancelling the reset dispatches nothing`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.reset_settings)).performClick()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `deleting all data asks first`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.delete_all_data)).performClick()
+
+        composeRule.onAllNodesWithText(string(R.string.delete_all_data_dialog_title)).onLast()
+            .assertExists()
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `confirming the delete dispatches delete, not reset`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.delete_all_data)).performClick()
+        composeRule.onNodeWithText(string(R.string.delete)).performClick()
+
+        assertThat(viewModel.events).containsExactly(SettingsEvent.DeleteAllData)
+    }
+
+    @Test
+    fun `cancelling the delete dispatches nothing`() {
+        setContent()
+
+        composeRule.settingsRow(string(R.string.delete_all_data)).performClick()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(viewModel.events).isEmpty()
+    }
+
+    @Test
+    fun `the app restarts when the ViewModel says the change needs it, not when it is tapped`() {
+        // The write happens asynchronously; restarting from the tap would race it, and a
+        // language change would come back on the old locale roughly half the time.
+        setContent()
+        assertThat(restarts).isEqualTo(0)
+
+        viewModel.shouldRestart.value = true
+        composeRule.waitForIdle()
+
+        assertThat(restarts).isEqualTo(1)
+    }
+
+    @Test
+    fun `the version is shown, and a package that cannot be read does not crash the screen`() {
+        setContent()
+
+        composeRule.onNodeWithText(
+            string(
+                R.string.version_format,
+                context.packageManager.getPackageInfo(context.packageName, 0).versionName
+                    ?: string(R.string.version_unknown),
+            )
+        ).assertExists()
+    }
+
+    @Test
+    fun `the title is Settings and the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.settings)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SyncScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SyncScreenTest.kt
@@ -1,0 +1,434 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.data.sync.CancelReason
+import com.arshadshah.nimaz.data.sync.ConnectionState
+import com.arshadshah.nimaz.data.sync.SyncCategory
+import com.arshadshah.nimaz.presentation.viewmodel.UiError
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ActivityLogEntry
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncDataSummary
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncEvent
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncMode
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Device-to-device sync, which is one screen wearing seven faces.
+ *
+ * The `when` that picks between them is ordered, not exhaustive over a sealed type, so the
+ * ordering *is* the logic: `Cancelled` is checked before `Connecting`, `error != null` before
+ * `Completed`, and everything unmatched falls through to progress. Two consequences are worth
+ * pinning because neither is visible from reading one branch:
+ *
+ * - **A cancelled sync must not show the pairing screen**, even though the state carrying the
+ *   cancellation may still hold an endpoint. Reordering those two arms offers "Accept" for a
+ *   connection the partner has already dropped.
+ * - **An error outranks completion.** A transfer that failed part-way can leave `Completed`
+ *   behind it, and reporting "Sync Complete!" over a failed import is the single worst thing
+ *   this screen can say — the user walks away believing their data moved.
+ *
+ * The verification code is the security-relevant one: it exists so both people can confirm they
+ * are pairing with each other, so it must be rendered exactly and both answers must reach the
+ * *endpoint the state names* rather than a remembered one.
+ *
+ * Leaving the screen cancels first, on every route out — back arrow, Close, and Done. A route that
+ * navigated without cancelling leaves the connection advertising after the screen is gone.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class SyncScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MutableStateFlow(SyncUiState())
+    private val events = mutableListOf<SyncEvent>()
+    private val viewModel: SyncViewModel = mockk(relaxed = true) {
+        every { uiState } returns this@SyncScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<SyncEvent>() }
+    }
+    private var backs = 0
+
+    private fun setContent(uiState: SyncUiState = SyncUiState()) {
+        state.value = uiState
+        composeRule.setThemedContent {
+            SyncScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    // ── Mode selection ───────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the screen opens on the choice between sending and receiving`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.sync_device_to_device)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.sync_send_data)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_receive_data)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_intro)).assertExists()
+    }
+
+    @Test
+    fun `Send starts sending and Receive starts receiving`() {
+        // Two buttons, two events, one block. Crossing them makes the device that meant to
+        // receive start advertising its own data instead — and the screen looks identical until
+        // the transfer runs the wrong way.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.sync_send_data)).performClick()
+        assertThat(events).containsExactly(SyncEvent.StartSend)
+
+        events.clear()
+        composeRule.onNodeWithText(string(R.string.sync_receive_data)).performClick()
+        assertThat(events).containsExactly(SyncEvent.StartReceive)
+    }
+
+    @Test
+    fun `no role badge is shown before a mode is chosen`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.sync_sending)).assertDoesNotExist()
+        composeRule.onNodeWithText(string(R.string.sync_receiving)).assertDoesNotExist()
+    }
+
+    // ── The pairing code ─────────────────────────────────────────────────────────────────────
+
+    private fun connecting(mode: SyncMode = SyncMode.SEND) = SyncUiState(
+        mode = mode,
+        connectionState = ConnectionState.Connecting(
+            endpointId = "endpoint-7",
+            endpointName = "Pixel 8",
+            authToken = "4821",
+        ),
+    )
+
+    @Test
+    fun `the verification code is shown exactly, with the partner's name`() {
+        // The code exists so two people can confirm they are pairing with each other. A
+        // truncated, reformatted or partially-rendered code cannot be compared, which defeats
+        // the only check standing between the transfer and the wrong device.
+        setContent(connecting())
+
+        composeRule.onNodeWithText("4821").assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_connecting_to_format, "Pixel 8"))
+            .assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_verification_code)).assertExists()
+    }
+
+    @Test
+    fun `accepting answers the endpoint the state names`() {
+        // The id comes from the state rather than from anything the screen remembers, because
+        // the state can change under a screen that is waiting for a tap.
+        setContent(connecting())
+
+        composeRule.onNodeWithText(string(R.string.sync_accept)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.AcceptConnection("endpoint-7"))
+    }
+
+    @Test
+    fun `rejecting answers the same endpoint, and is not an accept`() {
+        setContent(connecting())
+
+        composeRule.onNodeWithText(string(R.string.sync_reject)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.RejectConnection("endpoint-7"))
+    }
+
+    @Test
+    fun `the pairing screen says which way the data will move`() {
+        // "Accept" is asked of both devices, and the two answers mean opposite things. Without
+        // the role line there is nothing on the screen that says which one you are.
+        setContent(connecting(SyncMode.SEND))
+
+        composeRule.onNodeWithText(string(R.string.sync_role_sending)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_sending)).assertExists()
+    }
+
+    @Test
+    fun `the receiving device says it is receiving`() {
+        setContent(connecting(SyncMode.RECEIVE))
+
+        composeRule.onNodeWithText(string(R.string.sync_role_receiving)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_receiving)).assertExists()
+    }
+
+    // ── Waiting, progress, completion ────────────────────────────────────────────────────────
+
+    @Test
+    fun `waiting for the partner offers a way out`() {
+        // The other device may never answer. Without the cancel button the only exit is the
+        // back arrow, which is not obviously an exit while a spinner is running.
+        composeRule.mainClock.autoAdvance = false
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.WaitingForPartnerAccept("e", "Pixel 8"),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_waiting_partner)).assertExists()
+        composeRule.onNodeWithText(string(R.string.cancel)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.Cancel)
+    }
+
+    @Test
+    fun `progress reports which step of how many, not just a spinner`() {
+        // A transfer with no visible step count is indistinguishable from a stalled one, and
+        // this screen asks people to keep two devices awake and near each other while it runs.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Transferring(0.5f),
+                currentStep = "Exporting prayer records",
+                stepsCompleted = 3,
+                totalSteps = 12,
+            )
+        )
+
+        composeRule.onNodeWithText("Exporting prayer records").assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_step_format, 3, 12)).assertExists()
+        composeRule.onNodeWithText("25%").assertExists()
+    }
+
+    @Test
+    fun `progress with no steps yet does not divide by zero`() {
+        // `totalSteps` is 0 for the whole window between choosing a mode and the first step
+        // arriving — every sync passes through it.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Discovering,
+                stepsCompleted = 0,
+                totalSteps = 0,
+            )
+        )
+
+        composeRule.onNodeWithText("0%").assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_preparing)).assertExists()
+    }
+
+    @Test
+    fun `a completed send says data was sent, not imported`() {
+        // The same screen serves both devices and the two sentences are opposites. Getting it
+        // backwards tells the sender their data was replaced.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Completed(bytesReceived = 4096),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_complete)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_sent_success)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_imported_success)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a completed receive says data was imported`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 4096),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_imported_success)).assertExists()
+    }
+
+    @Test
+    fun `the completion summary names what actually moved`() {
+        // "Sync complete" without a manifest is unverifiable. The categories come from
+        // `SyncPayload.categories()`, so the label map is what turns a key into something a
+        // person can check against what they expected to move.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 4096),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(
+                        SyncCategory(key = "prayerRecords", count = 120),
+                        SyncCategory(key = "bookmarks", count = 8),
+                    ),
+                    totalBytes = 4096,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_item_prayer_records)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_item_bookmarks)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_data_imported_title)).assertExists()
+    }
+
+    @Test
+    fun `Done cancels the connection before leaving`() {
+        // Leaving without cancelling leaves the device advertising after the screen is gone.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Completed(bytesReceived = 1),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.done)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.Cancel)
+        assertThat(backs).isEqualTo(1)
+    }
+
+    // ── Cancellation and failure ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a cancellation says who cancelled it`() {
+        // "Sync cancelled" alone leaves the reader wondering whether they did something wrong.
+        // Which of the three happened decides whether retrying is worth anything.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Cancelled(CancelReason.BY_PARTNER),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_cancelled_by_partner)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_cancelled_by_you)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a cancellation by the user says so`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Cancelled(CancelReason.BY_USER),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_cancelled_by_you)).assertExists()
+    }
+
+    @Test
+    fun `a lost connection is reported as lost, not as a cancellation`() {
+        // Only this one is worth retrying immediately — the other two need the other person.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Cancelled(CancelReason.CONNECTION_LOST),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_connection_lost)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_connection_lost_msg)).assertExists()
+    }
+
+    @Test
+    fun `a cancelled sync keeps the transcript of what got through`() {
+        // The log is the one thing a reader can use to decide whether to retry or start over.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Cancelled(CancelReason.BY_USER),
+                activityLog = listOf(ActivityLogEntry("Started sending mode")),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_activity)).assertExists()
+        composeRule.onNodeWithText("Started sending mode").assertExists()
+    }
+
+    @Test
+    fun `an error is shown instead of a completion, even with a completed connection`() {
+        // The `when` checks `error != null` before `Completed`, and the ordering is the point:
+        // a transfer that failed part-way can leave a completed connection behind it, and
+        // "Sync Complete!" over a failed import is the worst thing this screen can say.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 0),
+                error = UiError(message = R.string.sync_failed),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_failed)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_complete)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a cancellation is shown instead of the pairing screen`() {
+        // `Cancelled` is checked before `Connecting`. Reordering them offers "Accept" for a
+        // connection the partner has already dropped.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Cancelled(CancelReason.BY_PARTNER),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_accept)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `an error keeps the transcript and offers both a retry and a way out`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                error = UiError(message = R.string.sync_failed),
+                activityLog = listOf(ActivityLogEntry("Received 2 KB of data")),
+            )
+        )
+
+        composeRule.onNodeWithText("Received 2 KB of data").assertExists()
+        composeRule.onNodeWithText(string(R.string.try_again)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.Cancel)
+    }
+
+    @Test
+    fun `Close on a failure cancels before leaving`() {
+        setContent(
+            SyncUiState(mode = SyncMode.RECEIVE, error = UiError(message = R.string.sync_failed))
+        )
+
+        composeRule.onNodeWithText(string(R.string.close)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.Cancel)
+        assertThat(backs).isEqualTo(1)
+    }
+
+    @Test
+    fun `the back arrow cancels the connection before leaving`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Transferring(0.3f),
+            )
+        )
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(events).containsExactly(SyncEvent.Cancel)
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SyncScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/SyncScreenTest.kt
@@ -10,7 +10,11 @@ import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.ui.R
 import com.arshadshah.nimaz.data.sync.CancelReason
 import com.arshadshah.nimaz.data.sync.ConnectionState
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.onRoot
 import com.arshadshah.nimaz.data.sync.SyncCategory
+import com.arshadshah.nimaz.data.sync.SyncPayload
+import com.arshadshah.nimaz.data.sync.categories
 import com.arshadshah.nimaz.presentation.viewmodel.UiError
 import com.arshadshah.nimaz.presentation.viewmodel.settings.ActivityLogEntry
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SyncDataSummary
@@ -431,4 +435,247 @@ class SyncScreenTest {
         assertThat(events).containsExactly(SyncEvent.Cancel)
         assertThat(backs).isEqualTo(1)
     }
+
+    // ── The transfer manifest ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every category a payload can carry has a label of its own`() {
+        // The card is driven entirely by `SyncPayload.categories()`, and the key→label map is a
+        // `when` with an `else` that renders "No data". A category added to the payload without
+        // a label here therefore shows up as a row reading *No data* beside a real count —
+        // which reads as a bug in the transfer rather than a missing string. `SyncPayloadCoverage
+        // Test` guards the data side; this is the presentation half of the same contract.
+        val everyCategory = SyncPayload().categories().map { it.key }
+        assertThat(everyCategory).isNotEmpty()
+
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 8192),
+                dataSummary = SyncDataSummary(
+                    categories = everyCategory.map { SyncCategory(key = it, count = 3) },
+                    totalBytes = 8192,
+                ),
+            )
+        )
+
+        val rendered = composeRule.onRoot().fetchSemanticsNode().renderedTexts()
+        assertThat(rendered).doesNotContain(string(R.string.sync_no_data))
+        assertThat(rendered).containsAtLeast(
+            string(R.string.sync_item_bookmarks),
+            string(R.string.sync_item_reading_progress),
+            string(R.string.sync_item_qaida_cells),
+            string(R.string.sync_item_locations),
+            string(R.string.sync_item_preferences),
+        )
+    }
+
+    @Test
+    fun `a key the map does not know renders the fallback rather than the raw key`() {
+        // The `else` arm. A raw camelCase key in the manifest is worse than "No data": it looks
+        // like an internal identifier leaking into the UI.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 1),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "somethingNew", count = 3)),
+                    totalBytes = 1,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_no_data)).assertExists()
+        composeRule.onNodeWithText("somethingNew").assertDoesNotExist()
+    }
+
+    @Test
+    fun `only categories that actually carry something are listed`() {
+        // Every payload reports all twenty-four categories, most of them empty. Listing the
+        // empty ones would bury the two rows that matter under twenty-two zeroes.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Completed(bytesReceived = 4096),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(
+                        SyncCategory(key = "bookmarks", count = 12),
+                        SyncCategory(key = "zakatHistory", count = 0),
+                    ),
+                    totalBytes = 4096,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_item_bookmarks)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_item_zakat)).assertDoesNotExist()
+        composeRule.onNodeWithText("12").assertExists()
+    }
+
+    @Test
+    fun `a manifest with nothing in it says so`() {
+        // A sync that moved nothing is a real outcome — a fresh install syncing to a fresh
+        // install — and an empty card reads as a rendering failure.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Completed(bytesReceived = 0),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "bookmarks", count = 0)),
+                    totalBytes = 0,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_no_data)).assertExists()
+    }
+
+    @Test
+    fun `a flag category shows no count, because it has none to show`() {
+        // Reading progress and preferences are present-or-absent, not countable. Rendering "1"
+        // beside them invites the reader to wonder what the other zero was.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Completed(bytesReceived = 100),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(
+                        SyncCategory(key = "readingProgress", count = 1, isFlag = true)
+                    ),
+                    totalBytes = 100,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_item_reading_progress)).assertExists()
+        composeRule.onNodeWithText("1").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the total size is shown only once there is one`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Completed(bytesReceived = 0),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "bookmarks", count = 4)),
+                    totalBytes = 0,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_total_size)).assertDoesNotExist()
+    }
+
+    // ── Progress detail ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the sender sees the partner's import step count while it runs`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.PartnerImporting(
+                    step = 5,
+                    total = 12,
+                    label = "Importing khatam data...",
+                ),
+                stepsCompleted = 11,
+                totalSteps = 13,
+            )
+        )
+
+        composeRule.onNodeWithText("Importing khatam data...", substring = true).assertExists()
+    }
+
+    @Test
+    fun `a partner import with no total yet does not divide by zero`() {
+        // `ImportStarted` carries (0, 0) — the state every import passes through before the
+        // first progress signal arrives.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.PartnerImporting(0, 0, "Starting..."),
+                stepsCompleted = 11,
+                totalSteps = 13,
+            )
+        )
+
+        composeRule.onNodeWithText("Starting...", substring = true).assertExists()
+    }
+
+    @Test
+    fun `a transfer in flight reports its percentage and the size being moved`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Transferring(0.4f),
+                stepsCompleted = 6,
+                totalSteps = 13,
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "bookmarks", count = 4)),
+                    totalBytes = 4096,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_transfer_progress)).assertExists()
+        composeRule.onNodeWithText(
+            string(R.string.sync_transferred_format, 40) + " (4 KB)"
+        ).assertExists()
+    }
+
+    @Test
+    fun `a transfer whose size is not known yet reports the percentage alone`() {
+        // The sender learns the encoded size only after the export finishes, so the first
+        // frames of the transfer have a percentage and no bytes.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Transferring(0.1f),
+                dataSummary = null,
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_transferred_format, 10)).assertExists()
+    }
+
+    @Test
+    fun `the in-flight manifest says which way the data is moving`() {
+        // The same card serves both devices, and "being sent" against "being received" is the
+        // only thing on it that says which one you are looking at.
+        setContent(
+            SyncUiState(
+                mode = SyncMode.SEND,
+                connectionState = ConnectionState.Transferring(0.5f),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "bookmarks", count = 4)),
+                    totalBytes = 4096,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_data_being_sent)).assertExists()
+        composeRule.onNodeWithText(string(R.string.sync_data_being_received)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the receiving device's in-flight manifest says received`() {
+        setContent(
+            SyncUiState(
+                mode = SyncMode.RECEIVE,
+                connectionState = ConnectionState.Transferring(0.5f),
+                dataSummary = SyncDataSummary(
+                    categories = listOf(SyncCategory(key = "bookmarks", count = 4)),
+                    totalBytes = 4096,
+                ),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.sync_data_being_received)).assertExists()
+    }
+
+    /** Every string the tree renders, flattened. */
+    private fun androidx.compose.ui.semantics.SemanticsNode.renderedTexts(): List<String> =
+        config.getOrNull(androidx.compose.ui.semantics.SemanticsProperties.Text).orEmpty()
+            .map { it.text } + children.flatMap { it.renderedTexts() }
 }

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/WidgetsScreenTest.kt
@@ -1,0 +1,240 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.FallbackLocation
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.prayer.PrayerTimeCalculator
+import com.arshadshah.nimaz.presentation.components.atoms.ProvideNimazClock
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import kotlinx.datetime.Instant
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The widget gallery: six live previews rendered from the user's own stored location.
+ *
+ * "Live" is what makes this worth testing rather than looking at. Every preview is built by
+ * `buildWidgetPreviewData`, which runs the **real** `PrayerTimeCalculator` against the stored
+ * coordinates once a second, so a gallery that showed placeholder dashes would be indistinguishable
+ * from one that worked — until someone added a widget and found it disagreed with the preview that
+ * sold it to them.
+ *
+ * Three specific claims:
+ *
+ * - **The preferences come from the ViewModel's seam.** This screen used to construct its own
+ *   `PreferencesDataStore(context)` — a second instance of a `@Singleton`, built outside Hilt,
+ *   reading the file the injected one owns. Passing a null preference must therefore still render
+ *   the gallery rather than crash it, because null is what the `WhileSubscribed` flow starts at.
+ * - **A location that was never set falls back to Dublin** rather than computing prayer times for
+ *   (0, 0), which is in the Atlantic and produces times nobody's day resembles.
+ * - **The countdown is derived from the shared ticker**, so it can be driven from a fixed clock —
+ *   which is the only way to assert that it says something specific rather than a dash.
+ *
+ * The clock is pinned through `ProvideNimazClock(timeSource = …)`, the seam `:core:ui` publishes
+ * for exactly this. Without it the countdown is whatever the wall clock says when the test runs,
+ * and the only assertable thing left is that the screen did not crash.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class WidgetsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    /** A fixed instant, so the countdown and the "next prayer" are the same on every run. */
+    private val fixedNow = Instant.parse("2026-08-26T09:00:00Z")
+
+    private fun preferences(
+        latitude: Double = 51.5074,
+        longitude: Double = -0.1278,
+        locationName: String = "London, United Kingdom",
+    ) = UserPreferences(
+        onboardingCompleted = true,
+        themeMode = "system",
+        dynamicColor = false,
+        appLanguage = "en",
+        calculationMethod = "MUSLIM_WORLD_LEAGUE",
+        asrCalculation = "standard",
+        latitude = latitude,
+        longitude = longitude,
+        locationName = locationName,
+        prayerNotificationsEnabled = true,
+        quranTranslatorId = "sahih_international",
+        showTranslation = true,
+    )
+
+    private fun setContent(prefs: UserPreferences? = preferences()) {
+        // The real calculator, not a mock: the previews exist to show what the widgets will
+        // show, and a stubbed one would let the gallery agree with nothing.
+        every { viewModel.mock.prayerTimeCalculator } returns PrayerTimeCalculator()
+        viewModel.widgetPreviewPreferences.value = prefs
+        composeRule.setThemedContent {
+            ProvideNimazClock(timeSource = { fixedNow }) {
+                WidgetsScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+            }
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `all six widgets are shown in the gallery`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.widget_next_prayer_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_prayer_times_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_hijri_date_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_prayer_tracker_title)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_hijri_calendar_title)).assertExists()
+        composeRule.onAllNodesWithText(string(R.string.khatam_widget_label)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `each widget's info row names its size, so the gallery is usable before adding one`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.widget_next_prayer_size)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_prayer_times)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_hijri_date)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_prayer_tracker)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widget_hijri_calendar)).assertExists()
+    }
+
+    @Test
+    fun `the previews render the stored location's own name, not a placeholder`() {
+        // The name is split on the first comma — "London, United Kingdom" is a location, "London"
+        // is what fits in a 2x2 widget.
+        setContent(preferences(locationName = "London, United Kingdom"))
+
+        composeRule.onAllNodesWithText("London").onFirst().assertExists()
+    }
+
+    @Test
+    fun `a blank stored location name falls back rather than rendering an empty widget`() {
+        setContent(preferences(locationName = ""))
+
+        composeRule.onAllNodesWithText("Dublin").onFirst().assertExists()
+    }
+
+    @Test
+    fun `an unset location computes against Dublin, not against the Atlantic`() {
+        // (0, 0) is in the Gulf of Guinea. `resolveLocation` exists so a user who has not set a
+        // location yet still sees plausible times rather than ones nobody's day resembles.
+        setContent(preferences(latitude = 0.0, longitude = 0.0, locationName = ""))
+
+        composeRule.onAllNodesWithText("Dublin").onFirst().assertExists()
+    }
+
+    @Test
+    fun `the gallery still renders before the preferences have arrived`() {
+        // `widgetPreviewPreferences` is a `WhileSubscribed` flow starting at null, so this is
+        // the state every cold open passes through. A non-null assumption crashes on entry.
+        setContent(prefs = null)
+
+        composeRule.onNodeWithText(string(R.string.widget_next_prayer_title)).assertExists()
+        composeRule.onAllNodesWithText("—").onFirst().assertExists()
+    }
+
+    @Test
+    fun `the previews show times the calculator worked out, not placeholders`() {
+        // The assertion that the gallery is *computed* rather than mocked up. The exact times
+        // depend on the date the suite runs on, so what is pinned is that five real clock times
+        // were formatted — an unwired preview renders the em dash for every one of them, and
+        // looks entirely plausible in a screenshot.
+        setContent()
+
+        val times = composeRule.onRoot().fetchSemanticsNode().renderedTexts()
+            .filter { CLOCK_TIME.matches(it) }
+
+        assertThat(times.size).isAtLeast(5)
+    }
+
+    @Test
+    fun `a gallery with no preferences renders placeholders instead of times`() {
+        // The other half: the em dash is correct *here*, before the flow has emitted, and the
+        // two states have to be distinguishable or the test above proves nothing.
+        setContent(prefs = null)
+
+        val rendered = composeRule.onRoot().fetchSemanticsNode().renderedTexts()
+
+        assertThat(rendered.none { CLOCK_TIME.matches(it) }).isTrue()
+        assertThat(rendered).contains("—")
+    }
+
+    @Test
+    fun `the previews name the five daily prayers`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.widget_prayer_short_fajr)).onFirst()
+            .assertExists()
+        composeRule.onAllNodesWithText(string(R.string.widget_prayer_short_maghrib)).onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun `the screen explains how to add a widget, since nothing on it can`() {
+        // The gallery cannot place a widget — only the launcher can — so the steps are the only
+        // actionable thing on the screen.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.widgets_how_to)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widgets_how_to_step_1)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widgets_how_to_step_4)).assertExists()
+        composeRule.onNodeWithText(string(R.string.widgets_intro)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a location that cannot be resolved still renders the gallery`() {
+        // The `try` around the preview build is deliberate — a preview is not worth taking the
+        // screen down for — and coordinates outside the valid range are the input that reaches
+        // it from a malformed stored value.
+        setContent(preferences(latitude = 999.0, longitude = 999.0, locationName = "Nowhere"))
+
+        composeRule.onNodeWithText(string(R.string.widget_next_prayer_title)).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    /** Every string the tree renders, flattened — the previews carry no test tags of their own. */
+    private fun SemanticsNode.renderedTexts(): List<String> =
+        config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } +
+            children.flatMap { it.renderedTexts() }
+
+    private companion object {
+        /** What `formatWidgetTime` produces for a prayer: "3:37", "12:03". */
+        val CLOCK_TIME = Regex("""\d{1,2}:\d{2}""")
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/WorshipRemindersScreenTest.kt
@@ -1,0 +1,276 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.WorshipReminderCategory
+import com.arshadshah.nimaz.domain.model.WorshipReminderType
+import com.arshadshah.nimaz.domain.worship.WorshipReminderCalculator
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
+import com.arshadshah.nimaz.testing.accordionRow
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.tappableAncestorCount
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The eleven optional Sunnah reminders, in three categories.
+ *
+ * **The Ramadan group is shown year-round, and that is the point.** Hiding it outside Ramadan made
+ * the app look like it had lost a feature and left no way to set the reminders up in advance;
+ * nothing depends on their absence, because the scheduler gates them on the Hijri date itself. A
+ * regression back to hiding them would be invisible for eleven months of the year, which is
+ * exactly why it is asserted here rather than left to a glance at the screen.
+ *
+ * The rest is the partition. A reminder that can be timed becomes an accordion carrying its own
+ * offset; the rest are plain switch rows. Getting that backwards either hides an offset the user
+ * needs or puts an empty accordion under a reminder with nothing to set.
+ *
+ * Witr is the one with a mode as well as an offset — after Isha or before Fajr — and it is a
+ * toggle rendered as a row, so the label has to report the *current* mode rather than the one the
+ * tap would produce.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h4000dp")
+class WorshipRemindersScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val viewModel = FakeSettingsScreenViewModel()
+    private var backs = 0
+
+    private fun setContent(state: NotificationSettingsUiState = NotificationSettingsUiState()) {
+        viewModel.notificationState.value = state
+        composeRule.setThemedContent {
+            WorshipRemindersScreen(onNavigateBack = { backs++ }, viewModel = viewModel.mock)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    @Test
+    fun `all three categories are shown`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.worship_settings_section_night)).assertExists()
+        composeRule.onNodeWithText(string(R.string.worship_settings_section_ramadan)).assertExists()
+        composeRule.onNodeWithText(string(R.string.worship_settings_section_fasting)).assertExists()
+    }
+
+    @Test
+    fun `the Ramadan reminders are offered outside Ramadan, with a notice rather than a gap`() {
+        // The scheduler gates these on the Hijri date, so setting one in Sha'ban arms nothing
+        // until Ramadan arrives. Hiding the group made the app look like it had lost a feature
+        // for eleven months of the year.
+        setContent()
+
+        WorshipReminderType.entries
+            .filter { it.category == WorshipReminderCategory.RAMADAN }
+            .forEach { type ->
+                composeRule.onNodeWithText(string(worshipName(type))).assertExists()
+            }
+        composeRule.onNodeWithText(string(R.string.worship_settings_ramadan_notice)).assertExists()
+    }
+
+    @Test
+    fun `every declared reminder gets a row`() {
+        // Two `when`s over the enum supply the name and the "when it fires" line. Adding a
+        // twelfth type without touching them fails to compile — but a type moved between
+        // categories silently disappears from the screen, which this catches.
+        setContent()
+
+        WorshipReminderType.entries.forEach { type ->
+            composeRule.onNodeWithText(string(worshipName(type))).assertExists()
+        }
+    }
+
+    @Test
+    fun `the screen says up front that none of these carries an adhan`() {
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.worship_settings_intro)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a reminder with no timing is a plain row, not an empty accordion`() {
+        // Laylatul Qadr has no offset and no mode. An accordion there would open onto nothing.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.worship_when_laylatul_qadr)).assertExists()
+        assertThat(
+            composeRule.tappableAncestorCount(string(R.string.worship_laylatul_qadr_name))
+        ).isEqualTo(1)
+    }
+
+    @Test
+    fun `a switched-off timed reminder describes when it fires rather than its offset`() {
+        setContent(NotificationSettingsUiState(worshipReminders = mapOf("suhoor" to false)))
+
+        composeRule.onNodeWithText(string(R.string.worship_when_suhoor)).assertExists()
+    }
+
+    @Test
+    fun `a switched-on timed reminder reports its own offset`() {
+        setContent(
+            NotificationSettingsUiState(
+                worshipReminders = mapOf("suhoor" to true),
+                worshipOffsets = mapOf("suhoor" to 45),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.worship_settings_minutes, 45)).assertExists()
+    }
+
+    @Test
+    fun `an offset with nothing stored falls back to that type's own default`() {
+        // `?: type.defaultOffsetMinutes`, per type. One shared default would put Suhoor's
+        // 30-minute lead on Iftar, whose default is 0 — a reminder at the wrong end of the fast.
+        setContent(NotificationSettingsUiState(worshipReminders = mapOf("taraweeh" to true)))
+
+        composeRule.onNodeWithText(
+            string(R.string.worship_settings_minutes, WorshipReminderType.TARAWEEH.defaultOffsetMinutes)
+        ).assertExists()
+    }
+
+    @Test
+    fun `a switch writes its own reminder's key`() {
+        // Eleven rows over one keyed surface. Nothing at the call site names the reminder except
+        // the key, which is the one thing a copy-paste leaves unchanged.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.worship_tahajjud_name)).performClick()
+
+        val event = viewModel.only<SettingsEvent.SetWorshipReminderEnabled>()
+        assertThat(event.key).isEqualTo(WorshipReminderType.TAHAJJUD.key)
+        assertThat(event.enabled).isTrue()
+    }
+
+    @Test
+    fun `Witr reports the mode it is in, not the one a tap would produce`() {
+        setContent(
+            NotificationSettingsUiState(
+                worshipReminders = mapOf("witr" to true),
+                worshipModes = mapOf("witr" to WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.worship_witr_name)).performClick()
+
+        // Asserted as "one node carries both strings" rather than "the screen shows this
+        // string": "Before Fajr" is also *Suhoor's* when-it-fires line and "After Isha" is
+        // Taraweeh's, so a screen-wide match would pass against a mode row showing nothing.
+        assertThat(modeRowsShowing(R.string.worship_witr_mode_before_fajr)).isNotEmpty()
+        assertThat(modeRowsShowing(R.string.worship_witr_mode_after_isha)).isEmpty()
+    }
+
+    @Test
+    fun `Witr defaults to after Isha when no mode is stored`() {
+        setContent(NotificationSettingsUiState(worshipReminders = mapOf("witr" to true)))
+
+        composeRule.onNodeWithText(string(R.string.worship_witr_name)).performClick()
+
+        assertThat(modeRowsShowing(R.string.worship_witr_mode_after_isha)).isNotEmpty()
+        assertThat(modeRowsShowing(R.string.worship_witr_mode_before_fajr)).isEmpty()
+    }
+
+    @Test
+    fun `tapping the Witr mode row flips it to the other mode`() {
+        // It is a toggle wearing a row's clothes, so it must send the *opposite* of what it
+        // shows. Sending the current mode makes the row inert and looks identical.
+        setContent(
+            NotificationSettingsUiState(
+                worshipReminders = mapOf("witr" to true),
+                worshipModes = mapOf("witr" to WorshipReminderCalculator.WITR_MODE_AFTER_ISHA),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.worship_witr_name)).performClick()
+        composeRule.accordionRow(string(R.string.worship_witr_mode_title)).performClick()
+
+        val event = viewModel.only<SettingsEvent.SetWorshipReminderMode>()
+        assertThat(event.key).isEqualTo(WorshipReminderType.WITR.key)
+        assertThat(event.mode).isEqualTo(WorshipReminderCalculator.WITR_MODE_BEFORE_FAJR)
+    }
+
+    @Test
+    fun `the Witr mode row is off-limits while the reminder is off`() {
+        // Choosing when a reminder fires that will not fire is a setting with no effect.
+        setContent(NotificationSettingsUiState(worshipReminders = mapOf("witr" to false)))
+
+        composeRule.onNodeWithText(string(R.string.worship_witr_name)).performClick()
+
+        assertThat(composeRule.tappableAncestorCount(string(R.string.worship_witr_mode_title)))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `the offset stepper writes against the reminder whose accordion it is in`() {
+        setContent(
+            NotificationSettingsUiState(
+                worshipReminders = mapOf("iftar" to true),
+                worshipOffsets = mapOf("iftar" to 10),
+            )
+        )
+
+        composeRule.onNodeWithText(string(R.string.worship_iftar_name)).performClick()
+        composeRule
+            .onAllNodesWithContentDescription(string(R.string.cd_increase), useUnmergedTree = true)
+            .onFirst()
+            .performClick()
+
+        val event = viewModel.only<SettingsEvent.SetWorshipReminderOffset>()
+        assertThat(event.key).isEqualTo(WorshipReminderType.IFTAR.key)
+        assertThat(event.minutes).isEqualTo(15)
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+
+    /** Nodes carrying the Witr timing label *and* [mode] — i.e. the mode row, reporting [mode]. */
+    private fun modeRowsShowing(@StringRes mode: Int) =
+        composeRule
+            .onAllNodes(
+                hasText(string(R.string.worship_witr_mode_title)) and hasText(string(mode))
+            )
+            .fetchSemanticsNodes()
+
+    private fun worshipName(type: WorshipReminderType): Int = when (type) {
+        WorshipReminderType.TAHAJJUD -> R.string.worship_tahajjud_name
+        WorshipReminderType.WITR -> R.string.worship_witr_name
+        WorshipReminderType.SUHOOR -> R.string.worship_suhoor_name
+        WorshipReminderType.IFTAR -> R.string.worship_iftar_name
+        WorshipReminderType.TARAWEEH -> R.string.worship_taraweeh_name
+        WorshipReminderType.LAYLATUL_QADR -> R.string.worship_laylatul_qadr_name
+        WorshipReminderType.ADHKAR_MORNING -> R.string.worship_adhkar_morning_name
+        WorshipReminderType.ADHKAR_EVENING -> R.string.worship_adhkar_evening_name
+        WorshipReminderType.MONDAY_THURSDAY_FAST -> R.string.worship_mon_thu_name
+        WorshipReminderType.WHITE_DAYS_FAST -> R.string.worship_white_days_name
+        WorshipReminderType.ARAFAH_ASHURA_FAST -> R.string.worship_arafah_ashura_name
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/ZakatSettingsScreenTest.kt
@@ -1,0 +1,245 @@
+package com.arshadshah.nimaz.presentation.screens.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.core.app.ApplicationProvider
+import com.arshadshah.nimaz.core.common.currencyLabel
+import com.arshadshah.nimaz.core.common.formatCurrency
+import com.arshadshah.nimaz.core.ui.R
+import com.arshadshah.nimaz.domain.model.NisabType
+import com.arshadshah.nimaz.domain.model.ZakatCalculator
+import com.arshadshah.nimaz.domain.model.ZakatDefaults
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ZakatSettingsViewModel
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.arshadshah.nimaz.testing.settingsRow
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The zakat basis: which nisab applies, what the two metals are worth, and the currency.
+ *
+ * The hero at the top is the reason this screen is ordered as it is — it shows the exact figure
+ * `ZakatCalculator` will compare net wealth against, so every control below has a visible
+ * consequence. It is asserted against `ZakatCalculator.nisabValue` rather than against a number
+ * spelled out here: a preview computing its own threshold would eventually promise one the
+ * calculation does not use, and nothing on screen would say so.
+ *
+ * Two formatting rules carry real weight. The subtitle shows the *working* — "612.36g @ $0.80/g" —
+ * and it used to be built from `price.toInt()`, which rendered silver's 0.80 as "0" and made the
+ * threshold look like it came from nothing. The currency symbol used to be a hardcoded "$",
+ * which quietly relabelled everyone else's money.
+ *
+ * `ZakatSummaryHero` sets `clearAndSetSemantics`, so the hero is addressable only by its content
+ * description — which is the better contract to pin anyway, since it is what TalkBack reads.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h2200dp")
+class ZakatSettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MutableStateFlow(ZakatSettingsUiState())
+    private val events = mutableListOf<ZakatSettingsEvent>()
+    private val viewModel: ZakatSettingsViewModel = mockk(relaxed = true) {
+        every { uiState } returns this@ZakatSettingsScreenTest.state
+        every { onEvent(any()) } answers { events += firstArg<ZakatSettingsEvent>() }
+    }
+    private var backs = 0
+
+    private fun setContent(uiState: ZakatSettingsUiState = ZakatSettingsUiState()) {
+        state.value = uiState
+        composeRule.setThemedContent {
+            ZakatSettingsScreen(onNavigateBack = { backs++ }, viewModel = viewModel)
+        }
+    }
+
+    private fun string(@StringRes res: Int, vararg args: Any): String =
+        context.getString(res, *args)
+
+    private inline fun <reified T : ZakatSettingsEvent> only(): T = events.filterIsInstance<T>()
+        .also { check(it.size == 1) { "expected one ${T::class.simpleName}, got $events" } }
+        .single()
+
+    @Test
+    fun `the four sections render`() {
+        setContent()
+
+        composeRule.onAllNodesWithText(string(R.string.zakat_section_nisab)).onFirst()
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.zakat_metal_prices)).assertExists()
+        composeRule.onAllNodesWithText(string(R.string.zakat_currency)).onFirst().assertExists()
+    }
+
+    @Test
+    fun `the hero shows the threshold the calculator will actually use`() {
+        val uiState = ZakatSettingsUiState(
+            nisabType = NisabType.GOLD,
+            goldPricePerGram = 70.0,
+            silverPricePerGram = 0.9,
+            currency = "USD",
+        )
+        setContent(uiState)
+
+        val expected = formatCurrency(
+            ZakatCalculator.nisabValue(NisabType.GOLD, 70.0, 0.9),
+            "USD",
+        )
+        composeRule.onNodeWithContentDescription(expected, substring = true).assertExists()
+    }
+
+    @Test
+    fun `switching the basis changes the threshold to the other metal's`() {
+        // Gold and silver nisab are different weights of different metals, and the silver one
+        // works out far lower — which is the whole reason the choice exists.
+        setContent(
+            ZakatSettingsUiState(
+                nisabType = NisabType.SILVER,
+                goldPricePerGram = 65.0,
+                silverPricePerGram = 0.8,
+            )
+        )
+
+        val silverThreshold = formatCurrency(
+            ZakatCalculator.nisabValue(NisabType.SILVER, 65.0, 0.8),
+            ZakatDefaults.CURRENCY,
+        )
+        composeRule.onNodeWithContentDescription(silverThreshold, substring = true).assertExists()
+    }
+
+    @Test
+    fun `a silver price under one is shown as a price, not rounded away to zero`() {
+        // `price.toInt()` rendered 0.80 as "0", so the subtitle read "612.36g @ $0/g" and the
+        // threshold above it looked as if it had come from nothing.
+        setContent(
+            ZakatSettingsUiState(nisabType = NisabType.SILVER, silverPricePerGram = 0.80)
+        )
+
+        composeRule.onAllNodesWithText(
+            string(R.string.zakat_nisab_silver_subtitle, formatCurrency(0.80, "USD"))
+        ).onFirst().assertExists()
+    }
+
+    @Test
+    fun `prices are shown in the chosen currency, not in dollars`() {
+        // A hardcoded "$" quietly relabelled everyone else's money — the figure was right and
+        // the unit was not, which is the version of wrong nobody checks.
+        setContent(
+            ZakatSettingsUiState(
+                nisabType = NisabType.GOLD,
+                goldPricePerGram = 55.0,
+                currency = "EUR",
+            )
+        )
+
+        composeRule.onAllNodesWithText(
+            string(R.string.zakat_nisab_gold_subtitle, formatCurrency(55.0, "EUR"))
+        ).onFirst().assertExists()
+    }
+
+    @Test
+    fun `both metal prices are offered whichever basis is selected`() {
+        // Gold and silver held as *assets* are valued from these prices regardless of basis, so
+        // hiding the unselected one would hide a price that is still in the sum.
+        setContent(ZakatSettingsUiState(nisabType = NisabType.SILVER))
+
+        composeRule.onNodeWithText(string(R.string.zakat_gold_price_label)).assertExists()
+        composeRule.onNodeWithText(string(R.string.zakat_silver_price_label)).assertExists()
+    }
+
+    @Test
+    fun `picking gold as the basis dispatches gold`() {
+        setContent(ZakatSettingsUiState(nisabType = NisabType.SILVER))
+
+        composeRule.onAllNodesWithText(string(R.string.gold)).onFirst().performClick()
+
+        assertThat(only<ZakatSettingsEvent.SetNisabType>().nisabType).isEqualTo(NisabType.GOLD)
+    }
+
+    @Test
+    fun `picking silver as the basis dispatches silver`() {
+        // Two cards built from one composable with the label swapped. Crossing them switches the
+        // ruling the user follows to the other one.
+        setContent(ZakatSettingsUiState(nisabType = NisabType.GOLD))
+
+        composeRule.onAllNodesWithText(string(R.string.silver)).onFirst().performClick()
+
+        assertThat(only<ZakatSettingsEvent.SetNisabType>().nisabType).isEqualTo(NisabType.SILVER)
+    }
+
+    @Test
+    fun `the currency row names the currency and its full name`() {
+        setContent(ZakatSettingsUiState(currency = "GBP"))
+
+        composeRule.onNodeWithText(currencyLabel("GBP")).assertExists()
+    }
+
+    @Test
+    fun `picking a currency dispatches that code`() {
+        setContent(ZakatSettingsUiState(currency = "USD"))
+
+        composeRule.settingsRow(string(R.string.zakat_currency)).performClick()
+        composeRule.onNodeWithText(currencyLabel(ZakatDefaults.CURRENCIES[1])).performClick()
+
+        assertThat(only<ZakatSettingsEvent.SetCurrency>().currency)
+            .isEqualTo(ZakatDefaults.CURRENCIES[1])
+    }
+
+    @Test
+    fun `the screen says these prices are estimates, not looked-up rates`() {
+        // A default read as a market rate is how a zakat figure goes quietly wrong, and there is
+        // no other signal on the screen that 65.00 was not fetched from anywhere.
+        setContent()
+
+        composeRule.onNodeWithText(string(R.string.zakat_metal_prices_hint)).assertExists()
+        composeRule.onNodeWithText(string(R.string.zakat_settings_nisab_hint)).assertExists()
+    }
+
+    @Test
+    fun `a zero threshold is not presented as a full-strength figure`() {
+        // A nisab priced at zero has not been met; it has failed to be established, and
+        // `ZakatCalculator` treats it that way too.
+        setContent(
+            ZakatSettingsUiState(
+                nisabType = NisabType.GOLD,
+                goldPricePerGram = 0.0,
+                silverPricePerGram = 0.0,
+            )
+        )
+
+        // The hero reads as one phrase — label then amount — so the assertion is the whole
+        // a11y string rather than the figure, which at zero also matches both price tiles.
+        composeRule.onNodeWithContentDescription(
+            "${string(R.string.nisab_threshold)}, ${formatCurrency(0.0, ZakatDefaults.CURRENCY)}",
+            substring = true,
+        ).assertExists()
+    }
+
+    @Test
+    fun `the back button navigates back`() {
+        setContent()
+
+        composeRule.onNodeWithContentDescription(string(R.string.cd_back)).performClick()
+
+        assertThat(backs).isEqualTo(1)
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/location/LocationViewModelTest.kt
@@ -1,0 +1,504 @@
+package com.arshadshah.nimaz.presentation.viewmodel.location
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.model.SearchLocation
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.Coordinates
+import com.arshadshah.nimaz.domain.repository.DeviceLocationRepository
+import com.arshadshah.nimaz.domain.repository.PermissionChecker
+import com.arshadshah.nimaz.domain.repository.PrayerRepository
+import com.arshadshah.nimaz.domain.repository.settings.LocationSettings
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.buildPrayerUseCases
+import com.arshadshah.nimaz.testing.testLocation
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Everything the location ViewModel does apart from the debounce, which
+ * `LocationSearchDebounceTest` already owns.
+ *
+ * Two things carry real weight here.
+ *
+ * **Selecting a place writes twice, and both writes matter.** The preference is what the prayer
+ * calculator reads; the database row is what the recents list and the location table are built
+ * from. Writing only one leaves the app calculating for a city the settings screen does not show,
+ * or showing a city the calculator has never heard of. It also goes through
+ * `saveCurrentLocation` rather than composing a `Location` here — the previous version built one
+ * with `id = 0` against an autogenerate key, which inserted a duplicate on every selection and
+ * left several rows flagged current at once.
+ *
+ * **Every failure surfaces.** These four paths — load, search, select, detect — all touch the
+ * network, the Geocoder or DataStore, and each one's `catch` decides whether the user sees an
+ * explanation or a screen that quietly does nothing. Two of them are deliberately silent (the
+ * initial load, and a geocode that returns nothing), and the difference is worth pinning: a
+ * failed *load* leaves the previous value on screen, while a failed *save* must not.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LocationViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val telemetry = RecordingTelemetry()
+
+    private val preferences = MutableStateFlow(
+        UserPreferences(
+            onboardingCompleted = true,
+            themeMode = "system",
+            dynamicColor = false,
+            appLanguage = "en",
+            calculationMethod = "MUSLIM_WORLD_LEAGUE",
+            asrCalculation = "standard",
+            latitude = 0.0,
+            longitude = 0.0,
+            locationName = "",
+            prayerNotificationsEnabled = true,
+            quranTranslatorId = "sahih_international",
+            showTranslation = true,
+        )
+    )
+
+    private val locationSettings = mockk<LocationSettings>(relaxed = true) {
+        every { userPreferences } returns this@LocationViewModelTest.preferences
+    }
+
+    private val recents = MutableStateFlow<List<Location>>(emptyList())
+    private val prayerRepository = mockk<PrayerRepository>(relaxed = true) {
+        every { getRecentLocations(any()) } returns this@LocationViewModelTest.recents
+    }
+    private val prayerUseCases: PrayerUseCases = buildPrayerUseCases(prayerRepository)
+
+    private var coordinates: Coordinates? = null
+    private var reverseName: String? = "London, United Kingdom"
+    private var searchResults: List<SearchLocation> = emptyList()
+    private var searchThrows: Throwable? = null
+    private var reverseThrows: Throwable? = null
+
+    private val deviceLocation = object : DeviceLocationRepository {
+        override suspend fun currentCoordinates(): Coordinates? = coordinates
+
+        override suspend fun search(query: String, limit: Int): List<SearchLocation> {
+            searchThrows?.let { throw it }
+            return searchResults
+        }
+
+        override suspend fun reverseGeocode(latitude: Double, longitude: Double): String? {
+            reverseThrows?.let { throw it }
+            return reverseName
+        }
+    }
+
+    private var permissionGranted = true
+    private val permissions = object : PermissionChecker {
+        override fun hasLocationPermission() = permissionGranted
+        override fun hasNotificationPermission() = true
+    }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = LocationViewModel(
+        deviceLocation,
+        permissions,
+        locationSettings,
+        prayerUseCases,
+        telemetry,
+    )
+
+    private val london = SearchLocation("London", "United Kingdom", 51.5074, -0.1278)
+
+    // ── Loading what is already stored ───────────────────────────────────────────────────────
+
+    @Test
+    fun `a stored location is loaded on open`() = runTest(dispatcher) {
+        preferences.value = preferences.value.copy(
+            latitude = 51.5074,
+            longitude = -0.1278,
+            locationName = "London, United Kingdom",
+        )
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        val current = vm.state.value.currentLocation as CurrentLocationState.Set
+        assertThat(current.name).isEqualTo("London, United Kingdom")
+        assertThat(current.latitude).isEqualTo(51.5074)
+    }
+
+    @Test
+    fun `coordinates of zero are treated as no location, not as the Atlantic`() = runTest(dispatcher) {
+        // (0, 0) is what an unset preference reads back as. Honouring it would open the screen
+        // claiming a location in the Gulf of Guinea.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.currentLocation).isEqualTo(CurrentLocationState.NotSet)
+    }
+
+    @Test
+    fun `a location stored without a name still gets one`() = runTest(dispatcher) {
+        // The GPS path can store coordinates the Geocoder could not name. An empty title in the
+        // card reads as a rendering failure.
+        preferences.value = preferences.value.copy(
+            latitude = 51.5,
+            longitude = -0.12,
+            locationName = "",
+        )
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat((vm.state.value.currentLocation as CurrentLocationState.Set).name)
+            .isEqualTo("Current Location")
+    }
+
+    // ── Recents ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `recent locations are taken in the order the database returns them`() = runTest(dispatcher) {
+        // Taking the first five of `getAllLocations()` — sorted `isFavorite DESC, name ASC` —
+        // produced an alphabetical "recent" row that a newly-saved location never entered.
+        recents.value = listOf(
+            testLocation(id = 1, name = "Zurich", latitude = 47.37, longitude = 8.54),
+            testLocation(id = 2, name = "Amman", latitude = 31.95, longitude = 35.93),
+        )
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.recentLocations.map { it.name })
+            .containsExactly("Zurich", "Amman").inOrder()
+    }
+
+    @Test
+    fun `recents are capped at five`() = runTest(dispatcher) {
+        recents.value = (1..9).map {
+            testLocation(id = it.toLong(), name = "City $it", latitude = it * 1.0, longitude = it * 2.0)
+        }
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.recentLocations).hasSize(5)
+    }
+
+    @Test
+    fun `two rows for the same place appear once`() = runTest(dispatcher) {
+        // Deduplicated on coordinates rounded to ~110m, not on the name: the Geocoder and the
+        // curated catalogue spell one place differently, and a recents row showing "London" and
+        // "London, Greater London" is two entries for one tap.
+        recents.value = listOf(
+            testLocation(id = 1, name = "London", latitude = 51.50741, longitude = -0.12781),
+            testLocation(id = 2, name = "London, Greater London", latitude = 51.50742, longitude = -0.12782),
+        )
+
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.recentLocations).hasSize(1)
+    }
+
+    @Test
+    fun `a recent row with no country renders with an empty one rather than crashing`() =
+        runTest(dispatcher) {
+            recents.value = listOf(
+                testLocation(id = 1, name = "Somewhere", country = null, latitude = 5.0, longitude = 6.0)
+            )
+
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.recentLocations.single().country).isEmpty()
+        }
+
+    // ── Search ───────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an explicit search runs the current query and records it`() = runTest(dispatcher) {
+        searchResults = listOf(london)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        vm.onEvent(LocationEvent.Search)
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.searchResults).containsExactly(london)
+        assertThat(telemetry.featureUsages.map { it.action }).contains("search")
+    }
+
+    @Test
+    fun `the geocoder returning the same place twice yields one row`() = runTest(dispatcher) {
+        // Distinct on "name, country", because the Geocoder happily returns a street, a
+        // district and a city that all flatten to the same label.
+        searchResults = listOf(london, london.copy(latitude = 51.6))
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.searchResults).hasSize(1)
+    }
+
+    @Test
+    fun `a geocoder that throws leaves an empty list rather than an error`() = runTest(dispatcher) {
+        // Deliberately quiet: a failed geocode is a search that found nothing, and a red banner
+        // on every keystroke over a flaky connection is worse than an empty list.
+        searchThrows = IllegalStateException("geocoder unavailable")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.searchResults).isEmpty()
+        assertThat(vm.state.value.error).isNull()
+        assertThat(telemetry.errors.map { it.type }).contains("geocode_search")
+    }
+
+    @Test
+    fun `clearing the search empties both the query and the results`() = runTest(dispatcher) {
+        searchResults = listOf(london)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.ClearSearch)
+
+        assertThat(vm.state.value.searchQuery).isEmpty()
+        assertThat(vm.state.value.searchResults).isEmpty()
+    }
+
+    @Test
+    fun `shortening the query below two characters clears the results`() = runTest(dispatcher) {
+        // Otherwise the previous query's results stay on screen under a box that no longer
+        // says what produced them.
+        searchResults = listOf(london)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UpdateSearchQuery("l"))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.searchResults).isEmpty()
+    }
+
+    // ── Selecting ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `selecting a place writes the preference and the database row`() = runTest(dispatcher) {
+        // Only one of the two leaves the calculator and the settings screen disagreeing about
+        // where the user is.
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.SelectLocation(london))
+        advanceUntilIdle()
+
+        coVerify {
+            locationSettings.updateLocation(51.5074, -0.1278, "London, United Kingdom")
+        }
+        // Composed by the use case rather than here: the previous version built a `Location`
+        // in the ViewModel with `id = 0` against an autogenerate key, which inserted a
+        // duplicate on every selection and left several rows flagged current at once.
+        val saved = slot<Location>()
+        coVerify { prayerRepository.saveCurrentLocation(capture(saved), any()) }
+        assertThat(saved.captured.name).isEqualTo("London")
+        assertThat(saved.captured.country).isEqualTo("United Kingdom")
+        assertThat(saved.captured.latitude).isEqualTo(51.5074)
+        assertThat(saved.captured.longitude).isEqualTo(-0.1278)
+    }
+
+    @Test
+    fun `selecting a place clears the search it was found through`() = runTest(dispatcher) {
+        searchResults = listOf(london)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(LocationEvent.UpdateSearchQuery("london"))
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.SelectLocation(london))
+        advanceUntilIdle()
+
+        assertThat(vm.state.value.searchQuery).isEmpty()
+        assertThat(vm.state.value.searchResults).isEmpty()
+        assertThat((vm.state.value.currentLocation as CurrentLocationState.Set).name)
+            .isEqualTo("London, United Kingdom")
+    }
+
+    @Test
+    fun `a save that fails says so rather than showing the place as selected`() =
+        runTest(dispatcher) {
+            // The failure that must not be silent: the card would show the new city while every
+            // prayer time still came from the old one.
+            coEvery {
+                locationSettings.updateLocation(any(), any(), any())
+            } throws IllegalStateException("disk full")
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(LocationEvent.SelectLocation(london))
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.error).contains("disk full")
+            assertThat(vm.state.value.currentLocation).isEqualTo(CurrentLocationState.NotSet)
+        }
+
+    @Test
+    fun `an error can be dismissed`() = runTest(dispatcher) {
+        coEvery {
+            locationSettings.updateLocation(any(), any(), any())
+        } throws IllegalStateException("disk full")
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(LocationEvent.SelectLocation(london))
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.DismissError)
+
+        assertThat(vm.state.value.error).isNull()
+    }
+
+    // ── GPS ──────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `detecting without permission says so and asks the device for nothing`() =
+        runTest(dispatcher) {
+            permissionGranted = false
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(LocationEvent.UseCurrentGpsLocation)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.error).contains("permission")
+            assertThat(vm.state.value.isLoadingGps).isFalse()
+        }
+
+    @Test
+    fun `a detected location is named, stored and shown`() = runTest(dispatcher) {
+        coordinates = Coordinates(51.5074, -0.1278)
+        reverseName = "London, United Kingdom"
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UseCurrentGpsLocation)
+        advanceUntilIdle()
+
+        coVerify { locationSettings.updateLocation(51.5074, -0.1278, "London, United Kingdom") }
+        assertThat((vm.state.value.currentLocation as CurrentLocationState.Set).name)
+            .isEqualTo("London, United Kingdom")
+        assertThat(vm.state.value.isLoadingGps).isFalse()
+    }
+
+    @Test
+    fun `a location the geocoder cannot name is still stored`() = runTest(dispatcher) {
+        // Coordinates the Geocoder has no label for are still perfectly good for a prayer time.
+        // Refusing to store them would leave someone in a remote place with no way to set one.
+        coordinates = Coordinates(70.0, 25.0)
+        reverseName = null
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(LocationEvent.UseCurrentGpsLocation)
+        advanceUntilIdle()
+
+        coVerify { locationSettings.updateLocation(70.0, 25.0, "Unknown Location") }
+    }
+
+    @Test
+    fun `a reverse geocode that throws does not lose the detected coordinates`() =
+        runTest(dispatcher) {
+            reverseThrows = IllegalStateException("geocoder unavailable")
+            coordinates = Coordinates(70.0, 25.0)
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(LocationEvent.UseCurrentGpsLocation)
+            advanceUntilIdle()
+
+            coVerify { locationSettings.updateLocation(70.0, 25.0, "Unknown Location") }
+            assertThat(telemetry.errors.map { it.type }).contains("reverse_geocode")
+        }
+
+    @Test
+    fun `a device that cannot fix a position says so and stops the spinner`() =
+        runTest(dispatcher) {
+            // Indoors, or with location services off at the OS level. A spinner that never
+            // stops is the failure mode this replaces.
+            coordinates = null
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onEvent(LocationEvent.UseCurrentGpsLocation)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value.error).contains("Could not detect location")
+            assertThat(vm.state.value.isLoadingGps).isFalse()
+        }
+
+    @Test
+    fun `reloading the stored location is available as its own event`() = runTest(dispatcher) {
+        // The screen re-reads after a permission grant, which changes what the OS will return
+        // without anything on this side having changed.
+        val vm = viewModel()
+        advanceUntilIdle()
+        preferences.value = preferences.value.copy(
+            latitude = 30.0444,
+            longitude = 31.2357,
+            locationName = "Cairo, Egypt",
+        )
+
+        vm.onEvent(LocationEvent.LoadCurrentLocation)
+        advanceUntilIdle()
+
+        assertThat((vm.state.value.currentLocation as CurrentLocationState.Set).name)
+            .isEqualTo("Cairo, Egypt")
+    }
+
+    @Test
+    fun `filtering by region is recorded and reaches the state`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        val region = com.arshadshah.nimaz.domain.model.CityRegion.entries.first()
+
+        vm.onEvent(LocationEvent.SelectRegion(region))
+
+        assertThat(vm.state.value.selectedRegion).isEqualTo(region)
+        assertThat(telemetry.featureUsages.map { it.action }).contains("filter_region")
+    }
+
+    @Test
+    fun `clearing the region filter is also recorded`() = runTest(dispatcher) {
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onEvent(LocationEvent.SelectRegion(com.arshadshah.nimaz.domain.model.CityRegion.entries.first()))
+
+        vm.onEvent(LocationEvent.SelectRegion(null))
+
+        assertThat(vm.state.value.selectedRegion).isNull()
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsEventTableTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsEventTableTest.kt
@@ -1,0 +1,778 @@
+package com.arshadshah.nimaz.presentation.viewmodel.settings
+
+import com.arshadshah.nimaz.core.monitoring.TelemetryCall
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
+import com.arshadshah.nimaz.testing.SettingsViewModelHarness
+import com.arshadshah.nimaz.testing.testLocation
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Every `SettingsEvent`, against the preference it must actually write.
+ *
+ * This is the module's central risk. Seventy-eight branches of one `when`, each a two-line body
+ * that updates a state field and writes a setter, and every one of them looks like its neighbour.
+ * A branch that updates the right field and writes the *wrong* setter is invisible from the
+ * screen — the switch moves, the row reads correctly, and the preference the user thinks they
+ * changed is untouched until the next launch reloads it. `:core:datastore` (#603) pins the
+ * persistence half exhaustively; nothing has ever pinned that the event reaching it is the right
+ * one.
+ *
+ * So each assertion is a pair: the optimistic state update the screen paints on the frame of the
+ * tap, and a `coVerify` naming the exact setter. A verify against `any()` would pass against the
+ * bug this is written for.
+ *
+ * The reschedule calls are asserted separately and deliberately. Alarms are baked at scheduling
+ * time, so a preference that changes *when* a notification fires must rearm and one that changes
+ * only *how* it fires must not — and getting that backwards either leaves a stale alarm or
+ * rewrites every alarm on every keystroke of a stepper.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsEventTableTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val harness = SettingsViewModelHarness()
+    private val repo get() = harness.repo
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        viewModel = harness.build()
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun send(vararg events: SettingsEvent) = runTest(dispatcher) {
+        advanceUntilIdle()
+        events.forEach { viewModel.onEvent(it) }
+        advanceUntilIdle()
+    }
+
+    // ── General ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `choosing a theme writes that theme's own mode string`() {
+        // Three enum values mapped to three lowercase strings by hand. `LIGHT -> "dark"` would
+        // show the light row selected and open the app dark.
+        send(SettingsEvent.SetTheme(AppTheme.DARK))
+        assertThat(viewModel.generalState.value.theme).isEqualTo(AppTheme.DARK)
+        coVerify { repo.mock.setThemeMode("dark") }
+
+        send(SettingsEvent.SetTheme(AppTheme.LIGHT))
+        coVerify { repo.mock.setThemeMode("light") }
+
+        send(SettingsEvent.SetTheme(AppTheme.SYSTEM))
+        coVerify { repo.mock.setThemeMode("system") }
+    }
+
+    @Test
+    fun `choosing a language persists its code, applies the locale and asks for a restart`() {
+        // Three things must happen together: the code is stored, the locale is applied *now*
+        // (otherwise the change waits for a cold start), and the restart flag is raised. Storing
+        // without applying is the plausible failure, and it looks like nothing happened.
+        send(SettingsEvent.SetLanguage(AppLanguage.FRENCH))
+
+        assertThat(viewModel.generalState.value.language).isEqualTo(AppLanguage.FRENCH)
+        coVerify { repo.mock.setAppLanguage("fr") }
+        coVerify { harness.appLocale.apply("fr") }
+        assertThat(viewModel.shouldRestart.value).isTrue()
+    }
+
+    @Test
+    fun `the language is also recorded as a user property`() {
+        // Declared and never set, so every segmentation by language was empty.
+        send(SettingsEvent.SetLanguage(AppLanguage.INDONESIAN))
+
+        assertThat(harness.telemetry.userProperties.map { it.name to it.value })
+            .contains("app_language" to "id")
+    }
+
+    @Test
+    fun `each general toggle writes its own preference`() {
+        send(
+            SettingsEvent.SetHijriPrimary(true),
+            SettingsEvent.SetHijriDayOffset(-1),
+            SettingsEvent.Set24HourFormat(true),
+            SettingsEvent.SetHapticFeedback(false),
+            SettingsEvent.SetAnimationsEnabled(false),
+            SettingsEvent.SetShowCountdown(false),
+            SettingsEvent.SetShowQuickActions(false),
+        )
+
+        val state = viewModel.generalState.value
+        assertThat(state.useHijriPrimary).isTrue()
+        assertThat(state.hijriDayOffset).isEqualTo(-1)
+        assertThat(state.use24HourFormat).isTrue()
+        assertThat(state.hapticFeedback).isFalse()
+        assertThat(state.animationsEnabled).isFalse()
+        assertThat(state.showCountdown).isFalse()
+        assertThat(state.showQuickActions).isFalse()
+
+        coVerify { repo.mock.setUseHijriPrimary(true) }
+        coVerify { repo.mock.setHijriDayOffset(-1) }
+        coVerify { repo.mock.setUse24HourFormat(true) }
+        coVerify { repo.mock.setHapticFeedback(false) }
+        coVerify { repo.mock.setAnimationsEnabled(false) }
+        coVerify { repo.mock.setShowCountdown(false) }
+        coVerify { repo.mock.setShowQuickActions(false) }
+    }
+
+    @Test
+    fun `switching the ornament off keeps the legacy boolean in step`() {
+        // The style is the source of truth and the boolean is kept only for import/export and
+        // the readers that still ask it. Writing one without the other is how the two disagree.
+        send(SettingsEvent.SetPatternStyle(NimazPatternStyle.NONE))
+
+        assertThat(viewModel.generalState.value.patternStyle).isEqualTo(NimazPatternStyle.NONE)
+        assertThat(viewModel.generalState.value.showIslamicPatterns).isFalse()
+        coVerify { repo.mock.setPatternStyle("NONE") }
+        coVerify { repo.mock.setShowIslamicPatterns(false) }
+    }
+
+    @Test
+    fun `choosing any real ornament switches patterns back on`() {
+        send(SettingsEvent.SetPatternStyle(NimazPatternStyle.NONE))
+        send(SettingsEvent.SetPatternStyle(NimazPatternStyle.CORNER_MEDALLION))
+
+        assertThat(viewModel.generalState.value.showIslamicPatterns).isTrue()
+        coVerify { repo.mock.setPatternStyle("CORNER_MEDALLION") }
+        coVerify { repo.mock.setShowIslamicPatterns(true) }
+    }
+
+    // ── Prayer ───────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the calculation method is stored by name and rearms every alarm`() {
+        // Changing the method moves every prayer time, so the alarms already set are wrong until
+        // they are rebuilt. Not rescheduling here is a notification that fires at yesterday's
+        // time and no error anywhere.
+        send(SettingsEvent.SetCalculationMethod(CalculationMethod.EGYPTIAN))
+
+        assertThat(viewModel.prayerState.value.calculationMethod)
+            .isEqualTo(CalculationMethod.EGYPTIAN)
+        coVerify { repo.mock.setCalculationMethod("EGYPTIAN") }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `the asr method is stored lowercased, as the loader reads it back`() {
+        // `setAsrCalculation(name.lowercase())` writing and `AsrCalculation.fromString` reading.
+        // Storing "HANAFI" where the reader expects "hanafi" is a round-trip that silently
+        // resets to Standard on the next launch.
+        send(SettingsEvent.SetAsrMethod(AsrCalculation.HANAFI))
+
+        assertThat(viewModel.prayerState.value.asrMethod).isEqualTo(AsrCalculation.HANAFI)
+        coVerify { repo.mock.setAsrCalculation("hanafi") }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `the high latitude rule is stored by name and rearms`() {
+        send(SettingsEvent.SetHighLatitudeRule(HighLatitudeRule.SEVENTH_OF_THE_NIGHT))
+
+        assertThat(viewModel.prayerState.value.highLatitudeRule)
+            .isEqualTo(HighLatitudeRule.SEVENTH_OF_THE_NIGHT)
+        coVerify { repo.mock.setHighLatitudeRule("SEVENTH_OF_THE_NIGHT") }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `a manual adjustment lands on the prayer it names, whatever its case`() {
+        // Six branches over a lowercased string. The screens pass "Fajr", "fajr" and "FAJR" from
+        // three different call sites, so the lowercasing is load-bearing rather than defensive.
+        send(
+            SettingsEvent.SetPrayerAdjustment("Fajr", 3),
+            SettingsEvent.SetPrayerAdjustment("SUNRISE", -2),
+            SettingsEvent.SetPrayerAdjustment("dhuhr", 1),
+            SettingsEvent.SetPrayerAdjustment("Asr", 4),
+            SettingsEvent.SetPrayerAdjustment("maghrib", -5),
+            SettingsEvent.SetPrayerAdjustment("Isha", 6),
+        )
+
+        val state = viewModel.prayerState.value
+        assertThat(state.fajrAdjustment).isEqualTo(3)
+        assertThat(state.sunriseAdjustment).isEqualTo(-2)
+        assertThat(state.dhuhrAdjustment).isEqualTo(1)
+        assertThat(state.asrAdjustment).isEqualTo(4)
+        assertThat(state.maghribAdjustment).isEqualTo(-5)
+        assertThat(state.ishaAdjustment).isEqualTo(6)
+        // The *unlowered* name goes to the repository, which is what the persistence layer keys
+        // on — so this is the pair that has to agree, not the two halves separately.
+        coVerify { repo.mock.setPrayerAdjustment("Fajr", 3) }
+    }
+
+    @Test
+    fun `an adjustment for a prayer that does not exist changes nothing`() {
+        val before = viewModel.prayerState.value
+
+        send(SettingsEvent.SetPrayerAdjustment("tahajjud", 99))
+
+        assertThat(viewModel.prayerState.value).isEqualTo(before)
+    }
+
+    // ── Notifications ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the notification master switch is stored and rearms`() {
+        send(SettingsEvent.SetNotificationsEnabled(false))
+
+        assertThat(viewModel.notificationState.value.notificationsEnabled).isFalse()
+        coVerify { repo.mock.setPrayerNotificationsEnabled(false) }
+        coVerify { harness.rescheduleNotifications.invoke() }
+        assertThat(harness.telemetry.userProperties.map { it.name to it.value })
+            .contains("notifications_enabled" to "false")
+    }
+
+    @Test
+    fun `a per-prayer notification lands on its own field and its own preference`() {
+        // Six identical rows. This is the exact shape the issue names: a toggle wired to its
+        // neighbour's event moves both switches on screen and changes the wrong prayer.
+        send(
+            SettingsEvent.SetPrayerNotification("fajr", false),
+            SettingsEvent.SetPrayerNotification("Sunrise", true),
+            SettingsEvent.SetPrayerNotification("isha", false),
+        )
+
+        val state = viewModel.notificationState.value
+        assertThat(state.fajrNotification).isFalse()
+        assertThat(state.sunriseNotification).isTrue()
+        assertThat(state.dhuhrNotification).isTrue()
+        assertThat(state.ishaNotification).isFalse()
+        coVerify { repo.mock.setPrayerNotificationEnabled("fajr", false) }
+        coVerify { repo.mock.setPrayerNotificationEnabled("Sunrise", true) }
+    }
+
+    @Test
+    fun `a notification toggle for an unknown prayer leaves the state alone`() {
+        send(SettingsEvent.SetPrayerNotification("tarawih", true))
+
+        val state = viewModel.notificationState.value
+        assertThat(state.fajrNotification).isTrue()
+        assertThat(state.sunriseNotification).isFalse()
+    }
+
+    @Test
+    fun `an alert style is keyed lowercased and does not rearm`() {
+        // The style is read when the alarm *fires*, not when it is set, so rescheduling here
+        // would rewrite every alarm for a change that cannot affect any of their times.
+        send(SettingsEvent.SetPrayerAlertStyle("Fajr", PrayerAlertStyle.ADHAN))
+
+        assertThat(viewModel.notificationState.value.alertStyles)
+            .containsEntry("fajr", PrayerAlertStyle.ADHAN)
+        coVerify { repo.mock.setPrayerAlertStyle("fajr", PrayerAlertStyle.ADHAN) }
+        coVerify(exactly = 0) { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `a per-prayer reminder does rearm, because its lead time is baked into the alarm`() {
+        send(SettingsEvent.SetPrayerReminderEnabled("Maghrib", true))
+
+        assertThat(viewModel.notificationState.value.reminderEnabled)
+            .containsEntry("maghrib", true)
+        coVerify { repo.mock.setPrayerReminderEnabled("maghrib", true) }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `a per-prayer reminder offset is keyed lowercased and rearms`() {
+        send(SettingsEvent.SetPrayerReminderMinutes("ISHA", 45))
+
+        assertThat(viewModel.notificationState.value.reminderOffsets).containsEntry("isha", 45)
+        coVerify { repo.mock.setPrayerReminderMinutes("isha", 45) }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `setting one prayer's reminder leaves the other four alone`() {
+        send(
+            SettingsEvent.SetPrayerReminderEnabled("fajr", true),
+            SettingsEvent.SetPrayerReminderEnabled("asr", true),
+        )
+        send(SettingsEvent.SetPrayerReminderEnabled("fajr", false))
+
+        val reminders = viewModel.notificationState.value.reminderEnabled
+        assertThat(reminders).containsEntry("fajr", false)
+        assertThat(reminders).containsEntry("asr", true)
+    }
+
+    @Test
+    fun `vibration and do-not-disturb are stored without rearming anything`() {
+        // Both are read at fire time. A reschedule here is a full alarm rewrite for a switch
+        // that cannot move a single alarm.
+        send(SettingsEvent.SetVibrationEnabled(false), SettingsEvent.SetRespectDnd(false))
+
+        assertThat(viewModel.notificationState.value.vibrationEnabled).isFalse()
+        assertThat(viewModel.notificationState.value.respectDnd).isFalse()
+        coVerify { repo.mock.setNotificationVibration(false) }
+        coVerify { repo.mock.setAdhanRespectDnd(false) }
+        coVerify(exactly = 0) { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `the persistent notification is stored without rearming`() {
+        send(SettingsEvent.SetPersistentNotification(true))
+
+        assertThat(viewModel.notificationState.value.persistentNotification).isTrue()
+        coVerify { repo.mock.setPersistentNotification(true) }
+        coVerify(exactly = 0) { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `the reminder-before pair changes when a notification fires, so both rearm`() {
+        send(
+            SettingsEvent.SetReminderMinutes(30),
+            SettingsEvent.SetShowReminderBefore(false),
+        )
+
+        assertThat(viewModel.notificationState.value.reminderMinutes).isEqualTo(30)
+        assertThat(viewModel.notificationState.value.showReminderBefore).isFalse()
+        coVerify { repo.mock.setNotificationReminderMinutes(30) }
+        coVerify { repo.mock.setShowReminderBefore(false) }
+        coVerify(exactly = 2) { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `the friday and khatam reminders write their own values and rearm`() {
+        send(
+            SettingsEvent.SetFridayReminderEnabled(true),
+            SettingsEvent.SetFridayReminderMinutes(120),
+            SettingsEvent.SetKhatamReminderEnabled(true),
+            SettingsEvent.SetKhatamReminderTime("22:15"),
+        )
+
+        val state = viewModel.notificationState.value
+        assertThat(state.fridayReminderEnabled).isTrue()
+        assertThat(state.fridayReminderMinutes).isEqualTo(120)
+        assertThat(state.khatamReminderEnabled).isTrue()
+        assertThat(state.khatamReminderTime).isEqualTo("22:15")
+        coVerify { repo.mock.setFridayReminderEnabled(true) }
+        coVerify { repo.mock.setFridayReminderMinutes(120) }
+        coVerify { repo.mock.setKhatamReminderEnabled(true) }
+        coVerify { repo.mock.setKhatamReminderTime("22:15") }
+    }
+
+    @Test
+    fun `a worship reminder writes under its own key`() {
+        // Eleven reminders share one keyed surface, so nothing about the call site says which
+        // reminder it is except the key — the one thing a copy-paste does not change.
+        send(
+            SettingsEvent.SetWorshipReminderEnabled("tahajjud", true),
+            SettingsEvent.SetWorshipReminderOffset("suhoor", 45),
+            SettingsEvent.SetWorshipReminderMode("witr", "before_fajr"),
+        )
+
+        val state = viewModel.notificationState.value
+        assertThat(state.worshipReminders).containsEntry("tahajjud", true)
+        assertThat(state.worshipOffsets).containsEntry("suhoor", 45)
+        assertThat(state.worshipModes).containsEntry("witr", "before_fajr")
+        coVerify { repo.mock.setWorshipReminderEnabled("tahajjud", true) }
+        coVerify { repo.mock.setWorshipReminderOffset("suhoor", 45) }
+        coVerify { repo.mock.setWorshipReminderMode("witr", "before_fajr") }
+        coVerify(exactly = 3) { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `switching one worship reminder on leaves the rest as they were`() {
+        send(SettingsEvent.SetWorshipReminderEnabled("iftar", true))
+        send(SettingsEvent.SetWorshipReminderEnabled("taraweeh", true))
+        send(SettingsEvent.SetWorshipReminderEnabled("iftar", false))
+
+        val reminders = viewModel.notificationState.value.worshipReminders
+        assertThat(reminders).containsEntry("iftar", false)
+        assertThat(reminders).containsEntry("taraweeh", true)
+    }
+
+    @Test
+    fun `picking an adhan that is not downloaded fetches it`() {
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns false
+
+        send(SettingsEvent.SetAdhanSound(AdhanSound.entries.first().name))
+
+        coVerify { repo.mock.setSelectedAdhanSound(AdhanSound.entries.first().name) }
+        coVerify { harness.adhanDownloader.download(AdhanSound.entries.first().name) }
+    }
+
+    @Test
+    fun `picking an adhan that is already downloaded does not fetch it again`() {
+        // A settings screen that re-downloads a 3 MB file every time the row is tapped is not a
+        // visible bug — it is a data bill.
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns true
+
+        send(SettingsEvent.SetAdhanSound(AdhanSound.entries.first().name))
+
+        coVerify(exactly = 0) { harness.adhanDownloader.download(any()) }
+    }
+
+    @Test
+    fun `the adhan master switch is stored and rearms`() {
+        send(SettingsEvent.SetAdhanEnabled(true))
+
+        assertThat(viewModel.notificationState.value.adhanEnabled).isTrue()
+        coVerify { repo.mock.setAdhanEnabled(true) }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `previewing an adhan already on disk plays it without downloading`() {
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns true
+
+        send(SettingsEvent.PreviewAdhanSound)
+
+        coVerify { harness.adhanAudioManager.preview(any(), false) }
+        assertThat(viewModel.adhanPreviewError.value).isNull()
+    }
+
+    @Test
+    fun `a preview whose download fails explains itself instead of playing silence`() {
+        // The failure arm is the one a user actually meets — on a plane, or on a metered
+        // connection. Without the message the preview button simply does nothing.
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns false
+        coEvery { harness.adhanAudioManager.downloadAdhanWithFajr(any()) } returns false
+
+        send(SettingsEvent.PreviewAdhanSound)
+
+        assertThat(viewModel.adhanPreviewError.value).contains("internet connection")
+        coVerify(exactly = 0) { harness.adhanAudioManager.preview(any(), any()) }
+    }
+
+    @Test
+    fun `a preview whose download succeeds goes on to play`() {
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns false
+        coEvery { harness.adhanAudioManager.downloadAdhanWithFajr(any()) } returns true
+
+        send(SettingsEvent.PreviewAdhanSound)
+
+        coVerify { harness.adhanAudioManager.preview(any(), false) }
+        assertThat(viewModel.adhanPreviewError.value).isNull()
+    }
+
+    @Test
+    fun `a preview that throws reports the failure and surfaces the message`() {
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns true
+        coEvery { harness.adhanAudioManager.preview(any(), any()) } throws
+            IllegalStateException("codec missing")
+
+        send(SettingsEvent.PreviewAdhanSound)
+
+        assertThat(viewModel.adhanPreviewError.value).contains("codec missing")
+        assertThat(harness.telemetry.errors.map { it.type }).contains("adhan_preview")
+    }
+
+    @Test
+    fun `the preview error can be dismissed`() {
+        coEvery { harness.adhanAudioManager.isFullyDownloaded(any()) } returns false
+        coEvery { harness.adhanAudioManager.downloadAdhanWithFajr(any()) } returns false
+        send(SettingsEvent.PreviewAdhanSound)
+        assertThat(viewModel.adhanPreviewError.value).isNotNull()
+
+        viewModel.clearAdhanPreviewError()
+
+        assertThat(viewModel.adhanPreviewError.value).isNull()
+    }
+
+    @Test
+    fun `stopping the adhan preview stops the engine`() {
+        send(SettingsEvent.StopAdhanPreview)
+
+        verify { harness.adhanAudioManager.stopPreview() }
+    }
+
+    // ── Quran, Dua, Hadith ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every Quran control writes its own preference`() {
+        send(
+            SettingsEvent.SetTranslator("pickthall"),
+            SettingsEvent.SetArabicFont("scheherazade"),
+            SettingsEvent.SetShowTranslation(false),
+            SettingsEvent.SetShowTransliteration(true),
+            SettingsEvent.SetArabicFontSize(34f),
+            SettingsEvent.SetTranslationFontSize(20f),
+            SettingsEvent.SetContinuousReading(false),
+            SettingsEvent.SetKeepScreenOn(false),
+            SettingsEvent.SetShowTajweed(true),
+            SettingsEvent.SetTajweedUnderline(true),
+            SettingsEvent.SetMushafScript(MushafScript.entries.last()),
+            SettingsEvent.SetReciter("alafasy"),
+        )
+
+        coVerify { repo.mock.setQuranTranslatorId("pickthall") }
+        coVerify { repo.mock.setQuranArabicFont("scheherazade") }
+        coVerify { repo.mock.setShowTranslation(false) }
+        coVerify { repo.mock.setShowTransliteration(true) }
+        // The two font sizes are the pair most likely to be crossed: same type, adjacent rows,
+        // near-identical setter names.
+        coVerify { repo.mock.setQuranArabicFontSize(34f) }
+        coVerify { repo.mock.setQuranTranslationFontSize(20f) }
+        coVerify { repo.mock.setContinuousReading(false) }
+        coVerify { repo.mock.setKeepScreenOn(false) }
+        coVerify { repo.mock.setShowTajweed(true) }
+        coVerify { repo.mock.setTajweedUnderline(true) }
+        coVerify { repo.mock.setQuranMushafScript(MushafScript.entries.last().name) }
+        coVerify { repo.mock.setSelectedReciterId("alafasy") }
+    }
+
+    @Test
+    fun `clearing the reciter stores a null rather than an empty id`() {
+        send(SettingsEvent.SetReciter(null))
+
+        assertThat(viewModel.quranState.value.selectedReciterId).isNull()
+        coVerify { repo.mock.setSelectedReciterId(null) }
+    }
+
+    @Test
+    fun `previewing a reciter plays one explicit ayah rather than whatever is loaded`() {
+        // The picker loads no surah, so a preview built from the reader's state hands
+        // `playFromAyah` an empty list and it returns without playing. That bug played silence
+        // and set the spinner, and a `verify { … any() }` would pass against it.
+        send(SettingsEvent.PreviewReciter("alafasy"))
+
+        verify { harness.quranPlayback.setReciter("alafasy", restartIfPlaying = false) }
+        verify { harness.quranPlayback.setContinuousPlayback(false) }
+        verify {
+            harness.quranPlayback.playFromAyah(
+                ayahGlobalId = 1,
+                allAyahs = match { it.size == 1 && it.single().ayahGlobalId == 1 },
+                title = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `stopping a reciter preview clears the previewing id as well as the player`() {
+        // Clearing only the player leaves the card's spinner running forever.
+        send(SettingsEvent.PreviewReciter("alafasy"))
+        send(SettingsEvent.StopReciterPreview)
+
+        verify { harness.quranPlayback.stop() }
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            assertThat(viewModel.reciterPreview.value.reciterId).isNull()
+        }
+    }
+
+    @Test
+    fun `every Dua control writes its own preference`() {
+        send(
+            SettingsEvent.SetDuaArabicFont("noto"),
+            SettingsEvent.SetDuaArabicFontSize(31f),
+            SettingsEvent.SetDuaTranslationFontSize(18f),
+            SettingsEvent.SetDuaShowArabic(false),
+            SettingsEvent.SetDuaShowTransliteration(false),
+            SettingsEvent.SetDuaShowTranslation(false),
+        )
+
+        val state = viewModel.duaState.value
+        assertThat(state.selectedArabicFontId).isEqualTo("noto")
+        assertThat(state.arabicFontSize).isEqualTo(31f)
+        assertThat(state.translationFontSize).isEqualTo(18f)
+        assertThat(state.showArabic).isFalse()
+        assertThat(state.showTransliteration).isFalse()
+        assertThat(state.showTranslation).isFalse()
+
+        coVerify { repo.mock.setDuaArabicFont("noto") }
+        coVerify { repo.mock.setDuaArabicFontSize(31f) }
+        coVerify { repo.mock.setDuaTranslationFontSize(18f) }
+        coVerify { repo.mock.setDuaShowArabic(false) }
+        coVerify { repo.mock.setDuaShowTransliteration(false) }
+        coVerify { repo.mock.setDuaShowTranslation(false) }
+    }
+
+    @Test
+    fun `a Dua control does not write the Quran preference of the same name`() {
+        // Three screens carry a row called "Arabic font size" and each must reach its own
+        // corpus's preference. Crossing them changes the reader's font from the Dua screen.
+        send(SettingsEvent.SetDuaArabicFontSize(31f))
+
+        coVerify(exactly = 0) { repo.mock.setQuranArabicFontSize(any()) }
+        coVerify(exactly = 0) { repo.mock.setHadithArabicFontSize(any()) }
+    }
+
+    @Test
+    fun `every Hadith control writes its own preference`() {
+        send(
+            SettingsEvent.SetHadithArabicFont("kfgqpc"),
+            SettingsEvent.SetHadithArabicFontSize(26f),
+            SettingsEvent.SetHadithTranslationFontSize(15f),
+            SettingsEvent.SetHadithShowArabic(false),
+            SettingsEvent.SetHadithShowTranslation(false),
+            SettingsEvent.SetHadithShowGrade(false),
+            SettingsEvent.SetHadithShowChain(false),
+        )
+
+        val state = viewModel.hadithState.value
+        assertThat(state.selectedArabicFontId).isEqualTo("kfgqpc")
+        assertThat(state.arabicFontSize).isEqualTo(26f)
+        assertThat(state.translationFontSize).isEqualTo(15f)
+        assertThat(state.showArabic).isFalse()
+        assertThat(state.showTranslation).isFalse()
+        assertThat(state.showGrade).isFalse()
+        assertThat(state.showChain).isFalse()
+
+        coVerify { repo.mock.setHadithArabicFont("kfgqpc") }
+        coVerify { repo.mock.setHadithArabicFontSize(26f) }
+        coVerify { repo.mock.setHadithTranslationFontSize(15f) }
+        coVerify { repo.mock.setHadithShowArabic(false) }
+        coVerify { repo.mock.setHadithShowTranslation(false) }
+        coVerify { repo.mock.setHadithShowGrade(false) }
+        coVerify { repo.mock.setHadithShowChain(false) }
+    }
+
+    // ── Locations and the destructive actions ────────────────────────────────────────────────
+
+    @Test
+    fun `choosing a location inserts it and then makes the inserted row current`() {
+        // Two calls that must be in that order and must use the *returned* id: setting the
+        // current location to the id the caller happened to hold points prayer times at the
+        // wrong city.
+        coEvery { harness.prayerUseCases.insertLocation.invoke(any()) } returns 77L
+
+        send(SettingsEvent.SetCurrentLocation(testLocation(id = 0L, name = "Cairo")))
+
+        coVerify { harness.prayerUseCases.setCurrentLocation.invoke(77L) }
+    }
+
+    @Test
+    fun `adding a location saves it without making it current`() {
+        coEvery { harness.prayerUseCases.insertLocation.invoke(any()) } returns 5L
+        val cairo = testLocation(id = 0L, name = "Cairo")
+
+        send(SettingsEvent.AddLocation(cairo))
+
+        coVerify { harness.prayerUseCases.insertLocation.invoke(cairo) }
+        coVerify(exactly = 0) { harness.prayerUseCases.setCurrentLocation.invoke(any()) }
+    }
+
+    @Test
+    fun `removing and favouriting a location reach their own use cases`() {
+        val cairo = testLocation(id = 9L, name = "Cairo")
+
+        send(SettingsEvent.RemoveLocation(cairo), SettingsEvent.ToggleLocationFavorite(9L))
+
+        coVerify { harness.prayerUseCases.deleteLocation.invoke(cairo) }
+        coVerify { harness.prayerUseCases.toggleFavorite.invoke(9L) }
+    }
+
+    @Test
+    fun `a test notification is sent and recorded as one prayer, not all`() {
+        send(SettingsEvent.TestNotification)
+
+        verify { harness.prayerNotificationTester.sendTestNotification() }
+        assertThat(harness.telemetry.calls).contains(
+            TelemetryCall.TestNotification(allPrayers = false)
+        )
+    }
+
+    @Test
+    fun `testing all notifications is a different call and a different record`() {
+        send(SettingsEvent.TestAllNotifications)
+
+        verify { harness.prayerNotificationTester.sendAllPrayerTestNotifications() }
+        assertThat(harness.telemetry.calls).contains(
+            TelemetryCall.TestNotification(allPrayers = true)
+        )
+    }
+
+    @Test
+    fun `resetting notifications cancels the existing alarms before rebuilding them`() {
+        // Rebuilding without cancelling leaves the old alarms armed, which is how "reset" ends
+        // up doubling the notifications rather than fixing them.
+        send(SettingsEvent.ResetNotifications)
+
+        coVerify { harness.prayerAlarmScheduler.cancelAllPrayerNotifications() }
+        coVerify { harness.rescheduleNotifications.invoke() }
+    }
+
+    @Test
+    fun `reset to defaults clears the preferences and every state holder`() {
+        // Dua and Hadith are the two this used to forget, so after a reset those screens went on
+        // showing pre-reset font sizes until the process restarted.
+        send(
+            SettingsEvent.SetHapticFeedback(false),
+            SettingsEvent.SetDuaArabicFontSize(40f),
+            SettingsEvent.SetHadithShowChain(false),
+        )
+
+        send(SettingsEvent.ResetToDefaults)
+
+        coVerify { repo.mock.clearAllData() }
+        assertThat(viewModel.generalState.value).isEqualTo(GeneralSettingsUiState())
+        assertThat(viewModel.duaState.value).isEqualTo(DuaSettingsUiState())
+        assertThat(viewModel.hadithState.value).isEqualTo(HadithSettingsUiState())
+        assertThat(viewModel.shouldRestart.value).isTrue()
+    }
+
+    @Test
+    fun `delete all data clears the user database as well as the preferences`() {
+        // The content database is deliberately untouched: the corpus is ours to replace and
+        // never theirs to lose. Clearing preferences alone would leave every tracked prayer.
+        send(SettingsEvent.DeleteAllData)
+
+        coVerify { harness.clearAllUserData.invoke() }
+        coVerify { repo.mock.clearAllData() }
+        assertThat(viewModel.locationState.value).isEqualTo(LocationSettingsUiState())
+        assertThat(viewModel.shouldRestart.value).isTrue()
+    }
+
+    @Test
+    fun `the destructive actions are recorded before the work, so a half-failure still shows`() {
+        send(SettingsEvent.ResetToDefaults)
+        send(SettingsEvent.DeleteAllData)
+
+        val actions = harness.telemetry.featureUsages.map { it.action }
+        assertThat(actions).contains("reset_to_defaults")
+        assertThat(actions).contains("delete_all_data")
+    }
+
+    @Test
+    fun `a setting change reports itself from the shared table`() {
+        // 78 branches report through one table rather than a line each, which is how 56 of them
+        // came to report nothing at all. One representative from each family, so a family
+        // dropped from the table is caught.
+        send(
+            SettingsEvent.SetHapticFeedback(false),
+            SettingsEvent.SetCalculationMethod(CalculationMethod.KARACHI),
+            SettingsEvent.SetVibrationEnabled(false),
+            SettingsEvent.SetShowTajweed(true),
+            SettingsEvent.SetDuaShowArabic(false),
+            SettingsEvent.SetHadithShowGrade(false),
+        )
+
+        val settings = harness.telemetry.settingChanges.map { it.setting }
+        assertThat(settings).containsAtLeast(
+            "haptic_feedback",
+            "calculation_method",
+            "notification_vibration",
+            "quran_show_tajweed",
+            "dua_show_arabic",
+            "hadith_show_grade",
+        )
+    }
+
+    @Test
+    fun `an action that is not a setting change reports nothing to the settings table`() {
+        send(SettingsEvent.TestNotification, SettingsEvent.StopAdhanPreview)
+
+        assertThat(harness.telemetry.settingChanges).isEmpty()
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsLoadTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsLoadTest.kt
@@ -1,0 +1,491 @@
+package com.arshadshah.nimaz.presentation.viewmodel.settings
+
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.MushafScript
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.WorshipReminderType
+import com.arshadshah.nimaz.presentation.theme.NimazPatternStyle
+import com.arshadshah.nimaz.testing.SettingsViewModelHarness
+import com.arshadshah.nimaz.testing.testLocation
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What the settings screens show when they open — the loader, not the writes.
+ *
+ * `loadSettings()` reads fifty-odd preferences with `.first()` and folds them into six state
+ * holders. Nothing in the module has ever run it: the existing `SettingsViewModelTest` builds the
+ * ViewModel on a relaxed `SettingsRepository`, whose flows never emit, so `first()` throws on the
+ * loader's *first* line and `launchSafely` swallows it. All 152 lines were dead, and the failure
+ * mode that hides behind them is the worst kind for a settings screen — every control renders its
+ * **compile-time default** rather than what the user chose, and the first toggle they touch writes
+ * that default back over their real preference.
+ *
+ * The parsing arms are the other half. Three of these values are persisted as strings and parsed
+ * back, and each parser has a fallback that is indistinguishable from a correct read on screen: a
+ * calculation method that will not parse silently becomes Muslim World League, which changes every
+ * prayer time in the app. The two telemetry errors are the only evidence that happened, so they
+ * are asserted rather than the fallback alone.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsLoadTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val harness = SettingsViewModelHarness()
+    private val repo get() = harness.repo
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun buildViewModel(): SettingsViewModel = harness.build()
+
+    @Test
+    fun `every stored general preference reaches the general state`() = runTest {
+        repo.themeMode.value = "dark"
+        repo.appLanguage.value = "tr"
+        repo.animationsEnabled.value = false
+        repo.showCountdown.value = false
+        repo.showQuickActions.value = false
+        repo.hapticFeedback.value = false
+        repo.use24HourFormat.value = true
+        repo.useHijriPrimary.value = true
+        repo.hijriDayOffset.value = -1
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.generalState.value
+        assertThat(state.theme).isEqualTo(AppTheme.DARK)
+        assertThat(state.language).isEqualTo(AppLanguage.TURKISH)
+        assertThat(state.animationsEnabled).isFalse()
+        assertThat(state.showCountdown).isFalse()
+        assertThat(state.showQuickActions).isFalse()
+        assertThat(state.hapticFeedback).isFalse()
+        assertThat(state.use24HourFormat).isTrue()
+        assertThat(state.useHijriPrimary).isTrue()
+        assertThat(state.hijriDayOffset).isEqualTo(-1)
+    }
+
+    @Test
+    fun `a stored light theme is not read as system`() = runTest {
+        // Three arms over one string, and the `else` catches everything — so a typo'd or renamed
+        // "light" reads as SYSTEM and the app opens in the wrong theme with no error anywhere.
+        repo.themeMode.value = "light"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.generalState.value.theme).isEqualTo(AppTheme.LIGHT)
+    }
+
+    @Test
+    fun `an unrecognised theme falls back to following the system`() = runTest {
+        repo.themeMode.value = "midnight"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.generalState.value.theme).isEqualTo(AppTheme.SYSTEM)
+    }
+
+    @Test
+    fun `an unrecognised language falls back to English rather than to no language`() = runTest {
+        // `AppLanguage.entries.find { it.code == … }` returns null for a code the app has since
+        // dropped, and the elvis is the only thing between that and a crash on a settings screen.
+        repo.appLanguage.value = "xx"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.generalState.value.language).isEqualTo(AppLanguage.ENGLISH)
+    }
+
+    @Test
+    fun `patterns switched off force the ornament style to NONE`() = runTest {
+        // Two preferences describe one thing, and the boolean wins. A stored style plus
+        // `showIslamicPatterns = false` must not paint the ornament — which is what would happen
+        // if the style were read on its own.
+        repo.showIslamicPatterns.value = false
+        repo.patternStyle.value = NimazPatternStyle.CORNER_MEDALLION.name
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.generalState.value.patternStyle).isEqualTo(NimazPatternStyle.NONE)
+        assertThat(viewModel.generalState.value.showIslamicPatterns).isFalse()
+    }
+
+    @Test
+    fun `patterns switched on keep the stored ornament style`() = runTest {
+        repo.showIslamicPatterns.value = true
+        repo.patternStyle.value = NimazPatternStyle.entries.last().name
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.generalState.value.patternStyle)
+            .isEqualTo(NimazPatternStyle.entries.last())
+    }
+
+    @Test
+    fun `the six per-prayer adjustments land on their own fields`() = runTest {
+        // Six near-identical reads assigned to six near-identical fields is exactly where a
+        // copy-paste puts maghrib's offset on asr — and the only visible symptom is one prayer
+        // time being minutes out, which reads as a calculation bug rather than a settings bug.
+        repo.fajrAdjustment.value = 1
+        repo.sunriseAdjustment.value = 2
+        repo.dhuhrAdjustment.value = 3
+        repo.asrAdjustment.value = 4
+        repo.maghribAdjustment.value = 5
+        repo.ishaAdjustment.value = 6
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.prayerState.value
+        assertThat(state.fajrAdjustment).isEqualTo(1)
+        assertThat(state.sunriseAdjustment).isEqualTo(2)
+        assertThat(state.dhuhrAdjustment).isEqualTo(3)
+        assertThat(state.asrAdjustment).isEqualTo(4)
+        assertThat(state.maghribAdjustment).isEqualTo(5)
+        assertThat(state.ishaAdjustment).isEqualTo(6)
+    }
+
+    @Test
+    fun `a stored calculation method is parsed rather than reset`() = runTest {
+        repo.calculationMethod.value = CalculationMethod.EGYPTIAN.name
+        repo.asrCalculation.value = "hanafi"
+        repo.highLatitudeRule.value = HighLatitudeRule.TWILIGHT_ANGLE.name
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.prayerState.value
+        assertThat(state.calculationMethod).isEqualTo(CalculationMethod.EGYPTIAN)
+        assertThat(state.asrMethod).isEqualTo(AsrCalculation.HANAFI)
+        assertThat(state.highLatitudeRule).isEqualTo(HighLatitudeRule.TWILIGHT_ANGLE)
+    }
+
+    @Test
+    fun `an unreadable calculation method falls back to MWL and reports it`() = runTest {
+        // The fallback alone is invisible: the user sees "Muslim World League" selected and has
+        // no way to tell it is not what they chose. The telemetry error is the only evidence,
+        // which is why it is what this asserts.
+        repo.calculationMethod.value = "NOT_A_METHOD"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.prayerState.value.calculationMethod)
+            .isEqualTo(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+        assertThat(harness.telemetry.errors.map { it.type })
+            .contains("unreadable_calculation_method")
+    }
+
+    @Test
+    fun `an unreadable high latitude rule falls back and reports it`() = runTest {
+        repo.highLatitudeRule.value = "NOT_A_RULE"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.prayerState.value.highLatitudeRule)
+            .isEqualTo(HighLatitudeRule.MIDDLE_OF_THE_NIGHT)
+        assertThat(harness.telemetry.errors.map { it.type })
+            .contains("unreadable_high_latitude_rule")
+    }
+
+    @Test
+    fun `each prayer's notification flag lands on its own field`() = runTest {
+        // Sunrise is the one that matters: `:core:datastore` pins that it defaults off, and a
+        // loader that read dhuhr's flag into sunrise's field would show it on.
+        repo.fajrNotificationEnabled.value = true
+        repo.sunriseNotificationEnabled.value = false
+        repo.dhuhrNotificationEnabled.value = false
+        repo.asrNotificationEnabled.value = true
+        repo.maghribNotificationEnabled.value = false
+        repo.ishaNotificationEnabled.value = true
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.notificationState.value
+        assertThat(state.fajrNotification).isTrue()
+        assertThat(state.sunriseNotification).isFalse()
+        assertThat(state.dhuhrNotification).isFalse()
+        assertThat(state.asrNotification).isTrue()
+        assertThat(state.maghribNotification).isFalse()
+        assertThat(state.ishaNotification).isTrue()
+    }
+
+    @Test
+    fun `the notification preferences load onto their own fields`() = runTest {
+        repo.prayerNotificationsEnabled.value = false
+        repo.adhanEnabled.value = true
+        repo.notificationVibration.value = false
+        repo.notificationReminderMinutes.value = 25
+        repo.showReminderBefore.value = false
+        repo.persistentNotification.value = true
+        repo.fridayReminderEnabled.value = true
+        repo.fridayReminderMinutes.value = 90
+        repo.khatamReminderEnabled.value = true
+        repo.khatamReminderTime.value = "21:45"
+        repo.adhanRespectDnd.value = false
+        repo.selectedAdhanSound.value = "MAKKAH"
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.notificationState.value
+        assertThat(state.notificationsEnabled).isFalse()
+        assertThat(state.adhanEnabled).isTrue()
+        assertThat(state.vibrationEnabled).isFalse()
+        assertThat(state.reminderMinutes).isEqualTo(25)
+        assertThat(state.showReminderBefore).isFalse()
+        assertThat(state.persistentNotification).isTrue()
+        assertThat(state.fridayReminderEnabled).isTrue()
+        assertThat(state.fridayReminderMinutes).isEqualTo(90)
+        assertThat(state.khatamReminderEnabled).isTrue()
+        assertThat(state.khatamReminderTime).isEqualTo("21:45")
+        assertThat(state.respectDnd).isFalse()
+        assertThat(state.selectedAdhanSound).isEqualTo("MAKKAH")
+    }
+
+    @Test
+    fun `the per-prayer alert style map is keyed by the prayer it was read for`() = runTest {
+        // Five reads through one keyed accessor. A loader that passed the same key five times
+        // would look right — every prayer would simply show fajr's setting.
+        repo.alertStyles.getValue("fajr").value = PrayerAlertStyle.ADHAN
+        repo.alertStyles.getValue("isha").value = PrayerAlertStyle.SILENT
+        repo.reminderEnabled.getValue("maghrib").value = true
+        repo.reminderMinutes.getValue("maghrib").value = 40
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.notificationState.value
+        assertThat(state.alertStyles).containsEntry("fajr", PrayerAlertStyle.ADHAN)
+        assertThat(state.alertStyles).containsEntry("isha", PrayerAlertStyle.SILENT)
+        assertThat(state.alertStyles).containsEntry("dhuhr", PrayerAlertStyle.NOTIFICATION)
+        assertThat(state.alertStyles.keys)
+            .containsExactlyElementsIn(PrayerAlertStyle.PRAYER_KEYS)
+        assertThat(state.reminderEnabled).containsEntry("maghrib", true)
+        assertThat(state.reminderEnabled).containsEntry("fajr", false)
+        assertThat(state.reminderOffsets).containsEntry("maghrib", 40)
+    }
+
+    @Test
+    fun `every worship reminder type is loaded, not only the ones a screen lists`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.notificationState.value
+        assertThat(state.worshipReminders.keys)
+            .containsExactlyElementsIn(WorshipReminderType.entries.map { it.key })
+        assertThat(state.worshipOffsets.keys)
+            .containsExactlyElementsIn(WorshipReminderType.entries.map { it.key })
+        // Only Witr has a mode, and reading a mode for the others would be a preference that
+        // never gets written.
+        assertThat(state.worshipModes.keys).containsExactly(WorshipReminderType.WITR.key)
+    }
+
+    @Test
+    fun `a worship reminder's offset defaults to its own type's default`() = runTest {
+        // `worshipReminderOffset(key, default)` takes the default per type. Passing one type's
+        // default for another puts suhoor's lead time on iftar, and the reminder fires at the
+        // wrong end of the fast.
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.notificationState.value
+        WorshipReminderType.entries.forEach { type ->
+            assertThat(state.worshipOffsets[type.key]).isEqualTo(type.defaultOffsetMinutes)
+        }
+    }
+
+    @Test
+    fun `the dua and hadith display preferences load onto their own states`() = runTest {
+        // These two states are the ones both reset paths used to forget, and they read from
+        // near-identical preference names — `duaArabicFontSize` against `hadithArabicFontSize`.
+        repo.duaArabicFont.value = "scheherazade"
+        repo.duaArabicFontSize.value = 33f
+        repo.duaTranslationFontSize.value = 19f
+        repo.duaShowArabic.value = false
+        repo.duaShowTransliteration.value = false
+        repo.duaShowTranslation.value = false
+        repo.hadithArabicFont.value = "noto"
+        repo.hadithArabicFontSize.value = 21f
+        repo.hadithTranslationFontSize.value = 14f
+        repo.hadithShowArabic.value = false
+        repo.hadithShowTranslation.value = false
+        repo.hadithShowGrade.value = false
+        repo.hadithShowChain.value = false
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        val dua = viewModel.duaState.value
+        assertThat(dua.selectedArabicFontId).isEqualTo("scheherazade")
+        assertThat(dua.arabicFontSize).isEqualTo(33f)
+        assertThat(dua.translationFontSize).isEqualTo(19f)
+        assertThat(dua.showArabic).isFalse()
+        assertThat(dua.showTransliteration).isFalse()
+        assertThat(dua.showTranslation).isFalse()
+
+        val hadith = viewModel.hadithState.value
+        assertThat(hadith.selectedArabicFontId).isEqualTo("noto")
+        assertThat(hadith.arabicFontSize).isEqualTo(21f)
+        assertThat(hadith.translationFontSize).isEqualTo(14f)
+        assertThat(hadith.showArabic).isFalse()
+        assertThat(hadith.showTranslation).isFalse()
+        assertThat(hadith.showGrade).isFalse()
+        assertThat(hadith.showChain).isFalse()
+    }
+
+    @Test
+    fun `the Quran state follows DataStore rather than a construction-time snapshot`() = runTest {
+        // The bug this exists for: a picker screen runs its own `SettingsViewModel`, writes the
+        // new reciter, and the settings screen behind it kept the value it read at construction.
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+        assertThat(viewModel.quranState.value.selectedReciterId).isNull()
+
+        repo.selectedReciterId.value = "alafasy"
+        repo.quranTranslatorId.value = "pickthall"
+        repo.quranMushafScript.value = MushafScript.entries.last().name
+        repo.showTajweed.value = true
+        advanceUntilIdle()
+
+        val state = viewModel.quranState.value
+        assertThat(state.selectedReciterId).isEqualTo("alafasy")
+        assertThat(state.selectedTranslatorId).isEqualTo("pickthall")
+        assertThat(state.mushafScript).isEqualTo(MushafScript.entries.last())
+        assertThat(state.showTajweed).isTrue()
+    }
+
+    @Test
+    fun `the preview card shows the text of the translation that is selected`() = runTest {
+        harness.previewTranslationIs("In the name of Allah")
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.quranState.value.previewTranslation).isEqualTo("In the name of Allah")
+    }
+
+    @Test
+    fun `a failed preview read keeps the previous text and does not end the chain`() = runTest {
+        // The `catchAndReport` is *inside* the flatMapLatest deliberately: outside it, one failed
+        // read would complete the upstream and freeze the preview on the old translation for the
+        // ViewModel's whole life, with every later change silently doing nothing.
+        harness.previewTranslationIs("first translation")
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        harness.previewTranslationThrows()
+        repo.quranTranslatorId.value = "broken"
+        advanceUntilIdle()
+        assertThat(viewModel.quranState.value.previewTranslation).isEqualTo("first translation")
+
+        harness.previewTranslationIs("third translation")
+        repo.quranTranslatorId.value = "recovered"
+        advanceUntilIdle()
+        assertThat(viewModel.quranState.value.previewTranslation).isEqualTo("third translation")
+    }
+
+    @Test
+    fun `a null preview read leaves the card showing the previous text`() = runTest {
+        harness.previewTranslationIs("kept")
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        harness.previewTranslationIs(null)
+        repo.quranTranslatorId.value = "missing"
+        advanceUntilIdle()
+
+        assertThat(viewModel.quranState.value.previewTranslation).isEqualTo("kept")
+    }
+
+    @Test
+    fun `the three location flows each land on their own list`() = runTest {
+        val london = testLocation(id = 1L, name = "London")
+        val cairo = testLocation(id = 2L, name = "Cairo", latitude = 30.0, longitude = 31.2)
+
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+        // `isLoading` starts true and is cleared only by the saved-locations collector — a screen
+        // that never sees it cleared shows a spinner forever.
+        assertThat(viewModel.locationState.value.isLoading).isFalse()
+
+        harness.currentLocation.value = london
+        harness.allLocations.value = listOf(london, cairo)
+        harness.favoriteLocations.value = listOf(cairo)
+        advanceUntilIdle()
+
+        val state = viewModel.locationState.value
+        assertThat(state.currentLocation).isEqualTo(london)
+        assertThat(state.savedLocations).containsExactly(london, cairo).inOrder()
+        assertThat(state.favoriteLocations).containsExactly(cairo)
+    }
+
+    @Test
+    fun `the notification rollup counts only the prayers that are switched on`() = runTest {
+        repo.dhuhrNotificationEnabled.value = false
+        repo.ishaNotificationEnabled.value = false
+        repo.alertStyles.getValue("fajr").value = PrayerAlertStyle.ADHAN
+        repo.reminderEnabled.getValue("fajr").value = true
+        repo.reminderMinutes.getValue("fajr").value = 20
+
+        val viewModel = buildViewModel()
+        // `WhileSubscribed`, so the combine does not run at all until something collects — and a
+        // test reading `.value` without a subscriber sees the initial value and passes whatever
+        // the rollup would have computed.
+        backgroundScope.launch { viewModel.notificationSummary.collect {} }
+        advanceUntilIdle()
+
+        val summary = viewModel.notificationSummary.value
+        assertThat(summary.enabledPrayerCount).isEqualTo(3)
+        assertThat(summary.fajrAlertStyle).isEqualTo(PrayerAlertStyle.ADHAN)
+        assertThat(summary.reminderEnabled).isTrue()
+        assertThat(summary.reminderMinutes).isEqualTo(20)
+    }
+
+    @Test
+    fun `the rollup follows a change made on another screen's ViewModel instance`() = runTest {
+        // Each settings destination has its own `SettingsViewModel`; DataStore is the singleton
+        // they share. That is the entire reason this rollup collects rather than snapshots.
+        val viewModel = buildViewModel()
+        backgroundScope.launch { viewModel.notificationSummary.collect {} }
+        advanceUntilIdle()
+        assertThat(viewModel.notificationSummary.value.enabledPrayerCount).isEqualTo(5)
+
+        repo.maghribNotificationEnabled.value = false
+        advanceUntilIdle()
+
+        assertThat(viewModel.notificationSummary.value.enabledPrayerCount).isEqualTo(4)
+    }
+
+    @Test
+    fun `the widget previews read the stored preferences, not a second DataStore`() = runTest {
+        val viewModel = buildViewModel()
+        backgroundScope.launch { viewModel.widgetPreviewPreferences.collect {} }
+        advanceUntilIdle()
+
+        assertThat(viewModel.widgetPreviewPreferences.value?.locationName).isEqualTo("London")
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SyncViewModelTest.kt
@@ -1,12 +1,17 @@
 package com.arshadshah.nimaz.presentation.viewmodel.settings
 
 import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.data.sync.CancelReason
 import com.arshadshah.nimaz.data.sync.ConnectionState
 import com.arshadshah.nimaz.data.sync.NearbyConnectionsManager
 import com.arshadshah.nimaz.data.sync.SyncDataExporter
 import com.arshadshah.nimaz.data.sync.SyncDataImporter
+import com.arshadshah.nimaz.data.sync.SyncSignal
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.slot
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -117,7 +122,339 @@ class SyncViewModelTest {
         assertThat(vm.uiState.value.connectionState)
             .isInstanceOf(ConnectionState.Error::class.java)
     }
+
+    // ── The connection state machine ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `connecting as the sender starts the export without waiting to be asked`() {
+        // The sender's job begins the moment the connection is up: signal Ready, then export.
+        // A sender that waited for something would leave both devices staring at a spinner,
+        // because the receiver's next move is to wait for data.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            vm.onEvent(SyncEvent.StartSend)
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Connected("e1", "Pixel 8")
+            advanceUntilIdle()
+
+            verify { connections.sendSignal(SyncSignal.Ready) }
+            coVerify { exporter.export(any()) }
+        }
+    }
+
+    @Test
+    fun `connecting as the receiver exports nothing and says it is waiting`() {
+        // The mirror image, and the one that matters: a receiver that exported would send its
+        // own data back over the connection meant to replace it.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            vm.onEvent(SyncEvent.StartReceive)
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Connected("e1", "Pixel 8")
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { exporter.export(any()) }
+            verify(exactly = 0) { connections.sendSignal(SyncSignal.Ready) }
+            assertThat(vm.uiState.value.currentStep).contains("waiting")
+        }
+    }
+
+    @Test
+    fun `transfer progress reaches the state the bar is drawn from`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Transferring(0.42f)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.transferProgress).isEqualTo(0.42f)
+        }
+    }
+
+    @Test
+    fun `a completed send is not reported as finished until the partner has imported`() {
+        // "Completed" on the transport means the bytes left this device, not that they landed
+        // anywhere useful. Reporting the sync done here would let the sender walk away while
+        // the import was still running — and a failed import would never be seen.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            vm.onEvent(SyncEvent.StartSend)
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Completed(bytesReceived = 0)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.currentStep).contains("waiting for partner")
+            assertThat(vm.uiState.value.stepsCompleted)
+                .isEqualTo(vm.uiState.value.totalSteps - 1)
+        }
+    }
+
+    @Test
+    fun `each cancellation reason is recorded as its own event`() {
+        // A sync people abandon and a sync the transport drops need different fixes, and from
+        // outside they looked identical.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Cancelled(CancelReason.CONNECTION_LOST)
+            advanceUntilIdle()
+
+            assertThat(telemetry.featureUsages.map { it.action })
+                .contains("cancelled_connection_lost")
+            assertThat(vm.uiState.value.activityLog.map { it.label })
+                .contains("Connection lost")
+        }
+    }
+
+    @Test
+    fun `a partner cancellation is distinguished from the user's own`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Cancelled(CancelReason.BY_PARTNER)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.activityLog.map { it.label })
+                .contains("Cancelled by partner")
+            assertThat(telemetry.featureUsages.map { it.action })
+                .contains("cancelled_by_partner")
+        }
+    }
+
+    // ── Signals from the other device ────────────────────────────────────────────────────────
+
+    /** The handler the transport was armed with in `init`. */
+    private fun signalHandler(): (SyncSignal) -> Unit {
+        val slot = slot<(SyncSignal) -> Unit>()
+        verify { connections.setOnSignalReceived(capture(slot)) }
+        return slot.captured
+    }
+
+    @Test
+    fun `a partner's cancel signal ends the sync and disconnects`() {
+        // Without the disconnect the transport stays up after the other side has gone, and the
+        // screen shows a live connection to nobody.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            signalHandler()(SyncSignal.Cancel)
+            advanceUntilIdle()
+
+            verify { connections.disconnect() }
+            assertThat(vm.uiState.value.connectionState)
+                .isEqualTo(ConnectionState.Cancelled(CancelReason.BY_PARTNER))
+        }
+    }
+
+    @Test
+    fun `the partner's import progress is shown on the sender's screen`() {
+        // The sender has nothing left to do at this point, so without the relayed progress the
+        // screen sits still through the longest part of the transfer.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            signalHandler()(SyncSignal.ImportStarted)
+            advanceUntilIdle()
+            assertThat(vm.uiState.value.connectionState)
+                .isInstanceOf(ConnectionState.PartnerImporting::class.java)
+
+            signalHandler()(
+                SyncSignal.ImportProgress(step = 4, total = 12, label = "Importing khatam data...")
+            )
+            advanceUntilIdle()
+
+            val state = vm.uiState.value.connectionState as ConnectionState.PartnerImporting
+            assertThat(state.step).isEqualTo(4)
+            assertThat(state.total).isEqualTo(12)
+            assertThat(vm.uiState.value.currentStep).contains("Importing khatam data...")
+        }
+    }
+
+    @Test
+    fun `the partner's import completing acknowledges and finishes the sync`() {
+        // The Ack is what lets the *other* device stop waiting. Completing without it leaves
+        // the receiver on a spinner after a sync that succeeded.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            signalHandler()(SyncSignal.ImportComplete)
+            advanceUntilIdle()
+
+            verify { connections.sendSignal(SyncSignal.Ack) }
+            verify { connections.disconnect() }
+            assertThat(vm.uiState.value.connectionState)
+                .isInstanceOf(ConnectionState.Completed::class.java)
+        }
+    }
+
+    @Test
+    fun `an Ack from the partner finishes this side too`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            signalHandler()(SyncSignal.Ack)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.connectionState)
+                .isInstanceOf(ConnectionState.Completed::class.java)
+            assertThat(vm.uiState.value.stepsCompleted)
+                .isEqualTo(vm.uiState.value.totalSteps)
+            verify { connections.disconnect() }
+        }
+    }
+
+    @Test
+    fun `a Ready signal is logged without changing the connection state`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            signalHandler()(SyncSignal.Ready)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.activityLog.map { it.label }).contains("Sender is ready")
+            assertThat(vm.uiState.value.connectionState).isEqualTo(ConnectionState.Idle)
+        }
+    }
+
+    // ── Cancelling ───────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `cancelling a live connection tells the partner before stopping`() {
+        // Stopping without signalling leaves the other device waiting on a connection that is
+        // already gone — it learns only from a timeout.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Transferring(0.5f)
+            advanceUntilIdle()
+
+            vm.onEvent(SyncEvent.Cancel)
+            advanceUntilIdle()
+
+            verify { connections.cancelWithSignal() }
+            verify { connections.stopAll() }
+        }
+    }
+
+    @Test
+    fun `cancelling before anything is connected does not signal a partner there is none`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            vm.onEvent(SyncEvent.StartSend)
+            advanceUntilIdle()
+
+            vm.onEvent(SyncEvent.Cancel)
+            advanceUntilIdle()
+
+            verify(exactly = 0) { connections.cancelWithSignal() }
+            verify { connections.stopAll() }
+        }
+    }
+
+    @Test
+    fun `cancelling after a finished sync resets the screen rather than marking it cancelled`() {
+        // This is the "Done" button's path. Marking a sync that succeeded as cancelled would
+        // be the last thing the user saw about it.
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            signalHandler()(SyncSignal.Ack)
+            advanceUntilIdle()
+
+            vm.onEvent(SyncEvent.Cancel)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value).isEqualTo(SyncUiState())
+            verify(exactly = 0) { connections.cancelWithSignal() }
+        }
+    }
+
+    @Test
+    fun `cancelling an already-cancelled sync also resets rather than re-cancelling`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            connectionState.value = ConnectionState.Cancelled(CancelReason.BY_PARTNER)
+            advanceUntilIdle()
+
+            vm.onEvent(SyncEvent.Cancel)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value).isEqualTo(SyncUiState())
+        }
+    }
+
+    @Test
+    fun `accepting and rejecting reach the transport with the endpoint they name`() {
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+
+            vm.onEvent(SyncEvent.AcceptConnection("endpoint-7"))
+            vm.onEvent(SyncEvent.RejectConnection("endpoint-9"))
+            advanceUntilIdle()
+
+            verify { connections.acceptConnection("endpoint-7") }
+            verify { connections.rejectConnection("endpoint-9") }
+        }
+    }
+
+    // ── Export failure ───────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an export that throws is reported to the user, not only swallowed`() {
+        // Without the error state the sender's progress bar simply stops, and the receiver
+        // waits for data that will never arrive.
+        coEvery { exporter.export(any()) } throws IllegalStateException("database locked")
+        val vm = viewModel()
+        runTest(dispatcher) {
+            advanceUntilIdle()
+            vm.onEvent(SyncEvent.StartSend)
+            advanceUntilIdle()
+
+            connectionState.value = ConnectionState.Connected("e1", "Pixel 8")
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value.error).isNotNull()
+            assertThat(vm.uiState.value.error!!.details).isEqualTo("database locked")
+            assertThat(telemetry.errors.map { it.type }).contains("export")
+            assertThat(vm.uiState.value.activityLog.map { it.label })
+                .contains("Export failed: database locked")
+        }
+    }
+
+    // ── Byte formatting ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `byte sizes are reported in the unit a person can read`() {
+        // This is what the progress caption and the activity log both show. A payload reported
+        // as "4194304 B" tells the reader nothing about whether to expect a wait.
+        assertThat(SyncViewModel.formatBytes(512)).isEqualTo("512 B")
+        assertThat(SyncViewModel.formatBytes(1024)).isEqualTo("1 KB")
+        assertThat(SyncViewModel.formatBytes(2048)).isEqualTo("2 KB")
+        assertThat(SyncViewModel.formatBytes(1024L * 1024)).contains("MB")
+    }
+
+    @Test
+    fun `the boundary between each unit falls where the reader expects`() {
+        // 1023 bytes is not "0 KB", and 1 MB minus a byte is not "0.9 MB rounded to 1024 KB".
+        assertThat(SyncViewModel.formatBytes(1023)).isEqualTo("1023 B")
+        assertThat(SyncViewModel.formatBytes(1024L * 1024 - 1)).isEqualTo("1023 KB")
+    }
 }
+
 
 /** `onCleared` is protected on `ViewModel`; the test lives in the same module, not the same package. */
 private fun SyncViewModel.callOnCleared() {

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/FakeSettingsScreenViewModel.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/FakeSettingsScreenViewModel.kt
@@ -1,0 +1,93 @@
+package com.arshadshah.nimaz.testing
+
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.data.audio.DownloadState
+import com.arshadshah.nimaz.domain.model.PrayerTimes
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.presentation.viewmodel.settings.DuaSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.GeneralSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.HadithSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.LocationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSummary
+import com.arshadshah.nimaz.presentation.viewmodel.settings.PrayerSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.QuranSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.ReciterPreviewUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsViewModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * A `SettingsViewModel` for a **screen** test: every state holder a screen might collect, and a
+ * list of the events it dispatched.
+ *
+ * Nineteen of this module's twenty-four screens take `SettingsViewModel`, and each collects two or
+ * three of its eleven state flows. Mocking only the ones a given screen reads works right up until
+ * a refactor makes it read a fourth, at which point the test fails inside Compose with a null flow
+ * and no indication which one. Stubbing all of them once is both shorter and steadier.
+ *
+ * [events] is the assertion surface. A settings screen's whole job is to turn a tap into the right
+ * `SettingsEvent`, so what the tests check is the event, not a repository call — the ViewModel's
+ * own tests own the half after that.
+ */
+class FakeSettingsScreenViewModel {
+
+    val generalState = MutableStateFlow(GeneralSettingsUiState())
+    val prayerState = MutableStateFlow(PrayerSettingsUiState())
+    val notificationState = MutableStateFlow(NotificationSettingsUiState())
+    val quranState = MutableStateFlow(QuranSettingsUiState())
+    val duaState = MutableStateFlow(DuaSettingsUiState())
+    val hadithState = MutableStateFlow(HadithSettingsUiState())
+    val locationState = MutableStateFlow(LocationSettingsUiState(isLoading = false))
+    val notificationSummary = MutableStateFlow(NotificationSummary())
+    val reciterPreview = MutableStateFlow(ReciterPreviewUiState())
+    val todayPrayerTimes = MutableStateFlow<PrayerTimes?>(null)
+    val widgetPreviewPreferences = MutableStateFlow<UserPreferences?>(null)
+    val shouldRestart = MutableStateFlow(false)
+    val adhanPreviewError = MutableStateFlow<String?>(null)
+    val adhanDownloadState = MutableStateFlow<Map<AdhanSound, DownloadState>>(emptyMap())
+    val isAdhanPlaying = MutableStateFlow(false)
+    val currentlyPlayingAdhan = MutableStateFlow<AdhanSound?>(null)
+
+    /** Everything the screen under test dispatched, in order. */
+    val events = mutableListOf<SettingsEvent>()
+
+    val mock: SettingsViewModel = mockk(relaxed = true) {
+        every { generalState } returns this@FakeSettingsScreenViewModel.generalState
+        every { prayerState } returns this@FakeSettingsScreenViewModel.prayerState
+        every { notificationState } returns this@FakeSettingsScreenViewModel.notificationState
+        every { quranState } returns this@FakeSettingsScreenViewModel.quranState
+        every { duaState } returns this@FakeSettingsScreenViewModel.duaState
+        every { hadithState } returns this@FakeSettingsScreenViewModel.hadithState
+        every { locationState } returns this@FakeSettingsScreenViewModel.locationState
+        every {
+            notificationSummary
+        } returns this@FakeSettingsScreenViewModel.notificationSummary
+        every { reciterPreview } returns this@FakeSettingsScreenViewModel.reciterPreview
+        every { todayPrayerTimes } returns this@FakeSettingsScreenViewModel.todayPrayerTimes
+        every {
+            widgetPreviewPreferences
+        } returns this@FakeSettingsScreenViewModel.widgetPreviewPreferences
+        every { shouldRestart } returns this@FakeSettingsScreenViewModel.shouldRestart
+        every { adhanPreviewError } returns this@FakeSettingsScreenViewModel.adhanPreviewError
+        every { adhanDownloadState } returns this@FakeSettingsScreenViewModel.adhanDownloadState
+        every { isAdhanPlaying } returns this@FakeSettingsScreenViewModel.isAdhanPlaying
+        every {
+            currentlyPlayingAdhan
+        } returns this@FakeSettingsScreenViewModel.currentlyPlayingAdhan
+        every { onEvent(any()) } answers {
+            this@FakeSettingsScreenViewModel.events += firstArg<SettingsEvent>()
+        }
+    }
+
+    /** The single event of type [T] the screen dispatched, failing the test if there is not one. */
+    inline fun <reified T : SettingsEvent> only(): T {
+        val matches = events.filterIsInstance<T>()
+        check(matches.size == 1) {
+            "expected exactly one ${T::class.simpleName}, got ${matches.size} in $events"
+        }
+        return matches.single()
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRepositoryStub.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRepositoryStub.kt
@@ -1,0 +1,255 @@
+package com.arshadshah.nimaz.testing
+
+import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
+import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.repository.SettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * A [SettingsRepository] whose **reads are real flows** and whose writes are recorded by mockk.
+ *
+ * The distinction is the whole reason this exists. `SettingsViewModel.loadSettings()` reads
+ * fifty-odd preferences with `.first()`, and a `mockk(relaxed = true)` answers each of those
+ * properties with a *relaxed `Flow`* — an object whose `collect` returns without ever emitting.
+ * `first()` on that throws `NoSuchElementException`, which `launchSafely` swallows, so the loader
+ * dies on its first line and every one of the 152 lines after it is dead. The module's existing
+ * `SettingsViewModelTest` stubbed the fifteen flows its own assertions needed and left the rest;
+ * the result reads as a passing test of a ViewModel whose constructor never finished its work.
+ *
+ * Every flow here is a [MutableStateFlow], so a test can also *change* a preference after
+ * construction and watch the reactive rollups ([SettingsViewModel.notificationSummary],
+ * `observeQuranSettings`) follow it — which is the behaviour those two exist for.
+ *
+ * Writes stay on the mockk so `coVerify { repo.setHapticFeedback(false) }` keeps working: the
+ * question this module's tests ask most often is "did the control the user touched write the
+ * preference it names, or its neighbour's", and a verify against the exact setter is how that is
+ * asked.
+ */
+class SettingsRepositoryStub {
+
+    // --- General -----------------------------------------------------------------------------
+    val themeMode = MutableStateFlow("system")
+    val appLanguage = MutableStateFlow("en")
+    val showIslamicPatterns = MutableStateFlow(true)
+    val patternStyle = MutableStateFlow("CORNER_MEDALLION")
+    val animationsEnabled = MutableStateFlow(true)
+    val showCountdown = MutableStateFlow(true)
+    val showQuickActions = MutableStateFlow(true)
+    val hapticFeedback = MutableStateFlow(true)
+    val use24HourFormat = MutableStateFlow(false)
+    val useHijriPrimary = MutableStateFlow(false)
+    val hijriDayOffset = MutableStateFlow(0)
+
+    // --- Prayer ------------------------------------------------------------------------------
+    val calculationMethod = MutableStateFlow("MUSLIM_WORLD_LEAGUE")
+    val asrCalculation = MutableStateFlow("standard")
+    val highLatitudeRule = MutableStateFlow("MIDDLE_OF_THE_NIGHT")
+    val fajrAdjustment = MutableStateFlow(0)
+    val sunriseAdjustment = MutableStateFlow(0)
+    val dhuhrAdjustment = MutableStateFlow(0)
+    val asrAdjustment = MutableStateFlow(0)
+    val maghribAdjustment = MutableStateFlow(0)
+    val ishaAdjustment = MutableStateFlow(0)
+
+    // --- Notifications -----------------------------------------------------------------------
+    val prayerNotificationsEnabled = MutableStateFlow(true)
+    val adhanEnabled = MutableStateFlow(false)
+    val notificationVibration = MutableStateFlow(true)
+    val notificationReminderMinutes = MutableStateFlow(15)
+    val showReminderBefore = MutableStateFlow(true)
+    val persistentNotification = MutableStateFlow(false)
+    val fridayReminderEnabled = MutableStateFlow(false)
+    val fridayReminderMinutes = MutableStateFlow(60)
+    val khatamReminderEnabled = MutableStateFlow(false)
+    val khatamReminderTime = MutableStateFlow("06:00")
+    val adhanRespectDnd = MutableStateFlow(true)
+    val selectedAdhanSound = MutableStateFlow("MISHARY")
+    val fajrNotificationEnabled = MutableStateFlow(true)
+
+    /** Off by default, and `:core:datastore` pins that it is. The screens must agree. */
+    val sunriseNotificationEnabled = MutableStateFlow(false)
+    val dhuhrNotificationEnabled = MutableStateFlow(true)
+    val asrNotificationEnabled = MutableStateFlow(true)
+    val maghribNotificationEnabled = MutableStateFlow(true)
+    val ishaNotificationEnabled = MutableStateFlow(true)
+
+    /** Per-prayer, so a test can make one prayer differ from the other four. */
+    val alertStyles = PrayerAlertStyle.PRAYER_KEYS
+        .associateWith { MutableStateFlow(PrayerAlertStyle.NOTIFICATION) }
+    val reminderEnabled = PrayerAlertStyle.PRAYER_KEYS.associateWith { MutableStateFlow(false) }
+    val reminderMinutes = PrayerAlertStyle.PRAYER_KEYS.associateWith { MutableStateFlow(15) }
+    val worshipEnabled = mutableMapOf<String, MutableStateFlow<Boolean>>()
+    val worshipOffsets = mutableMapOf<String, MutableStateFlow<Int>>()
+    val worshipModes = mutableMapOf<String, MutableStateFlow<String>>()
+
+    // --- Quran / Dua / Hadith ------------------------------------------------------------------
+    val quranTranslatorId = MutableStateFlow("sahih_international")
+    val quranArabicFont = MutableStateFlow("amiri")
+    val selectedReciterId = MutableStateFlow<String?>(null)
+    val quranMushafScript = MutableStateFlow("DEFAULT")
+    val showTranslation = MutableStateFlow(true)
+    val showTransliteration = MutableStateFlow(false)
+    val quranArabicFontSize = MutableStateFlow(28f)
+    val quranTranslationFontSize = MutableStateFlow(16f)
+    val continuousReading = MutableStateFlow(true)
+    val keepScreenOn = MutableStateFlow(true)
+    val showTajweed = MutableStateFlow(false)
+    val tajweedUnderline = MutableStateFlow(false)
+
+    val duaArabicFont = MutableStateFlow("amiri")
+    val duaArabicFontSize = MutableStateFlow(28f)
+    val duaTranslationFontSize = MutableStateFlow(16f)
+    val duaShowArabic = MutableStateFlow(true)
+    val duaShowTransliteration = MutableStateFlow(true)
+    val duaShowTranslation = MutableStateFlow(true)
+
+    val hadithArabicFont = MutableStateFlow("amiri")
+    val hadithArabicFontSize = MutableStateFlow(24f)
+    val hadithTranslationFontSize = MutableStateFlow(16f)
+    val hadithShowArabic = MutableStateFlow(true)
+    val hadithShowTranslation = MutableStateFlow(true)
+    val hadithShowGrade = MutableStateFlow(true)
+    val hadithShowChain = MutableStateFlow(true)
+
+    val userPreferences = MutableStateFlow(
+        UserPreferences(
+            onboardingCompleted = true,
+            themeMode = "system",
+            dynamicColor = false,
+            appLanguage = "en",
+            calculationMethod = "MUSLIM_WORLD_LEAGUE",
+            asrCalculation = "standard",
+            latitude = 51.5074,
+            longitude = -0.1278,
+            locationName = "London",
+            prayerNotificationsEnabled = true,
+            quranTranslatorId = "sahih_international",
+            showTranslation = true,
+        )
+    )
+
+    /** The mock every assertion verifies against. Reads are wired to the flows above. */
+    val mock: SettingsRepository = mockk(relaxed = true) {
+        every { themeMode } returns this@SettingsRepositoryStub.themeMode
+        every { appLanguage } returns this@SettingsRepositoryStub.appLanguage
+        every { showIslamicPatterns } returns this@SettingsRepositoryStub.showIslamicPatterns
+        every { patternStyle } returns this@SettingsRepositoryStub.patternStyle
+        every { animationsEnabled } returns this@SettingsRepositoryStub.animationsEnabled
+        every { showCountdown } returns this@SettingsRepositoryStub.showCountdown
+        every { showQuickActions } returns this@SettingsRepositoryStub.showQuickActions
+        every { hapticFeedback } returns this@SettingsRepositoryStub.hapticFeedback
+        every { use24HourFormat } returns this@SettingsRepositoryStub.use24HourFormat
+        every { useHijriPrimary } returns this@SettingsRepositoryStub.useHijriPrimary
+        every { hijriDayOffset } returns this@SettingsRepositoryStub.hijriDayOffset
+
+        every { calculationMethod } returns this@SettingsRepositoryStub.calculationMethod
+        every { asrCalculation } returns this@SettingsRepositoryStub.asrCalculation
+        every { highLatitudeRule } returns this@SettingsRepositoryStub.highLatitudeRule
+        every { fajrAdjustment } returns this@SettingsRepositoryStub.fajrAdjustment
+        every { sunriseAdjustment } returns this@SettingsRepositoryStub.sunriseAdjustment
+        every { dhuhrAdjustment } returns this@SettingsRepositoryStub.dhuhrAdjustment
+        every { asrAdjustment } returns this@SettingsRepositoryStub.asrAdjustment
+        every { maghribAdjustment } returns this@SettingsRepositoryStub.maghribAdjustment
+        every { ishaAdjustment } returns this@SettingsRepositoryStub.ishaAdjustment
+
+        every {
+            prayerNotificationsEnabled
+        } returns this@SettingsRepositoryStub.prayerNotificationsEnabled
+        every { adhanEnabled } returns this@SettingsRepositoryStub.adhanEnabled
+        every { notificationVibration } returns this@SettingsRepositoryStub.notificationVibration
+        every {
+            notificationReminderMinutes
+        } returns this@SettingsRepositoryStub.notificationReminderMinutes
+        every { showReminderBefore } returns this@SettingsRepositoryStub.showReminderBefore
+        every {
+            persistentNotification
+        } returns this@SettingsRepositoryStub.persistentNotification
+        every { fridayReminderEnabled } returns this@SettingsRepositoryStub.fridayReminderEnabled
+        every { fridayReminderMinutes } returns this@SettingsRepositoryStub.fridayReminderMinutes
+        every { khatamReminderEnabled } returns this@SettingsRepositoryStub.khatamReminderEnabled
+        every { khatamReminderTime } returns this@SettingsRepositoryStub.khatamReminderTime
+        every { adhanRespectDnd } returns this@SettingsRepositoryStub.adhanRespectDnd
+        every { selectedAdhanSound } returns this@SettingsRepositoryStub.selectedAdhanSound
+        every {
+            fajrNotificationEnabled
+        } returns this@SettingsRepositoryStub.fajrNotificationEnabled
+        every {
+            sunriseNotificationEnabled
+        } returns this@SettingsRepositoryStub.sunriseNotificationEnabled
+        every {
+            dhuhrNotificationEnabled
+        } returns this@SettingsRepositoryStub.dhuhrNotificationEnabled
+        every { asrNotificationEnabled } returns this@SettingsRepositoryStub.asrNotificationEnabled
+        every {
+            maghribNotificationEnabled
+        } returns this@SettingsRepositoryStub.maghribNotificationEnabled
+        every {
+            ishaNotificationEnabled
+        } returns this@SettingsRepositoryStub.ishaNotificationEnabled
+
+        every { prayerAlertStyle(any()) } answers {
+            this@SettingsRepositoryStub.alertStyles[firstArg<String>()]
+                ?: MutableStateFlow(PrayerAlertStyle.NOTIFICATION)
+        }
+        every { prayerReminderEnabled(any()) } answers {
+            this@SettingsRepositoryStub.reminderEnabled[firstArg<String>()]
+                ?: MutableStateFlow(false)
+        }
+        every { prayerReminderMinutes(any()) } answers {
+            this@SettingsRepositoryStub.reminderMinutes[firstArg<String>()]
+                ?: MutableStateFlow(15)
+        }
+        every { worshipReminderEnabled(any()) } answers {
+            this@SettingsRepositoryStub.worshipEnabled
+                .getOrPut(firstArg()) { MutableStateFlow(false) }
+        }
+        every { worshipReminderOffset(any(), any()) } answers {
+            this@SettingsRepositoryStub.worshipOffsets
+                .getOrPut(firstArg()) { MutableStateFlow(secondArg()) }
+        }
+        every { worshipReminderMode(any(), any()) } answers {
+            this@SettingsRepositoryStub.worshipModes
+                .getOrPut(firstArg()) { MutableStateFlow(secondArg()) }
+        }
+
+        every { quranTranslatorId } returns this@SettingsRepositoryStub.quranTranslatorId
+        every { quranArabicFont } returns this@SettingsRepositoryStub.quranArabicFont
+        every { selectedReciterId } returns this@SettingsRepositoryStub.selectedReciterId
+        every { quranMushafScript } returns this@SettingsRepositoryStub.quranMushafScript
+        every { showTranslation } returns this@SettingsRepositoryStub.showTranslation
+        every { showTransliteration } returns this@SettingsRepositoryStub.showTransliteration
+        every { quranArabicFontSize } returns this@SettingsRepositoryStub.quranArabicFontSize
+        every {
+            quranTranslationFontSize
+        } returns this@SettingsRepositoryStub.quranTranslationFontSize
+        every { continuousReading } returns this@SettingsRepositoryStub.continuousReading
+        every { keepScreenOn } returns this@SettingsRepositoryStub.keepScreenOn
+        every { showTajweed } returns this@SettingsRepositoryStub.showTajweed
+        every { tajweedUnderline } returns this@SettingsRepositoryStub.tajweedUnderline
+
+        every { duaArabicFont } returns this@SettingsRepositoryStub.duaArabicFont
+        every { duaArabicFontSize } returns this@SettingsRepositoryStub.duaArabicFontSize
+        every {
+            duaTranslationFontSize
+        } returns this@SettingsRepositoryStub.duaTranslationFontSize
+        every { duaShowArabic } returns this@SettingsRepositoryStub.duaShowArabic
+        every {
+            duaShowTransliteration
+        } returns this@SettingsRepositoryStub.duaShowTransliteration
+        every { duaShowTranslation } returns this@SettingsRepositoryStub.duaShowTranslation
+
+        every { hadithArabicFont } returns this@SettingsRepositoryStub.hadithArabicFont
+        every { hadithArabicFontSize } returns this@SettingsRepositoryStub.hadithArabicFontSize
+        every {
+            hadithTranslationFontSize
+        } returns this@SettingsRepositoryStub.hadithTranslationFontSize
+        every { hadithShowArabic } returns this@SettingsRepositoryStub.hadithShowArabic
+        every { hadithShowTranslation } returns this@SettingsRepositoryStub.hadithShowTranslation
+        every { hadithShowGrade } returns this@SettingsRepositoryStub.hadithShowGrade
+        every { hadithShowChain } returns this@SettingsRepositoryStub.hadithShowChain
+
+        every { userPreferences } returns this@SettingsRepositoryStub.userPreferences
+    }
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRowMatchers.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRowMatchers.kt
@@ -1,0 +1,37 @@
+package com.arshadshah.nimaz.testing
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+
+/**
+ * The tappable settings **row** carrying [title], as opposed to the `Text` that renders the title.
+ *
+ * Two problems make a bare `onNodeWithText(title)` wrong on these screens, and both of them read
+ * as the screen being broken rather than as a test artefact:
+ *
+ * - **A section header repeats its rows' words.** "Translation" is a section *and* a row on the
+ *   Quran settings screen; "Mushaf Script" is a header and a dropdown label. `onNodeWithText`
+ *   finds two nodes and fails with "expected exactly 1".
+ * - **A disabled row is not merged.** `NimazSettingsItem` only attaches `Modifier.clickable` when
+ *   it is enabled, so on a disabled row there is no merged parent and the match lands on the raw
+ *   `Text` — which reports neither `enabled` nor `disabled`, and `assertIsNotEnabled` fails
+ *   against a row that is, in fact, correctly disabled.
+ *
+ * Requiring a click action solves both: it picks the merged row over the header, and it is the
+ * exact property "this row is off-limits" is about.
+ */
+fun ComposeContentTestRule.settingsRow(title: String): SemanticsNodeInteraction =
+    onNode(hasText(title) and hasClickAction())
+
+/**
+ * Asserts that no tappable row carries [title] — the shape a *disabled* settings row takes.
+ *
+ * `NimazSettingsItem` expresses "disabled" by dimming to 50% and dropping its `clickable`, so the
+ * assertion that matters is that nothing is left to tap. A row that merely looked disabled and
+ * still fired its event would be worse than one that was never dimmed.
+ */
+fun ComposeContentTestRule.assertSettingsRowNotTappable(title: String) {
+    onNode(hasText(title) and hasClickAction()).assertDoesNotExist()
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRowMatchers.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsRowMatchers.kt
@@ -1,9 +1,11 @@
 package com.arshadshah.nimaz.testing
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onLast
 
 /**
  * The tappable settings **row** carrying [title], as opposed to the `Text` that renders the title.
@@ -35,3 +37,28 @@ fun ComposeContentTestRule.settingsRow(title: String): SemanticsNodeInteraction 
 fun ComposeContentTestRule.assertSettingsRowNotTappable(title: String) {
     onNode(hasText(title) and hasClickAction()).assertDoesNotExist()
 }
+
+/**
+ * The same two, for a row that sits **inside an accordion**.
+ *
+ * An accordion is a clickable card, so it merges everything in its body into one node — a merged
+ * node that carries every row's text *and* the card's own `OnClick`. `settingsRow` therefore
+ * matches the card rather than the row, and its disabled counterpart matches the card too, which
+ * makes "this row is off-limits" unassertable in the merged tree. In the unmerged tree the rows
+ * keep their own nodes and the card's click action stays on the card.
+ */
+fun ComposeContentTestRule.accordionRow(title: String): SemanticsNodeInteraction =
+    onAllNodes(hasAnyDescendant(hasText(title)) and hasClickAction(), useUnmergedTree = true)
+        .onLast()
+
+/**
+ * How many tappable things enclose [title] in the unmerged tree.
+ *
+ * Inside an accordion the answer is the assertion. An **enabled** row gives two — the accordion
+ * card, which collapses the row, and the row itself; a **disabled** one gives only the card,
+ * because `NimazSettingsItem` expresses "disabled" by dropping its `clickable` entirely.
+ */
+fun ComposeContentTestRule.tappableAncestorCount(title: String): Int =
+    onAllNodes(hasAnyDescendant(hasText(title)) and hasClickAction(), useUnmergedTree = true)
+        .fetchSemanticsNodes()
+        .size

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsViewModelHarness.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/SettingsViewModelHarness.kt
@@ -1,0 +1,114 @@
+package com.arshadshah.nimaz.testing
+
+import com.arshadshah.nimaz.core.monitoring.RecordingTelemetry
+import com.arshadshah.nimaz.data.audio.AdhanAudioManager
+import com.arshadshah.nimaz.data.audio.AdhanSound
+import com.arshadshah.nimaz.data.audio.DownloadState
+import com.arshadshah.nimaz.domain.model.AudioState
+import com.arshadshah.nimaz.domain.model.Location
+import com.arshadshah.nimaz.domain.prayer.PrayerTimeCalculator
+import com.arshadshah.nimaz.domain.repository.AdhanDownloader
+import com.arshadshah.nimaz.domain.repository.AppLocale
+import com.arshadshah.nimaz.domain.repository.PrayerAlarmScheduler
+import com.arshadshah.nimaz.domain.repository.PrayerNotificationTester
+import com.arshadshah.nimaz.domain.repository.QuranPlayback
+import com.arshadshah.nimaz.domain.time.FakeTodayProvider
+import com.arshadshah.nimaz.domain.usecase.ClearAllUserDataUseCase
+import com.arshadshah.nimaz.domain.usecase.PrayerUseCases
+import com.arshadshah.nimaz.domain.usecase.QuranUseCases
+import com.arshadshah.nimaz.domain.usecase.notification.RescheduleNotificationsUseCase
+import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsViewModel
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDate
+
+/**
+ * One assembled [SettingsViewModel] and every seam it was built from, held for assertion.
+ *
+ * Fourteen constructor arguments is a lot to re-declare per test class, and the cost of doing it
+ * per class is not the typing — it is that each copy stubs only what its own assertions touch, so
+ * the ViewModel under test is subtly a different object in every file. This builds the same one
+ * everywhere: preferences that actually emit (see [SettingsRepositoryStub]), a recording telemetry,
+ * a fixed today, and relaxed mocks for the ports.
+ */
+class SettingsViewModelHarness(
+    val repo: SettingsRepositoryStub = SettingsRepositoryStub(),
+    val telemetry: RecordingTelemetry = RecordingTelemetry(),
+    today: LocalDate = LocalDate.of(2026, 8, 26),
+) {
+    val todayProvider = FakeTodayProvider(today)
+
+    /**
+     * A real flow behind `audioState`: `reciterPreview` combines it with the previewing id, and a
+     * relaxed mock's flow never emits, so the combine would have nothing to produce.
+     */
+    val playbackAudioState = MutableStateFlow(AudioState())
+    val quranPlayback = mockk<QuranPlayback>(relaxed = true) {
+        every { audioState } returns this@SettingsViewModelHarness.playbackAudioState
+    }
+
+    val adhanDownloadState = MutableStateFlow<Map<AdhanSound, DownloadState>>(emptyMap())
+    val adhanIsPlaying = MutableStateFlow(false)
+    val adhanCurrentlyPlaying = MutableStateFlow<AdhanSound?>(null)
+    val adhanAudioManager = mockk<AdhanAudioManager>(relaxed = true) {
+        every { downloadState } returns this@SettingsViewModelHarness.adhanDownloadState
+        every { isPlaying } returns this@SettingsViewModelHarness.adhanIsPlaying
+        every { currentlyPlaying } returns this@SettingsViewModelHarness.adhanCurrentlyPlaying
+    }
+
+    val currentLocation = MutableStateFlow<Location?>(null)
+    val allLocations = MutableStateFlow<List<Location>>(emptyList())
+    val favoriteLocations = MutableStateFlow<List<Location>>(emptyList())
+
+    val prayerUseCases = mockk<PrayerUseCases>(relaxed = true) {
+        every { getCurrentLocation() } returns this@SettingsViewModelHarness.currentLocation
+        every { getAllLocations() } returns this@SettingsViewModelHarness.allLocations
+        every { getFavoriteLocations() } returns this@SettingsViewModelHarness.favoriteLocations
+        every { observeCalculationSettings() } returns flowOf()
+    }
+
+    val quranUseCases = mockk<QuranUseCases>(relaxed = true)
+    val appLocale = mockk<AppLocale>(relaxed = true)
+    val adhanDownloader = mockk<AdhanDownloader>(relaxed = true)
+    val prayerAlarmScheduler = mockk<PrayerAlarmScheduler>(relaxed = true)
+    val prayerNotificationTester = mockk<PrayerNotificationTester>(relaxed = true)
+    val rescheduleNotifications = mockk<RescheduleNotificationsUseCase>(relaxed = true)
+    val clearAllUserData = mockk<ClearAllUserDataUseCase>(relaxed = true)
+    val prayerTimeCalculator = mockk<PrayerTimeCalculator>(relaxed = true)
+
+    /**
+     * The text the Quran settings preview card resolves to for the selected translation.
+     *
+     * `getAyahTranslation` is a *property* holding a use case whose `invoke` is an operator, so
+     * the stub has to name `invoke` rather than the property — `coEvery { …getAyahTranslation(…) }`
+     * would stub nothing and read as if it had.
+     */
+    fun previewTranslationIs(text: String?) {
+        coEvery { quranUseCases.getAyahTranslation.invoke(any(), any()) } returns text
+    }
+
+    /** Make the preview read fail, which is the arm `catchAndReport` exists for. */
+    fun previewTranslationThrows(error: Throwable = IllegalStateException("no translation")) {
+        coEvery { quranUseCases.getAyahTranslation.invoke(any(), any()) } throws error
+    }
+
+    fun build(): SettingsViewModel = SettingsViewModel(
+        prayerTimeCalculator = prayerTimeCalculator,
+        appLocale = appLocale,
+        adhanDownloader = adhanDownloader,
+        prayerUseCases = prayerUseCases,
+        settingsRepository = repo.mock,
+        quranUseCases = quranUseCases,
+        prayerAlarmScheduler = prayerAlarmScheduler,
+        prayerNotificationTester = prayerNotificationTester,
+        rescheduleNotificationsUseCase = rescheduleNotifications,
+        telemetry = telemetry,
+        adhanAudioManager = adhanAudioManager,
+        quranPlayback = quranPlayback,
+        clearAllUserData = clearAllUserData,
+        todayProvider = todayProvider,
+    )
+}

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/TestLocations.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/testing/TestLocations.kt
@@ -1,0 +1,45 @@
+package com.arshadshah.nimaz.testing
+
+import com.arshadshah.nimaz.domain.model.AsrCalculation
+import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.HighLatitudeRule
+import com.arshadshah.nimaz.domain.model.Location
+
+/**
+ * A [Location] with fourteen fields filled in, of which a settings test cares about four.
+ *
+ * The location screen and the settings ViewModel both handle lists of these, and spelling the
+ * other ten out per test file is how one of them ends up with `isFavorite = true` by accident in
+ * a test about something else.
+ */
+fun testLocation(
+    id: Long = 1L,
+    name: String = "London",
+    latitude: Double = 51.5074,
+    longitude: Double = -0.1278,
+    country: String? = "United Kingdom",
+    city: String? = name,
+    isCurrentLocation: Boolean = false,
+    isFavorite: Boolean = false,
+    timezone: String = "Europe/London",
+    calculationMethod: CalculationMethod = CalculationMethod.MUSLIM_WORLD_LEAGUE,
+    asrCalculation: AsrCalculation = AsrCalculation.STANDARD,
+    highLatitudeRule: HighLatitudeRule? = null,
+    fajrAngle: Double? = null,
+    ishaAngle: Double? = null,
+) = Location(
+    id = id,
+    name = name,
+    latitude = latitude,
+    longitude = longitude,
+    timezone = timezone,
+    country = country,
+    city = city,
+    isCurrentLocation = isCurrentLocation,
+    isFavorite = isFavorite,
+    calculationMethod = calculationMethod,
+    asrCalculation = asrCalculation,
+    highLatitudeRule = highLatitudeRule,
+    fajrAngle = fajrAngle,
+    ishaAngle = ishaAngle,
+)

--- a/feature/settings/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/VoiceOptionCardTest.kt
+++ b/feature/settings/src/testDebug/kotlin/com/arshadshah/nimaz/presentation/components/molecules/VoiceOptionCardTest.kt
@@ -1,0 +1,190 @@
+package com.arshadshah.nimaz.presentation.components.molecules
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.arshadshah.nimaz.testing.compose.createComponentComposeRule
+import com.arshadshah.nimaz.testing.compose.setThemedContent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The one "voice" row, shared by the reciter picker and the muezzin section.
+ *
+ * Its two taps are the whole point and they must not be one: tapping the **card** selects the
+ * voice, tapping the **round button** auditions it. A card that treated the button as part of
+ * itself would change the user's reciter every time they pressed play, which is exactly the kind
+ * of thing nobody notices until their recitation has silently changed.
+ *
+ * The button also has four states over three flags, and the ordering is load-bearing: downloading
+ * outranks playing, playing outranks downloaded, and only the last arm offers a download. Getting
+ * that wrong shows a play button on a file that has not arrived.
+ *
+ * `voiceInitials` looks trivial and is not — it feeds the avatar for every reciter and muezzin in
+ * the app, and the names it is given carry brackets, hyphens and honorifics.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class VoiceOptionCardTest {
+
+    @get:Rule
+    val composeRule = createComponentComposeRule()
+
+    private var selects = 0
+    private var previews = 0
+
+    private fun setContent(
+        name: String = "Mishary Rashid Alafasy",
+        primaryTag: String = "Murattal",
+        secondaryTag: String? = "Kuwait",
+        isSelected: Boolean = false,
+        isPlaying: Boolean = false,
+        isDownloading: Boolean = false,
+        isDownloaded: Boolean = true,
+    ) {
+        composeRule.setThemedContent {
+            VoiceOptionCard(
+                name = name,
+                primaryTag = primaryTag,
+                secondaryTag = secondaryTag,
+                isSelected = isSelected,
+                isPlaying = isPlaying,
+                isDownloading = isDownloading,
+                isDownloaded = isDownloaded,
+                previewContentDescription = PREVIEW,
+                onClick = { selects++ },
+                onPreviewClick = { previews++ },
+            )
+        }
+    }
+
+    @Test
+    fun `the card shows the name and both chips`() {
+        setContent()
+
+        composeRule.onNodeWithText("Mishary Rashid Alafasy").assertIsDisplayed()
+        composeRule.onNodeWithText("Murattal").assertExists()
+        composeRule.onNodeWithText("Kuwait").assertExists()
+    }
+
+    @Test
+    fun `a voice with one chip renders without an empty second one`() {
+        setContent(secondaryTag = null)
+
+        composeRule.onNodeWithText("Murattal").assertExists()
+        composeRule.onNodeWithText("Kuwait").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the card selects the voice without auditioning it`() {
+        setContent()
+
+        composeRule.onNodeWithText("Mishary Rashid Alafasy").performClick()
+
+        assertThat(selects).isEqualTo(1)
+        assertThat(previews).isEqualTo(0)
+    }
+
+    @Test
+    fun `tapping the preview button auditions without changing the selection`() {
+        // The button sits inside a clickable card. If its tap fell through, every press of play
+        // would also switch the user's reciter — and the row would look identical.
+        setContent()
+
+        composeRule.onNodeWithContentDescription(PREVIEW).performClick()
+
+        assertThat(previews).isEqualTo(1)
+        assertThat(selects).isEqualTo(0)
+    }
+
+    @Test
+    fun `the avatar shows the monogram when the voice is idle`() {
+        setContent(name = "Mishary Rashid Alafasy")
+
+        composeRule.onNodeWithText("MR").assertExists()
+    }
+
+    @Test
+    fun `the avatar swaps the monogram for an equalizer while playing`() {
+        // The equalizer is an infinite animation, so the clock is pinned before `setContent`;
+        // `waitForIdle` on a running one never returns.
+        composeRule.mainClock.autoAdvance = false
+        setContent(isPlaying = true)
+
+        composeRule.onNodeWithText("MR").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a playing voice offers a pause, not another play`() {
+        composeRule.mainClock.autoAdvance = false
+        setContent(isPlaying = true)
+
+        composeRule.onNodeWithContentDescription(PREVIEW).performClick()
+
+        assertThat(previews).isEqualTo(1)
+    }
+
+    @Test
+    fun `a downloading voice shows a spinner rather than a play button`() {
+        // Downloading outranks playing in the `when`. A play glyph on a file that has not
+        // arrived invites a second tap and a second download.
+        composeRule.mainClock.autoAdvance = false
+        setContent(isDownloading = true, isDownloaded = false)
+
+        composeRule.onNodeWithText("MR").assertExists()
+    }
+
+    @Test
+    fun `a voice that is not downloaded still offers its control`() {
+        setContent(isDownloaded = false)
+
+        composeRule.onNodeWithContentDescription(PREVIEW).performClick()
+
+        assertThat(previews).isEqualTo(1)
+    }
+
+    @Test
+    fun `the initials come from the first two words`() {
+        assertThat(voiceInitials("Mishary Rashid Alafasy")).isEqualTo("MR")
+    }
+
+    @Test
+    fun `a single-word name uses its first two letters`() {
+        // "M" alone in a 48dp circle reads as a placeholder rather than a name.
+        assertThat(voiceInitials("Sudais")).isEqualTo("SU")
+    }
+
+    @Test
+    fun `punctuation between names is a separator, not part of a word`() {
+        // Reciter names arrive with brackets, hyphens and en dashes, and each is split on —
+        // "Mishary (Mujawwad)" must not produce "M(", and a bracketed style must not become
+        // the second initial by accident of position.
+        assertThat(voiceInitials("Mishary (Mujawwad)")).isEqualTo("MM")
+        assertThat(voiceInitials("Saad — Al-Ghamdi")).isEqualTo("SA")
+        // A hyphenated given name is two words to this splitter, so "Abdul-Basit Abdus-Samad"
+        // is AB rather than AA. Pinned as the behaviour it is: the avatar is a monogram, not a
+        // transliteration, and changing the split would change every hyphenated reciter's badge.
+        assertThat(voiceInitials("Abdul-Basit Abdus-Samad")).isEqualTo("AB")
+    }
+
+    @Test
+    fun `a name with no letters falls back rather than rendering blank`() {
+        // An empty monogram is an empty circle, which reads as a rendering failure.
+        assertThat(voiceInitials("")).isEqualTo("?")
+        assertThat(voiceInitials("123 456")).isEqualTo("?")
+    }
+
+    @Test
+    fun `initials are uppercased whatever case the name arrives in`() {
+        assertThat(voiceInitials("mishary rashid")).isEqualTo("MR")
+    }
+
+    private companion object {
+        const val PREVIEW = "Preview"
+    }
+}


### PR DESCRIPTION
Closes #615.

**The last module in the repo. With this one locked, every module is on the ratchet.**

| | Before | After | Floors |
|---|---|---|---|
| Line | 11.3% (778 / 6885) | **94.2%** (6489 / 6885) | 0.80 |
| Branch | 14.9% | **82.6%** (1321 / 1600) | 0.80 |

35 test classes, **521 `@Test` methods**. **No production code changed.** No
`COVERAGE_EXCLUSIONS` entry added or widened.

---

## The thing that was actually broken

**`SettingsViewModel.loadSettings()` had never run in a test at all — all 152 of its lines were
dead behind a green suite.**

It reads fifty-odd preferences with `.first()`, and the module's existing `SettingsViewModelTest`
builds the ViewModel on a `mockk(relaxed = true)` `SettingsRepository`. A relaxed mock answers a
`Flow` property with a *relaxed `Flow`* — one whose `collect` returns without ever emitting — so
`first()` throws on the loader's **first** line, `launchSafely` swallows it, and everything after
is unreachable. The test passed; the ViewModel under it never finished its work.

What that hides is the worst thing a settings screen can do: every control renders its
**compile-time default** rather than what the user chose, and the first toggle they touch writes
that default back over their real preference.

`testing/SettingsRepositoryStub.kt` fixes it by making the **reads** real `MutableStateFlow`s
while leaving the writes on the mockk — so the loader runs, the reactive rollups can be driven,
and `coVerify { repo.setHapticFeedback(false) }` still works. Worth reusing for anything that
takes the whole `SettingsRepository`.

## What the new tests pin, and the failure each catches

**The event table (51 tests).** Seventy-eight branches of one `when`, each a two-line body that
looks exactly like its neighbour. A branch that updates the right *field* and writes the wrong
*setter* is invisible from the screen — the switch moves, the row reads correctly, and the
preference the user thinks they changed is untouched until the next launch reloads it. Every
assertion is a pair: the optimistic state update, and a `coVerify` naming the exact setter. It
also pins which events rearm the alarms: a preference that changes *when* a notification fires
must reschedule, one that changes only *how* must not — backwards either way leaves a stale alarm
or rewrites every alarm on every keystroke of a stepper.

**Prayer notifications — the highest-stakes screen.** Sunrise is not a sixth prayer: no alert
style, no reminder, its toggle inside Fajr's row, writing the `"sunrise"` key.
And "remind me before every prayer" writes the app-wide pair **and** all five per-prayer events —
the pair alone changes no notification, which is exactly what the control did before the
per-prayer split.

**Sync is one screen wearing seven faces**, chosen by an *ordered* `when`, so the ordering is the
logic. A cancelled sync must not offer "Accept" for a connection the partner already dropped, and
an error must outrank a completed connection — "Sync Complete!" over a failed import tells the
user their data moved when it did not. Every key `SyncPayload.categories()` can produce has a
label, so a new category cannot appear in the transfer manifest as *No data* beside a real count.

**The widget gallery's previews are computed, not mocked up.** Pinned by *five formatted clock
times* from the real `PrayerTimeCalculator`, because an unwired gallery renders an em dash for
every one and looks entirely plausible in a screenshot. Plus the fallbacks: a blank stored name,
and an unset location computing against Dublin rather than (0, 0) in the Atlantic.

**Location's GPS permission callback is answered from the test** — the only way to reach the arm
where "fine **or** coarse counts as granted" lives. An app demanding fine location would refuse to
work for someone who deliberately granted approximate, whose accuracy is far more than a prayer
time needs. Selecting a place writes both the preference the calculator reads and the database row
the recents list is built from; a save that fails must not leave the card showing a city the
calculator has never heard of.

**The AI opt-in must ask, not toggle.** Enabling opens the disclosure sheet rather than writing
the preference — a plain toggle would opt someone into sending their question to a Worker without
ever showing them what is shared. And a consent write that *fails* says so, instead of closing
over a switch that quietly stayed off. Separately: the last search source on cannot be switched
off, because `SearchPreferences.sanitised` reads an empty set straight back as "everything" — a
switch that flips itself.

**The settings hub's two destructive confirmations are asserted apart**, because crossing them
makes "reset settings" clear every tracked prayer under a dialog that promised only a reset.

**`AdaptiveSettingsScreen` is reached without Hilt**, through a pre-seeded `ViewModelStore`
(playbook item 8) — four ViewModels, because four of the nine panes take one of their own. It pins
the difference the layout makes: on a phone each row navigates, on a tablet the same row opens a
detail pane, and the two rows that *still* navigate on a tablet are exactly the ones a refactor
would tidy into the pane path.

## The floors

**80/80 — the tenth Compose module in a row to hold the standard.** Of the 279 branches still
missing, **141 sit on composable signature and parameter lines** — the `$dirty` skippability check
and the `$default` parameter mask, emitted once per parameter of every restartable composable
across 24 screens. Discount those and the module stands at **89.9%**.

The margin is 41 branches and 939 lines — the widest line margin of any locked module. What bought
it was breadth rather than the last twenty branches: the module's *screens* had never been
composed at all.

Three pockets are left uncovered rather than excluded, and recorded in the build file:
`SyncMode.NONE` in the two role helpers (reached only from a `when` arm that has already
established the mode is SEND or RECEIVE); the `check()` guarding `IMPORT_STEP_COUNT` against the
list beside it, whose failing arm exists so a future edit to one and not the other stops the
import rather than reporting "step 13 of 10"; and the `Locale`-dependent `replaceFirstChar` arms
in the widget preview's date formatting.

### The gate bites

Floors temporarily set to `0.99`:

```
> Task :feature:settings:coverageFloor FAILED
  :feature:settings:coverageFloor: line coverage 94.2% is below the floor this module is
  locked at (99.0%), covering 6489/6885 (94.2%).
  :feature:settings:coverageFloor: branch coverage 82.6% is below the floor this module is
  locked at (99.0%), covering 1321/1600 (82.6%).

  Raise the tests, not the floor: it is a ratchet, and a module that has been brought up to
  it is not meant to come back down.
```

Restored to `0.80` / `0.80`, green.

## Two matchers worth knowing about

`testing/SettingsRowMatchers.kt`. A settings row must be addressed as
`hasText(title) and hasClickAction()` rather than by text — a section header repeats its rows'
words, *and* `NimazSettingsItem` expresses "disabled" by dropping its `clickable`, so a bare
`onNodeWithText` lands on the raw `Text`, which reports neither enabled nor disabled and makes
"this row is off-limits" unassertable. Inside an **accordion** even that fails: the accordion is a
clickable card and merges its whole body into one node carrying every row's text *and* the card's
own `OnClick`. There, `tappableAncestorCount(title)` is the assertion — an enabled row has two
tappable ancestors, a disabled one has only the card.

## Verification

```
./gradlew :feature:settings:testDebugUnitTest --rerun-tasks   BUILD SUCCESSFUL  (521 tests, 0 failures)
./gradlew :feature:settings:check                             BUILD SUCCESSFUL  (includes coverageFloor)
./gradlew :feature:settings:lintDebug --rerun-tasks           BUILD SUCCESSFUL
./gradlew coverageFloor --rerun-tasks --continue              BUILD SUCCESSFUL  (all 18 gated modules, 12m 22s)
python3 scripts/check_docs.py                                 All 23 checks passed
```

`lintDebug` caught one real error in a test of mine — `ContextCastToActivity` on
`LocalContext.current as? Activity` — fixed by using `LocalActivity` and adding
`testImplementation(libs.androidx.activity.compose)`. The three remaining warnings are
pre-existing, in `src/main`.

**`:app:lintDebug` and `:app:testDebugUnitTest` need `NIMAZ_DATA_TOKEN` and were not run** — they
cannot be, here. No `androidTest` sources were added, so there is nothing in this PR awaiting an
emulator.

**One unrelated flake seen and ruled out.** A first whole-repo `coverageFloor` run hit
`:feature:prayer > QiblaScreenTest > without the camera, the toggle asks for it rather than
entering AR`. That is playbook item 7 — CameraX cannot complete on a machine with no camera and
poisons whichever Robolectric class launches an activity next. The whole prayer suite passes on a
clean worktree of `epic/multi-module`, and the fully uncached 18-module `coverageFloor` above —
`--rerun-tasks --continue`, so every module's tests genuinely ran — is green including
`:feature:prayer`. Nothing in `:feature:settings` shares state with it.