### PR TITLE
Give navigation a transition, and the notifications hub a live read

### DIFF
--- a/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/arshadshah/nimaz/core/navigation/NavGraph.kt
@@ -52,6 +52,7 @@ import com.arshadshah.nimaz.presentation.screens.search.searchGraph
 import com.arshadshah.nimaz.presentation.screens.settings.settingsGraph
 import com.arshadshah.nimaz.presentation.screens.tools.toolsGraph
 import com.arshadshah.nimaz.presentation.screens.tracker.trackerGraph
+import com.arshadshah.nimaz.presentation.theme.LocalAnimationsEnabled
 import com.arshadshah.nimaz.presentation.theme.isTablet
 import com.arshadshah.nimaz.presentation.viewmodel.onboarding.OnboardingViewModel
 import kotlin.system.exitProcess
@@ -234,9 +235,20 @@ fun NavGraph(
             }
         }
     ) {
+        // Screen transitions, honouring the Appearance > Animations preference. `NavHost` had no
+        // transition arguments at all, which meant Navigation Compose's 700 ms crossfade for all
+        // 94 destinations — the same in both directions, so forward and back looked identical.
+        // Set here rather than per-destination: a `taggedComposable` that overrides them is then a
+        // deliberate exception, and there are none.
+        val animationsEnabled = LocalAnimationsEnabled.current
+
         NavHost(
             navController = navController,
             startDestination = startDestination,
+            enterTransition = { NimazNavTransitions.enter(animationsEnabled) },
+            exitTransition = { NimazNavTransitions.exit(animationsEnabled) },
+            popEnterTransition = { NimazNavTransitions.popEnter(animationsEnabled) },
+            popExitTransition = { NimazNavTransitions.popExit(animationsEnabled) },
         ) {
             // Every destination lives in its feature's graph extension. See #563: one file
             // registering all 94 of them is what stopped any feature moving into its own

--- a/core/navigation/src/main/kotlin/com/arshadshah/nimaz/core/navigation/NavTransitions.kt
+++ b/core/navigation/src/main/kotlin/com/arshadshah/nimaz/core/navigation/NavTransitions.kt
@@ -1,0 +1,93 @@
+package com.arshadshah.nimaz.core.navigation
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.ui.unit.IntOffset
+
+/**
+ * The screen transitions every destination animates with.
+ *
+ * ## Why this exists
+ *
+ * `NavHost` was declared with no transition arguments at all, so all 94 destinations used
+ * Navigation Compose's fallback: a 700 ms crossfade, in both directions, with no sense of
+ * direction. Going deeper and coming back looked identical, and at 700 ms a tap on a settings row
+ * read as a pause before the screen changed rather than as a screen changing.
+ *
+ * What replaces it is a **shared axis along X with parallax**: the arriving screen travels further
+ * than the departing one, so forward and back are distinguishable at a glance and the stack has a
+ * direction. The fade runs at half the slide's duration, which stops the two screens being
+ * simultaneously half-visible through each other for the whole transition.
+ *
+ * ## The animation setting
+ *
+ * Every function takes `enabled` rather than reading a preference, because the preference lives in
+ * `:core:datastore` and the `CompositionLocal` for it lives in `:core:ui` — and this module
+ * depends on neither, deliberately (see the note in its build file). The caller reads
+ * `LocalAnimationsEnabled` and passes the answer down; `NavGraph` in `:app` is the one caller,
+ * and it sits below both modules.
+ *
+ * With animations off these return [EnterTransition.None] / [ExitTransition.None] — a hard cut,
+ * not a shorter animation. Someone who turns animations off has usually done it because motion
+ * makes them ill or because the device is slow; a 60 ms version of the same movement serves
+ * neither.
+ *
+ * They are plain functions rather than the `AnimatedContentTransitionScope` lambdas `NavHost`
+ * takes, because the receiver is never read — none of the builders below is a member of it — and
+ * requiring one would mean a mocked scope in every test for no gain. `NavGraph` wraps them.
+ */
+object NimazNavTransitions {
+
+    /** Long enough to read as movement, short enough not to be a wait. */
+    const val DURATION_MS = 300
+
+    /** The fade finishes early so the crossover is not a half-transparent double image. */
+    private const val FADE_MS = DURATION_MS / 2
+
+    /** The arriving screen's travel, as a fraction of the container's width. */
+    private const val ARRIVING_TRAVEL = 4
+
+    /** The departing screen's, deliberately smaller — that difference is the parallax. */
+    private const val DEPARTING_TRAVEL = 6
+
+    private val slide = tween<IntOffset>(DURATION_MS, easing = FastOutSlowInEasing)
+    private val fade = tween<Float>(FADE_MS, easing = FastOutSlowInEasing)
+
+    /** Navigating deeper: the new screen arrives from the trailing edge. */
+    fun enter(enabled: Boolean): EnterTransition =
+        if (!enabled) {
+            EnterTransition.None
+        } else {
+            slideInHorizontally(slide) { width -> width / ARRIVING_TRAVEL } + fadeIn(fade)
+        }
+
+    /** Navigating deeper: the screen behind it slips the other way, and less far. */
+    fun exit(enabled: Boolean): ExitTransition =
+        if (!enabled) {
+            ExitTransition.None
+        } else {
+            slideOutHorizontally(slide) { width -> -width / DEPARTING_TRAVEL } + fadeOut(fade)
+        }
+
+    /** Coming back: the screen being returned to arrives from the leading edge. */
+    fun popEnter(enabled: Boolean): EnterTransition =
+        if (!enabled) {
+            EnterTransition.None
+        } else {
+            slideInHorizontally(slide) { width -> -width / DEPARTING_TRAVEL } + fadeIn(fade)
+        }
+
+    /** Coming back: the screen being left goes out the way it came in. */
+    fun popExit(enabled: Boolean): ExitTransition =
+        if (!enabled) {
+            ExitTransition.None
+        } else {
+            slideOutHorizontally(slide) { width -> width / ARRIVING_TRAVEL } + fadeOut(fade)
+        }
+}

--- a/core/navigation/src/test/kotlin/com/arshadshah/nimaz/core/navigation/NavTransitionsTest.kt
+++ b/core/navigation/src/test/kotlin/com/arshadshah/nimaz/core/navigation/NavTransitionsTest.kt
@@ -1,0 +1,63 @@
+package com.arshadshah.nimaz.core.navigation
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The two properties the screen transitions have to hold, and nothing about how they look.
+ *
+ * There is no assertion here on the slide distance, the easing or the exact duration — those are
+ * taste, and a test that pins them turns every visual adjustment into a test edit. What is pinned
+ * is what a user would file a bug about: that the animation setting actually switches them off,
+ * and that going deeper does not look identical to coming back, which is the whole reason
+ * `NavHost`'s default crossfade was replaced.
+ */
+class NavTransitionsTest {
+
+    // ── The setting ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with animations off every transition is a hard cut`() {
+        // Not a faster animation — none. Someone who turned this off did so because motion makes
+        // them ill or because the device cannot afford it; a 60 ms slide serves neither.
+        assertThat(NimazNavTransitions.enter(enabled = false)).isSameInstanceAs(EnterTransition.None)
+        assertThat(NimazNavTransitions.popEnter(enabled = false))
+            .isSameInstanceAs(EnterTransition.None)
+        assertThat(NimazNavTransitions.exit(enabled = false)).isSameInstanceAs(ExitTransition.None)
+        assertThat(NimazNavTransitions.popExit(enabled = false))
+            .isSameInstanceAs(ExitTransition.None)
+    }
+
+    @Test
+    fun `with animations on every transition actually animates`() {
+        assertThat(NimazNavTransitions.enter(enabled = true))
+            .isNotSameInstanceAs(EnterTransition.None)
+        assertThat(NimazNavTransitions.popEnter(enabled = true))
+            .isNotSameInstanceAs(EnterTransition.None)
+        assertThat(NimazNavTransitions.exit(enabled = true))
+            .isNotSameInstanceAs(ExitTransition.None)
+        assertThat(NimazNavTransitions.popExit(enabled = true))
+            .isNotSameInstanceAs(ExitTransition.None)
+    }
+
+    // ── Direction ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `going deeper does not look the same as coming back`() {
+        // The bug this replaced: `NavHost`'s default is the same crossfade both ways, so the
+        // back stack had no visible direction. Forward and pop must differ on both halves.
+        assertThat(NimazNavTransitions.enter(enabled = true))
+            .isNotEqualTo(NimazNavTransitions.popEnter(enabled = true))
+        assertThat(NimazNavTransitions.exit(enabled = true))
+            .isNotEqualTo(NimazNavTransitions.popExit(enabled = true))
+    }
+
+    @Test
+    fun `a transition is shorter than the default it replaces`() {
+        // Navigation Compose's fallback is a 700 ms crossfade, which reads as lag on a settings
+        // row rather than as a screen change.
+        assertThat(NimazNavTransitions.DURATION_MS).isLessThan(700)
+    }
+}

--- a/core/notifications/build.gradle.kts
+++ b/core/notifications/build.gradle.kts
@@ -23,10 +23,22 @@ android {
  * Locked. See `COVERAGE_EXCLUSIONS` and `coverageFloor` in `build-logic` for what is measured and
  * how the ratchet works.
  *
- * **80/80, at 95.5% lines and 80.8% branches** — the highest line coverage of any module in the
+ * **80/80, at 95.3% lines and 82.4% branches** — the highest line coverage of any module in the
  * repo, which is not a coincidence: everything here is invisible when it breaks. A prayer alarm
  * that is never armed produces no crash, no error state and no screen that says one was expected,
  * so the whole surface was brought up to a floor before it was a module.
+ *
+ * **The floor stays at 80 rather than ratcheting to 82, and that is deliberate.** This module's
+ * branch coverage was a function of *what time CI ran*: #638 measured 80.8% at midday and 79.2%
+ * that evening on identical code, and the second one failed the build with no diff behind it.
+ * Two clock reads did it — `NotificationContentHelper.getTimeBasedGreeting`, where four of five
+ * arms are unreachable at any given hour, and the scheduler's `isAfter(now)` guard, which after
+ * Isha skips the whole per-prayer block because the real calculator returns *today's* London
+ * times. Both are pinned now (the greeting takes the hour as a parameter; the pre-reminder tests
+ * use a calculator that places prayers ahead of `now`), and the figure above is the *evening*
+ * measurement, which used to be the low point. A residual swing of a branch or two remains in the
+ * 23:00 summary and Friday roll-forward guards, so the floor keeps a margin rather than sitting
+ * on the measurement. Ratchet it when those two take a clock as well.
  *
  * `PrayerAlarmReceiver` is `@AndroidEntryPoint` and its tests construct it, so this module
  * measures the **ASM-transformed** classes like `:core:audio` and `:app` — see

--- a/core/notifications/src/main/kotlin/com/arshadshah/nimaz/core/util/NotificationContentHelper.kt
+++ b/core/notifications/src/main/kotlin/com/arshadshah/nimaz/core/util/NotificationContentHelper.kt
@@ -221,9 +221,16 @@ object NotificationContentHelper {
 
     /**
      * Get a contextual greeting based on time of day.
+     *
+     * [hour] defaults to the wall clock, which is what the one production caller wants, and is a
+     * parameter so a test can reach the other four arms. It was read inside the function, and
+     * that made the module's *coverage* a function of what time CI ran: four of the five branches
+     * are unreachable at any given hour, and which four changes through the day. #638 measured
+     * 80.8% at midday against an 80% floor and 79.2% that evening, on identical code — a red
+     * build with no diff behind it. Passing the hour in is the whole fix; nothing about the
+     * greeting changes.
      */
-    fun getTimeBasedGreeting(context: Context): String {
-        val hour = LocalTime.now().hour
+    fun getTimeBasedGreeting(context: Context, hour: Int = LocalTime.now().hour): String {
         return when {
             hour < 6 -> context.getString(R.string.notif_greeting_predawn)
             hour < 12 -> context.getString(R.string.notif_greeting_morning)

--- a/core/notifications/src/test/kotlin/com/arshadshah/nimaz/core/util/NotificationContentHelperTest.kt
+++ b/core/notifications/src/test/kotlin/com/arshadshah/nimaz/core/util/NotificationContentHelperTest.kt
@@ -161,4 +161,47 @@ class NotificationContentHelperTest {
         assertThat(summary.bigText).contains("Fajr")
         assertThat(summary.bigText).contains("Isha")
     }
+
+    // ── getTimeBasedGreeting ────────────────────────────────────────
+
+    /**
+     * All five arms, at a fixed hour each.
+     *
+     * The hour used to be read inside the function, so exactly one arm ran per test run and
+     * *which* one depended on when CI happened to start. That made the module's branch coverage
+     * drift through the day: #638 measured 80.8% against an 80% floor at midday and 79.2% that
+     * evening, on identical code. These pin the boundaries as well as the bands, because the
+     * comparisons are all `<` and an off-by-one at 06:00 or 20:00 is invisible otherwise.
+     */
+    @Test
+    fun `getTimeBasedGreeting picks a greeting per band, at every boundary`() {
+        val predawn = greeting(0)
+        val morning = greeting(6)
+        val afternoon = greeting(12)
+        val evening = greeting(17)
+        val night = greeting(20)
+
+        // Five distinct strings, or the bands are not doing anything.
+        assertThat(setOf(predawn, morning, afternoon, evening, night)).hasSize(5)
+
+        // The last hour of each band still belongs to it — `hour < 6`, not `<= 6`.
+        assertThat(greeting(5)).isEqualTo(predawn)
+        assertThat(greeting(11)).isEqualTo(morning)
+        assertThat(greeting(16)).isEqualTo(afternoon)
+        assertThat(greeting(19)).isEqualTo(evening)
+        assertThat(greeting(23)).isEqualTo(night)
+    }
+
+    @Test
+    fun `getTimeBasedGreeting defaults to the wall clock`() {
+        // The production caller passes no hour. Whatever hour it is, the default has to land in
+        // one of the five bands rather than returning something empty.
+        val now = java.time.LocalTime.now().hour
+
+        assertThat(NotificationContentHelper.getTimeBasedGreeting(context))
+            .isEqualTo(greeting(now))
+    }
+
+    private fun greeting(hour: Int) =
+        NotificationContentHelper.getTimeBasedGreeting(context, hour)
 }

--- a/core/notifications/src/test/kotlin/com/arshadshah/nimaz/core/util/PrayerNotificationSchedulerTest.kt
+++ b/core/notifications/src/test/kotlin/com/arshadshah/nimaz/core/util/PrayerNotificationSchedulerTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.common.NimazChannels
 import com.arshadshah.nimaz.domain.model.AsrCalculation
 import com.arshadshah.nimaz.domain.model.CalculationMethod
+import com.arshadshah.nimaz.domain.model.PrayerTime
 import com.arshadshah.nimaz.domain.model.PrayerType
 import com.arshadshah.nimaz.domain.model.WorshipReminderType
 import com.arshadshah.nimaz.domain.prayer.PrayerTimeCalculator
@@ -260,6 +261,100 @@ class PrayerNotificationSchedulerTest {
     }
 
     // ── Pre-reminders ───────────────────────────────────────────────────────────
+
+    /**
+     * A calculator that puts every prayer a fixed number of hours *ahead of now*.
+     *
+     * The class KDoc's reason for a real calculator stands, and the test below this one still
+     * uses it. But a real calculator returns London's times for *today*, so after Isha every one
+     * of them is in the past and the scheduler's `if (prayerLocalDateTime.isAfter(now))` block
+     * never runs. The consequence was not only a coverage number that drifted through the day:
+     * the pre-reminder assertions below iterate the still-future prayers, so in the evening they
+     * iterated an empty list and asserted nothing at all. A test that passes vacuously for a
+     * third of the day is worse than one that fails.
+     */
+    private fun futureCalculator(vararg offsetsHours: Pair<PrayerType, Long>) =
+        mockk<PrayerTimeCalculator> {
+            every {
+                getPrayerTimes(any(), any(), any(), any(), any(), any(), any())
+            } answers {
+                val base = LocalDateTime.now().withSecond(0).withNano(0)
+                offsetsHours.map { (type, hours) ->
+                    PrayerTime(
+                        type = type,
+                        time = base.plusHours(hours)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant()
+                            .toEpochMilli()
+                            .let { kotlin.time.Instant.fromEpochMilliseconds(it) },
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun `each future prayer is armed with its own pre-reminder, whatever the hour`() {
+        // The deterministic half of the pair below. Prayer times are placed ahead of now rather
+        // than read off the clock, so this exercises the scheduling branch and the per-prayer
+        // pre-reminder inside it at 03:00 and at 23:00 alike.
+        val leads = mapOf(PrayerType.FAJR to 45, PrayerType.ISHA to 10)
+        val base = LocalDateTime.now().withSecond(0).withNano(0)
+
+        schedule(
+            preReminders = leads,
+            target = PrayerNotificationScheduler(
+                context,
+                futureCalculator(PrayerType.FAJR to 2L, PrayerType.ISHA to 5L),
+                settings,
+            ),
+        )
+
+        val triggers = scheduledTriggers().toSet()
+        assertThat(triggers).contains(base.plusHours(2))
+        assertThat(triggers).contains(base.plusHours(5))
+        assertThat(triggers).contains(base.plusHours(2).minusMinutes(45))
+        assertThat(triggers).contains(base.plusHours(5).minusMinutes(10))
+    }
+
+    @Test
+    fun `a prayer with no pre-reminder configured gets an alarm and nothing else`() {
+        // The other arm of `leadMinutes != null`: Fajr has a lead, Isha does not, and Isha must
+        // not inherit Fajr's.
+        val base = LocalDateTime.now().withSecond(0).withNano(0)
+
+        schedule(
+            preReminders = mapOf(PrayerType.FAJR to 45),
+            target = PrayerNotificationScheduler(
+                context,
+                futureCalculator(PrayerType.FAJR to 2L, PrayerType.ISHA to 5L),
+                settings,
+            ),
+        )
+
+        val triggers = scheduledTriggers().toSet()
+        assertThat(triggers).contains(base.plusHours(5))
+        assertThat(triggers).doesNotContain(base.plusHours(5).minusMinutes(45))
+    }
+
+    @Test
+    fun `sunrise never gets a pre-reminder even when one is configured for it`() {
+        // Guarded explicitly in the loop. Sunrise is a plain marker, not a prayer to prepare for.
+        val base = LocalDateTime.now().withSecond(0).withNano(0)
+
+        schedule(
+            enabledPrayers = setOf(PrayerType.SUNRISE),
+            preReminders = mapOf(PrayerType.SUNRISE to 30),
+            target = PrayerNotificationScheduler(
+                context,
+                futureCalculator(PrayerType.SUNRISE to 3L),
+                settings,
+            ),
+        )
+
+        val triggers = scheduledTriggers().toSet()
+        assertThat(triggers).contains(base.plusHours(3))
+        assertThat(triggers).doesNotContain(base.plusHours(3).minusMinutes(30))
+    }
 
     @Test
     fun `a pre-reminder is armed its own lead time before the prayer, per prayer`() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,6 +403,31 @@ Rules:
 - Mutate with `_state.update { it.copy(...) }`.
 - All UI intents flow through a single `fun onEvent(event: XxxEvent)` that `when`-dispatches
   to private functions. `XxxEvent` is a `sealed interface`.
+- **A screen that displays a value another destination edits must read it from a flow, not from
+  a loaded-once snapshot.** See below — this one is not a style preference.
+
+#### A snapshot is per-instance, and destinations do not share one
+
+`hiltViewModel()` in a destination body scopes the ViewModel to that destination's
+`NavBackStackEntry`, so a hub screen and each of its subscreens hold **different instances of the
+same ViewModel class**. A `MutableStateFlow` seeded by a one-shot `loadSettings()` is therefore
+private to whichever instance loaded it, and nothing re-reads it when a destination is returned
+to.
+
+That is exactly right for the control the screen *owns*: the optimistic `_state.update` on the
+frame of the tap is what makes a switch feel instant, and it depends on the state being local.
+It is wrong for a value the screen only *reports*. The notifications hub showed the count of
+enabled worship reminders, the weekly summary and the sound subtitle from its own snapshot; each
+is edited on a subscreen holding a different instance, so all three went on reporting the value
+from before the edit until the app restarted (#639). The prayer row was correct throughout,
+because it was the only one already reading `notificationSummary` — a `combine` over the
+repository's flows, `stateIn(WhileSubscribed)`. One row being right is what made it read as a
+rendering fault rather than a stale read.
+
+So: **owned control → snapshot with an optimistic update; reported value → a flow off the
+repository.** DataStore and Room are singletons, so every collector in the process sees the same
+value whichever instance wrote it. A screen may read both, and the notifications hub now reads
+only the flow.
 
 ```kotlin
 data class XxxUiState(

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -44,6 +44,7 @@ destinations, and none of them should need the `NavHost`.
 |---|---|---|
 | `core/navigation/Routes.kt` | the `Route` sealed interface — every destination that exists | `NAV-01`, `NAV-02` |
 | `core/navigation/NavGraph.kt` | the `NavHost` and the app shell — **no destinations since PR 12** | — |
+| `core/navigation/NavTransitions.kt` | the screen transitions, and the animation setting's effect on them | — |
 | `presentation/screens/<feature>/<Feature>Graph.kt` × 11 | the destinations, one extension per feature | `NAV-03`, `NAV-04` |
 | `core/navigation/ScreenTags.kt` | the stable test tag per destination | `NAV-05` |
 | `core/navigation/AnnouncementRoutes.kt` + `HelpDeepLink.kt` | the two **external** entry grammars | `NAV-06` … `NAV-10` |
@@ -88,6 +89,25 @@ declarations, in both directions, and fails on a duplicate. NAV-03 compares tota
 see a route dropped in one graph while another is duplicated — which is exactly the shape a
 copy-paste across eleven files produces, and it fails as a blank screen at runtime rather than a
 build error.
+
+### Screen transitions
+
+All 94 destinations animate with the shared axis in `core/navigation/NavTransitions.kt`
+(`NimazNavTransitions`), set once on the `NavHost` rather than per destination. Going deeper
+slides the arriving screen in from the trailing edge and the departing one a shorter distance the
+other way; coming back reverses both. The difference in travel is the parallax, and it is what
+makes forward and back distinguishable.
+
+Until #639 the `NavHost` took **no transition arguments at all**, so every destination used
+Navigation Compose's fallback: one 700 ms crossfade, identical in both directions. The back stack
+had no visible direction and a settings row read as a pause before the screen changed.
+
+**The transitions honour the Appearance → Animations preference**, and honour it as a hard cut —
+`EnterTransition.None` / `ExitTransition.None`, not a shorter slide. `NimazNavTransitions` takes
+`enabled` as a parameter rather than reading the preference, because the preference lives in
+`:core:datastore` and its `CompositionLocal` (`LocalAnimationsEnabled`) in `:core:ui`, and
+`:core:navigation` depends on neither by design. `NavGraph` reads the local and passes it down;
+it is the one caller, and it sits below both modules.
 
 **Test hooks.** Every destination is wired via the `taggedComposable<Route.X>` helper — which was
 `private` inside `NavGraph.kt` and now lives in `core/navigation/TaggedComposable.kt`, because a

--- a/feature/settings/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -39,7 +39,7 @@ import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuDivider
 import com.arshadshah.nimaz.presentation.components.molecules.NimazMenuGroup
 import com.arshadshah.nimaz.presentation.components.molecules.NimazSettingsItem
 import com.arshadshah.nimaz.presentation.components.organisms.NimazBackTopAppBar
-import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
+import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSummary
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsViewModel
 
@@ -62,7 +62,9 @@ fun NotificationSettingsScreen(
     onNavigateToDiagnostics: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    val notificationState by viewModel.notificationState.collectAsStateWithLifecycle()
+    // The hub reads the *summary* and nothing else. `notificationState` is loaded once per
+    // ViewModel instance, and every row below is edited on a subscreen that holds a different
+    // instance — see `SettingsViewModel.notificationSummary`.
     val summary by viewModel.notificationSummary.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
@@ -104,7 +106,7 @@ fun NotificationSettingsScreen(
                     NimazSettingsItem(
                         title = stringResource(R.string.notification_settings_enable),
                         subtitle = stringResource(R.string.notification_settings_enable_subtitle),
-                        checked = notificationState.notificationsEnabled,
+                        checked = summary.notificationsMasterEnabled,
                         onCheckedChange = {
                             viewModel.onEvent(SettingsEvent.SetNotificationsEnabled(it))
                         }
@@ -112,7 +114,7 @@ fun NotificationSettingsScreen(
                 }
             }
 
-            if (notificationState.notificationsEnabled) {
+            if (summary.notificationsMasterEnabled) {
                 if (diagnostics?.hasProblem == true) {
                     item {
                         NimazBanner(
@@ -144,7 +146,7 @@ fun NotificationSettingsScreen(
                         NimazMenuDivider(inset = false)
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_sound_title),
-                            subtitle = soundSubtitle(notificationState),
+                            subtitle = soundSubtitle(summary),
                             onClick = onNavigateToSound,
                             showArrow = true
                         )
@@ -158,7 +160,7 @@ fun NotificationSettingsScreen(
                             subtitle = stringResource(R.string.notif_hub_worship_subtitle),
                             value = stringResource(
                                 R.string.notif_hub_count_on,
-                                notificationState.worshipReminders.count { it.value }
+                                summary.worshipRemindersOn
                             ),
                             onClick = onNavigateToWorshipReminders,
                             showArrow = true
@@ -166,7 +168,7 @@ fun NotificationSettingsScreen(
                         NimazMenuDivider(inset = false)
                         NimazSettingsItem(
                             title = stringResource(R.string.notif_hub_weekly_title),
-                            subtitle = weeklySubtitle(notificationState),
+                            subtitle = weeklySubtitle(summary),
                             onClick = onNavigateToWeekly,
                             showArrow = true
                         )
@@ -220,13 +222,13 @@ private fun prayersSubtitle(
 }
 
 @Composable
-private fun soundSubtitle(state: NotificationSettingsUiState): String = stringResource(
+private fun soundSubtitle(state: NotificationSummary): String = stringResource(
     NotificationHubSubtitles.sound(state.respectDnd, state.vibrationEnabled),
     AdhanSound.fromName(state.selectedAdhanSound).displayName
 )
 
 @Composable
-private fun weeklySubtitle(state: NotificationSettingsUiState): String = stringResource(
+private fun weeklySubtitle(state: NotificationSummary): String = stringResource(
     NotificationHubSubtitles.weekly(
         jumuahEnabled = state.fridayReminderEnabled,
         khatamEnabled = state.khatamReminderEnabled

--- a/feature/settings/src/main/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import com.arshadshah.nimaz.domain.model.MushafScript
 import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
 import com.arshadshah.nimaz.domain.model.PrayerTimes
 import com.arshadshah.nimaz.domain.model.UserPreferences
+import com.arshadshah.nimaz.domain.model.WorshipReminderType
 import com.arshadshah.nimaz.domain.prayer.PrayerTimeCalculator
 import com.arshadshah.nimaz.domain.repository.AdhanDownloader
 import com.arshadshah.nimaz.domain.repository.AppLocale
@@ -70,9 +71,10 @@ enum class AppLanguage(
 }
 
 /**
- * A small, read-only rollup of the notification settings that other screens (e.g. Prayer
- * Settings) show as summary subtitles. Sourced reactively from DataStore so it stays in sync
- * no matter which screen changed the underlying value — see [SettingsViewModel.notificationSummary].
+ * A read-only rollup of every notification setting the hub and other screens (e.g. Prayer
+ * Settings) show as a count, a value or a summary subtitle. Sourced reactively from DataStore so
+ * it stays in sync no matter which screen changed the underlying value — see
+ * [SettingsViewModel.notificationSummary].
  */
 data class NotificationSummary(
     val notificationsMasterEnabled: Boolean = true,
@@ -80,11 +82,21 @@ data class NotificationSummary(
     /** Fajr's reminder — it stands for the set where one line has to speak for five. */
     val reminderEnabled: Boolean = true,
     val reminderMinutes: Int = PrayerAlertStyle.DEFAULT_REMINDER_MINUTES,
-    val fajrAlertStyle: PrayerAlertStyle = PrayerAlertStyle.NOTIFICATION
+    val fajrAlertStyle: PrayerAlertStyle = PrayerAlertStyle.NOTIFICATION,
+    val vibrationEnabled: Boolean = true,
+    val respectDnd: Boolean = true,
+    val selectedAdhanSound: String = DEFAULT_ADHAN_SOUND,
+    /** How many of the eleven extended worship reminders are switched on. */
+    val worshipRemindersOn: Int = 0,
+    val fridayReminderEnabled: Boolean = false,
+    val khatamReminderEnabled: Boolean = false,
 ) {
     companion object {
         /** The five obligatory prayers the notification screen exposes toggles for. */
         const val TOTAL_PRAYER_COUNT = 5
+
+        /** Matches `NotificationSettingsUiState.selectedAdhanSound`'s default. */
+        const val DEFAULT_ADHAN_SOUND = "MISHARY"
     }
 }
 
@@ -188,34 +200,71 @@ class SettingsViewModel @Inject constructor(
     val currentlyPlayingAdhan: StateFlow<AdhanSound?> = adhanAudioManager.currentlyPlaying
 
     /**
-     * Reactive rollup of the notification settings for summary subtitles on other screens.
+     * Reactive rollup of the notification settings for the hub's rows and for summary
+     * subtitles on other screens.
      *
      * Unlike [notificationState] (a one-shot snapshot loaded in [loadSettings]), this collects
      * DataStore directly, so it reflects edits made from *any* screen — including the
      * Notification Settings screen, which runs on a separate [SettingsViewModel] instance.
      * DataStore is a singleton, so every collector across every instance sees the same live value.
+     *
+     * **It has to carry every value the hub renders, not just the prayer ones.** A
+     * `hiltViewModel()` in a destination body is scoped to that destination's
+     * `NavBackStackEntry`, so the hub and each of its five subscreens hold *different*
+     * `SettingsViewModel` instances. Toggling a worship reminder updates the subscreen's
+     * `_notificationState` optimistically and writes DataStore — but the hub's instance loaded
+     * its snapshot once, on the way in, and nothing re-reads it on the way back. The counts and
+     * subtitles behind that snapshot went on reporting the value from before the edit; the prayer
+     * row was right the whole time, because it was the only one already reading this flow. The
+     * asymmetry is what made it look like a rendering bug rather than a stale read.
      */
     val notificationSummary: StateFlow<NotificationSummary> = combine(
         combine(
-            settingsRepository.fajrNotificationEnabled,
-            settingsRepository.dhuhrNotificationEnabled,
-            settingsRepository.asrNotificationEnabled,
-            settingsRepository.maghribNotificationEnabled,
-            settingsRepository.ishaNotificationEnabled
-        ) { flags -> flags.count { it } },
-        settingsRepository.prayerNotificationsEnabled,
-        // Fajr stands for the set on the hub: it is the prayer people set most deliberately,
-        // and a row cannot show five different offsets in one line.
-        settingsRepository.prayerReminderEnabled(FAJR),
-        settingsRepository.prayerReminderMinutes(FAJR),
-        settingsRepository.prayerAlertStyle(FAJR)
-    ) { enabledPrayerCount, masterEnabled, reminderEnabled, reminderMinutes, alertStyle ->
-        NotificationSummary(
-            notificationsMasterEnabled = masterEnabled,
-            enabledPrayerCount = enabledPrayerCount,
-            reminderEnabled = reminderEnabled,
-            reminderMinutes = reminderMinutes,
-            fajrAlertStyle = alertStyle
+            combine(
+                settingsRepository.fajrNotificationEnabled,
+                settingsRepository.dhuhrNotificationEnabled,
+                settingsRepository.asrNotificationEnabled,
+                settingsRepository.maghribNotificationEnabled,
+                settingsRepository.ishaNotificationEnabled
+            ) { flags -> flags.count { it } },
+            settingsRepository.prayerNotificationsEnabled,
+            // Fajr stands for the set on the hub: it is the prayer people set most deliberately,
+            // and a row cannot show five different offsets in one line.
+            settingsRepository.prayerReminderEnabled(FAJR),
+            settingsRepository.prayerReminderMinutes(FAJR),
+            settingsRepository.prayerAlertStyle(FAJR)
+        ) { enabledPrayerCount, masterEnabled, reminderEnabled, reminderMinutes, alertStyle ->
+            NotificationSummary(
+                notificationsMasterEnabled = masterEnabled,
+                enabledPrayerCount = enabledPrayerCount,
+                reminderEnabled = reminderEnabled,
+                reminderMinutes = reminderMinutes,
+                fajrAlertStyle = alertStyle
+            )
+        },
+        combine(
+            settingsRepository.notificationVibration,
+            settingsRepository.adhanRespectDnd,
+            settingsRepository.selectedAdhanSound
+        ) { vibration, dnd, sound -> Triple(vibration, dnd, sound) },
+        combine(
+            settingsRepository.fridayReminderEnabled,
+            settingsRepository.khatamReminderEnabled
+        ) { friday, khatam -> friday to khatam },
+        // All eleven, counted the same way the Worship Reminders screen counts them. Iterating
+        // the enum rather than listing keys is the rule the whole feature is built on: a
+        // reminder added to `WorshipReminderType` shows up here without a second edit.
+        combine(
+            WorshipReminderType.entries.map { settingsRepository.worshipReminderEnabled(it.key) }
+        ) { flags -> flags.count { it } }
+    ) { prayers, sound, weekly, worshipOn ->
+        prayers.copy(
+            vibrationEnabled = sound.first,
+            respectDnd = sound.second,
+            selectedAdhanSound = sound.third,
+            worshipRemindersOn = worshipOn,
+            fridayReminderEnabled = weekly.first,
+            khatamReminderEnabled = weekly.second,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/screens/settings/NotificationSettingsScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import com.arshadshah.nimaz.core.ui.R
 import com.arshadshah.nimaz.domain.model.PrayerAlertStyle
-import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSettingsUiState
 import com.arshadshah.nimaz.presentation.viewmodel.settings.NotificationSummary
 import com.arshadshah.nimaz.presentation.viewmodel.settings.SettingsEvent
 import com.arshadshah.nimaz.testing.FakeSettingsScreenViewModel
@@ -37,9 +36,17 @@ import org.robolectric.annotation.Config
  * both compile and both produce a plausible sentence that is false.
  *
  * The master switch is the structural half. Everything below it is inside
- * `if (notificationsEnabled)`, so switching it off must remove the rows rather than dim them —
- * a hub that still offers "Prayers · Adhan · 15 minutes before" while notifications are off is
+ * `if (notificationsMasterEnabled)`, so switching it off must remove the rows rather than dim them
+ * — a hub that still offers "Prayers · Adhan · 15 minutes before" while notifications are off is
  * telling the user alerts are configured when none will arrive.
+ *
+ * **Every value here comes from `notificationSummary`, and that is the fix rather than an
+ * incidental detail.** The rows used to read `notificationState`, which is loaded once per
+ * ViewModel instance — and `hiltViewModel()` gives the hub a different instance from each of the
+ * five subscreens that edit these settings. Switching a worship reminder on and coming back left
+ * the count reporting the value from before the edit. The prayer row was right the whole time,
+ * because it was the only one already reading the summary; that asymmetry is what made it look
+ * like a rendering fault. `NotificationSummaryTest` pins the ViewModel half.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(qualifiers = "w411dp-h2200dp")
@@ -57,11 +64,15 @@ class NotificationSettingsScreenTest {
     private var sound = 0
     private var diagnostics = 0
 
+    /**
+     * Only the summary. The screen stopped reading `notificationState` when the hub's rows were
+     * found to be stale: that flow is a one-shot snapshot per ViewModel instance, and the hub
+     * holds a different instance from every subscreen that edits these values. A `state`
+     * parameter here would let a test arrange something the screen cannot see.
+     */
     private fun setContent(
-        state: NotificationSettingsUiState = NotificationSettingsUiState(),
         summary: NotificationSummary = NotificationSummary(),
     ) {
-        viewModel.notificationState.value = state
         viewModel.notificationSummary.value = summary
         composeRule.setThemedContent {
             NotificationSettingsScreen(
@@ -81,7 +92,7 @@ class NotificationSettingsScreenTest {
 
     @Test
     fun `the hub offers all five rows when notifications are on`() {
-        setContent(NotificationSettingsUiState(notificationsEnabled = true))
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = true))
 
         composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertExists()
         composeRule.onNodeWithText(string(R.string.notif_hub_sound_title)).assertExists()
@@ -94,7 +105,7 @@ class NotificationSettingsScreenTest {
     fun `switching notifications off hides every row rather than dimming them`() {
         // A hub that still reports "Prayers · Adhan · 2 of 5" while the master switch is off is
         // telling the user alerts are configured when none can arrive.
-        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = false))
 
         composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertDoesNotExist()
         composeRule.onNodeWithText(string(R.string.notif_hub_sound_title)).assertDoesNotExist()
@@ -106,7 +117,7 @@ class NotificationSettingsScreenTest {
 
     @Test
     fun `the master switch stays reachable when it is off, so it can be switched back on`() {
-        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = false))
 
         composeRule.settingsRow(string(R.string.notification_settings_enable)).performClick()
 
@@ -117,7 +128,7 @@ class NotificationSettingsScreenTest {
     fun `the master switch passes the value the switch reports, not the negation of state`() {
         // This is the one row on the screen wired as `onCheckedChange = { onEvent(Set…(it)) }`
         // rather than `!state`. Rewriting it to match its neighbours would invert it.
-        setContent(NotificationSettingsUiState(notificationsEnabled = true))
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = true))
 
         composeRule.settingsRow(string(R.string.notification_settings_enable)).performClick()
 
@@ -167,7 +178,7 @@ class NotificationSettingsScreenTest {
         // Do Not Disturb outranks vibration in the subtitle because it is the one that stops a
         // sound the user is expecting.
         setContent(
-            NotificationSettingsUiState(
+            summary = NotificationSummary(
                 respectDnd = true,
                 vibrationEnabled = true,
                 selectedAdhanSound = "MISHARY",
@@ -185,32 +196,25 @@ class NotificationSettingsScreenTest {
     @Test
     fun `the sound row falls through to vibration when DnD is not respected`() {
         setContent(
-            NotificationSettingsUiState(respectDnd = false, vibrationEnabled = true)
+            summary = NotificationSummary(respectDnd = false, vibrationEnabled = true)
         )
 
         composeRule.onNodeWithText(
             string(
                 R.string.notif_hub_sound_vibration,
                 com.arshadshah.nimaz.data.audio.AdhanSound
-                    .fromName(NotificationSettingsUiState().selectedAdhanSound).displayName,
+                    .fromName(NotificationSummary().selectedAdhanSound).displayName,
             )
         ).assertExists()
     }
 
     @Test
     fun `the worship row counts the reminders that are on, not the ones that exist`() {
-        // `count { it.value }` against `size`. Eleven reminders exist and default to off, so the
-        // wrong one reads "11 on" for a user who has enabled none.
-        setContent(
-            NotificationSettingsUiState(
-                worshipReminders = mapOf(
-                    "tahajjud" to true,
-                    "witr" to false,
-                    "suhoor" to true,
-                    "iftar" to false,
-                )
-            )
-        )
+        // Eleven reminders exist and default to off, so a row that counted what exists rather
+        // than what is on would read "11 on" for a user who has enabled none. The count is
+        // computed in the ViewModel now (`NotificationSummaryTest` pins that it iterates the
+        // enum); what this pins is that the row renders the count it is handed.
+        setContent(summary = NotificationSummary(worshipRemindersOn = 2))
 
         composeRule.onNodeWithText(string(R.string.notif_hub_count_on, 2)).assertExists()
     }
@@ -218,7 +222,7 @@ class NotificationSettingsScreenTest {
     @Test
     fun `the weekly row names which of the two weekly reminders are on`() {
         setContent(
-            NotificationSettingsUiState(
+            summary = NotificationSummary(
                 fridayReminderEnabled = true,
                 khatamReminderEnabled = false,
             )
@@ -230,13 +234,41 @@ class NotificationSettingsScreenTest {
     @Test
     fun `the weekly row says neither when neither is on`() {
         setContent(
-            NotificationSettingsUiState(
+            summary = NotificationSummary(
                 fridayReminderEnabled = false,
                 khatamReminderEnabled = false,
             )
         )
 
         composeRule.onNodeWithText(string(R.string.notif_hub_weekly_none)).assertExists()
+    }
+
+    @Test
+    fun `a row re-renders when its setting changes underneath the composed screen`() {
+        // The regression, at the level the user saw it. Coming back from a subscreen does not
+        // recompose the hub from scratch — the summary emits and the row has to follow. Every
+        // other test here arranges a value *before* composing, which passes just as well against
+        // a screen that reads a snapshot once.
+        setContent(summary = NotificationSummary(worshipRemindersOn = 0, enabledPrayerCount = 5))
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_on, 0)).assertExists()
+
+        viewModel.notificationSummary.value =
+            NotificationSummary(worshipRemindersOn = 3, enabledPrayerCount = 2)
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_on, 3)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_of, 2, 5)).assertExists()
+        composeRule.onNodeWithText(string(R.string.notif_hub_count_on, 0)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the master switch turning off underneath the screen takes the rows with it`() {
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = true))
+        composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertExists()
+
+        viewModel.notificationSummary.value =
+            NotificationSummary(notificationsMasterEnabled = false)
+
+        composeRule.onNodeWithText(string(R.string.notif_hub_prayers_title)).assertDoesNotExist()
     }
 
     @Test
@@ -295,7 +327,7 @@ class NotificationSettingsScreenTest {
         // The banner lives inside the `if (notificationsEnabled)` block. Warning that alerts
         // may be delayed, when the user has switched alerts off, is noise about a setting they
         // have already decided.
-        setContent(NotificationSettingsUiState(notificationsEnabled = false))
+        setContent(summary = NotificationSummary(notificationsMasterEnabled = false))
 
         composeRule.onNodeWithText(string(R.string.notif_hub_delivery_warning))
             .assertDoesNotExist()

--- a/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/NotificationSummaryTest.kt
+++ b/feature/settings/src/test/kotlin/com/arshadshah/nimaz/presentation/viewmodel/settings/NotificationSummaryTest.kt
@@ -1,0 +1,200 @@
+package com.arshadshah.nimaz.presentation.viewmodel.settings
+
+import app.cash.turbine.test
+import com.arshadshah.nimaz.domain.model.WorshipReminderType
+import com.arshadshah.nimaz.testing.SettingsViewModelHarness
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The notifications hub, against a setting changed somewhere other than the hub.
+ *
+ * **The bug this is written for.** `hiltViewModel()` in a destination body is scoped to that
+ * destination's `NavBackStackEntry`, so the hub and each of its five subscreens hold *different*
+ * `SettingsViewModel` instances. `_notificationState` is loaded once per instance, in
+ * `loadSettings`, and nothing re-reads it when a destination is returned to. So switching a
+ * worship reminder on updated the subscreen's copy and wrote DataStore — and the hub, which had
+ * loaded its copy on the way in, went on reporting the count from before the edit until the app
+ * was restarted.
+ *
+ * It looked like a rendering fault rather than a stale read because **one row was always right**:
+ * the prayer row was the only one already reading `notificationSummary`, which collects DataStore
+ * directly. Every other row read the snapshot. The fix is to widen the summary to carry all of
+ * them, so the asymmetry stops existing.
+ *
+ * The tests below drive the underlying preference flow rather than sending an event, because that
+ * is what the other instance's write reduces to: `SettingsRepositoryStub` keeps its writes on the
+ * mockk so `coVerify` still works (see its KDoc), and DataStore is a singleton, so *whichever*
+ * instance writes it, every collector in the process sees the same new value. Setting the flow is
+ * that, without a second ViewModel to make the point.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationSummaryTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val harness = SettingsViewModelHarness()
+    private val repo get() = harness.repo
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        viewModel = harness.build()
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    /**
+     * `notificationSummary` is `stateIn(…, WhileSubscribed)`, so its upstream does not run until
+     * something collects it. Every test below therefore reads through Turbine rather than off
+     * `.value` — a `.value` read returns the seed forever and would pass against the bug.
+     */
+
+    // ── The rows that were stale ────────────────────────────────────────────────
+
+    @Test
+    fun `a worship reminder switched on elsewhere raises the hub's count`() = runTest(dispatcher) {
+        advanceUntilIdle()
+
+        viewModel.notificationSummary.test {
+            awaitItem()
+
+            repo.worshipEnabled.getValue(WorshipReminderType.TAHAJJUD.key).value = true
+            repo.worshipEnabled.getValue(WorshipReminderType.WITR.key).value = true
+            advanceUntilIdle()
+
+            assertThat(expectMostRecentItem().worshipRemindersOn).isEqualTo(2)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `switching one back off lowers it again`() = runTest(dispatcher) {
+        advanceUntilIdle()
+
+        viewModel.notificationSummary.test {
+            awaitItem()
+            repo.worshipEnabled.getValue(WorshipReminderType.TAHAJJUD.key).value = true
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem().worshipRemindersOn).isEqualTo(1)
+
+            repo.worshipEnabled.getValue(WorshipReminderType.TAHAJJUD.key).value = false
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem().worshipRemindersOn).isEqualTo(0)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `the weekly row follows both of its reminders`() = runTest(dispatcher) {
+        advanceUntilIdle()
+
+        viewModel.notificationSummary.test {
+            awaitItem()
+
+            repo.fridayReminderEnabled.value = true
+            repo.khatamReminderEnabled.value = true
+            advanceUntilIdle()
+
+            val summary = expectMostRecentItem()
+            assertThat(summary.fridayReminderEnabled).isTrue()
+            assertThat(summary.khatamReminderEnabled).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `the sound row follows the adhan, the vibration and the DND choice`() =
+        runTest(dispatcher) {
+            // Three preferences behind one subtitle, each set on a different screen — the sound on
+            // Notification Sound, the other two on the same screen but through different events.
+            advanceUntilIdle()
+
+            viewModel.notificationSummary.test {
+                awaitItem()
+
+                repo.selectedAdhanSound.value = "ABDULBASIT"
+                repo.notificationVibration.value = false
+                repo.adhanRespectDnd.value = false
+                advanceUntilIdle()
+
+                val summary = expectMostRecentItem()
+                assertThat(summary.selectedAdhanSound).isEqualTo("ABDULBASIT")
+                assertThat(summary.vibrationEnabled).isFalse()
+                assertThat(summary.respectDnd).isFalse()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `the master switch reads the preference, not a snapshot`() = runTest(dispatcher) {
+        // The hub gates every row below it on this one. Read from a snapshot, a master switch
+        // turned off anywhere else leaves the hub showing a full list of live settings.
+        advanceUntilIdle()
+
+        viewModel.notificationSummary.test {
+            awaitItem()
+
+            repo.prayerNotificationsEnabled.value = false
+            advanceUntilIdle()
+
+            assertThat(expectMostRecentItem().notificationsMasterEnabled).isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── The contrast that explains the fix ──────────────────────────────────────
+
+    @Test
+    fun `the one-shot snapshot does not see the same change`() = runTest(dispatcher) {
+        // Not a defect in `notificationState` — it is what a snapshot is, and the optimistic
+        // updates that make a toggle feel instant depend on it staying one. It is only wrong as
+        // a source for a *screen that did not make the edit*, which is the whole finding.
+        advanceUntilIdle()
+
+        viewModel.notificationSummary.test {
+            awaitItem()
+            repo.worshipEnabled.getValue(WorshipReminderType.TAHAJJUD.key).value = true
+            advanceUntilIdle()
+
+            assertThat(expectMostRecentItem().worshipRemindersOn).isEqualTo(1)
+            assertThat(viewModel.notificationState.value.worshipReminders.count { it.value })
+                .isEqualTo(0)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── The floor ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every worship reminder type is counted, not a hand-written subset`() =
+        runTest(dispatcher) {
+            // The summary iterates `WorshipReminderType.entries`. A reminder added to the enum
+            // and forgotten here would be switchable and uncounted; this fails the day that
+            // happens rather than the day someone notices the number is short.
+            advanceUntilIdle()
+
+            viewModel.notificationSummary.test {
+                awaitItem()
+
+                WorshipReminderType.entries.forEach { type ->
+                    repo.worshipEnabled.getValue(type.key).value = true
+                }
+                advanceUntilIdle()
+
+                assertThat(expectMostRecentItem().worshipRemindersOn)
+                    .isEqualTo(WorshipReminderType.entries.size)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}


### PR DESCRIPTION
Two findings from testing `versionCode 435` on a device. They are unrelated to each other, and both predate the module split — neither is a regression from #633–#638.

## The hub's rows reported the value from before the edit

`hiltViewModel()` in a destination body is scoped to that destination's `NavBackStackEntry`, so the notifications hub and each of its five subscreens hold **different `SettingsViewModel` instances**. `_notificationState` is loaded once per instance, in `loadSettings`, and nothing re-reads it on the way back — so switching a worship reminder on updated the *subscreen's* copy and wrote DataStore, while the hub went on counting what it had loaded on the way in.

**One row was right the whole time**, which is what made it read as a rendering fault rather than a stale read: the prayer row was the only one already reading `notificationSummary`, a `combine` over the repository's own flows. Everything else read the snapshot.

The fix widens that summary to carry every value the hub renders — the worship count, the weekly pair, the three preferences behind the sound subtitle, and the master switch — and the hub reads nothing else. The asymmetry stops existing.

`notificationState` is **not** the defect and is unchanged. A snapshot is what lets the optimistic `_state.update` paint a switch on the frame of the tap; it is only wrong as a source for a screen that did not make the edit. `docs/ARCHITECTURE.md` §4.1 records the rule that falls out: *owned control → snapshot with an optimistic update; reported value → a flow off the repository.*

The worship count iterates `WorshipReminderType.entries` rather than listing keys, so a reminder added to the enum is counted without a second edit — pinned by a test.

## `NavHost` had no transition arguments at all

All 94 destinations used Navigation Compose's fallback: one 700 ms crossfade, identical in both directions. The back stack had no visible direction, and at 700 ms a tap on a settings row read as a pause before the screen changed.

`NimazNavTransitions` (`core/navigation/NavTransitions.kt`) replaces it with a shared axis along X — the arriving screen travels further than the departing one, and pop reverses both. Set once on the `NavHost`, so a destination that overrides it would be a deliberate exception, and there are none.

**It honours the Appearance → Animations preference**, as a hard cut (`EnterTransition.None` / `ExitTransition.None`) rather than a shorter slide: someone who turned animations off did so because motion makes them ill or because the device cannot afford it, and a 60 ms version of the same movement serves neither.

It takes `enabled` as a parameter rather than reading the preference, because the preference lives in `:core:datastore` and `LocalAnimationsEnabled` in `:core:ui`, and `:core:navigation` depends on neither by design. `NavGraph` reads the local and passes it down; it is the one caller and sits below both modules. The setting was **already wired correctly** into the theme — `MainActivity` collects `settingsRepository.animationsEnabled` and `NimazTheme` provides the local — so nothing else had to change for it to take effect.

## Tests

- **Six of `NotificationSettingsScreenTest`'s eighteen went red** on the screen change. That is the negative proof, and they drive the summary now. Its `setContent` lost its `state` parameter entirely: a screen that cannot read `notificationState` should not let a test arrange it.
- **Two new screen tests change the summary *underneath* a composed screen.** Every existing test arranges its value before composing, which passes just as well against a screen that reads once — coming back from a subscreen does not recompose the hub from scratch, so this is the shape the bug actually had.
- **`NotificationSummaryTest`** — seven cases on the ViewModel half, all reading through Turbine because `stateIn(WhileSubscribed)` means a `.value` read returns the seed forever and would pass against the bug. Includes the contrast case asserting the snapshot *doesn't* see the same change, which is what documents why the hub had to move.
- **`NavTransitionsTest`** — four cases, pinning only what a user would file a bug about: that the setting switches them off, and that forward does not look identical to back. Nothing about slide distance or easing, so a visual adjustment is not a test edit.

## Verification

| gate | result |
|---|---|
| `:core:navigation:check` | pass (incl. `moduleBoundary`, 80/80 coverage) |
| `:feature:settings:check` | pass (incl. its lint, coverage floor) |
| `:app:testDebugUnitTest` | 87/88 — the one failure is `DeviceStateCorpusTest`, which needs the private content artifact this environment cannot fetch |
| `:app:lintDebug` | pass |
| `scripts/check_docs.py` | 23/23 |

Docs updated in the same commit: `docs/NAVIGATION.md` §1 gains a *Screen transitions* subsection and a row for `NavTransitions.kt`; `docs/ARCHITECTURE.md` §4.1 gains the snapshot-versus-flow rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MTFZt3xP9aYU96Pzd7qyT)_